### PR TITLE
時価総額ファクターを山型分布に変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,23 @@ pytest tests/test_gyoseki.py -v
 
 GitHub Actions（`.github/workflows/test.yml`）でPR/push時に自動実行。
 
+### 統合テスト（make_stock_db.py サブコマンド）
+
+スコアリングやランキングのロジックを変更した場合、ローカルDB上で実際の銘柄データを使って検証する。
+
+```bash
+source .venv/bin/activate
+cd scripts
+
+# ランキング全体を再生成して確認
+python make_stock_db.py list_all_db
+```
+
+**注意: コンソールに出力されない。** `log_print` 経由のためすべてログファイルとCSVに出力される。確認先:
+- **ログ**: `logs/make_stock_db.log`（処理経過・エラー）
+- **ランキングCSV**: `data/code_rank_data/code_rank.csv`（最終結果）
+- 正常終了時はGoogle Driveへの自動アップロードも実行される（`Upload Complete` ログで確認）
+
 ## データ保存場所
 
 - **メインDB (shelve)**: `data/stock_data/stocks_shelve`

--- a/scripts/shihyou.py
+++ b/scripts/shihyou.py
@@ -352,16 +352,15 @@ def calc_shihyo_pt(code_s, upd=UPD_INTERVAL, stock={}):
     # PER_MAX = 25
     # PBR_MAX = 10
     # PSR_MAX = 35
-    # 時価総額(小型株ファクター)
-    # 500億>300億>100億
+    # 時価総額ファクター（成長性×流動性×外国資本流入の山型分布）
     jikasogaku_pt = 0
     if "jikasogaku" in shiyo:
-        if shiyo["jikasogaku"] <= 10000 / 100:
-            jikasogaku_pt = JIKASOGAKU_MAX
-        elif shiyo["jikasogaku"] <= 30000 / 100:
-            jikasogaku_pt = JIKASOGAKU_MAX / 2
-        elif shiyo["jikasogaku"] <= 50000 / 100:
-            jikasogaku_pt = JIKASOGAKU_MAX / 3
+        jikasogaku_pt = step_func(
+            shiyo["jikasogaku"],
+            [100, 400, 1000, 3000],
+            [25, JIKASOGAKU_MAX, 15, 5],
+            min_val=0,
+        )
     # 発行株式数(小型株ファクター)
 
     # 有利子負債自己資本比率(クォリティファクター)


### PR DESCRIPTION
## Summary
- 時価総額ファクターを「小型株ほど高評価」の降順から、中型株（400〜1000億）を頂点とする山型分布に変更
- if-elif連鎖を `step_func` に置き換えてコード簡潔化
- CLAUDE.mdに統合テスト（`make_stock_db.py list_all_db`）の手順・注意事項を追記

| 区分 | 時価総額 | 旧PT | 新PT |
|---|---|---|---|
| 超小型 | 100億以下 | 30 | **0** |
| 小型 | 100〜400億 | 15 | **25** |
| 中型 | 400〜1000億 | 10 | **30** |
| 大型 | 1000〜3000億 | 0 | **15** |
| 超大型 | 3000億超 | 0 | **5** |

## Test plan
- [x] pytest tests/ -v（106件パス）
- [x] `make_stock_db.py list_all_db` でランキングCSV正常生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)