### PR TITLE
データモデルの明確化

### DIFF
--- a/.claude/PR_06_data_model.md
+++ b/.claude/PR_06_data_model.md
@@ -1,0 +1,37 @@
+# PR #6: データモデルの明確化
+
+## 概要
+Pydantic等でデータモデルを定義し、型制約・バリデーションを導入する。
+
+## 背景・課題
+
+- stocks dict に多種のキーが混在
+- 型ヒントが部分的
+- スクレイピングデータの妥当性チェック不足
+- 株価が負数、出来高がNaN等の異常データへの対処が不明確
+
+## 実装予定
+
+### データモデル定義
+```python
+from pydantic import BaseModel, validator
+
+class StockPrice(BaseModel):
+    code_s: str
+    price: int
+    volume: float
+
+    @validator('price')
+    def price_must_be_positive(cls, v):
+        if v <= 0:
+            raise ValueError('price must be positive')
+        return v
+```
+
+### 新規ファイル
+- `scripts/models/stock.py`
+- `scripts/models/price.py`
+- `scripts/models/earnings.py`
+
+## 工数見積もり
+5日


### PR DESCRIPTION
## 概要
Pydantic等でデータモデルを定義し、型制約・バリデーションを導入する提案です。

## 課題
- stocks dict に多種のキーが混在
- 型ヒントが部分的
- スクレイピングデータの妥当性チェック不足

## 提案内容
- dataclass/Pydantic で Stock, PriceSeries, Earnings, Indicators の構造を定義
- 型制約・バリデーション導入

詳細は .claude/PR_06_data_model.md を参照してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)