### PR TITLE
テーマランクのモメンタム順位変動インジケーターを追加

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -325,6 +325,10 @@ def update_market_db():
     """マーケットDBを読み込んで最新に更新"""
     market_db = get_market_db()
 
+    # 前回のモメンタム順位を退避（上書き前）
+    if "theme_rank" in market_db:
+        market_db["prev_theme_rank"] = list(market_db["theme_rank"])
+
     theme_db = make_theme_data()
     market_db.update(theme_db)
 
@@ -343,6 +347,19 @@ def update_market_db():
     return market_db
 
 
+def _theme_rank_label(theme, cur_rank, prev_rank_dict):
+    """テーマ名にモメンタム順位変動インジケーターを付加する"""
+    if theme not in prev_rank_dict:
+        return "%s(NEW)" % theme
+    diff = prev_rank_dict[theme] - cur_rank  # 正=上昇、負=下降
+    if diff > 0:
+        return "%s(↑%d)" % (theme, diff)
+    elif diff < 0:
+        return "%s(↓%d)" % (theme, -diff)
+    else:
+        return "%s(←)" % theme
+
+
 def create_market_csv(market_db=None, shintakane_theme_csv=None):
     """市場DBから表示用CSVデータにする"""
     if shintakane_theme_csv is None:
@@ -355,7 +372,10 @@ def create_market_csv(market_db=None, shintakane_theme_csv=None):
     rows = []
     rows.append(["■ テーマランク"])
     row = ["ランク"]
-    row.extend(market_db["theme_rank"])
+    prev_theme_rank = market_db.get("prev_theme_rank", [])
+    prev_rank_dict = {v: i + 1 for (i, v) in enumerate(prev_theme_rank)}
+    for i, theme in enumerate(market_db["theme_rank"]):
+        row.append(_theme_rank_label(theme, i + 1, prev_rank_dict))
     rows.append(row)
     # テーマ別騰落率行
     theme_momentum = market_db.get("theme_momentum", {})

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -175,6 +175,43 @@ class TestUpdateShintakaneTheme:
 
 
 # ==================================================
+# _theme_rank_label
+# ==================================================
+class TestThemeRankLabel:
+    """モメンタム順位変動ラベルテスト"""
+
+    def test_rank_up(self):
+        """順位上昇: ↑表示"""
+        prev = {"AI": 5}
+        assert make_market_db._theme_rank_label("AI", 1, prev) == "AI(↑4)"
+
+    def test_rank_down(self):
+        """順位下降: ↓表示"""
+        prev = {"AI": 2}
+        assert make_market_db._theme_rank_label("AI", 5, prev) == "AI(↓3)"
+
+    def test_rank_unchanged(self):
+        """変動なし: ←表示"""
+        prev = {"AI": 3}
+        assert make_market_db._theme_rank_label("AI", 3, prev) == "AI(←)"
+
+    def test_new_theme(self):
+        """新規テーマ: NEW表示"""
+        prev = {}
+        assert make_market_db._theme_rank_label("AI", 1, prev) == "AI(NEW)"
+
+    def test_rank_up_by_one(self):
+        """1つ上昇"""
+        prev = {"防衛": 3}
+        assert make_market_db._theme_rank_label("防衛", 2, prev) == "防衛(↑1)"
+
+    def test_rank_down_by_one(self):
+        """1つ下降"""
+        prev = {"DX": 2}
+        assert make_market_db._theme_rank_label("DX", 3, prev) == "DX(↓1)"
+
+
+# ==================================================
 # calc_theme_price_momentum
 # ==================================================
 class TestCalcThemePriceMomentum:


### PR DESCRIPTION
## Summary
- `update_market_db()` で `theme_rank` 上書き前に `prev_theme_rank` として前回順位を退避・保存
- `_theme_rank_label()` ヘルパー関数でテーマ名に変動インジケーター（`↑N`/`↓N`/`←`/`NEW`）を付加
- `create_market_csv()` のランク行で変動表示付きテーマ名を出力
- `_theme_rank_label` のユニットテスト6ケース追加

## Test plan
- [x] `pytest tests/test_make_market_db.py -v` で全テスト通過確認
- [x] ローカルで `python make_market_db.py` 実行し `market_data.csv` の2行目を目視確認
- [x] 初回実行時は全テーマが `(←)` または `(NEW)` 表示になることを確認
- [ ] 2回目以降（テーマランク更新後）に変動が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)