### PR TITLE
決算分析時のresearch_shelveスナップショット自動追記(#94)

### DIFF
--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1261,6 +1261,88 @@ def test():
 
 
 # ==================================================
+# research_shelve スナップショット自動追記
+# ==================================================
+
+KESSAN_WINDOW_DAYS = 14
+
+
+def update_research_snapshots(*, db_path=None):
+    """research_shelve 管理銘柄のうち決算更新があったものにスナップショットを自動追記する。
+
+    research_shelve の全レコードを走査し、各銘柄の kessanbi / kessan_mod_date が
+    14 日以内なら追記対象。同じ date_yy_m のスナップショットが既にあればスキップ。
+    """
+    import research_shelve
+
+    stocks = load_stock_db()
+    today = get_price_day(datetime.today())
+
+    all_records = research_shelve.list_research_records(db_path=db_path)
+
+    count = 0
+    skipped_existing = 0
+    for record in all_records:
+        code_s = record.get("code_s", "")
+        stock = stocks.get(code_s, {})
+        if not stock:
+            continue
+
+        trigger_dates = []
+        for date_field in ("kessanbi", "kessan_mod_date"):
+            date_str = stock.get(date_field, "")
+            if not date_str:
+                continue
+            try:
+                dt = datetime.strptime(date_str, "%Y/%m/%d").date()
+                if 0 <= (today - dt).days <= KESSAN_WINDOW_DAYS:
+                    trigger_dates.append(date_str)
+            except ValueError:
+                pass
+
+        if not trigger_dates:
+            continue
+
+        existing_dates = {
+            s["date_yy_m"] for s in record.get("snapshots", [])
+        }
+
+        for trigger_date_str in trigger_dates:
+            try:
+                dt = datetime.strptime(trigger_date_str, "%Y/%m/%d")
+                date_yy_m = f"{dt.year % 100}.{dt.month}.{dt.day}"
+
+                if date_yy_m in existing_dates:
+                    skipped_existing += 1
+                    continue
+
+                progress_expr, growth_expr = gyoseki.get_gyoseki_expr(stock)
+                ir_quant = progress_expr + growth_expr
+                quality_indicators = shihyou.get_shihyo_expr(stock)
+                rironkabuka_kairi = rironkabuka.get_rironkabuka_expr(stock)
+
+                snapshot = research_shelve.create_snapshot(
+                    date_yy_m,
+                    ir_quant=ir_quant,
+                    quality_indicators=quality_indicators,
+                    rironkabuka_kairi=rironkabuka_kairi,
+                    data_source="auto",
+                )
+                research_shelve.upsert_snapshot(
+                    code_s, snapshot, overwrite_same_date=True, db_path=db_path,
+                )
+                existing_dates.add(date_yy_m)
+                count += 1
+            except Exception as e:
+                log_warning(f"[research] スナップショット追記失敗: {code_s} {e}")
+
+    log_print(
+        f"[research] スナップショット自動追記: {count} 件追記"
+        + (f", {skipped_existing} 件スキップ(既存)" if skipped_existing else "")
+    )
+
+
+# ==================================================
 # main
 # ==================================================
 def main():
@@ -1315,6 +1397,7 @@ def main():
         UPLOAD_CSV = True  # True/False
         UPDATE_PORTFOLIO = True
         list_all_db(UPLOAD_CSV, UPDATE_PORTFOLIO)
+        update_research_snapshots()
     elif command == "edit":
         edit_db()
     elif command == "backup":

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -52,8 +52,8 @@ except ImportError:
 # 厳密に4文字。"123" / "1234A" / "A215" は reject する。
 CODE_S_PATTERN = re.compile(r"^(?:\d{4}|\d{3}[A-Z])$")
 
-# 日付形式 (スプレッドシート準拠の YY.M 表記)
-DATE_YY_M_PATTERN = re.compile(r"^(\d{2})\.(\d{1,2})$")
+# 日付形式 (YY.M = 月精度, YY.M.D = 日精度)
+DATE_YY_M_PATTERN = re.compile(r"^(\d{2})\.(\d{1,2})(?:\.(\d{1,2}))?$")
 
 # 総合評価の許容値
 VALID_RATINGS = frozenset({"", "S", "A", "B", "C", "D", "E"})
@@ -121,21 +121,27 @@ def validate_code_s(code_s: Any) -> None:
 def validate_date_yy_m(date_yy_m: Any) -> None:
     """スナップショットの日付形式を検証する。
 
-    形式: "YY.M" または "YY.MM" (例: "26.1", "25.11")
-    月が1-12の範囲にない場合は ValueError。
+    形式: "YY.M" / "YY.MM"（月精度）または "YY.M.D" / "YY.MM.DD"（日精度）
+    例: "26.1", "25.11", "26.4.15"
     """
     if not isinstance(date_yy_m, str):
         raise TypeError(f"date_yy_m must be str, got {type(date_yy_m).__name__}")
     m = DATE_YY_M_PATTERN.match(date_yy_m)
     if not m:
         raise ValueError(
-            f"invalid date_yy_m: {date_yy_m!r} (期待形式は 'YY.M' or 'YY.MM')"
+            f"invalid date_yy_m: {date_yy_m!r} (期待形式は 'YY.M' or 'YY.M.D')"
         )
     month = int(m.group(2))
     if not 1 <= month <= 12:
         raise ValueError(
             f"invalid date_yy_m month: {date_yy_m!r} (月は1-12の範囲)"
         )
+    if m.group(3) is not None:
+        day = int(m.group(3))
+        if not 1 <= day <= 31:
+            raise ValueError(
+                f"invalid date_yy_m day: {date_yy_m!r} (日は1-31の範囲)"
+            )
 
 
 def validate_rating(rating: Any) -> None:
@@ -158,13 +164,15 @@ def validate_data_source(data_source: Any) -> None:
 def date_yy_m_sort_key(date_yy_m: str) -> tuple:
     """スナップショット並び替え用のソートキーを返す。
 
-    "26.1" -> (26, 1), "25.11" -> (25, 11) のように (年, 月) タプルを返す。
+    "26.1" -> (26, 1, 0), "25.11" -> (25, 11, 0), "26.4.15" -> (26, 4, 15)
+    日なしは day=0 として同月内で先に来る。
     降順ソート時は sort(..., reverse=True) で最新が先頭になる。
     """
     m = DATE_YY_M_PATTERN.match(date_yy_m)
     if not m:
         raise ValueError(f"invalid date_yy_m for sort: {date_yy_m!r}")
-    return (int(m.group(1)), int(m.group(2)))
+    day = int(m.group(3)) if m.group(3) else 0
+    return (int(m.group(1)), int(m.group(2)), day)
 
 
 # ===========================================

--- a/tests/test_append_research_snapshots.py
+++ b/tests/test_append_research_snapshots.py
@@ -1,0 +1,251 @@
+"""update_research_snapshots のテスト (issue #94)"""
+
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+import research_shelve as rs
+import make_stock_db
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """テスト用一時 research_shelve パス"""
+    return str(tmp_path / "test_research")
+
+
+def _today_str(offset_days=0):
+    """テスト用: 今日 ± offset の日付を "YYYY/MM/DD" 形式で返す"""
+    dt = datetime.today() + timedelta(days=offset_days)
+    return dt.strftime("%Y/%m/%d")
+
+
+def _today_yy_m_d(offset_days=0):
+    """テスト用: 今日 ± offset の日付を "YY.M.D" 形式で返す"""
+    dt = datetime.today() + timedelta(days=offset_days)
+    return f"{dt.year % 100}.{dt.month}.{dt.day}"
+
+
+def _make_stock(code_s, kessanbi="", kessan_mod_date="", stock_name="テスト銘柄"):
+    """最小限の stock dict を生成する"""
+    return {
+        "code_s": code_s,
+        "stock_name": stock_name,
+        "kessanbi": kessanbi,
+        "kessan_mod_date": kessan_mod_date,
+        "score_gyoseki": "0",
+        "shihyo_pt": 0,
+        "shihyo": {},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _fix_today(monkeypatch):
+    """get_price_day を固定して 18:00 前後のテスト不安定を排除"""
+    monkeypatch.setattr(
+        make_stock_db, "get_price_day",
+        lambda dt: datetime.today().date(),
+    )
+
+
+class TestUpdateResearchSnapshots:
+    """update_research_snapshots のユニットテスト"""
+
+    def test_basic_append(self, db_path, monkeypatch):
+        """決算日が今日の銘柄にスナップショットが追記される"""
+        today = _today_str()
+        stock = _make_stock("3496", kessanbi=today, stock_name="アズーム")
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert len(loaded["snapshots"]) == 1
+        snap = loaded["snapshots"][0]
+        assert snap["date_yy_m"] == _today_yy_m_d()
+        assert snap["data_source"] == "auto"
+
+    def test_unregistered_stock_skipped(self, db_path, monkeypatch):
+        """research_shelve にレコードがない銘柄はスキップ"""
+        today = _today_str()
+        stock = _make_stock("9999", kessanbi=today)
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"9999": stock})
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("9999", db_path=db_path)
+        assert loaded is None
+
+    def test_skip_existing_auto(self, db_path, monkeypatch):
+        """同一 date_yy_m の auto スナップショットがある場合はスキップ"""
+        today = _today_str()
+        stock = _make_stock("3496", kessanbi=today)
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+        snap = rs.create_snapshot(_today_yy_m_d(), data_source="auto")
+        rs.upsert_snapshot("3496", snap, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert len(loaded["snapshots"]) == 1
+
+    def test_skip_existing_manual_protects_data(self, db_path, monkeypatch):
+        """同一 date_yy_m の manual スナップショットがある場合もスキップ（manual 保護）"""
+        today = _today_str()
+        stock = _make_stock("3496", kessanbi=today)
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+        snap = rs.create_snapshot(_today_yy_m_d(), ir_quant="手動入力", data_source="manual")
+        rs.upsert_snapshot("3496", snap, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert len(loaded["snapshots"]) == 1
+        assert loaded["snapshots"][0]["data_source"] == "manual"
+        assert loaded["snapshots"][0]["ir_quant"] == "手動入力"
+
+    def test_kessanbi_and_mod_date_separate_snapshots(self, db_path, monkeypatch):
+        """決算発表と決算修正が別日なら 2 件の別スナップショット"""
+        ann_date = _today_str(-3)
+        mod_date = _today_str()
+        stock = _make_stock("3496", kessanbi=ann_date, kessan_mod_date=mod_date)
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert len(loaded["snapshots"]) == 2
+        dates = {s["date_yy_m"] for s in loaded["snapshots"]}
+        assert _today_yy_m_d(-3) in dates
+        assert _today_yy_m_d() in dates
+
+    def test_migration_not_affected_by_auto(self, db_path, monkeypatch):
+        """既存の migration (月精度) があっても auto (日精度) は追記される"""
+        today = _today_str()
+        stock = _make_stock("3496", kessanbi=today)
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+
+        dt = datetime.strptime(today, "%Y/%m/%d")
+        month_key = f"{dt.year % 100}.{dt.month}"
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+        snap = rs.create_snapshot(month_key, data_source="migration")
+        rs.upsert_snapshot("3496", snap, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert len(loaded["snapshots"]) == 2
+        sources = {s["data_source"] for s in loaded["snapshots"]}
+        assert sources == {"migration", "auto"}
+
+    def test_old_kessanbi_not_triggered(self, db_path, monkeypatch):
+        """15 日以上前の決算日はトリガーされない"""
+        old_date = _today_str(-15)
+        stock = _make_stock("3496", kessanbi=old_date)
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert len(loaded["snapshots"]) == 0
+
+    def test_no_targets_no_error(self, db_path, monkeypatch):
+        """対象銘柄なしでもエラーにならない"""
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {})
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+    def test_date_yy_m_d_conversion(self, db_path, monkeypatch):
+        """YYYY/MM/DD → YY.M.D の変換が正しい"""
+        stock = _make_stock("3496", kessanbi="2026/04/15")
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+        monkeypatch.setattr(
+            make_stock_db, "get_price_day",
+            lambda dt: datetime(2026, 4, 15).date(),
+        )
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["snapshots"][0]["date_yy_m"] == "26.4.15"
+
+    def test_date_yy_m_d_november(self, db_path, monkeypatch):
+        """11月1日 → 25.11.1 の変換"""
+        stock = _make_stock("3496", kessanbi="2025/11/01")
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+        monkeypatch.setattr(
+            make_stock_db, "get_price_day",
+            lambda dt: datetime(2025, 11, 1).date(),
+        )
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["snapshots"][0]["date_yy_m"] == "25.11.1"
+
+    def test_exception_does_not_stop_others(self, db_path, monkeypatch):
+        """1 銘柄の失敗が他に波及しない"""
+        today = _today_str()
+        stocks = {
+            "9998": _make_stock("9998", kessanbi=today),
+            "3496": _make_stock("3496", kessanbi=today),
+        }
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: stocks)
+
+        orig_get_gyoseki_expr = make_stock_db.gyoseki.get_gyoseki_expr
+
+        def _boom_for_9998(stock):
+            if stock.get("code_s") == "9998":
+                raise RuntimeError("強制エラー")
+            return orig_get_gyoseki_expr(stock)
+
+        monkeypatch.setattr(make_stock_db.gyoseki, "get_gyoseki_expr", _boom_for_9998)
+
+        for code_s in ("9998", "3496"):
+            rec = rs.create_research_record(code_s, "テスト")
+            rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert len(loaded["snapshots"]) == 1
+
+    def test_ir_quant_contains_progress_and_growth(self, db_path, monkeypatch):
+        """ir_quant に progress_expr + growth_expr が連結されている"""
+        today = _today_str()
+        stock = _make_stock("3496", kessanbi=today)
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        snap = loaded["snapshots"][0]
+        assert isinstance(snap["ir_quant"], str)
+        assert isinstance(snap["quality_indicators"], str)
+        assert isinstance(snap["rironkabuka_kairi"], str)

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -149,8 +149,8 @@ class TestSchema:
         assert sorted_desc == ["26.1", "25.11", "25.7", "24.2"]
 
     def test_date_yy_m_sort_key_value(self):
-        assert rs.date_yy_m_sort_key("26.1") == (26, 1)
-        assert rs.date_yy_m_sort_key("25.11") == (25, 11)
+        assert rs.date_yy_m_sort_key("26.1") == (26, 1, 0)
+        assert rs.date_yy_m_sort_key("25.11") == (25, 11, 0)
 
     # --- ケース8: overall_rating 不正値 ---
     @pytest.mark.parametrize("bad", ["Z", "s", "A+", "不明"])
@@ -598,3 +598,70 @@ class TestAnalysisKessanDateFields:
             rs.create_research_record(
                 "3496", "アズーム", kessan_date_raw=None,
             )
+
+
+# ==================================================
+# date_yy_m 日精度拡張 (issue #94)
+# ==================================================
+class TestDateYyMDayPrecision:
+    """YY.M.D 形式の日精度拡張テスト"""
+
+    def test_validate_yy_m_d_accepted(self):
+        """日精度 YY.M.D が許容される"""
+        rs.validate_date_yy_m("26.4.15")
+        rs.validate_date_yy_m("25.11.1")
+        rs.validate_date_yy_m("26.1.31")
+
+    def test_validate_yy_m_d_invalid_day(self):
+        """日が 32 以上で ValueError"""
+        with pytest.raises(ValueError, match="日は1-31"):
+            rs.validate_date_yy_m("26.4.32")
+
+    def test_validate_yy_m_d_day_zero(self):
+        """日が 0 で ValueError"""
+        with pytest.raises(ValueError, match="日は1-31"):
+            rs.validate_date_yy_m("26.4.0")
+
+    def test_sort_key_with_day(self):
+        """日精度の sort_key が (year, month, day) の 3-tuple"""
+        assert rs.date_yy_m_sort_key("26.4.15") == (26, 4, 15)
+
+    def test_sort_key_without_day(self):
+        """月精度の sort_key が (year, month, 0) の 3-tuple"""
+        assert rs.date_yy_m_sort_key("26.4") == (26, 4, 0)
+
+    def test_sort_order_mixed(self):
+        """月精度と日精度が混在時のソート順: 26.4 < 26.4.15 < 26.5"""
+        dates = ["26.5", "26.4", "26.4.15", "26.1"]
+        sorted_desc = sorted(dates, key=rs.date_yy_m_sort_key, reverse=True)
+        assert sorted_desc == ["26.5", "26.4.15", "26.4", "26.1"]
+
+    def test_upsert_yy_m_and_yy_m_d_coexist(self, db_path):
+        """同一銘柄に YY.M と YY.M.D が並存できる"""
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+        rs.upsert_snapshot(
+            "3496", rs.create_snapshot("26.4", data_source="migration"),
+            db_path=db_path,
+        )
+        rs.upsert_snapshot(
+            "3496", rs.create_snapshot("26.4.15", data_source="auto"),
+            db_path=db_path,
+        )
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert len(loaded["snapshots"]) == 2
+        dates = {s["date_yy_m"] for s in loaded["snapshots"]}
+        assert dates == {"26.4", "26.4.15"}
+
+    def test_create_snapshot_with_day(self):
+        """create_snapshot が日精度を受け付ける"""
+        snap = rs.create_snapshot("26.4.15", ir_quant="[P]1Q28%", data_source="auto")
+        assert snap["date_yy_m"] == "26.4.15"
+        assert snap["data_source"] == "auto"
+
+    def test_existing_yy_m_tests_still_pass(self):
+        """既存の月精度形式が引き続き動作する回帰テスト"""
+        rs.validate_date_yy_m("26.1")
+        rs.validate_date_yy_m("25.11")
+        assert rs.date_yy_m_sort_key("26.1") == (26, 1, 0)
+        assert rs.date_yy_m_sort_key("25.11") == (25, 11, 0)


### PR DESCRIPTION
## Summary
- `list_all_db` 実行後に `update_research_snapshots()` を呼び出し、research_shelve 管理銘柄のうち決算更新（発表/修正）があった銘柄にスナップショットを自動追記
- `date_yy_m` に `YY.M.D` 日精度形式を追加（移行データの月精度 `26.4` と自動追記の日精度 `26.4.15` が並存可能）
- 既存スナップショットの重複防止（同一 `date_yy_m` が存在すればスキップ、manual/migration データを保護）

## Test plan
- [ ] `pytest tests/test_research_shelve.py -v` — YY.M.D バリデーション/ソート/並存テスト 9 件追加（計 81 件通過）
- [ ] `pytest tests/test_append_research_snapshots.py -v` — 自動追記テスト 12 件（基本追記、未登録スキップ、重複防止、manual 保護、例外安全等）
- [ ] `pytest tests/test_db_shelve.py tests/test_migrate_research_from_csv.py -v` — 既存テスト回帰なし（計 170 件通過）
- [ ] `python make_stock_db.py list_all_db` 実行後にログで `[research] スナップショット自動追記: N 件追記` を確認
- [ ] `python research_shelve.py show <銘柄コード>` で `data_source=auto` の日精度スナップショットが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)