### PR TITLE
DATA_DIRを環境変数・Git commondirで柔軟に解決可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - 新規ログ追加時は上記の基準で `log_print` / `log_debug` を使い分けること
 - DB操作は `update_db_rows()` を経由。バルク操作は `sync=False` で非同期化可能。
 - 日付判定は `ks_util.get_price_day()` を使用（18:00前は前日扱い）。
+- `DATA_DIR` のパス解決は `ks_util._resolve_data_dir()` で行う。環境変数 `KS_DATA_DIR` で上書き可能。詳細は [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md) の「データパス解決」を参照。
 
 ## アーキテクチャ
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -81,6 +81,23 @@
 - **直接**: セッション非使用時は `requests.get()` フォールバック
 - `update_db_rows_async()` はThreadPoolExecutor（5ワーカー）使用、同時HTTP数は `MAX_REQUESTS=3` で制限
 
+## データパス解決
+
+`DATA_DIR` は `ks_util.py` の `_resolve_data_dir()` で以下の優先順位で解決される:
+
+1. **環境変数 `KS_DATA_DIR`**: 明示指定。`data/` を別の場所に移動した場合に使用
+2. **Git commondir**: `git rev-parse --git-common-dir` でメインリポジトリの `.git/` を取得し、その親の `data/` を参照。ワークツリーからメインの `data/` を自動検出する
+3. **フォールバック**: `ROOT_DIR/data`（従来通り `__file__` 起点）
+
+```
+# data/ を別の場所に移動した場合
+export KS_DATA_DIR=/path/to/new/data
+
+# ワークツリーからの実行時は自動でメインの data/ を参照（設定不要）
+```
+
+`LOGS_DIR` は常に `ROOT_DIR/logs`（ワークツリー側）を使用し、ログはワークツリーごとに分離される。
+
 ## データ保存場所
 
 - **メインDB (shelve)**: `data/stock_data/stocks_shelve`

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -12,6 +12,7 @@ import os.path
 from pathlib import Path
 import sys
 import shutil
+import subprocess
 from datetime import datetime, timedelta
 import pickle
 import contextvars
@@ -27,7 +28,47 @@ import logging.handlers
 # プロジェクトルートとデータパスの定義
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))  # ks_util.py の場所
 ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
-DATA_DIR = os.path.join(ROOT_DIR, "data")
+
+
+def _resolve_data_dir(fallback_root: str) -> str:
+    """
+    DATA_DIR を解決する。優先順位:
+    1. 環境変数 KS_DATA_DIR（data/ を別の場所に移動した場合に使用）
+    2. git rev-parse --git-common-dir でメインリポジトリの data/ を検出
+       （ワークツリーからメインの data/ を自動参照）
+    3. フォールバック: fallback_root/data（従来通り）
+    """
+    # 1. 環境変数で明示指定
+    env = os.environ.get("KS_DATA_DIR")
+    if env:
+        return os.path.abspath(env)
+    # 2. Git commondir でメインリポジトリを検出（ワークツリー対応）
+    #    ワークツリーでは --git-common-dir がメインの .git/ の絶対パスを返す
+    #    通常リポジトリでは ".git" （相対パス）を返す
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=fallback_root,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        git_common = result.stdout.strip() if result.returncode == 0 else ""
+        if git_common:
+            if not os.path.isabs(git_common):
+                git_common = os.path.join(fallback_root, git_common)
+            git_common = os.path.abspath(git_common)
+            # .git/ の親ディレクトリ = メインリポジトリルート
+            candidate = os.path.join(os.path.dirname(git_common), "data")
+            if os.path.isdir(candidate):
+                return candidate
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    # 3. フォールバック
+    return os.path.join(fallback_root, "data")
+
+
+DATA_DIR = _resolve_data_dir(ROOT_DIR)
 LOGS_DIR = os.path.join(ROOT_DIR, "logs")
 
 # ==================================================


### PR DESCRIPTION
## Summary
- ワークツリーからメインリポジトリの `data/` を自動参照できるよう `_resolve_data_dir()` を `ks_util.py` に追加
- 優先順位: 環境変数 `KS_DATA_DIR` → `git rev-parse --git-common-dir` → 従来の `ROOT_DIR/data`
- 将来 `data/` を別の場所に移動する際は `KS_DATA_DIR` 環境変数で対応可能

## Test plan
- [x] `pytest tests/ -v -m "not local_db"` 全187テスト通過
- [x] メインリポジトリからの `DATA_DIR` 解決が従来通り動作
- [x] `KS_DATA_DIR` 環境変数による上書きが動作
- [x] ワークツリーからの git commondir パス解決ロジックが正しく動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)