### PR TITLE
キャッシュ戦略の改善: 決算更新の精密制御とエラーレスポンス汚染防止

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,14 +33,45 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `ShelveDB` はスレッドセーフ（RLock）、メモ化キャッシュ（`enable_memo()`）対応
 - バックエンドは `dbm.dumb`（macOSの `dbm.ndbm` はハッシュ衝突問題があるため）
 
-### キャッシュ管理 (`ks_util.py` の UPD_* 定数)
+### キャッシュ戦略
 
-- `UPD_CACHE (0)`: キャッシュがあればそのまま使用
-- `UPD_INTERVAL (1)`: 間隔超過時のみ更新
-- `UPD_REEVAL (2)`: DBキャッシュは使わず再評価
-- `UPD_FORCE (3)`: すべてのキャッシュを無視して強制取得
+3層の階層構造で、`UPD_*` 定数（`ks_util.py`）が全層を横断して制御する。
 
-各データタイプは `has_*_data()` / `get_*_data()` パターンを持つ。決算発表日後は強制更新ロジックあり。
+**UPD_* 定数（キャッシュ鮮度レベル）:**
+
+| 定数 | 値 | DB層 | ファイル層 | HTTP層 |
+|------|---|------|-----------|--------|
+| `UPD_CACHE` | 0 | DBにあればそのまま使用 | ファイルがあれば使用 | キャッシュ使用 |
+| `UPD_INTERVAL` | 1 | TTL超過時のみ更新 | TTL超過時のみ再取得 | キャッシュ使用 |
+| `UPD_REEVAL` | 2 | DBキャッシュ無視、再評価 | TTL超過時のみ再取得 | キャッシュ使用 |
+| `UPD_FORCE` | 3 | すべて無視 | すべて無視 | 強制取得 |
+
+**① DB層** (`make_stock_db.py`):
+- `has_*_data(stocks, code_s, latest)` でshelve DB上のレコード鮮度を確認（`access_date_*` フィールド）
+- `has_active_dbdata()` ヘルパーで共通化。決算発表後は `need_kessan_upd()` で強制更新
+- `_update_db_code()` 内で `has_*` → False の場合のみ `get_*_data()` を呼ぶ2段階制御
+
+**② ファイル層** (各モジュール):
+- `is_file_timestamp(fname, interval_day)` (`price.py`): ファイル更新日時を営業日ベースでTTL判定
+- `is_cache_latest(url, interval_day)` (`rironkabuka.py`): HTMLキャッシュファイルのTTL判定
+
+| モジュール | データ種別 | TTL | チェック関数 |
+|-----------|-----------|-----|------------|
+| `price.py` | 日次株価 | 1日 | `is_file_timestamp()` |
+| `price.py` | 週次株価 | 7日 | `is_file_timestamp()` |
+| `price.py` | yfinance JSON | 1日 | `is_file_timestamp()` |
+| `make_stock_db.py` | マスター情報 | 7日 | `access_date` 直接比較 |
+| `make_stock_db.py` | 指標 | 5日 | `access_date_shihyo` 直接比較 |
+| `gyoseki.py` | 業績 | 15日 | `is_cache_latest()` |
+| `rironkabuka.py` | 理論株価 | 5日 | `is_cache_latest()` |
+
+**③ HTTP層** (`ks_util.py`):
+- `http_get_html()` の `use_cache` パラメータでファイルキャッシュの読み書きを制御
+- キャッシュファイル名は `get_http_cachname(url)` でURL→ファイル名変換
+
+**④ メモリ層**:
+- `ShelveDB.enable_memo()`: 読み取り集中処理時のインメモリキャッシュ（`db_shelve.py`）
+- `memoize()` デコレータ: `load_pickle`, `load_file` のメモ化（`ks_util.py`）
 
 ### 価格データ取得 (`price.py`)
 

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -517,11 +517,18 @@ def http_get_html(
         # メタ指定での文字コードをutf8に
         # html = html.replace("charset=shift_jis", "charset=utf-8")
 
-        log_print(
-            "  取得したhtmlをファイルキャッシュに書き込みます:",
-            Path(cache_name).relative_to(DATA_DIR),
-        )
-        file_write(cache_name, html)
+        # 成功レスポンスのみキャッシュに書き込む（エラーレスポンスのキャッシュ汚染を防止）
+        if 200 <= res.status_code < 300:
+            log_print(
+                "  取得したhtmlをファイルキャッシュに書き込みます:",
+                Path(cache_name).relative_to(DATA_DIR),
+            )
+            file_write(cache_name, html)
+        else:
+            log_warning(
+                "  HTTPエラー(%d)のためキャッシュに書き込みません: %s"
+                % (res.status_code, url)
+            )
         if with_status:
             # ステータスコードも返す
             return html, res.status_code

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -266,7 +266,18 @@ def need_kessan_upd(stocks, code_s, dt_access):
     return kessan_upd
 
 
+_UPD_REASON_NONE = 0  # 更新不要
+_UPD_REASON_TTL = 1  # TTL超過による更新
+_UPD_REASON_KESSAN = 2  # 決算発表による更新
+_UPD_REASON_NO_DATA = 3  # データなし
+
+
 def has_active_dbdata(stocks, code_s, access_key, interval_day, latest):
+    """DB上のデータ鮮度を確認する。
+    Returns:
+        tuple(bool, int): (データがあるか, 更新理由)
+        更新理由は _UPD_REASON_* 定数
+    """
     if code_s in stocks:
         # 対象(業績など)データアクセス時間と現在時間を比較
         if access_key in stocks[code_s]:
@@ -276,21 +287,26 @@ def has_active_dbdata(stocks, code_s, access_key, interval_day, latest):
                 kessan_upd = need_kessan_upd(stocks, code_s, dt_access)
                 # アクセス日超過または決算更新
                 timedelta = datetime.today() - dt_access
-                if timedelta.days >= interval_day or kessan_upd:
+                if kessan_upd:
+                    log_print("%s決算更新: %d日ぶり" % (access_key, timedelta.days))
+                    return False, _UPD_REASON_KESSAN
+                if timedelta.days >= interval_day:
                     log_print("%s更新: %d日ぶり" % (access_key, timedelta.days))
-                    return False
+                    return False, _UPD_REASON_TTL
                 else:
                     # print "業績あり: %d日前"%timedelta.days
-                    return True
+                    return True, _UPD_REASON_NONE
             else:
-                return True
-    return False
+                return True, _UPD_REASON_NONE
+    return False, _UPD_REASON_NO_DATA
 
 
 def has_gyoseki_data(stocks, code_s, latest=False):
     """DBに業績情報があるか
     15日経過するか、決算日をすぎている
     @param	latest
+    Returns:
+        tuple(bool, int): (データがあるか, 更新理由)
     """
     INTERVAL_DAY = 15
     return has_active_dbdata(
@@ -312,9 +328,10 @@ def get_gyoseki_data(stocks, code_s, upd=UPD_INTERVAL):
 
 
 def has_rironkabuka_data(stocks, code_s, latest=False):
-    """
-    理論株価データがあるか？
+    """理論株価データがあるか？
     latest: Trueなら最新であるかを調査(一定期間アクセスがあったか)
+    Returns:
+        tuple(bool, int): (データがあるか, 更新理由)
     """
     INTERVAL_DAY = 15
     return has_active_dbdata(
@@ -339,23 +356,14 @@ def get_rironkabuka_data(stocks, code_s, upd=UPD_INTERVAL):
 
 
 def has_shihyo_data(stocks, code_s, latest=False):
-    INTERVAL_DAY = 5  # この設定は微妙
-    if code_s in stocks:
-        # 指標データの取得日と現在との日付チェック
-        if "access_date_shihyo" in stocks[code_s]:
-            if latest:
-                dt_access = stocks[code_s]["access_date_shihyo"]
-                kessan_upd = need_kessan_upd(stocks, code_s, dt_access)
-                timedelta = datetime.today() - dt_access
-                if timedelta.days >= INTERVAL_DAY or kessan_upd:
-                    log_print("指標更新: %d日ぶり" % timedelta.days)
-                    return False
-                else:
-                    # print "指標あり: %d日前"%timedelta.days
-                    return True
-            else:
-                return True
-    return False
+    """指標データがあるか？
+    Returns:
+        tuple(bool, int): (データがあるか, 更新理由)
+    """
+    INTERVAL_DAY = 5
+    return has_active_dbdata(
+        stocks, code_s, "access_date_shihyo", INTERVAL_DAY, latest
+    )
 
 
 def get_shihyo_data(stocks, code_s, upd=UPD_INTERVAL):
@@ -492,17 +500,21 @@ def _update_db_code(c_s, upd, tables, stocks, latest, force):
         if not has_price_data(stocks, c_s, latest) or force:
             stock_data.update(get_price_data(stocks, c_s, upd))
     if not tables or "gyoseki" in tables:
-        if not has_gyoseki_data(stocks, c_s, latest) or force:
-            # アクセス間隔以外でもみてるので、一反強制　TODO:やり方考える
-            stock_data.update(get_gyoseki_data(stocks, c_s, UPD_FORCE))
+        has_data, reason = has_gyoseki_data(stocks, c_s, latest)
+        if not has_data or force:
+            # 決算更新時はファイルキャッシュも無視して最新を取得
+            effective_upd = UPD_FORCE if reason == _UPD_REASON_KESSAN else upd
+            stock_data.update(get_gyoseki_data(stocks, c_s, effective_upd))
     if not tables or "rironkabuka" in tables:
-        if not has_rironkabuka_data(stocks, c_s, latest) or force:
-            # 業績と同じく一反強制
-            stock_data.update(get_rironkabuka_data(stocks, c_s, UPD_FORCE))
+        has_data, reason = has_rironkabuka_data(stocks, c_s, latest)
+        if not has_data or force:
+            effective_upd = UPD_FORCE if reason == _UPD_REASON_KESSAN else upd
+            stock_data.update(get_rironkabuka_data(stocks, c_s, effective_upd))
     if not tables or "shihyo" in tables:
-        if not has_shihyo_data(stocks, c_s, latest) or force:
-            # 業績と同じく一反強制
-            stock_data.update(get_shihyo_data(stocks, c_s, UPD_FORCE))
+        has_data, reason = has_shihyo_data(stocks, c_s, latest)
+        if not has_data or force:
+            effective_upd = UPD_FORCE if reason == _UPD_REASON_KESSAN else upd
+            stock_data.update(get_shihyo_data(stocks, c_s, effective_upd))
     return stock_data
 
 

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -37,17 +37,23 @@ class TestHasGyosekiData:
     def test_no_code(self):
         """DBに銘柄がない場合"""
         stocks = {}
-        assert make_stock_db.has_gyoseki_data(stocks, "1234") is False
+        has_data, reason = make_stock_db.has_gyoseki_data(stocks, "1234")
+        assert has_data is False
+        assert reason == make_stock_db._UPD_REASON_NO_DATA
 
     def test_no_access_date(self):
         """access_date_gyoseki がない場合"""
         stocks = {"1234": {"stock_name": "Test"}}
-        assert make_stock_db.has_gyoseki_data(stocks, "1234") is False
+        has_data, reason = make_stock_db.has_gyoseki_data(stocks, "1234")
+        assert has_data is False
+        assert reason == make_stock_db._UPD_REASON_NO_DATA
 
     def test_has_data_no_latest(self):
         """latest=False でアクセス日あり"""
         stocks = {"1234": {"access_date_gyoseki": datetime(2025, 1, 1)}}
-        assert make_stock_db.has_gyoseki_data(stocks, "1234", latest=False) is True
+        has_data, reason = make_stock_db.has_gyoseki_data(stocks, "1234", latest=False)
+        assert has_data is True
+        assert reason == make_stock_db._UPD_REASON_NONE
 
 
 # ==================================================


### PR DESCRIPTION
## Summary

- **UPD_FORCE ハードコード解消**: `_update_db_code()` で gyoseki/rironkabuka/shihyo が常に `UPD_FORCE` で呼ばれていた問題を修正。`has_active_dbdata()` の戻り値を `(bool, reason)` タプルに拡張し、決算更新時のみ `UPD_FORCE`、TTL超過時は `upd` をそのまま渡すように変更。不要なHTTP通信を削減
- **エラーレスポンスのキャッシュ汚染防止**: `http_get_html()` でHTTPステータス2xx以外のレスポンスをキャッシュに書き込まないように修正
- **キャッシュ戦略の文書化**: CLAUDE.md に3層キャッシュ階層の仕様・UPD_*の振る舞い・モジュール別TTL一覧を追記
- **has_shihyo_data の共通化**: 独自実装だった `has_shihyo_data` を `has_active_dbdata` ヘルパーに統一

Related: #56

## Test plan

- [x] `pytest tests/ -v -m "not local_db"` — 179 passed
- [ ] `cd scripts && python make_stock_db.py list_all_db` でランキング生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)