### PR TITLE
冗長ログを削減しlog_debugに降格

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **コメント・docstringは日本語で記述**。技術用語・関数名・外部ライブラリ名は英語のまま。
 - 銘柄コードは常に**文字列** (`code_s`) を使用。`"0001"`〜`"9999"` や `"215A"` 形式。レガシーの `code` (int) は非推奨。
-- ロギングは `log_print`, `log_warning`, `log_error` を使用（`ks_util.py`）。直接の `print()` は不可。
+- ロギングは `log_print`, `log_debug`, `log_warning`, `log_error` を使用（`ks_util.py`）。直接の `print()` は不可。
+  - `log_print`（INFO）: フェーズ開始/完了マーカー、サマリー、重要な処理経過など**運用時に必要な情報**
+  - `log_debug`（DEBUG）: 個別銘柄の中間値、per-row詳細、キャッシュ判定など**デバッグ時のみ必要な情報**
+  - ファイルハンドラは通常INFOレベル。`KS_LOG_DEBUG=1` 環境変数でDEBUGレベルに切替可能
+  - 新規ログ追加時は上記の基準で `log_print` / `log_debug` を使い分けること
 - DB操作は `update_db_rows()` を経由。バルク操作は `sync=False` で非同期化可能。
 - 日付判定は `ks_util.get_price_day()` を使用（18:00前は前日扱い）。
 
@@ -157,7 +161,7 @@ python make_stock_db.py list_all_db
 - **株価履歴**: `data/stock_data/yahoo/price/`（yfinance JSON + レガシーHTML）, `data/stock_data/kabutan/price/`
 - **市場指数**: `data/sisu_data/`
 - **結果CSV**: `data/shintakane_result_data/`, `data/code_rank_data/`
-- **ログ**: `logs/`（TimedRotatingFileHandler、7日保持）
+- **ログ**: `logs/`（TimedRotatingFileHandler、7日保持、通常INFOレベル、`KS_LOG_DEBUG=1` でDEBUG出力）
 
 ## 重要な注意事項
 

--- a/scripts/analyze_sisu_data.py
+++ b/scripts/analyze_sisu_data.py
@@ -108,8 +108,8 @@ def rankdata(a):
 #         log_print("asset_total_before:", [round(a, 1) for a in asset_total])
 #         total_return = sum(asset_total)
 #         asset_total = [total_return * r / 100 for t, r in zip(asset_total, asset_rate)]
-#         log_print("asset_total_after:", [round(a, 1) for a in asset_total])
-#         log_print("total_return:", round(total_return, 1), round(sum(asset_total), 1))
+#         log_debug("asset_total_after:", [round(a, 1) for a in asset_total])
+#         log_debug("total_return:", round(total_return, 1), round(sum(asset_total), 1))
 #     # 208
 #     log_print("バイアンドホールド(リバランス)	: ", int(total_return))
 
@@ -176,12 +176,12 @@ def rs_3612ma():
                 asset_signal[j] = "SELL"
             asset_return[j] = row[3]
             asset_return_1[j] = row[4]
-        log_print("-" * 15, _row[0])
-        log_print("signal:", asset_signal)
-        log_print("return:", asset_return)
+        log_debug("-" * 15, _row[0])
+        log_debug("signal:", asset_signal)
+        log_debug("return:", asset_return)
         asset_return_rank = rankdata(asset_return)
         asset_return_rank = [8 - r for r in asset_return_rank]
-        log_print("rank:", asset_return_rank)
+        log_debug("rank:", asset_return_rank)
         # アセットレートを更新
         for j, rank in enumerate(asset_return_rank):
             if rank <= 2 and asset_signal[j] == "BUY":
@@ -191,7 +191,7 @@ def rs_3612ma():
                 asset_rate[j] = 100
             elif asset_signal[j] == "SELL":
                 asset_rate[j] = 0
-        log_print("rate:", asset_rate)
+        log_debug("rate:", asset_rate)
         count_100 = asset_rate[:-1].count(100)
         val = 100 / count_100 if count_100 > 0 else 0
         # if val == 100: val = 50
@@ -199,10 +199,10 @@ def rs_3612ma():
             for j, rate in enumerate(asset_rate):
                 asset_rate[j] = val if rate == 100 else 0
             asset_rate[7] = 0  # キャッシュは0に
-        log_print("rate_mod:", asset_rate)
+        log_debug("rate_mod:", asset_rate)
         if not sum(asset_rate) == 100:
             asset_rate[7] = 100 - sum(asset_rate)
-            log_print("おかしいかも？ cash=", asset_rate[7])
+            log_debug("おかしいかも？ cash=", asset_rate[7])
             # break
         # 結果
         buy = []
@@ -221,11 +221,11 @@ def rs_3612ma():
                 have.append(asset + "(" + str(cur) + ")")
                 have_count[j] += 1
         if buy:
-            log_print("買い：", buy)
+            log_debug("買い：", buy)
         if sell:
-            log_print("売り：", sell)
+            log_debug("売り：", sell)
         if have:
-            log_print("保有：", have)
+            log_debug("保有：", have)
         # リターン計算
         tax = False  # 税金考慮ありか
         if i % 52 == 0:  # 年単位
@@ -240,7 +240,7 @@ def rs_3612ma():
             try:
                 total_return_current = total_return_all[index] - input_money_current
                 total_return_prev = total_return_all[max(index - 52 / 4, 0)]
-                log_print(
+                log_debug(
                     "年利益：%.2f(%.1f<-%.1f) %d%% input:%d"
                     % (
                         profit,
@@ -251,9 +251,9 @@ def rs_3612ma():
                     )
                 )
             except ZeroDivisionError as e:
-                log_print("年利益：0")
-        log_print("return1:", [round(a, 3) for a in asset_return_1])
-        log_print("asset_total_before:", [round(a, 1) for a in asset_total])
+                log_debug("年利益：0")
+        log_debug("return1:", [round(a, 3) for a in asset_return_1])
+        log_debug("asset_total_before:", [round(a, 1) for a in asset_total])
         asset_total = [
             t * r1 for t, r1 in zip(asset_total, asset_return_1)
         ]  # 1ヶ月リターン反映
@@ -265,7 +265,7 @@ def rs_3612ma():
             asset_total = [
                 total_return * r / 100 for r in asset_rate
             ]  # レートに基づき再配分
-        log_print("asset_total_after:", [round(a, 1) for a in asset_total])
+        log_debug("asset_total_after:", [round(a, 1) for a in asset_total])
         if isAccum:
             # print "asset_total_before_accum:", [round(a, 1) for a in asset_total]
             # 積立分を追加
@@ -274,10 +274,10 @@ def rs_3612ma():
             ]
             # asset_total = [a+1.0*float(r)/100 for a, r in zip(asset_total, asset_rate_initial)]
             input_money += sum(asset_total) - total_return
-            log_print("  accum:+%.1f(%d)" % (sum(asset_total) - total_return, input_money))
-            log_print("asset_total_accum:", [round(a, 1) for a in asset_total])
+            log_debug("  accum:+%.1f(%d)" % (sum(asset_total) - total_return, input_money))
+            log_debug("asset_total_accum:", [round(a, 1) for a in asset_total])
             total_return = sum(asset_total)
-        log_print("total_return:", round(total_return, 1), round(sum(asset_total), 1))
+        log_debug("total_return:", round(total_return, 1), round(sum(asset_total), 1))
 
         # asset_rate_all.append(asset_rate)
         total_return_all.append(total_return)
@@ -441,17 +441,17 @@ def rs_3612ma():
 #             # 	pass
 #             # else:
 #             # 	asset_rate[j] = 0 #ここ疑問?
-#         log_print("rate:", asset_rate)
+#         log_debug("rate:", asset_rate)
 #         count = asset_rate[:-1].count(100)
 #         val = 100 / count if count > 0 else 0
 #         if val > 0:
 #             for j, rate in enumerate(asset_rate):
 #                 asset_rate[j] = val if rate == 100 else 0
 #             asset_rate[7] = 0  # キャッシュは0に
-#         log_print("rate_mod:", asset_rate)
+#         log_debug("rate_mod:", asset_rate)
 #         if not sum(asset_rate) == 100:
 #             asset_rate[7] += 100 - sum(asset_rate)
-#             log_print("おかしいかも？ cash=", asset_rate[7])
+#             log_debug("おかしいかも？ cash=", asset_rate[7])
 #         # 売買結果
 #         buy = []
 #         sell = []
@@ -482,9 +482,9 @@ def rs_3612ma():
 #         total_return = sum(asset_total)
 #         log_print("   ", asset_rate)
 #         asset_total = [total_return * r / 100 for r in asset_rate]
-#         log_print("asset_total_after:", [round(a, 1) for a in asset_total])
+#         log_debug("asset_total_after:", [round(a, 1) for a in asset_total])
 #         # TODO: なんかここが違うことがある
-#         log_print("total_return:", round(total_return, 1), round(sum(asset_total), 1))
+#         log_debug("total_return:", round(total_return, 1), round(sum(asset_total), 1))
 #         if abs(total_return - sum(asset_total) >= 1):
 #             raise
 #         # break
@@ -519,9 +519,9 @@ def latest_3612ma():
     return_avg = [0] * len(ASSET_CLASSES)
     signal = [0] * len(ASSET_CLASSES)
     for i, asset in enumerate(ASSET_CLASSES):
-        log_print("-" * 15, asset)
+        log_debug("-" * 15, asset)
         table_key = ASSET_TO_FUND[asset]
-        log_print(table_key)
+        log_debug(table_key)
         prices = market_db[table_key]
         # prices = prices[:-1]
         current = float(prices[-1][CLM_PRICE])
@@ -532,7 +532,7 @@ def latest_3612ma():
             prev12 = prices[int(-1 - 52 * 12 // 12)][CLM_PRICE]
         except IndexError:
             prev12 = prices[0][CLM_PRICE]
-        log_print(current, prev1, prev3, prev6, prev12)
+        log_debug(current, prev1, prev3, prev6, prev12)
         return1[i] = 100 * (current / prev1 - 1)
         return3[i] = 100 * (current / prev3 - 1)
         return6[i] = 100 * (current / prev6 - 1)
@@ -547,7 +547,7 @@ def latest_3612ma():
                 avg12 += prices[month_ind][CLM_PRICE]
                 count += 1
             except IndexError:
-                log_print("prices_len:", len(prices), "month_ind:", month_ind)
+                log_debug("prices_len:", len(prices), "month_ind:", month_ind)
                 log_warning(" priceデータがたりません")
         if count < 12:
             log_warning(" priceデータがたりなかったようです", count)

--- a/scripts/gyoseki.py
+++ b/scripts/gyoseki.py
@@ -32,7 +32,7 @@ def parse_kabutan_account2(html):
 
     def parse_gyoseki_html_table(tbl_html, tble_name):
         # print year_tbl_html
-        log_print("----", tble_name, "の解析")
+        log_debug("----", tble_name, "の解析")
         table = []
 
         # htmlの列要素は↓
@@ -77,7 +77,7 @@ def parse_kabutan_account2(html):
                 try:
                     ldict["uriagedaka"] = int(val_uriagedaka.replace(",", ""))
                 except ValueError:
-                    log_print(
+                    log_debug(
                         "  !!! 売上高値が不正のため中断",
                         val_uriagedaka.replace(",", ""),
                     )
@@ -148,7 +148,7 @@ def parse_kabutan_account2(html):
                 ldict.get("diviednd_per1", ldict.get("uriage_eigyo_ratio", "")),
             ]
             # log_print("|", str(ldict_list).decode('string_escape')) # python2でエスケープ文字を実際に反映させて表示
-            log_print("|", ldict_list)  # python3対応
+            log_debug("|", ldict_list)  # python3対応
             table.append(ldict_list)
         # for文終了
 
@@ -183,7 +183,7 @@ def parse_kabutan_account2(html):
         ldict["date"] = ratio_rows[6]
         for k, v in list(ldict.items()):
             if v == "赤拡":
-                log_print("赤拡は-20%")
+                log_debug("赤拡は-20%")
                 ldict[k] = -20
         # print str(ratio_rows).decode('string_escape')
         ldict_list = [
@@ -202,7 +202,7 @@ def parse_kabutan_account2(html):
         # ldict.get("diviednd_per1", ldict.get("uriage_eigyo_ratio","")
 
         # log_print("前期比行:", str(ldict_list).decode('string_escape'))
-        log_print("前期比行:", ldict_list)  # python3対応
+        log_debug("前期比行:", ldict_list)  # python3対応
         table.append(ldict_list)
         # 決算期、売上高、営業益、経常益、純利益、一株純利益、分割調整後一株利益or売上営業利益
         return table
@@ -314,7 +314,7 @@ def check_table(code_s, table_current, table_quarter):
         while len(table_quarter) <= 8:
             log_warning("  四半期業績の期数が足りないため過去データを加えました")
             table_quarter.insert(0, table_quarter[0])
-            log_print(table_quarter[0])
+            log_debug(table_quarter[0])
             # table_quarter.insert(0, [table_quarter[0][0], 0,0,0,0,0,0])
             # print [table_quarter[0][0]
     return True, table_quarter
@@ -339,7 +339,7 @@ def calc_progress_rate(stock):
     # code = stock.get("code", 0)
     code_s = stock.get("code_s", "")
     if not check_table(code_s, table_current, table_quarter):
-        log_print("決算データ不足で進捗率取得できず", code_s)
+        log_debug("決算データ不足で進捗率取得できず", code_s)
         return ret
     # 見通しの期を取得
     predict_data = []
@@ -357,7 +357,7 @@ def calc_progress_rate(stock):
             predict_data = table_current[-2]
             exists_predict = False
         except IndexError:
-            log_print("会社予想と今期データなく進捗率取得できず", code_s)
+            log_debug("会社予想と今期データなく進捗率取得できず", code_s)
             return ret
     else:
         exists_predict = True
@@ -416,7 +416,7 @@ def calc_progress_rate(stock):
         # print "第1四半期を発表されていないため進捗率なし"
         ret["quarter"] = latest_quarter
         if not exists_predict:
-            log_print(
+            log_debug(
                 "会社予想がないため進捗率取得できず(第%d四半期)" % (latest_quarter),
                 code_s,
             )
@@ -431,7 +431,7 @@ def calc_progress_rate(stock):
             prog_sales += qdata[1]
             prog_profit += qdata[2]
     except (IndexError, TypeError) as e:
-        log_print("当期進捗率に必要なデータが不足しています")
+        log_debug("当期進捗率に必要なデータが不足しています")
     # 前年も同様に計算
     prog_sales_pre_total = prog_profit_pre_total = 0
     prog_sales_pre = prog_profit_pre = 0
@@ -464,13 +464,13 @@ def calc_progress_rate(stock):
     except TypeError:
         # 営利発表していない場合
         profit_per = 0
-        log_print("営業利益予想発表なしのため0")
+        log_debug("営業利益予想発表なしのため0")
     sales_per_pre = profit_per_pre = 0
     if prog_sales_pre_total > 0:
         sales_per_pre = 100 * prog_sales_pre / prog_sales_pre_total
     if prog_profit_pre_total > 0:  # 赤字なら計算しない
         profit_per_pre = 100 * prog_profit_pre / prog_profit_pre_total
-    log_print(
+    log_debug(
         "進捗率: 第%d四半期 売上%d%%(前年%d%%) 利益%d%%(前年%d%%)"
         % (latest_quarter, sales_per, sales_per_pre, profit_per, profit_per_pre)
     )
@@ -497,7 +497,7 @@ def calc_gyoseki_score(tables):
         return 20
 
     # ---- 四半期用の事前計算
-    log_print("----")
+    log_debug("----")
     # 0:決算期	1:売上高	2:営業益	3:経常益	4:最終益 を3四半期期分
     quarter_growth = [[0 for j in range(5)] for i in range(3)]  # 四半期毎の成長率
     quarter_score = [[0 for j in range(5)] for i in range(3)]  # 計算用
@@ -514,7 +514,7 @@ def calc_gyoseki_score(tables):
                         )  # 0割は無理やり1にする
                         if prev_quarter == "－":
                             quarter_growth[i - 1][col] = 100
-                            log_print("  業績の値がないため成長率100に", prev_quarter)
+                            log_debug("  業績の値がないため成長率100に", prev_quarter)
                         else:
                             quarter_growth[i - 1][col] = (
                                 float(table_quarter[i + 4][col]) / prev_quarter - 1
@@ -532,20 +532,20 @@ def calc_gyoseki_score(tables):
     except ValueError as e:
         log_warning(" 業績の値が不正です", quarter_growth)
         return 20
-    log_print("四半期業績　過去3四半期の成長率")
+    log_debug("四半期業績　過去3四半期の成長率")
     # 得点化: 売上10%以上 利益20%以上
     # (オニール:直近四半期売上25%以上)
     for i, row in enumerate(quarter_growth):
-        log_print([round(r, 1) for r in row])  # 四半期成長率
+        log_debug([round(r, 1) for r in row])  # 四半期成長率
         # 売上は10%以上なら1, 利益は20%以上なら1
         for col in (c + 1 for c in range(4)):
             if col == 1:  # 売上
                 quarter_score[i][col] = 1 if quarter_growth[i][col] >= 10 else 0
             else:  # 利益
                 quarter_score[i][col] = 1 if quarter_growth[i][col] >= 20 else 0
-    log_print("-- (得点化) -->")
+    log_debug("-- (得点化) -->")
     for i, row in enumerate(quarter_score):
-        log_print(row)
+        log_debug(row)
 
     # ---- スコアの計算
     # TODO: 全体的に無駄に複雑、シンプルに
@@ -571,8 +571,8 @@ def calc_gyoseki_score(tables):
     # print "営利平均成長率(%):", average_past_profit_rate
     # print "売上CAGR(%):", average_past_profit_rate
     term_count = len(term_data)
-    log_print("%d年平均利益成長率: %d%%" % (term_count, average_past_profit_rate))
-    log_print(
+    log_debug("%d年平均利益成長率: %d%%" % (term_count, average_past_profit_rate))
+    log_debug(
         "%d年平均売上CAGR: %d%%" % (len(term_sales_data), average_past_sales_rate)
     )
     # 平均7%以上>4%以上　赤字年は減点
@@ -608,14 +608,14 @@ def calc_gyoseki_score(tables):
         latest_term_profit = table_current[-2][2]
         latest_term_sales = table_current[-2][1]
         if not isLatestTerm or latest_term_profit == "－":  # 予想を出していない
-            log_print("来季利益データでないので減点", latest_term, latest_term_profit)
+            log_debug("来季利益データでないので減点", latest_term, latest_term_profit)
             score_past_profit *= 0.7
         if not isLatestTerm or latest_term_sales == "－":
-            log_print("来季売上データでないので減点", latest_term, latest_term_sales)
+            log_debug("来季売上データでないので減点", latest_term, latest_term_sales)
             score_past_sales *= 0.7
 
     score_past_profitsales = score_past_profit + score_past_sales
-    log_print(
+    log_debug(
         "score_past_profitsales:%d/%d" % (score_past_profitsales, SCORES[0]),
         "<- 過去平均各期利益-売上成長:%d%% %d%%"
         % (average_past_profit_rate, average_past_sales_rate),
@@ -665,16 +665,16 @@ def calc_gyoseki_score(tables):
             if past:
                 pt *= 0.8
             if pt > 0:
-                log_print(
+                log_debug(
                     "  直近期40%ルール補正:",
                     pt,
                     "売上成長: %.2f 利益率:%.2f" % (sales_rate, profit_rate),
                 )
             score_future_profit += pt
         except (ValueError, IndexError) as e:
-            log_print("  直近期40%ルール計算できず")
+            log_debug("  直近期40%ルール計算できず")
 
-    log_print(
+    log_debug(
         "score_future_profit: %d/%d" % (score_future_profit, SCORES[1]),
         "<- 直近期利益成長:%d%%" % (future_profit_rate),
     )
@@ -714,15 +714,15 @@ def calc_gyoseki_score(tables):
             if past:
                 pt *= 0.8
             if pt > 0:
-                log_print(
+                log_debug(
                     "  直近四半期40%ルール補正:",
                     pt,
                     "売上成長: %.2f 利益率:%.2f" % (sales_rate, profit_rate),
                 )
             score_latest_profit += pt
         except ValueError as e:
-            log_print("  直近四半期40%ルール計算できず")
-    log_print(
+            log_debug("  直近四半期40%ルール計算できず")
+    log_debug(
         "score_latest_profit: %d/%d" % (score_latest_profit, SCORES[2]),
         "<- 最直近四半期利益成長:%d%%" % round(latest_profit_rate, 1),
     )
@@ -736,12 +736,12 @@ def calc_gyoseki_score(tables):
     )
     score_sales_rate = ((SCORES[3] * 2 / 3) * quarter_score_avg) / 100
     if quarter_growth[-1][1] > quarter_growth[-2][1]:
-        log_print(
+        log_debug(
             "　四半期売上加速%.1f%%->%.1f%%"
             % (quarter_growth[-2][1], quarter_growth[-1][1])
         )
         score_sales_rate += SCORES[3] / 3
-    log_print(
+    log_debug(
         "score_sales_rate:%d/%d" % (score_sales_rate, SCORES[3]),
         "<- 3四半期売上成長:%d%%" % round(sales_rate, 1),
     )
@@ -760,7 +760,7 @@ def calc_gyoseki_score(tables):
         (SCORES[4] * 2 / 3) * score_quarter_profit_rate_avg
     ) / 100
     if quarter_growth[-1][2] > quarter_growth[-2][2]:
-        log_print(
+        log_debug(
             "　四半期経常益加速%.1f%%->%.1f%%"
             % (quarter_growth[-2][2], quarter_growth[-1][2])
         )
@@ -768,7 +768,7 @@ def calc_gyoseki_score(tables):
     profit_rate = (
         quarter_growth[-1][2] + quarter_growth[-2][2] + quarter_growth[-3][2]
     ) / 3
-    log_print(
+    log_debug(
         "score_quarter_profit_rate: %d/%d" % (score_quarter_profit_rate, SCORES[4]),
         "<- 3四半期利益成長:%d%%" % round(profit_rate, 1),
     )
@@ -816,7 +816,7 @@ def get_gyoseki_data(code_s, upd=UPD_INTERVAL):
     log_print("=" * 5, "業績スコアの計算完了")
     path = CACHE_DIR + get_http_cachname(URL_CODE % (str(code_s)))
     tables["access_date_gyoseki"] = get_file_datetime(path)
-    log_print("date:", tables["access_date_gyoseki"])
+    log_debug("date:", tables["access_date_gyoseki"])
     # tables["code"] = code
     set_db_code(tables, code_s)
     return tables
@@ -918,7 +918,7 @@ def calc_annual_quarity_expr(stock):
         annual_rate_list = []
         y_ind = get_latest_ind(tbl, ref_ind)
         if y_ind is None:
-            log_print("業績履歴データがない", y_ind, ref_ind)
+            log_debug("業績履歴データがない", y_ind, ref_ind)
             break
         while True:
             try:
@@ -950,7 +950,7 @@ def calc_quarter_quaraity_expr(stock):
         quarter_rate_list = []
         y_ind = get_latest_ind(tbl, ref_ind)
         if y_ind is None:
-            log_print("四半期業績履歴データがない", y_ind, ref_ind)
+            log_debug("四半期業績履歴データがない", y_ind, ref_ind)
             break
         while True:
             try:

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -93,7 +93,11 @@ def setup_logger(script_name=None):
         backupCount=7,
         encoding="utf-8",
     )
-    file_handler.setLevel(logging.DEBUG)
+    # 環境変数 KS_LOG_DEBUG=1 でDEBUGレベルに変更可能
+    if os.environ.get("KS_LOG_DEBUG") == "1":
+        file_handler.setLevel(logging.DEBUG)
+    else:
+        file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(formatter)
 
     # ハンドラーをロガーに追加
@@ -204,14 +208,14 @@ def ux_cmd_head(str, line=10):
 
 def print_dict(dict, ex_key=[]):
     """
-    dictのキー要素を表示
+    dictのキー要素を表示（デバッグレベル）
     """
-    log_print("----------")
+    log_debug("----------")
     for k in list(dict.keys()):
         if k in ex_key:
             continue
-        log_print(k, ": ", dict[k])
-    log_print("----------")
+        log_debug(k, ": ", dict[k])
+    log_debug("----------")
 
 
 def memoize(func):
@@ -221,7 +225,7 @@ def memoize(func):
         try:
             return cache[args]
         except KeyError:
-            log_print("no_memo:", args)
+            log_debug("no_memo:", args)
             value = func(*args)
             cache[args] = value
             return value
@@ -316,15 +320,15 @@ def chdir(path):
     """
     original_dir = os.getcwd()
     try:
-        log_print(f"(chdir)実行パス設定: {original_dir} -> {path}")
+        log_debug(f"(chdir)実行パス設定: {original_dir} -> {path}")
         os.chdir(path)
         yield
     except Exception as e:
-        log_print(f"Error changing directory to {path}: {e}")
+        log_debug(f"Error changing directory to {path}: {e}")
         raise
     finally:
         if os.getcwd() != original_dir:
-            log_print(f"(chdir)元のパスに戻します: {original_dir}")
+            log_debug(f"(chdir)元のパスに戻します: {original_dir}")
             os.chdir(original_dir)
 
 
@@ -403,7 +407,7 @@ def use_requests_session():
     """スレッドごとにSessionをセットするコンテキストマネージャ"""
     session = requests.Session()
     token = _current_session.set(session)  # 現在のセッションを設定
-    log_print(
+    log_debug(
         f"[{threading.current_thread().name}] コンテキストセッションを開始: {token}"
     )
     try:
@@ -411,7 +415,7 @@ def use_requests_session():
     finally:
         session.close()
         _current_session.reset(token)  # セッション終了＋ContextVarを元に戻す
-        log_print(
+        log_debug(
             f"[{threading.current_thread().name}] コンテキストセッションを終了: {token}"
         )
 
@@ -421,13 +425,13 @@ def use_requests_global_session():
     global _global_session
     session = requests.Session()
     _global_session = session
-    log_print(f"[{threading.current_thread().name}] グローバルセッションを開始")
+    log_debug(f"[{threading.current_thread().name}] グローバルセッションを開始")
     try:
         yield session  # 必要ならwith文内で明示的にも使える
     finally:
         session.close()
         _global_session = None
-        log_print(f"[{threading.current_thread().name}] グローバルセッションを終了")
+        log_debug(f"[{threading.current_thread().name}] グローバルセッションを終了")
 
 
 def get_http_cachname(url):
@@ -466,7 +470,7 @@ def http_get_html(
     if cache_dir:
         cache_name = os.path.join(cache_dir, cache_name)
     if use_cache and os.path.exists(cache_name):
-        log_print(
+        log_debug(
             "  htmlをファイルキャッシュから取得します",
             Path(cache_name).relative_to(DATA_DIR),
         )
@@ -476,7 +480,7 @@ def http_get_html(
         return html
 
     # ---- キャッシュがない場合は通信で取得
-    log_print("  htmlを通信で取得します..")
+    log_debug("  htmlを通信で取得します..")
     headers = {"User-Agent": USER_AGENT_CHROME}
     # headers["Connection"] = "Keep-Alive"
     with sema:  # セマフォを使って同時実行数を制限
@@ -485,17 +489,17 @@ def http_get_html(
             session = _global_session
             if session is not None:
                 req_get = session.get
-                log_print("グローバルセッションを使用")
+                log_debug("グローバルセッションを使用")
             else:
                 # 2. ContextVarセッションが有効ならそれを使う
                 session = _current_session.get()
                 if session is not None:
                     req_get = session.get
-                    log_print("ContextVarセッションを使用")
+                    log_debug("ContextVarセッションを使用")
                 else:
                     # 3. どちらもなければrequests.getを直接使う
                     req_get = requests.get
-                    log_print("単独セッションを使用")
+                    log_debug("単独セッションを使用")
             res = req_get(url, headers=headers, cookies=cookies, timeout=5)
         except (
             requests.exceptions.ConnectionError,
@@ -509,13 +513,13 @@ def http_get_html(
                 return ""
         # requests.exceptions.ReadTimeout TODO:
         if res.encoding != "utf-8":
-            log_print("html_encoding:", res.encoding, "encoding:", encoding)
+            log_debug("html_encoding:", res.encoding, "encoding:", encoding)
         # htmlをutf8で取得(python3ではエンコード済みのテキストが取得される)
         html = res.text
         # メタ指定での文字コードをutf8に
         # html = html.replace("charset=shift_jis", "charset=utf-8")
 
-        log_print(
+        log_debug(
             "  取得したhtmlをファイルキャッシュに書き込みます:",
             Path(cache_name).relative_to(DATA_DIR),
         )
@@ -571,18 +575,18 @@ def http_get_html_with_retry(url, use_cach, cache_dir="", cache_fname="", retry=
 def http_post_html(url, use_cache=True, data={}, cookies={}, encoding="utf-8"):
     cache_name = "post_" + get_http_cachname(url)
     if use_cache and os.path.exists(cache_name):
-        log_print("html(post)をファイルキャッシュから取得します", cache_name)
+        log_debug("html(post)をファイルキャッシュから取得します", cache_name)
         html = file_read(cache_name)
         return html, ""
 
     headers = {"User-Agent": USER_AGENT_CHROME}
     r = requests.post(url, headers=headers, data=data, cookies=cookies)
     if r.encoding != "utf-8":
-        log_print("encoding:", r.encoding, "encoding:", encoding)
+        log_debug("encoding:", r.encoding, "encoding:", encoding)
     html = r.text.encode(encoding)
     # html = html.replace("charset=UTF-8", "charset=euc-jp")
 
-    log_print("htmlをファイルキャッシュに書き込みます:", cache_name)
+    log_debug("htmlをファイルキャッシュに書き込みます:", cache_name)
     file_write(cache_name, html)
     return html, r.cookies
 
@@ -591,14 +595,14 @@ def http_post_html(url, use_cache=True, data={}, cookies={}, encoding="utf-8"):
 # pickleデータベースユーティリティ
 # ==================================================
 def save_pickle(fname, content):
-    log_print("%sにpickleセーブ" % fname)
+    log_debug("%sにpickleセーブ" % fname)
     with open(fname, "wb") as f:
         # 高速化のためプロトコル指定
         pickle.dump(content, f, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 def load_pickle(fname):
-    log_print("%sからpickleロード" % fname)
+    log_debug("%sからpickleロード" % fname)
     try:
         f = open(fname, "rb")
         dat = pickle.load(f)
@@ -613,7 +617,7 @@ memoized_load_pickle = memoize(load_pickle)  # noqa: E305
 
 
 def load_file(fname, tb="r"):
-    log_print("%sのfileロード" % fname)
+    log_debug("%sのfileロード" % fname)
     try:
         f = open(fname, tb)
         dat = f.read()

--- a/scripts/make_sisu_data.py
+++ b/scripts/make_sisu_data.py
@@ -139,7 +139,7 @@ def parse_yahoo_us(text):
 
 
 def make_price_list(price_list):
-    log_print("価格リストを作成します", len(price_list))
+    log_debug("価格リストを作成します", len(price_list))
     price_list2 = []
     itr = iter(reversed(price_list))
     # for price in reversed(price_list):
@@ -163,10 +163,10 @@ def make_price_list(price_list):
                         price = next(itr)
                     except StopIteration:
                         if w <= 34:
-                            log_print("データ終了補充", price)
+                            log_debug("データ終了補充", price)
                             dt = datetime.strptime("%04d%02d1" % (y, w), "%Y%W%w")
                             date_m = "%04d/%02d/%02d" % (dt.year, dt.month, dt.day)
-                            log_print(date_m)
+                            log_debug(date_m)
                             price_ = price[:]  # コピー
                             price_[0] = date_m
                             price_list2.append(price_)
@@ -177,13 +177,13 @@ def make_price_list(price_list):
                 d = date(int(price[0][0:4]), int(price[0][5:7]), int(price[0][8:10]))
                 y2 = d.isocalendar()[0]
                 w2 = d.isocalendar()[1]
-                log_print(y, w, "-", y2, w2)
+                log_debug(y, w, "-", y2, w2)
                 if y == y2 and w == w2:
                     price_list2.append(price)
                     flg = False
                     break
                 if y * 100 + w < y2 * 100 + w2:  # データがないので追加
-                    log_print("データを補充：", price)
+                    log_debug("データを補充：", price)
                     # 週番号から日付を取得
                     dt = datetime.strptime("%04d%02d1" % (y, w), "%Y%W%w")
                     date_m = "%04d/%02d/%02d" % (dt.year, dt.month, dt.day)
@@ -199,11 +199,11 @@ def make_price_list(price_list):
 
 
 def print_price_list(price_list2):
-    log_print("-" * 30)
+    log_debug("-" * 30)
     for p in price_list2:
-        log_print(p)
-    log_print(str(len(price_list2)) + "個のデータ")
-    log_print("-" * 30)
+        log_debug(p)
+    log_debug(str(len(price_list2)) + "個のデータ")
+    log_debug("-" * 30)
 
 
 def parse_topix():
@@ -280,7 +280,7 @@ def make_sisu_db():
         parse_spdr_goldshares,
     ]
     for i, asset in enumerate(ASSET_CLASSES[:7]):
-        log_print("DB作成:", asset)
+        log_debug("DB作成:", asset)
         db_dict[asset] = parser_list[i]()
 
     pickle.dump(db_dict, open("sisu_data/sisu_db.pickle", "wb"))
@@ -345,7 +345,7 @@ def parse_html_yahoo_jp(html, title=""):
 
             rows.append([date_s, price])
 
-    log_print("直近価格:", rows[:3])
+    log_debug("直近価格:", rows[:3])
     return rows
 
 
@@ -376,10 +376,10 @@ def parse_html_yahoo_us(html, is_all_price=False):
                 rows.append([day] + prices)
             else:
                 price = float(m.group(8).replace(",", ""))
-                log_print(day, price)
+                log_debug(day, price)
                 rows.append([day, price])
         else:
-            log_print("  DivideEnd ")  # , day
+            log_debug("  DivideEnd ")  # , day
 
     return rows
 
@@ -387,7 +387,7 @@ def parse_html_yahoo_us(html, is_all_price=False):
 def parse_html(html):
     m = re.search(r"<title>(.*?)</title>", html)
     title = m.group(1)
-    log_print("title:", title)
+    log_debug("title:", title)
     if "Yahoo!ファイナンス" in title:
         return parse_html_yahoo_jp(html, title)
     elif "Yahoo! Finance" in title:
@@ -414,7 +414,7 @@ def update_market_tbl(market_db, tbl_name, rows):
         for j, crow in enumerate(current_rows):
             if row[CLM_DATE] == crow[CLM_DATE]:
                 if not row[CLM_PRICE] == crow[CLM_PRICE]:
-                    log_print("更新: ", row)
+                    log_debug("更新: ", row)
                 crow[CLM_PRICE] = row[CLM_PRICE]
                 update = True
                 break
@@ -426,17 +426,17 @@ def update_market_tbl(market_db, tbl_name, rows):
                 if row_date < crow_date:
                     insert = True
                     current_rows.insert(j, row)
-                    log_print("データ挿入[%d]：" % j, row)
+                    log_debug("データ挿入[%d]：" % j, row)
                     break
             if not insert:
                 current_rows.append(row)
-                log_print("データ追加：", row)
+                log_debug("データ追加：", row)
     return current_rows
 
 
 def modify_distribute(code_name, rows):
     if code_name in DISTRIBUTE_DATA:
-        log_print("modify_distribute:", code_name)
+        log_debug("modify_distribute:", code_name)
         distribute = DISTRIBUTE_DATA[code_name]
         for row in rows:
             for k, v in list(distribute.items()):
@@ -466,7 +466,7 @@ def make_rs_db():
         market_db = pickle.load(open(RS_DB_NAME, "rb"))
 
     for i, url in enumerate(ASSET_URL2):
-        log_print("-" * 15)
+        log_debug("-" * 15)
         # 一年前の日付でリクエスト
         today = date.today()
         url = url % (
@@ -478,12 +478,12 @@ def make_rs_db():
             url_p = url
             url_p = url + "&page=%d" % (p + 1)
 
-            log_print("Request.. %s" % url_p)
+            log_debug("Request.. %s" % url_p)
             html = http_get_html(
                 url_p, cache_dir=os.path.join(DATA_DIR, "sisu_data"), use_cache=True
             )
             rows = parse_html(html)
-            log_print("parse完了:", url_p)
+            log_debug("parse完了:", url_p)
 
             # テーブル名はtbl_コード名
             # "https://finance.yahoo.co.jp/quote/1306.T/history?from=%s&to=%s&timeFrame=w"
@@ -495,7 +495,7 @@ def make_rs_db():
                 continue
 
             tbl_name = "tbl_" + code_name  # tbl_プレフィックス
-            log_print("tbl:", tbl_name)
+            log_debug("tbl:", tbl_name)
             rows = modify_distribute(code_name, rows)
             rows_new = update_market_tbl(market_db, tbl_name, rows)
             market_db[tbl_name] = rows_new
@@ -523,14 +523,14 @@ def make_rs_db():
     # market_db["tbl_myfrontier"] = rows
 
     # 表示
-    log_print("=" * 20)
-    log_print("テーブル一覧")
+    log_debug("=" * 20)
+    log_debug("テーブル一覧")
     for key in list(market_db.keys()):
         table = market_db[key]
-        log_print("-" * 3, end=" ")
-        log_print(key, len(table), "個の列")
-        log_print(table[0:3], "...")
-        log_print(table[-3:])
+        log_debug("-" * 3, end=" ")
+        log_debug(key, len(table), "個の列")
+        log_debug(table[0:3], "...")
+        log_debug(table[-3:])
     # DB保存
     pickle.dump(market_db, open(RS_DB_NAME, "wb"))
 

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -101,7 +101,7 @@ def get_price_data(stocks, code_s, upd=UPD_INTERVAL):
     # DBにありなおかつ最新である場合はそれを返す
     if code_s in stocks:  # and not latest: #デバッグ用強制
         if "access_date_price" in stocks[code_s] and upd < UPD_INTERVAL:
-            log_print("DBに最新価格情報があるためそれを取得します")
+            log_debug("DBに最新価格情報があるためそれを取得します")
             return stocks[code_s]
     # 価格データを新規更新
     stock = stocks.get(code_s, {})
@@ -305,7 +305,7 @@ def get_gyoseki_data(stocks, code_s, upd=UPD_INTERVAL):
     """
     if code_s in stocks:
         if "access_date_gyoseki" in stocks[code_s] and upd < UPD_INTERVAL:
-            log_print("DBから業績情報を取得します")
+            log_debug("DBから業績情報を取得します")
             return stocks[code_s]
     gyoseki_data = gyoseki.get_gyoseki_data(code_s, upd)
     return gyoseki_data
@@ -331,7 +331,7 @@ def get_rironkabuka_data(stocks, code_s, upd=UPD_INTERVAL):
     # code = int(code)
     if code_s in stocks:
         if "access_date_rironkabuka" in stocks[code_s] and upd < UPD_INTERVAL:
-            log_print("DBから理論株価情報を取得します")
+            log_debug("DBから理論株価情報を取得します")
             return stocks[code_s]
     stock = stocks[code_s] if code_s in stocks else None
     data = rironkabuka.get_rironkabuka_data(code_s, upd, stock)
@@ -366,7 +366,7 @@ def get_shihyo_data(stocks, code_s, upd=UPD_INTERVAL):
     latest = upd >= UPD_INTERVAL
     if code_s in stocks:
         if "access_date_shihyo" in stocks[code_s] and not latest:
-            log_print("DBから指標情報を取得します")
+            log_debug("DBから指標情報を取得します")
             return stocks[code_s]
     # 指標更新
     data = shihyou.get_shihyo_data(stocks, code_s, upd)
@@ -409,7 +409,7 @@ def update_db(stocks, stock_data):
         log_print(str(code_s) + "は新規DB銘柄")
     for k in list(stock_data.keys()):
         stock[k] = stock_data[k]
-    log_print("DB更新しました: ", code_s, list(stock_data.keys()))
+    log_debug("DB更新しました: ", code_s, list(stock_data.keys()))
     # 更新後のカラム表示
     print_dict(
         stock,

--- a/scripts/master.py
+++ b/scripts/master.py
@@ -36,7 +36,7 @@ def parse_master_html_kabutan(html):
 
     jikasogaku = shihyou.parse_jikasogaku_kabutan(html)
     detail["market_cap"] = jikasogaku
-    log_print("時価総額:", jikasogaku)
+    log_debug("時価総額:", jikasogaku)
 
     # 最低購入代金
     lowest_purchase_money = 0
@@ -48,7 +48,7 @@ def parse_master_html_kabutan(html):
             )
         except ValueError:
             pass
-    log_print("最低購入代金:", lowest_purchase_money)
+    log_debug("最低購入代金:", lowest_purchase_money)
     detail["lowest_purchase_money"] = lowest_purchase_money
     # 銘柄名
     m = re.search(r'<h1 id="kobetsu">(.*?)\(\d[0-9a-zA-Z]\d[0-9A-Z]\).*?</h1>', html)
@@ -61,33 +61,33 @@ def parse_master_html_kabutan(html):
         else:
             stock_name = m.group(1).strip()
         detail["stock_name"] = stock_name
-    log_print("銘柄名:", stock_name)
+    log_debug("銘柄名:", stock_name)
     # 市場
     m = re.search(r'<span class="market">(.*?)</span>', html)
     market = "市場名不明"
     if m:
         market = m.group(1).strip()
         detail["market"] = market
-    log_print("市場:", market)
+    log_debug("市場:", market)
     # 業種
     m = re.search(r'<a href="/themes/\?industry=\d{1,2}&market=\d">(.*?)</a>', html)
     sector_name = "セクター名不明"
     if m:
         sector_name = m.group(1).strip()
         detail["sector"] = sector_name
-    log_print("セクター名:", sector_name)
+    log_debug("セクター名:", sector_name)
     # 概要
     m = re.search(r"<th scope='row'>概要</th>\r\n      <td>(.*?)</td>", html)
     overview = ""
     if m:
         overview = m.group(1).strip()
         detail["overview"] = overview
-    log_print("概要:", overview)
+    log_debug("概要:", overview)
     # テーマ
     themes = []
     for m in re.finditer(r'<li><a href="/themes.*?>(.*?)</a></li>', html):
         themes.append(m.group(1))
-    log_print("テーマ:", ",".join(themes))
+    log_debug("テーマ:", ",".join(themes))
     detail["themes"] = ",".join(themes)
     # 比較される銘柄
     relates = []
@@ -95,7 +95,7 @@ def parse_master_html_kabutan(html):
         r'<dd><a href="javascript:set_stock_url\(2,\'(\d\d\d\d)\'', html
     ):
         relates.append(m.group(1))
-    log_print("比較銘柄:", relates)
+    log_debug("比較銘柄:", relates)
     detail["relates"] = ",".join(relates)
     # 決算日
     kessan = ""
@@ -105,7 +105,7 @@ def parse_master_html_kabutan(html):
         m2 = re.search(r'<time datetime=".*?">(.*?)</time>', m.group(1), re.DOTALL)
         if m2:
             kessan = m2.group(1)
-    log_print("決算日:", kessan)
+    log_debug("決算日:", kessan)
     detail["kessanbi"] = kessan
     # 会社サイト
     m = re.search(
@@ -118,7 +118,7 @@ def parse_master_html_kabutan(html):
 
 
 def get_master_data_kabutan(code_s, upd=UPD_INTERVAL):
-    log_print("銘柄詳細ファイルを取得 キャッシュ:")
+    log_debug("銘柄詳細ファイルを取得 キャッシュ:")
     html = rironkabuka.get_kabutan_base_html(code_s, upd)
     return html
 
@@ -153,7 +153,7 @@ get_report_evalutation = memoized_report_evaluation()
 
 
 def calc_fundamental(code_s, themes):
-    log_print("テーマポイントの計算")  # , themes
+    log_debug("テーマポイントの計算")  # , themes
     market_db = make_market_db.get_market_db()
     theme_rank_pt = {v: 30 - i for (i, v) in enumerate(market_db["theme_rank"])}
     total_pt = 0
@@ -162,7 +162,7 @@ def calc_fundamental(code_s, themes):
         # if theme_pt > 0:
         # 	print theme, theme_pt
         total_pt += theme_pt
-    log_print("テーマポイント:", total_pt)
+    log_debug("テーマポイント:", total_pt)
     total_pt = min(total_pt, 100)  # オレレポート封印のため80から100に
 
     # オレレポート分のファンダポイントを加算
@@ -202,7 +202,7 @@ def get_stock_master_data(code_s, upd):
         # print "銘柄名:%s,時価総額:%d百万円\n最低購入代金:%d"%\
         # (parsed_data["stock_name"], parsed_data["market_cap"], parsed_data["lowest_purchase_money"])
         for k, v in list(parsed_data.items()):
-            log_print("%s: %s" % (k, v))
+            log_debug("%s: %s" % (k, v))
         log_print("<<<<< 解析完了 ")
     # テーマからファンダポイントを計算
     funda_pt = calc_fundamental(code_s, parsed_data["themes"])

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -48,14 +48,14 @@ def get_daily_html_kabutan(code_s, cache=True):
         if cach:
             pass
         else:
-            log_print("キャッシュの期限切れ(%s)" % cach_date.date())
+            log_debug("キャッシュの期限切れ(%s)" % cach_date.date())
             cache = False
     # 株探から取得
     url = URL_PRICE_D_KABUTAN % (code_s, ind + 1)
     # html = http_get_html(url, use_cache=cache, cache_fname=price_fname)
     html = http_get_html_with_retry(url, use_cach=cache, cache_fname=price_fname)
 
-    log_print("<---- 取得完了")
+    log_debug("<---- 取得完了")
     return html
 
 
@@ -70,7 +70,7 @@ def is_file_timestamp(fname, interval_day):
     """キャッシュファイルの更新日時をチェック"""
     stat = os.stat(fname)
     cach_date = datetime.fromtimestamp(stat.st_mtime)
-    log_print("cach_date:", cach_date, fname)
+    log_debug("cach_date:", cach_date, fname)
     delta = get_price_interval_day(datetime.today(), cach_date)
     if delta < interval_day:  # キャッシュ使用可能
         return True, cach_date
@@ -105,7 +105,7 @@ def get_weekly_html(code_s, cache=True):
             if cach:
                 pass
             else:
-                log_print("キャッシュの期限切れ(%s)" % cach_date.date())
+                log_debug("キャッシュの期限切れ(%s)" % cach_date.date())
                 cache = False
         # 株探から取得
         url = URL_PRICE_KABUTAN % (code_s, ind + 1)
@@ -113,7 +113,7 @@ def get_weekly_html(code_s, cache=True):
         html = http_get_html_with_retry(url, use_cach=cache, cache_fname=price_fname)
         htmls.append(html)
 
-    log_print("<---- 取得完了")
+    log_debug("<---- 取得完了")
     return htmls
 
 
@@ -231,7 +231,7 @@ def calc_ratio(ratio_list, day_count):
         except IndexError as e:
             log_warning(" 日付が足りないため%d日で計算します" % i)
             break
-    log_print("%d日 買い:%d 売り:%d" % (day_count, buy_sum, sel_sum))
+    log_debug("%d日 買い:%d 売り:%d" % (day_count, buy_sum, sel_sum))
     # if buy_sum > 0:
     # 	ratio = (sel_sum*100) / buy_sum
     if buy_sum + sel_sum > 0:
@@ -280,7 +280,7 @@ def calc_sell_pressure_ratio(price_list):
 
     volatility_l, ma_l = calc_vola(DAY_L)
     volatility_s, ma_s = calc_vola(DAY_S)
-    log_print(
+    log_debug(
         "SRRレシオ(20,5):", ratios, "ボラティリティ(20,5):", volatility_l, volatility_s
     )
     # print "ボラ(H,L)=(%d, %s)"%(int(ma_l*(1+volatility_l/100)), int(ma_l*(1-volatility_l/100)) )
@@ -329,7 +329,7 @@ def parse_price_d_html_kabutan(html):
         return {}
     avg_vol = avg_vol / avg_len
     current_day = target_days[-1][0]
-    log_print(current_day, "のディストリビューションカウント")
+    log_debug(current_day, "のディストリビューションカウント")
     for d, pd in zip(target_days[1:], target_days[:-1]):
         try:
             dp = float(d[4].replace(",", ""))  # 終値
@@ -341,7 +341,7 @@ def parse_price_d_html_kabutan(html):
             dr = float(d[6].replace(",", ""))  # 前日比パーセント
         except ValueError:
             # TODO: ここに来ているみたい
-            log_print("%sはデータ取得できず" % d[0])
+            log_debug("%sはデータ取得できず" % d[0])
             continue
         # print d[0], "の解析"
         pr_pos = (dp - dpl) / (dph - dpl)
@@ -355,9 +355,9 @@ def parse_price_d_html_kabutan(html):
                     # print "ディストリビューション:", d[0]
         else:
             if dv > pdv:
-                log_print("dr", dr, "pr_pos", pr_pos)
+                log_debug("dr", dr, "pr_pos", pr_pos)
                 if dr <= 0.1 and pr_pos <= 0.25:
-                    log_print("前日よりわずかに高くても下で引けていけばカウント", d[0])
+                    log_debug("前日よりわずかに高くても下で引けていけばカウント", d[0])
                     distribution_day.append(d[0])
                     # print "ディストリビューション:", d[0]
         # フォロースルー: 反転から4~7日目で(ここは判定していない)
@@ -368,8 +368,8 @@ def parse_price_d_html_kabutan(html):
     dic = {}
     dic["distribution_days"] = distribution_day
     dic["followthrough_days"] = followthrough_day
-    log_print("ディストリビューション:", distribution_day)
-    log_print("フォロースルー:", followthrough_day)
+    log_debug("ディストリビューション:", distribution_day)
+    log_debug("フォロースルー:", followthrough_day)
 
     # ---- シグナル
     signal = "neutral"
@@ -378,7 +378,7 @@ def parse_price_d_html_kabutan(html):
         signal = "sell"
 
     dic["direction_signal"] = signal + "," + current_day
-    log_print("シグナル:", dic["direction_signal"])
+    log_debug("シグナル:", dic["direction_signal"])
 
     # ---- 売り圧力レシオ
     def to_numeric(str):
@@ -456,7 +456,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
     except IndexError:
         log_warning(" 10WMA乖離率計算できず")
         price_dict["price_kairi_wma10"] = 0
-    log_print("10WMA乖離率:", price_dict["price_kairi_wma10"])
+    log_debug("10WMA乖離率:", price_dict["price_kairi_wma10"])
 
     # ---- 売り圧力レシオ(買い集め指数)
     try:
@@ -476,7 +476,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
         # sell5 = calc_ratio(ratio_list, 5)
         buy_gather = calc_ratio(buygather_list, len(buygather_list))
         price_dict["sell_pressure_ratio_w"] = [sell20, 0, buy_gather]
-        log_print("週次売り圧力レシオ:", price_dict["sell_pressure_ratio_w"])
+        log_debug("週次売り圧力レシオ:", price_dict["sell_pressure_ratio_w"])
     except ValueError:
         log_warning(" 週次売り圧力レシオ計算できず")
         price_dict["sell_pressure_ratio_w"] = [0, 0, 0]
@@ -497,7 +497,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
             p_cur = cur_prices[0]
 
         past_prices = []
-        log_print("現在終値 %s" % p_cur)
+        log_debug("現在終値 %s" % p_cur)
         for w in [13, 26, 39, 52]:
             if w < price_len:
                 past_prices.append(float(weekly_price_list[w][4].replace(",", "")))
@@ -510,7 +510,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
         # print "weights:", weights
         try:
             ratios = [float(p_cur) / p for p in past_prices]
-            log_print("ratio:", [round(r, 2) for r in ratios])
+            log_debug("ratio:", [round(r, 2) for r in ratios])
             rs_raw = 0
             for r, w in zip(ratios, weights):
                 rs_raw += r * w
@@ -523,7 +523,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
                 % len(weekly_price_list)
             )
             rs_raw = 1.0  # 標準値にする
-        log_print("rs_raw:", rs_raw)
+        log_debug("rs_raw:", rs_raw)
         return rs_raw, p_cur
 
     rs_raw, p_cur = calc_rs()
@@ -548,7 +548,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
                 scale = 0.3  # code_rank実測のrs_raw標準偏差
                 # 平均1.0、標準偏差0.3の上側確率
                 rs_rank = int(100 * (1 - norm.sf(x=rs_rel, loc=1.0, scale=scale)))
-                log_print("rs_rank:", rs_rank)
+                log_debug("rs_rank:", rs_rank)
         else:
             rs_rank = 0
             log_warning(" TOPIXのモメンタムポイント存在せず、計算できず")
@@ -594,7 +594,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
                 misses.append("high(low)52")
             if not rs_rank >= 75:
                 misses.append("RS")
-            log_print("トレンドテンプレート:", misses)
+            log_debug("トレンドテンプレート:", misses)
             return misses
         except (ValueError, ZeroDivisionError, IndexError):
             log_warning(" 価格データがかけている")
@@ -670,7 +670,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
             p_high = max(p_high_list)
             p_high_ind = p_high_list.index(p_high)
             # print "価格", p_cur, len(weekly_price_list)
-            log_print(
+            log_debug(
                 "2週前以前新高値:%d %d週前(%s)"
                 % (p_high, p_high_ind, p_list_wk[p_high_ind][0])
             )
@@ -685,7 +685,7 @@ def parse_pricew_htmls_kabutan(htmls, cur_prices=[]):
             # print "最高値", p_max
             if p_cur >= p_max:
                 new_highs.append("最")
-            log_print("新高値:", "".join(new_highs))
+            log_debug("新高値:", "".join(new_highs))
         except ValueError:
             log_warning(" 新高値取得できず(価格データ不足)")
             pass
@@ -703,12 +703,12 @@ def adjust_divide_price(price_list):
     for price in price_list:
         ratio = float(price[4]) / price[6]
         if ratio > 1:
-            log_print("株式分割%d倍 %s %d->" % (ratio, price[0], price[4]), end=" ")
+            log_debug("株式分割%d倍 %s %d->" % (ratio, price[0], price[4]), end=" ")
             price[1] = int(price[1] / ratio)
             price[2] = int(price[2] / ratio)
             price[3] = int(price[3] / ratio)
             price[4] = int(price[4] / ratio)
-            log_print("%d" % price[4])
+            log_debug("%d" % price[4])
 
 
 def parse_price_text_yahoo_old(text):
@@ -760,7 +760,7 @@ def parse_price_text_yahoo_new(text):
         m = re.search(r'data-testid="currentPrice"[^>]*>([0-9,]+(?:\.[0-9]+)?)<', text)
         if m:
             price_current = _to_int(m.group(1))
-            log_print("現在株価 (data-testid):", price_current)
+            log_debug("現在株価 (data-testid):", price_current)
         else:
             # 2) span の class に StyledNumber__value を含むものを探して数値の最初の出現を使う
             for m in re.finditer(
@@ -770,10 +770,10 @@ def parse_price_text_yahoo_new(text):
                 val = m.group(1).strip()
                 if re.match(r"^[0-9,]+(?:\.[0-9]+)?$", val):
                     price_current = _to_int(val)
-                    log_print("現在株価 (StyledNumber):", price_current)
+                    log_debug("現在株価 (StyledNumber):", price_current)
                     break
     except Exception:
-        log_print("現在株価なし")  # 上場廃止時もこれ
+        log_debug("現在株価なし")  # 上場廃止時もこれ
 
     # 時系列価格データの取得
     price_list = []
@@ -826,7 +826,7 @@ def parse_price_text_yahoo_new(text):
         try:
             # 7番目のカラムに調整後終値が入っている想定
             price_current = price_list[0][6]
-            log_print("現在株価を履歴から取得", price_current)
+            log_debug("現在株価を履歴から取得", price_current)
         except Exception:
             log_warning("現在株価取得できず")
     # 株式分割の調整
@@ -839,10 +839,10 @@ def parse_price_text_yahoo(text):
     # 現在価格
     m = re.search(r'<td class="stoksPrice">(.*?)</td>', text)
     if m:
-        log_print("Yahoo価格: 古いフォーマット")
+        log_debug("Yahoo価格: 古いフォーマット")
         return parse_price_text_yahoo_old(text)
     # 新しいっぽいフォーマット
-    log_print("Yahoo価格: 新しいフォーマット")
+    log_debug("Yahoo価格: 新しいフォーマット")
     return parse_price_text_yahoo_new(text)
 
 
@@ -927,7 +927,7 @@ def get_daily_data_yfinance(code_s, stock={}, upd=UPD_INTERVAL):
             # UPD_CACHE: キャッシュがあればそのまま使用
             pc, pl = _load_yfinance_cache(cache_fname)
             if pc is not None:
-                log_print("yfinanceキャッシュ使用(UPD_CACHE): %s" % code_s)
+                log_debug("yfinanceキャッシュ使用(UPD_CACHE): %s" % code_s)
                 return pc, pl
         else:
             # UPD_INTERVAL: キャッシュの日付が期限内かチェック
@@ -935,7 +935,7 @@ def get_daily_data_yfinance(code_s, stock={}, upd=UPD_INTERVAL):
             if cache_ok:
                 pc, pl = _load_yfinance_cache(cache_fname)
                 if pc is not None:
-                    log_print("yfinanceキャッシュ使用(UPD_INTERVAL): %s" % code_s)
+                    log_debug("yfinanceキャッシュ使用(UPD_INTERVAL): %s" % code_s)
                     return pc, pl
 
     # yfinance APIで取得
@@ -1142,7 +1142,7 @@ def parse_price_text_from_list(price_current, price_list):
                     volumes.append(price_list[ind + j][5])
                 prices.append(price_list[ind + j][6])
             except IndexError:
-                log_print("%d日目のデータなし" % j)
+                log_debug("%d日目のデータなし" % j)
                 break
         if len(prices) == 0:
             break
@@ -1163,7 +1163,7 @@ def parse_price_text_from_list(price_current, price_list):
             else:
                 # フォーマット不明なら元文字列を短縮して使う
                 day = price_list[ind][0]
-            log_print("ポケットピポット:%s(%+d)" % (day, kairi))
+            log_debug("ポケットピポット:%s(%+d)" % (day, kairi))
             pockets.append("%s,%d" % (day, kairi))
         # break
     price["pocket_pivot"] = pockets
@@ -1220,7 +1220,7 @@ def parse_price_text_from_list(price_current, price_list):
                 else:
                     day = price_list[ind][0]
                 per = 100 * vol / avg_vol - 100
-                log_print("ブレイク:%s,%d" % (day, per))
+                log_debug("ブレイク:%s,%d" % (day, per))
                 breaks.append("%s,%d" % (day, per))
     price["breakout"] = breaks
     # print breaks

--- a/scripts/rironkabuka.py
+++ b/scripts/rironkabuka.py
@@ -42,11 +42,11 @@ def is_cache_latest(url, interval_day):
     cach_path = get_http_cachname(url)
     cach_path = os.path.join(KABUTAN_CACHE_DIR, cach_path)
     if not os.path.exists(cach_path):
-        log_print("キャッシュがない:", cach_path)
+        log_debug("キャッシュがない:", cach_path)
         return False
     cach_date = get_file_datetime(cach_path)
     timedelta = datetime.today() - cach_date
-    log_print("  キャッシュ:", cach_date)
+    log_debug("  キャッシュ:", cach_date)
     if timedelta.days < interval_day:
         return True
     else:
@@ -211,16 +211,16 @@ def get_from_kabutan3(html):
                 val = tbl[column - 1][row]
                 ind = column - 1
                 if val == "－":
-                    log_print("今季来季とも取得できないため0")
+                    log_debug("今季来季とも取得できないため0")
                     val = "0"
                     ind = -1
                 else:
-                    log_print("来季の%s値が取得できないため今季" % name)
+                    log_debug("来季の%s値が取得できないため今季" % name)
             else:
                 val = tbl[column][row]
                 ind = column
         except IndexError:
-            log_print("テーブルの値が取得できないため0")
+            log_debug("テーブルの値が取得できないため0")
             val = "0"
         return val, ind
 
@@ -230,19 +230,19 @@ def get_from_kabutan3(html):
     keijo = float(keijo.replace(",", ""))
     if ind < -1:
         isKonki = True
-    log_print("経常利益:", keijo)
+    log_debug("経常利益:", keijo)
     # 最終利益
     profit, ind = get_table_value(table, -1, 3, "最終利益")
     profit = float(profit.replace(",", ""))
     if ind < -1:
         isKonki = True
-    log_print("最終利益:", profit)
+    log_debug("最終利益:", profit)
     # EPS
     eps, eps_column = get_table_value(table, -1, 4, "一株益")
     eps = float(eps.replace(",", ""))
     if ind < -1:
         isKonki = True
-    log_print("EPS:", eps)
+    log_debug("EPS:", eps)
     # 発行株式数を取得
     issued_stock = 0
     if eps != 0:
@@ -256,13 +256,13 @@ def get_from_kabutan3(html):
             profit, _ = get_table_value(table, -2, 3, "最終利益")
             profit = float(profit.replace(",", ""))
             issued_stock = profit / eps
-    log_print("発行済株式数:", issued_stock)  # 単位: 百万株
+    log_debug("発行済株式数:", issued_stock)  # 単位: 百万株
     # 修正EPS(経常利益から計算)
     if issued_stock > 0:
         mod_eps = 0.7 * keijo / issued_stock  # 単位: 円
     else:
         mod_eps = 0
-    log_print("修正EPS:", mod_eps)
+    log_debug("修正EPS:", mod_eps)
 
     # ------------------------------
     # bps
@@ -285,7 +285,7 @@ def get_from_kabutan3(html):
         table.append(values)
     # 自己資本比率
     equity_ratio, _ = get_table_value(table, -1, 1, "equity_ratio")
-    log_print("自己資本比率:", equity_ratio)
+    log_debug("自己資本比率:", equity_ratio)
     try:
         equity_ratio = float(equity_ratio.replace(",", ""))
     except ValueError as e:
@@ -300,16 +300,16 @@ def get_from_kabutan3(html):
         self_asset = table[-1][3]
         if self_asset != "－":
             if issued_stock > 0:
-                log_print("自己資本:", self_asset)
+                log_debug("自己資本:", self_asset)
                 self_asset = float(self_asset.replace(",", ""))
                 bps = self_asset / issued_stock
-                log_print("BPSが未発表のため自己資本から計算")
+                log_debug("BPSが未発表のため自己資本から計算")
         else:
             bps = table[-2][0]
             bps = float(bps.replace(",", ""))
     else:
         bps = float(bps.replace(",", ""))
-    log_print("BPS:", bps)
+    log_debug("BPS:", bps)
 
     # ---- 価格
     # <span class="kabuka">2,478円</span>
@@ -318,7 +318,7 @@ def get_from_kabutan3(html):
         val = m.group(1)
         price = int(float(val.replace(",", "")))
     except (ValueError, AttributeError):
-        log_print("　株価取得できず", val)
+        log_debug("　株価取得できず", val)
         price = 0
 
     dic = {}
@@ -372,7 +372,7 @@ def calc_theory_price(bps, eps, equity_ratio, price=0, preceding_eps=None):
             [0.01, 0.1, 0.33, 0.5, 0.66, 0.8, 1.0],
         )  # 比率
         if risk_correction < 1:
-            log_print("リスク補正:", risk_correction)
+            log_debug("リスク補正:", risk_correction)
     theory_price = (asset_value + enterprise_value) * risk_correction
     theory_price_preceding = None
     if preceding_enterprise_value is not None:
@@ -444,7 +444,7 @@ def analyze_from_kabutan(code_s, upd=UPD_INTERVAL, stock=None):
                 dic["price"],
                 preceding_eps,
             )
-            log_print("理論株価:", theory_price)
+            log_debug("理論株価:", theory_price)
             theory_price = theory_price + (dic["price"], dic["isKonki"])
             calced = True
         except TypeError:
@@ -478,7 +478,7 @@ def get_rironkabuka_data(code_s, upd=UPD_INTERVAL, stock=None):
     cach_path = get_http_cachname(KABUTAN_URL_CODE % (str(code_s)))
     cach_path = os.path.join(KABUTAN_CACHE_DIR, cach_path)
     tables["access_date_rironkabuka"] = get_file_datetime(cach_path)
-    log_print("date:", tables["access_date_rironkabuka"])
+    log_debug("date:", tables["access_date_rironkabuka"])
     # tables["code"] = code
     set_db_code(tables, code_s)
     tables["isKonki"] = res[5]
@@ -527,7 +527,7 @@ def calc_theory_pt(code_s, stock=None):
     theroy, theory_up, theory_down, theory_proceding = get_rironkabuka_kairi_fromprice(
         *theory_price[0:5]
     )  # theory_priceの最後の要素は不要
-    log_print(
+    log_debug(
         "理論価格乖離: (%d %s %d %d)"
         % (
             theroy,
@@ -571,10 +571,10 @@ def calc_theory_pt(code_s, stock=None):
     else:
         log_warning(" 価格がないため理論PT計算できず")
     # thoery_total_pt = int(0.5*theory_pt + 0.35*theory_up_pt + 0.15*theory_down_pt)
-    log_print("理論価格pt: %d/%d" % (theory_pt, THEORY_MAX))
-    log_print("理論価格先行pt: %d" % (theory_proceding_pt))
-    log_print("理論価格上限pt: %d/%d" % (theory_up_pt, THEORY_UP_MAX))
-    log_print("理論価格下限pt: %d/%d" % (theory_down_pt, THEORY_DOWN_MAX))
+    log_debug("理論価格pt: %d/%d" % (theory_pt, THEORY_MAX))
+    log_debug("理論価格先行pt: %d" % (theory_proceding_pt))
+    log_debug("理論価格上限pt: %d/%d" % (theory_up_pt, THEORY_UP_MAX))
+    log_debug("理論価格下限pt: %d/%d" % (theory_down_pt, THEORY_DOWN_MAX))
     return theory_pt + theory_proceding_pt + theory_up_pt + theory_down_pt
 
 

--- a/scripts/shihyou.py
+++ b/scripts/shihyou.py
@@ -63,7 +63,7 @@ def get_from_kabutan(html):
     def get_table_prev(val, item_ind):
         try:
             if val.find("－") >= 0:
-                log_print("有利子負債倍率一つ前を見る")
+                log_debug("有利子負債倍率一つ前を見る")
                 items = get_table_row(ms_td[-2])
                 val = items[item_ind]
                 if val.find("－") >= 0:
@@ -77,8 +77,8 @@ def get_from_kabutan(html):
 
     debut = get_table_prev(debut.replace(",", ""), 5)
     jiko_ratio = get_table_prev(jiko_ratio, 1)
-    log_print("有利子負債自己資本比率:", debut)
-    log_print("自己資本比率:", jiko_ratio)
+    log_debug("有利子負債自己資本比率:", debut)
+    log_debug("自己資本比率:", jiko_ratio)
     shiyo_data = {}
     shiyo_data["debt_ratio"] = float(debut)
     shiyo_data["capital_ratio"] = float(jiko_ratio)
@@ -108,13 +108,13 @@ def get_from_kabutan(html):
 
     roe, profit_margin = get_roe_and_profit_margin(profit_htmls[-1])
     if roe == 0 or profit_margin == 0:
-        log_print("ROE一つ前を見る")
+        log_debug("ROE一つ前を見る")
         try:
             roe, profit_margin = get_roe_and_profit_margin(profit_htmls[-2])
         except IndexError:
             pass
-    log_print("ROE:", roe)
-    log_print("売上営業利益率:", profit_margin)
+    log_debug("ROE:", roe)
+    log_debug("売上営業利益率:", profit_margin)
     shiyo_data["ROE"] = roe
     shiyo_data["profit_margin"] = profit_margin
 
@@ -151,7 +151,7 @@ def get_from_kabutan_base(html, shiyo_data):
         return shiyo_data  # その後PER,PSR計算できないので
     else:
         shiyo_data["jikasogaku"] = jikasogaku  # 億円
-        log_print("時価総額(億円):", shiyo_data["jikasogaku"])
+        log_debug("時価総額(億円):", shiyo_data["jikasogaku"])
 
     # ---- PER
     stockinfo_m = re.search(r'<div id="stockinfo_i3">(.*?)</div>', html, re.DOTALL)
@@ -171,10 +171,10 @@ def get_from_kabutan_base(html, shiyo_data):
                 per_m = next(per_ms)
                 if per_m:
                     per = float(per_m.group(1))
-                    log_print("PER:", per)
+                    log_debug("PER:", per)
                     shiyo_data["PER"] = per
             except ValueError:
-                log_print("PER計算できない", per_m.group(1))
+                log_debug("PER計算できない", per_m.group(1))
                 shiyo_data["PER"] = 0
                 need_per = True  # PERを実績から計算する
         else:
@@ -185,10 +185,10 @@ def get_from_kabutan_base(html, shiyo_data):
         if pbr_m:
             try:
                 pbr = float(pbr_m.group(1))
-                log_print("PBR:", pbr)
+                log_debug("PBR:", pbr)
                 shiyo_data["PBR"] = pbr
             except ValueError:
-                log_print("PBR取得できず", pbr_m.group(1))
+                log_debug("PBR取得できず", pbr_m.group(1))
         # 信用倍率、信用買残、信用売残
         name = "credit_ratio"
         try:
@@ -196,12 +196,12 @@ def get_from_kabutan_base(html, shiyo_data):
             if dividend_nd:
                 try:
                     val = float(dividend_nd.group(1))
-                    log_print(name + ":", val)
+                    log_debug(name + ":", val)
                     shiyo_data[name] = val
                 except ValueError:
-                    log_print(name + "取得できず", dividend_nd.group(1))
+                    log_debug(name + "取得できず", dividend_nd.group(1))
         except StopIteration:
-            log_print(name + "取得できず")
+            log_debug(name + "取得できず")
         margin_m = re.search(
             r'<h2 class="mgt6">信用取引&nbsp;\(単位:千株\)</h2>\r\n<table>(.*?)</table>',
             html,
@@ -234,10 +234,10 @@ def get_from_kabutan_base(html, shiyo_data):
         if m:
             try:
                 val = float(m.group(1))
-                log_print("配当利回り:", val)
+                log_debug("配当利回り:", val)
                 shiyo_data["dividend_yield"] = val
             except ValueError:
-                log_print("配当利回り取得できず", m.group(1))
+                log_debug("配当利回り取得できず", m.group(1))
 
     if per == 0.0 and not need_per:
         log_warning(" PER取得できず(フォーマット変更？)")
@@ -272,31 +272,31 @@ def get_from_kabutan_base(html, shiyo_data):
                 latest_term = cur_term
                 uriage_lst.append(uriage)
             except ValueError:
-                log_print("  売上高取得できず:", uriage_m.group(1), cur_term)
+                log_debug("  売上高取得できず:", uriage_m.group(1), cur_term)
 
             try:
                 profit = float(uriage_m.group(3))  # 最終益
                 # latest_term = cur_term
             except ValueError:
-                log_print("  最終益取得できず:", uriage_m.group(3), cur_term)
+                log_debug("  最終益取得できず:", uriage_m.group(3), cur_term)
             try:
                 keijo = float(uriage_m.group(2))  # 経常益
             except ValueError:
                 keijo = 0
-                log_print("   経常益取得できず", uriage_m.group(2), cur_term)
+                log_debug("   経常益取得できず", uriage_m.group(2), cur_term)
             # print uriage
         if uriage_lst:
             uriage = uriage_lst[-1]  # 直近
             if uriage > 0:
                 psr = round(jikasogaku / uriage, 1)
-                log_print(
+                log_debug(
                     "PSR: %.1f 直近売上高(億円): %.1f(%s)" % (psr, uriage, latest_term)
                 )
             else:
-                log_print("売上が0のためPSR計算できず")
+                log_debug("売上が0のためPSR計算できず")
         if need_per and profit != 0:
             per = round(jikasogaku / profit, 1)
-            log_print("PERを実績から計算: ", per, "<- 最終益=%.1f億" % profit)
+            log_debug("PERを実績から計算: ", per, "<- 最終益=%.1f億" % profit)
             if per > 0:
                 shiyo_data["PER"] = per
         mper = 0
@@ -305,10 +305,10 @@ def get_from_kabutan_base(html, shiyo_data):
                 mper = round(jikasogaku / profit, 1)
                 mper = max(mper, 0)
             else:
-                log_print("修正PERを適用")
+                log_debug("修正PERを適用")
                 mper = round(jikasogaku / (keijo * 0.65), 1)
                 mper = max(mper, 0)
-            log_print("MPER:", mper)
+            log_debug("MPER:", mper)
         if mper != 0:
             shiyo_data["MPER"] = mper
         else:
@@ -397,8 +397,8 @@ def calc_shihyo_pt(code_s, upd=UPD_INTERVAL, stock={}):
     # if shiyo.has_key("PSR"):
     # 	psr_pt = step_func(shiyo["PSR"], [0, 0.75, 2.5, 10], [PSR_MAX, PSR_MAX/2, PSR_MAX/4, 0])
 
-    log_print("時価総額pt: %d/%d" % (jikasogaku_pt, JIKASOGAKU_MAX))
-    log_print("有利子負債自己資本比率pt: %d/%d" % (debt_ratio_pt, -DEBT_RATIO_MAX))
+    log_debug("時価総額pt: %d/%d" % (jikasogaku_pt, JIKASOGAKU_MAX))
+    log_debug("有利子負債自己資本比率pt: %d/%d" % (debt_ratio_pt, -DEBT_RATIO_MAX))
     # print "PER pt: %d/%d"%(per_pt, PER_MAX)
     # print "PBR pt: %d/%d"%(pbr_pt, PBR_MAX)
     # print "PSR pt: %d/%d"%(psr_pt, PSR_MAX)
@@ -434,7 +434,7 @@ def get_shihyo_data(stocks, code_s, upd=UPD_INTERVAL):
         CACHE_DIR_KABUTAN, get_http_cachname(URL_CODE_KABUTAN % str(code_s))
     )
     tables["access_date_shihyo"] = get_file_datetime(cache_path)
-    log_print("date_shihyo:", tables["access_date_shihyo"])
+    log_debug("date_shihyo:", tables["access_date_shihyo"])
     tables["shihyo_pt"] = shihyo_pt
     # 指標データ登録
     tables["shihyo"] = shihyo_data

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -146,7 +146,7 @@ def todays_shintakane(upd=UPD_INTERVAL):
     # today = datetime.today()
     today_data, latest_csv_dt = get_latest_shintakane_fname()
     today_data_d, latest_csv_dt_d = get_latest_dekidakaup_fname()
-    log_print("最新新高値ファイル:", today_data, today_data_d)
+    log_debug("最新新高値ファイル:", today_data, today_data_d)
 
     # 各種フィルタ関数：テンバガー成長株の条件
     # 出来高による候補フィルタ関数：一定以上の出来高に絞る
@@ -189,7 +189,7 @@ def todays_shintakane(upd=UPD_INTERVAL):
                 else:
                     day_list_d = []
                 # day_listとday_list_dを合成
-                log_print(
+                log_debug(
                     "新高値銘柄%d個と出来高急増銘柄%d個を合成(%s)"
                     % (len(day_list), len(day_list_d), day.date())
                 )
@@ -197,11 +197,11 @@ def todays_shintakane(upd=UPD_INTERVAL):
                 # print "---> 計%d個"%len(day_list)
             if len(day_list) == 0:
                 continue
-            log_print("----- %s(%d)を分析" % (day_csv, len(day_list)))
+            log_debug("----- %s(%d)を分析" % (day_csv, len(day_list)))
 
             # 各種フィルタ判定した上でリスト作成
             day_list_filtered = day_list
-            log_print("候補銘柄%d個" % len(day_list_filtered))
+            log_debug("候補銘柄%d個" % len(day_list_filtered))
             # まだalready_listにないものは追加
             already_code = [c["code_s"] for c in already_list]
             for d in day_list_filtered:
@@ -219,7 +219,7 @@ def todays_shintakane(upd=UPD_INTERVAL):
     already_list_code = [a["code_s"] for a in already_list]
 
     # 今日のを分析
-    log_print("本日:", today_data, "を分析")
+    log_debug("本日:", today_data, "を分析")
 
     def create_today_list():
         today_list = []  # 本日更新銘柄データ(dict)のリスト
@@ -227,13 +227,13 @@ def todays_shintakane(upd=UPD_INTERVAL):
             today_list = search_fromcsv(today_data)
             # 出来高急増も追加
             today_list_d = search_fromcsv_dekidakaup(today_data_d)
-            log_print(
+            log_debug(
                 "新高値銘柄%d個と出来高急増銘柄%d個を合成"
                 % (len(today_list), len(today_list_d))
             )
             compose_list(today_list, today_list_d)
             # today_listには本日銘柄: 本日の新高値と出来高銘柄リスト
-            log_print("本日銘柄%s個" % len(today_list))
+            log_debug("本日銘柄%s個" % len(today_list))
         return today_list
 
     today_list = create_today_list()
@@ -241,8 +241,8 @@ def todays_shintakane(upd=UPD_INTERVAL):
 
     # 決算発表/修正の銘柄を追加
     kessan_lst_code = get_todays_kessan_list()
-    log_print("決算更新追加:", len(kessan_lst_code), "個")
-    log_print(kessan_lst_code)
+    log_debug("決算更新追加:", len(kessan_lst_code), "個")
+    log_debug(kessan_lst_code)
     # 更新を行う必要のあるすべての銘柄
     updatelist_all_code = already_list_code + today_list_code + kessan_lst_code
     updatelist_all_code = list(set(updatelist_all_code))  # 重複削除
@@ -762,7 +762,7 @@ def get_todays_dekidakaup():
         # 	tdy = tdy-timedelta(days=1)
         goodissue_dt = datetime(tdy.year, tdy.month, tdy.day, PRICE_HOUR)
         if latest_csv_dt > goodissue_dt:
-            log_print(
+            log_debug(
                 "本日分のcsvは取得済みです",
                 latest_csv,
                 latest_csv_dt,
@@ -795,7 +795,7 @@ def get_todays_dekidakaup():
         )
         useCache = cach_dt.date() >= datetime.today().date()
         # TODO: ↑土日も取得してしまう
-        log_print("株探 出来高急増キャシュ：", cach_dt, useCache)
+        log_debug("株探 出来高急増キャシュ：", cach_dt, useCache)
     except (IOError, OSError) as e:
         log_warning("出来高急増ファイルがない", e)
         useCache = False
@@ -811,13 +811,13 @@ def get_todays_dekidakaup():
     )
     date = date_m.group(1) + date_m.group(2) + date_m.group(3)
     date = date[2:]
-    log_print("株探 出来高急増更新日：", date)
+    log_debug("株探 出来高急増更新日：", date)
     # ページ分のhtmlを取得
     # ページ数を取得
     page_div = re.search(r'<div class="pagination">(.*?)</div>', html, re.S).group(0)
     pages = [int(m.group(1)) for m in re.finditer(r"page=(\d)", page_div)]
     page_count = max(pages)
-    log_print("ページ数：", page_count)
+    log_debug("ページ数：", page_count)
     with use_requests_session():
         for p in range(page_count):
             if p < 1:
@@ -857,7 +857,7 @@ def get_todays_shintakane():
             tdy = tdy - timedelta(days=1)
         goodissue_dt = datetime(tdy.year, tdy.month, tdy.day, 17)
         if latest_csv_dt > goodissue_dt:
-            log_print(
+            log_debug(
                 "本日分のcsvは取得済みです",
                 latest_csv,
                 latest_csv_dt,
@@ -889,7 +889,7 @@ def get_todays_shintakane():
             int(latest_date_m.group(3)),
         )
         useCache = cach_dt.date() >= datetime.today().date()
-        log_print("株探新高値 キャシュ：", cach_dt, useCache)
+        log_debug("株探新高値 キャシュ：", cach_dt, useCache)
     except IOError:
         useCache = False
     # 最初のページ
@@ -905,7 +905,7 @@ def get_todays_shintakane():
         re.S,
     )  # re.S:改行を含む
     date = date_m.group(1)[-2:] + date_m.group(2) + date_m.group(3)
-    log_print("株探新高値更新日：", date)
+    log_debug("株探新高値更新日：", date)
     # ページ分のhtmlを取得
     # ページ数を取得
     try:
@@ -915,7 +915,7 @@ def get_todays_shintakane():
         pages = [int(m.group(1)) for m in re.finditer(r"page=(\d)", page_div)]
         page_count = max(pages)
     except AttributeError:
-        log_print("ページ情報がhtmlにないため1とする")
+        log_debug("ページ情報がhtmlにないため1とする")
         page_count = 1
     for p in range(page_count):
         if p < 1:


### PR DESCRIPTION
## Summary
- `log_print`（INFO）で出力していたデバッグ詳細ログを `log_debug`（DEBUG）に降格
- ファイルハンドラのレベルを DEBUG → INFO に変更し、通常運用時のログ量を大幅削減（92,000行 → 約1,200行）
- `KS_LOG_DEBUG=1` 環境変数で従来通りのDEBUGレベル出力に切替可能

## 変更対象（11ファイル）
- `ks_util.py`: ファイルハンドラINFO化、`print_dict` 降格、HTTP詳細ログ降格
- `make_stock_db.py`: DB更新詳細の降格
- `price.py`: per-stock RS/ratio値、トレンドテンプレート内訳の降格
- `gyoseki.py`: per-table/per-row 解析詳細の降格
- `shihyou.py`: PER/PBR/配当等の個別指標値の降格
- `master.py`: 銘柄名/市場/セクター等の個別フィールド値の降格
- `rironkabuka.py`: EPS/BPS/理論株価等の中間値の降格
- `shintakane.py`: per-day分析マーカー、キャッシュ情報の降格
- `analyze_sisu_data.py` / `make_sisu_data.py`: per-row/per-transaction 詳細の降格
- `CLAUDE.md`: ログレベル使い分けの規約を追記

## log_print（INFO）として維持したもの
- フェーズ開始/完了マーカー（`>>>>>` / `<<<<<` / `=====`）
- 業績スコア・指標PT等のサマリー
- エラー・警告

## Test plan
- [x] `pytest tests/ -v -m "not local_db"` — 179テスト全合格
- [ ] cron実行でログ量が適切か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)