### PR TITLE
コンソールログ出力を常に有効化し、各スクリプトにsetup_logger追加

### DIFF
--- a/scripts/disclosure.py
+++ b/scripts/disclosure.py
@@ -229,4 +229,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("disclosure")
     main()

--- a/scripts/gyoseki.py
+++ b/scripts/gyoseki.py
@@ -1054,4 +1054,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("gyoseki")
     main()

--- a/scripts/kessan.py
+++ b/scripts/kessan.py
@@ -254,4 +254,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("kessan")
     main()

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -99,12 +99,10 @@ def setup_logger(script_name=None):
     # ハンドラーをロガーに追加
     _logger.addHandler(file_handler)
 
-    # コンソールハンドラー（ターミナルからの実行のみ）
-    if sys.stdout.isatty():
-        console_handler = logging.StreamHandler()
-        console_handler.setLevel(logging.INFO)
-        # console_handler.setFormatter(formatter)  # コンソールはデフォルトフォーマッターで
-        _logger.addHandler(console_handler)
+    # コンソールハンドラー（常に追加。cron時はstdoutがファイルにリダイレクトされる）
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    _logger.addHandler(console_handler)
 
     return _logger
 

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -439,5 +439,6 @@ def test():
 
 
 if __name__ == "__main__":
+    setup_logger("make_market_db")
     main()
     # test()

--- a/scripts/make_sector_data.py
+++ b/scripts/make_sector_data.py
@@ -237,4 +237,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("make_sector_data")
     main()

--- a/scripts/make_sisu_data.py
+++ b/scripts/make_sisu_data.py
@@ -561,5 +561,6 @@ def test():
 
 
 if __name__ == "__main__":
+    setup_logger("make_sisu_data")
     main()
     # test()

--- a/scripts/master.py
+++ b/scripts/master.py
@@ -238,4 +238,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("master")
     main()

--- a/scripts/migrate_pickle_to_shelve.py
+++ b/scripts/migrate_pickle_to_shelve.py
@@ -392,4 +392,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("migrate_pickle_to_shelve")
     exit(main())

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -235,4 +235,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("portfolio")
     main()

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -1416,4 +1416,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("price")
     main()

--- a/scripts/rironkabuka.py
+++ b/scripts/rironkabuka.py
@@ -633,4 +633,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("rironkabuka")
     main()

--- a/scripts/shihyou.py
+++ b/scripts/shihyou.py
@@ -537,6 +537,7 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("shihyou")
     # TODO: 9272ブティックス 取得できてない？
     #!!! 不正な関連銘柄です
     # もでてる

--- a/scripts/test_functional.py
+++ b/scripts/test_functional.py
@@ -339,4 +339,5 @@ def main():
 
 
 if __name__ == "__main__":
+    setup_logger("test_functional")
     main()


### PR DESCRIPTION
## Summary
- `setup_logger()`の`isatty()`判定を廃止し、常にコンソールハンドラーを追加するよう変更
- Claude Codeやパイプ経由でもlog_print/log_warningの出力がコンソールに表示されるようになる
- 各スクリプトの`if __name__ == "__main__":`ブロックに`setup_logger()`を追加（12ファイル）

## 変更理由
各スクリプトを単体実行してテストする際、ログがファイルにしか出力されずコンソールで確認できなかった。原因は`sys.stdout.isatty()`がFalseの環境（Claude Code、パイプ等）ではコンソールハンドラーが追加されないため。cron(launchd)ではstdoutが`/tmp/shintakane_launchd_stdout.log`にリダイレクトされるため、常時追加でも影響なし。

## 変更ファイル
| ファイル | 変更 |
|---------|------|
| `scripts/ks_util.py` | `isatty()`判定を削除、常にコンソールハンドラー追加 |
| 他13スクリプト | `if __name__`に`setup_logger()`追加 |

## Test plan
- [x] `pytest tests/ -v -m "not local_db"` — 全179件パス
- [ ] ターミナルから`python price.py`でコンソールにログ出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)