### PR TITLE
銘柄調査Webビュー (Flask) を実装 (#95)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scipy==1.13.1
 oauth2client==4.1.3
 httplib2==0.22.0
 yfinance>=0.2.31
+flask>=3.0

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -17,8 +17,11 @@ delete_research_record 等) を経由して更新を行い、他のモジュー�
 直接 ShelveDB(RESEARCH_SHELVE) を開いて書き換えてはならない。
 """
 
+import fcntl
 import os
 import re
+import threading
+from contextlib import contextmanager
 from typing import Any, Dict, List, Optional
 
 from db_shelve import RESEARCH_SHELVE, ShelveDB
@@ -265,6 +268,58 @@ def create_snapshot(
 
 
 # ===========================================
+# プロセス間排他制御
+# ===========================================
+
+def _lock_path_for(db_path: Optional[str] = None) -> str:
+    """ロックファイルパスを返す。"""
+    base = db_path if db_path is not None else RESEARCH_SHELVE
+    return base + ".lock"
+
+
+# リエントラント検出用: 同一スレッドが既にロックを保持しているか
+_flock_holder = threading.local()
+
+
+@contextmanager
+def _flock(db_path: Optional[str] = None):
+    """research_shelve 書き込み用の排他ロック (fcntl.flock)。
+
+    Web側 (helpers.py) とバッチ側 (upsert_snapshot 等) の両方が
+    同じロックファイルを取ることで、プロセス間の read-modify-write
+    競合を防止する。
+
+    リエントラント対応: helpers が外側で _flock() を取得した状態で
+    upsert_research_record() を呼ぶと内部でも _flock() に入るが、
+    同一スレッドの場合はロック取得をスキップしてデッドロックを防ぐ。
+    """
+    if getattr(_flock_holder, "depth", 0) > 0:
+        # 同一スレッドで既にロック保持中 → そのまま通過
+        _flock_holder.depth += 1
+        try:
+            yield
+        finally:
+            _flock_holder.depth -= 1
+        return
+
+    lock_file = _lock_path_for(db_path)
+    lock_dir = os.path.dirname(lock_file)
+    if lock_dir and not os.path.exists(lock_dir):
+        os.makedirs(lock_dir, exist_ok=True)
+    fd = open(lock_file, "a")
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        _flock_holder.depth = 1
+        try:
+            yield
+        finally:
+            _flock_holder.depth = 0
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        fd.close()
+
+
+# ===========================================
 # CRUD層
 # ===========================================
 
@@ -323,16 +378,17 @@ def upsert_research_record(
     - record["code_s"] は必須
     - 既存レコードがあれば完全上書き (部分マージは行わない)
     - 未知フィールドは警告ログ付きで保存 (後方互換のため)
+    - fcntl.flock でプロセス間排他を保証
     """
     _validate_record_for_upsert(record)
     normalized = normalize_code_s(record["code_s"])
-    # 正規化した code_s で保存 (元 record が入力ミス混じりでも一貫性を保つ)
     stored = dict(record)
     stored["code_s"] = normalized
     path = _resolve_db_path(db_path)
-    with ShelveDB(path) as db:
-        existed = normalized in db
-        db[normalized] = stored
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            existed = normalized in db
+            db[normalized] = stored
     if existed:
         log_print("research_shelve: レコード更新", normalized)
     else:
@@ -347,14 +403,16 @@ def delete_research_record(
     """銘柄調査レコードを削除する。
 
     成功時は True、非存在時は False (KeyError ではなく bool を返す)。
+    fcntl.flock でプロセス間排他を保証。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
     path = _resolve_db_path(db_path)
-    with ShelveDB(path) as db:
-        if normalized not in db:
-            return False
-        del db[normalized]
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            if normalized not in db:
+                return False
+            del db[normalized]
     log_print("research_shelve: レコード削除", normalized)
     return True
 
@@ -406,27 +464,28 @@ def upsert_snapshot(
     new_date = snapshot["date_yy_m"]
     path = _resolve_db_path(db_path)
 
-    with ShelveDB(path) as db:
-        if normalized not in db:
-            raise KeyError(
-                f"research_shelve: レコード未登録の銘柄にスナップショットを"
-                f"追加できません: {normalized} "
-                f"(先に upsert_research_record を呼んでください)"
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            if normalized not in db:
+                raise KeyError(
+                    f"research_shelve: レコード未登録の銘柄にスナップショットを"
+                    f"追加できません: {normalized} "
+                    f"(先に upsert_research_record を呼んでください)"
+                )
+            record = db[normalized]
+            snapshots = list(record.get("snapshots") or [])
+
+            if overwrite_same_date:
+                snapshots = [s for s in snapshots if s.get("date_yy_m") != new_date]
+
+            snapshots.append(dict(snapshot))
+            snapshots.sort(
+                key=lambda s: date_yy_m_sort_key(s["date_yy_m"]),
+                reverse=True,
             )
-        record = db[normalized]
-        snapshots = list(record.get("snapshots") or [])
 
-        if overwrite_same_date:
-            snapshots = [s for s in snapshots if s.get("date_yy_m") != new_date]
-
-        snapshots.append(dict(snapshot))
-        snapshots.sort(
-            key=lambda s: date_yy_m_sort_key(s["date_yy_m"]),
-            reverse=True,
-        )
-
-        record["snapshots"] = snapshots
-        db[normalized] = record  # 再代入で永続化
+            record["snapshots"] = snapshots
+            db[normalized] = record  # 再代入で永続化
 
     log_print(
         "research_shelve: スナップショット追記",

--- a/scripts/webapp/__init__.py
+++ b/scripts/webapp/__init__.py
@@ -1,0 +1,31 @@
+"""
+銘柄調査Webアプリ (Flask)。
+
+research_shelve のデータをブラウザで閲覧・編集するためのWebアプリケーション。
+"""
+
+import os
+import sys
+
+from flask import Flask
+
+# scripts/ を sys.path に追加して research_shelve 等をインポート可能にする
+_SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+
+def create_app() -> Flask:
+    """Flask アプリケーションファクトリ。"""
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", "dev-secret-key")
+
+    from webapp.routes.search import search_bp
+    from webapp.routes.detail import detail_bp
+    from webapp.routes.memo import memo_bp
+
+    app.register_blueprint(search_bp)
+    app.register_blueprint(detail_bp)
+    app.register_blueprint(memo_bp)
+
+    return app

--- a/scripts/webapp/app.py
+++ b/scripts/webapp/app.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""
+Webアプリ起動エントリポイント。
+
+使い方:
+    cd scripts && python -m webapp.app
+"""
+
+from webapp import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5001)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1,0 +1,144 @@
+"""
+DB読み書きヘルパー。
+
+research_shelve のデータ取得・更新をWebアプリ用にラップする。
+fcntl.flock によるプロセス間排他制御を適用し、バッチ処理との安全な共存を保証する。
+"""
+
+import fcntl
+import os
+from typing import Any, Dict, List, Optional
+
+from db_shelve import RESEARCH_SHELVE
+from research_shelve import (
+    get_research_record,
+    upsert_research_record,
+    list_research_records,
+    validate_code_s,
+    normalize_code_s,
+    validate_rating,
+    VALID_RATINGS,
+)
+
+# ロックファイルパス (バッチ側と共通)
+_LOCK_PATH = RESEARCH_SHELVE + ".lock"
+
+
+def _ensure_lock_file() -> None:
+    """ロックファイルが存在しなければ作成する。"""
+    lock_dir = os.path.dirname(_LOCK_PATH)
+    if lock_dir and not os.path.exists(lock_dir):
+        os.makedirs(lock_dir, exist_ok=True)
+    if not os.path.exists(_LOCK_PATH):
+        open(_LOCK_PATH, "a").close()
+
+
+def get_research_detail(code_s: str) -> Optional[Dict[str, Any]]:
+    """1銘柄の調査レコードを取得する。"""
+    validate_code_s(code_s)
+    return get_research_record(code_s)
+
+
+def search_records(
+    *,
+    rating: Optional[str] = None,
+    keyword: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """銘柄調査レコードをフィルタ検索する。"""
+    return list_research_records(rating=rating, keyword=keyword)
+
+
+def save_memo(code_s: str, form_data: dict) -> None:
+    """手動メモフィールドを更新する。
+
+    対象: overall_rating, institutional_comment, memo, openwork, cramer
+    read-modify-write サイクル全体を flock で排他する。
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+
+    _ensure_lock_file()
+    with open(_LOCK_PATH, "r") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            record = get_research_record(normalized)
+            if record is None:
+                raise ValueError(f"レコード未登録: {normalized}")
+
+            # フォームから取得してレコードを更新
+            new_rating = form_data.get("overall_rating", "")
+            validate_rating(new_rating)
+            record["overall_rating"] = new_rating
+            record["institutional_comment"] = form_data.get(
+                "institutional_comment", ""
+            )
+            record["memo"] = form_data.get("memo", "")
+            record["openwork"] = form_data.get("openwork", "")
+            record["cramer"] = form_data.get("cramer", "")
+
+            upsert_research_record(record)
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+
+def save_shikiho(code_s: str, form_data: dict) -> None:
+    """四季報フィールドを更新する。
+
+    対象: overview, shikiho_comments (最大5件)
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+
+    _ensure_lock_file()
+    with open(_LOCK_PATH, "r") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            record = get_research_record(normalized)
+            if record is None:
+                raise ValueError(f"レコード未登録: {normalized}")
+
+            record["overview"] = form_data.get("overview", "")
+
+            # shikiho_comments_0, shikiho_comments_1, ... を収集
+            comments: List[str] = []
+            for i in range(5):
+                key = f"shikiho_comments_{i}"
+                val = form_data.get(key)
+                if val is not None:
+                    stripped = val.strip()
+                    if stripped:
+                        comments.append(stripped)
+            record["shikiho_comments"] = comments
+
+            upsert_research_record(record)
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+
+def save_ir_comments(code_s: str, form_data: dict) -> None:
+    """スナップショット内の ir_comment を一括更新する。
+
+    フォームキー形式: ir_comment_<date_yy_m> (例: ir_comment_26.4)
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+
+    _ensure_lock_file()
+    with open(_LOCK_PATH, "r") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            record = get_research_record(normalized)
+            if record is None:
+                raise ValueError(f"レコード未登録: {normalized}")
+
+            snapshots = record.get("snapshots") or []
+            for snap in snapshots:
+                date = snap.get("date_yy_m", "")
+                form_key = f"ir_comment_{date}"
+                if form_key in form_data:
+                    snap["ir_comment"] = form_data[form_key]
+
+            record["snapshots"] = snapshots
+            upsert_research_record(record)
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2,14 +2,12 @@
 DB読み書きヘルパー。
 
 research_shelve のデータ取得・更新をWebアプリ用にラップする。
-fcntl.flock によるプロセス間排他制御を適用し、バッチ処理との安全な共存を保証する。
+排他制御は research_shelve._flock() を共用し、Web側とバッチ側で
+同じロックファイルを取ることでプロセス間の安全な共存を保証する。
 """
 
-import fcntl
-import os
 from typing import Any, Dict, List, Optional
 
-from db_shelve import RESEARCH_SHELVE
 from research_shelve import (
     get_research_record,
     upsert_research_record,
@@ -17,20 +15,9 @@ from research_shelve import (
     validate_code_s,
     normalize_code_s,
     validate_rating,
+    _flock,
     VALID_RATINGS,
 )
-
-# ロックファイルパス (バッチ側と共通)
-_LOCK_PATH = RESEARCH_SHELVE + ".lock"
-
-
-def _ensure_lock_file() -> None:
-    """ロックファイルが存在しなければ作成する。"""
-    lock_dir = os.path.dirname(_LOCK_PATH)
-    if lock_dir and not os.path.exists(lock_dir):
-        os.makedirs(lock_dir, exist_ok=True)
-    if not os.path.exists(_LOCK_PATH):
-        open(_LOCK_PATH, "a").close()
 
 
 def get_research_detail(code_s: str) -> Optional[Dict[str, Any]]:
@@ -52,33 +39,29 @@ def save_memo(code_s: str, form_data: dict) -> None:
     """手動メモフィールドを更新する。
 
     対象: overall_rating, institutional_comment, memo, openwork, cramer
-    read-modify-write サイクル全体を flock で排他する。
+    read-modify-write サイクル全体を _flock で排他する。
+    upsert_research_record 内部でも _flock を取るが、fcntl.flock は
+    同一プロセス・同一スレッドからの再取得をブロックしないため問題ない。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
 
-    _ensure_lock_file()
-    with open(_LOCK_PATH, "r") as lock_fd:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        try:
-            record = get_research_record(normalized)
-            if record is None:
-                raise ValueError(f"レコード未登録: {normalized}")
+    with _flock():
+        record = get_research_record(normalized)
+        if record is None:
+            raise ValueError(f"レコード未登録: {normalized}")
 
-            # フォームから取得してレコードを更新
-            new_rating = form_data.get("overall_rating", "")
-            validate_rating(new_rating)
-            record["overall_rating"] = new_rating
-            record["institutional_comment"] = form_data.get(
-                "institutional_comment", ""
-            )
-            record["memo"] = form_data.get("memo", "")
-            record["openwork"] = form_data.get("openwork", "")
-            record["cramer"] = form_data.get("cramer", "")
+        new_rating = form_data.get("overall_rating", "")
+        validate_rating(new_rating)
+        record["overall_rating"] = new_rating
+        record["institutional_comment"] = form_data.get(
+            "institutional_comment", ""
+        )
+        record["memo"] = form_data.get("memo", "")
+        record["openwork"] = form_data.get("openwork", "")
+        record["cramer"] = form_data.get("cramer", "")
 
-            upsert_research_record(record)
-        finally:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        upsert_research_record(record)
 
 
 def save_shikiho(code_s: str, form_data: dict) -> None:
@@ -89,30 +72,24 @@ def save_shikiho(code_s: str, form_data: dict) -> None:
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
 
-    _ensure_lock_file()
-    with open(_LOCK_PATH, "r") as lock_fd:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        try:
-            record = get_research_record(normalized)
-            if record is None:
-                raise ValueError(f"レコード未登録: {normalized}")
+    with _flock():
+        record = get_research_record(normalized)
+        if record is None:
+            raise ValueError(f"レコード未登録: {normalized}")
 
-            record["overview"] = form_data.get("overview", "")
+        record["overview"] = form_data.get("overview", "")
 
-            # shikiho_comments_0, shikiho_comments_1, ... を収集
-            comments: List[str] = []
-            for i in range(5):
-                key = f"shikiho_comments_{i}"
-                val = form_data.get(key)
-                if val is not None:
-                    stripped = val.strip()
-                    if stripped:
-                        comments.append(stripped)
-            record["shikiho_comments"] = comments
+        comments: List[str] = []
+        for i in range(5):
+            key = f"shikiho_comments_{i}"
+            val = form_data.get(key)
+            if val is not None:
+                stripped = val.strip()
+                if stripped:
+                    comments.append(stripped)
+        record["shikiho_comments"] = comments
 
-            upsert_research_record(record)
-        finally:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        upsert_research_record(record)
 
 
 def save_ir_comments(code_s: str, form_data: dict) -> None:
@@ -123,22 +100,17 @@ def save_ir_comments(code_s: str, form_data: dict) -> None:
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
 
-    _ensure_lock_file()
-    with open(_LOCK_PATH, "r") as lock_fd:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        try:
-            record = get_research_record(normalized)
-            if record is None:
-                raise ValueError(f"レコード未登録: {normalized}")
+    with _flock():
+        record = get_research_record(normalized)
+        if record is None:
+            raise ValueError(f"レコード未登録: {normalized}")
 
-            snapshots = record.get("snapshots") or []
-            for snap in snapshots:
-                date = snap.get("date_yy_m", "")
-                form_key = f"ir_comment_{date}"
-                if form_key in form_data:
-                    snap["ir_comment"] = form_data[form_key]
+        snapshots = record.get("snapshots") or []
+        for snap in snapshots:
+            date = snap.get("date_yy_m", "")
+            form_key = f"ir_comment_{date}"
+            if form_key in form_data:
+                snap["ir_comment"] = form_data[form_key]
 
-            record["snapshots"] = snapshots
-            upsert_research_record(record)
-        finally:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        record["snapshots"] = snapshots
+        upsert_research_record(record)

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -1,0 +1,26 @@
+"""
+銘柄詳細ビュールート。
+
+GET /stock/<code_s> : 銘柄の全セクション表示
+"""
+
+from flask import Blueprint, render_template, abort
+
+from webapp.helpers import get_research_detail
+from research_shelve import VALID_RATINGS
+
+detail_bp = Blueprint("detail", __name__)
+
+
+@detail_bp.route("/stock/<code_s>")
+def stock_detail(code_s: str):
+    """銘柄詳細ビュー。"""
+    record = get_research_detail(code_s)
+    if record is None:
+        abort(404)
+
+    return render_template(
+        "detail.html",
+        record=record,
+        valid_ratings=sorted(VALID_RATINGS - {""}),
+    )

--- a/scripts/webapp/routes/memo.py
+++ b/scripts/webapp/routes/memo.py
@@ -1,0 +1,34 @@
+"""
+メモ保存ルート。
+
+POST /stock/<code_s>/memo       : 手動メモ保存
+POST /stock/<code_s>/shikiho    : 四季報保存
+POST /stock/<code_s>/ir_comment : IR分析コメント一括保存
+"""
+
+from flask import Blueprint, request, redirect, url_for
+
+from webapp.helpers import save_memo, save_shikiho, save_ir_comments
+
+memo_bp = Blueprint("memo", __name__)
+
+
+@memo_bp.route("/stock/<code_s>/memo", methods=["POST"])
+def post_memo(code_s: str):
+    """手動メモ保存 -> 302リダイレクト。"""
+    save_memo(code_s, request.form)
+    return redirect(url_for("detail.stock_detail", code_s=code_s))
+
+
+@memo_bp.route("/stock/<code_s>/shikiho", methods=["POST"])
+def post_shikiho(code_s: str):
+    """四季報保存 -> 302リダイレクト。"""
+    save_shikiho(code_s, request.form)
+    return redirect(url_for("detail.stock_detail", code_s=code_s))
+
+
+@memo_bp.route("/stock/<code_s>/ir_comment", methods=["POST"])
+def post_ir_comment(code_s: str):
+    """IR分析コメント一括保存 -> 302リダイレクト。"""
+    save_ir_comments(code_s, request.form)
+    return redirect(url_for("detail.stock_detail", code_s=code_s))

--- a/scripts/webapp/routes/search.py
+++ b/scripts/webapp/routes/search.py
@@ -1,0 +1,35 @@
+"""
+検索・ホーム画面ルート。
+
+GET / : 銘柄コード/名前/評価でフィルタし一覧表示
+"""
+
+from flask import Blueprint, render_template, request
+
+from webapp.helpers import search_records
+
+search_bp = Blueprint("search", __name__)
+
+
+@search_bp.route("/")
+def index():
+    """検索・ホーム画面。"""
+    rating = request.args.get("rating", "").strip() or None
+    keyword = request.args.get("keyword", "").strip() or None
+    code_s = request.args.get("code_s", "").strip()
+
+    records = search_records(rating=rating, keyword=keyword)
+
+    # 銘柄コードフィルタ (部分一致)
+    if code_s:
+        records = [
+            r for r in records if code_s.upper() in r.get("code_s", "")
+        ]
+
+    return render_template(
+        "search.html",
+        records=records,
+        filter_rating=rating or "",
+        filter_keyword=keyword or "",
+        filter_code_s=code_s,
+    )

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -8,6 +8,10 @@ document.querySelectorAll('.editable-field, .editable-select').forEach(function(
   initialValues[el.name] = el.value;
 });
 
+/* --- 四季報エリアのDOM構造スナップショット（revert用） --- */
+var shikihoEditArea = document.getElementById('shikiho-edit-area');
+var shikihoInitialHTML = shikihoEditArea ? shikihoEditArea.innerHTML : '';
+
 /* --- 変更検知: 編集すると保存バーを表示 --- */
 document.addEventListener('input', function(e) {
   var el = e.target;
@@ -28,6 +32,10 @@ function updateSaveBar(formName) {
 
 /* --- 元に戻す --- */
 function revertForm(formName) {
+  if (formName === 'shikiho') {
+    revertShikiho();
+    return;
+  }
   document.querySelectorAll('[data-form="' + formName + '"]').forEach(function(el) {
     if (initialValues[el.name] !== undefined) {
       el.value = initialValues[el.name];
@@ -35,6 +43,31 @@ function revertForm(formName) {
     el.classList.remove('dirty');
   });
   updateSaveBar(formName);
+}
+
+/* --- 四季報: DOM構造ごと復元して初期値を再適用 --- */
+function revertShikiho() {
+  var area = document.getElementById('shikiho-edit-area');
+  if (!area) return;
+  /* DOM構造を初期状態に復元（行の追加/削除を巻き戻す） */
+  area.innerHTML = shikihoInitialHTML;
+  /* 復元されたフィールドに初期値を再適用 */
+  area.querySelectorAll('.editable-field').forEach(function(el) {
+    if (initialValues[el.name] !== undefined) {
+      el.value = initialValues[el.name];
+    }
+    el.classList.remove('dirty');
+  });
+  /* overview も初期値に戻す（shikihoフォーム内の非四季報エリアフィールド） */
+  document.querySelectorAll('[data-form="shikiho"]').forEach(function(el) {
+    if (!area.contains(el)) {
+      if (initialValues[el.name] !== undefined) {
+        el.value = initialValues[el.name];
+      }
+      el.classList.remove('dirty');
+    }
+  });
+  updateSaveBar('shikiho');
 }
 
 /* --- 四季報コメント: 追加/削除 --- */

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -1,0 +1,83 @@
+/* 銘柄詳細ビュー: click-to-edit + 変更検知 + 四季報追加/削除 */
+
+var MAX_SHIKIHO = 5;
+
+/* --- 初期値を記録（変更検知用） --- */
+var initialValues = {};
+document.querySelectorAll('.editable-field, .editable-select').forEach(function(el) {
+  initialValues[el.name] = el.value;
+});
+
+/* --- 変更検知: 編集すると保存バーを表示 --- */
+document.addEventListener('input', function(e) {
+  var el = e.target;
+  if (!el.classList.contains('editable-field') && !el.classList.contains('editable-select')) return;
+  var formName = el.dataset.form;
+  if (!formName) return;
+  var changed = el.value !== (initialValues[el.name] || '');
+  el.classList.toggle('dirty', changed);
+  updateSaveBar(formName);
+});
+
+function updateSaveBar(formName) {
+  var fields = document.querySelectorAll('[data-form="' + formName + '"]');
+  var hasDirty = Array.from(fields).some(function(f) { return f.classList.contains('dirty'); });
+  var bar = document.getElementById('save-bar-' + formName);
+  if (bar) bar.classList.toggle('visible', hasDirty);
+}
+
+/* --- 元に戻す --- */
+function revertForm(formName) {
+  document.querySelectorAll('[data-form="' + formName + '"]').forEach(function(el) {
+    if (initialValues[el.name] !== undefined) {
+      el.value = initialValues[el.name];
+    }
+    el.classList.remove('dirty');
+  });
+  updateSaveBar(formName);
+}
+
+/* --- 四季報コメント: 追加/削除 --- */
+function updateShikihoState() {
+  var entries = document.querySelectorAll('#shikiho-edit-area .shikiho-entry');
+  var count = entries.length;
+  var countEl = document.getElementById('shikiho-count');
+  if (countEl) countEl.textContent = count;
+  entries.forEach(function(entry, i) {
+    entry.querySelector('span').textContent = (i + 1) + '.';
+    var ta = entry.querySelector('textarea');
+    ta.name = 'shikiho_comments_' + i;
+  });
+  var btn = document.getElementById('btn-add-shikiho');
+  if (btn) {
+    var remaining = MAX_SHIKIHO - count;
+    btn.style.display = remaining <= 0 ? 'none' : '';
+    btn.textContent = '+ 追加 (残り' + remaining + '件)';
+  }
+  /* 件数変更は常にdirty扱い */
+  var bar = document.getElementById('save-bar-shikiho');
+  if (bar) bar.classList.add('visible');
+}
+
+function addShikiho() {
+  var area = document.getElementById('shikiho-edit-area');
+  if (!area) return;
+  var entries = area.querySelectorAll('.shikiho-entry');
+  if (entries.length >= MAX_SHIKIHO) return;
+  var idx = entries.length;
+  var div = document.createElement('div');
+  div.className = 'shikiho-entry';
+  div.style.cssText = 'display:flex;align-items:start;gap:0.3em;margin-bottom:0.3em;';
+  div.innerHTML =
+    '<span style="font-size:0.8em;color:#888;width:1.5em;padding-top:0.6em;">' + (idx + 1) + '.</span>' +
+    '<textarea class="editable-field" name="shikiho_comments_' + idx + '" rows="2" style="flex:1;" data-form="shikiho" placeholder="四季報コメントを入力..."></textarea>' +
+    '<button type="button" class="outline secondary" style="padding:0.2em 0.5em;font-size:0.8em;margin:0;margin-top:0.4em;" onclick="removeShikiho(this)" title="削除">&times;</button>';
+  area.insertBefore(div, document.getElementById('btn-add-shikiho'));
+  updateShikihoState();
+  div.querySelector('textarea').focus();
+}
+
+function removeShikiho(btn) {
+  btn.closest('.shikiho-entry').remove();
+  updateShikihoState();
+}

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -1,0 +1,165 @@
+:root {
+  --pico-font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Noto Sans JP", sans-serif;
+  --pico-font-size: 15px;
+}
+
+/* ヘッダーの評価バッジ */
+.rating-badge {
+  display: inline-block;
+  padding: 0.15em 0.6em;
+  border-radius: 4px;
+  font-weight: bold;
+  font-size: 1.1em;
+  color: #fff;
+}
+.rating-S { background: #e74c3c; }
+.rating-A { background: #e67e22; }
+.rating-B { background: #f1c40f; color: #333; }
+.rating-C { background: #2ecc71; }
+.rating-D { background: #3498db; }
+.rating-E { background: #95a5a6; }
+
+/* スナップショットテーブル */
+table.snapshot-table {
+  font-size: 0.85em;
+}
+table.snapshot-table th {
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  background: var(--pico-background-color);
+}
+table.snapshot-table td {
+  vertical-align: top;
+}
+.source-auto { color: #888; font-size: 0.8em; }
+.source-manual { color: #2ecc71; font-size: 0.8em; font-weight: bold; }
+.source-migration { color: #3498db; font-size: 0.8em; }
+
+/* メモセクション */
+.memo-section {
+  background: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1.2em;
+  margin: 1em 0;
+}
+.memo-section h3 { margin-top: 0; }
+.memo-field { margin-bottom: 1em; }
+.memo-field label {
+  font-weight: bold;
+  font-size: 0.9em;
+  display: block;
+  margin-bottom: 0.2em;
+}
+
+/* click-to-edit テキストエリア */
+.editable-field {
+  width: 100%;
+  font-size: 0.9em;
+  font-family: inherit;
+  padding: 0.5em 0.8em;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  resize: vertical;
+  transition: border-color 0.15s, background 0.15s;
+  cursor: pointer;
+  margin-bottom: 0;
+  color: inherit;
+}
+.editable-field:hover {
+  border-color: #ddd;
+  background: #fafafa;
+}
+.editable-field:focus {
+  border-color: #3498db;
+  background: #fff;
+  outline: none;
+  cursor: text;
+  box-shadow: 0 0 0 2px rgba(52,152,219,0.15);
+}
+.editable-field.dirty {
+  border-left: 3px solid #e67e22;
+}
+
+/* セレクトボックス */
+.editable-select {
+  font-size: 0.9em;
+  padding: 0.3em 0.5em;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  margin-bottom: 0;
+}
+.editable-select:hover { border-color: #ddd; }
+.editable-select:focus { border-color: #3498db; outline: none; }
+.editable-select.dirty { border-left: 3px solid #e67e22; }
+
+/* 保存バー */
+.save-bar {
+  position: sticky;
+  bottom: 0;
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 6px;
+  padding: 0.5em 1em;
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1em;
+  z-index: 10;
+  font-size: 0.9em;
+}
+.save-bar.visible { display: flex; }
+
+/* 四季報リスト */
+.shikiho-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.shikiho-list li {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 0.5em 0.8em;
+  margin-bottom: 0.3em;
+  font-size: 0.9em;
+  white-space: pre-wrap;
+}
+
+/* ナビゲーション */
+nav .brand {
+  font-weight: bold;
+  font-size: 1.1em;
+  text-decoration: none;
+}
+nav .quick-search {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+}
+
+/* ヘッダーレイアウト */
+.stock-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+.stock-header .left h1 {
+  margin-bottom: 0.1em;
+}
+.stock-header .left .meta {
+  color: #666;
+  font-size: 0.9em;
+}
+
+.btn-group {
+  display: flex;
+  gap: 0.5em;
+}

--- a/scripts/webapp/templates/base.html
+++ b/scripts/webapp/templates/base.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% block title %}Shintakane Research{% endblock %}</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+
+<nav class="container-fluid">
+  <ul>
+    <li><a href="/" class="brand">Shintakane Research</a></li>
+  </ul>
+  <ul>
+    <li class="quick-search">
+      <form action="/" method="get" style="display:flex;align-items:center;gap:0.4em;margin:0;">
+        <input type="text" name="code_s" placeholder="銘柄コード" aria-label="銘柄コード検索"
+               style="width:8em;padding:0.3em 0.5em;margin:0;font-size:0.9em;height:auto;">
+        <button type="submit" class="outline" style="padding:0.3em 0.7em;margin:0;font-size:0.9em;">Go</button>
+      </form>
+    </li>
+  </ul>
+</nav>
+
+<main class="container">
+  {% block content %}{% endblock %}
+</main>
+
+<footer class="container" style="text-align:center;font-size:0.8em;color:#aaa;margin-top:2em;padding-bottom:1em;">
+  Shintakane Research
+</footer>
+
+<script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -1,0 +1,208 @@
+{% extends "base.html" %}
+{% block title %}[{{ record.code_s }}] {{ record.stock_name or '' }} - 銘柄詳細 | Shintakane Research{% endblock %}
+
+{% block content %}
+{# ===== 1. ヘッダー ===== #}
+<div class="stock-header">
+  <div class="left">
+    <h1>
+      {% if record.overall_rating %}
+      <span class="rating-badge rating-{{ record.overall_rating }}">{{ record.overall_rating }}</span>
+      {% endif %}
+      <small style="color:#888;font-size:0.5em;">{{ record.code_s }}</small>
+      {{ record.stock_name or '' }}
+    </h1>
+    <div class="meta">
+      {% if record.analysis_date_raw %}分析日: {{ record.analysis_date_raw }}{% endif %}
+      {% if record.analysis_date_raw and record.kessan_date_raw %} | {% endif %}
+      {% if record.kessan_date_raw %}決算日: {{ record.kessan_date_raw }}{% endif %}
+    </div>
+  </div>
+</div>
+
+{# ===== 2. 業績スナップショット時系列 ===== #}
+{% set snapshots = record.snapshots or [] %}
+{% if snapshots %}
+<details open>
+  <summary><strong>業績スナップショット時系列</strong> ({{ snapshots|length }}件)</summary>
+  <form id="ir-comment-form" action="/stock/{{ record.code_s }}/ir_comment" method="post">
+  <div style="overflow-x:auto;">
+    <table class="snapshot-table">
+      <thead>
+        <tr>
+          <th>日付</th>
+          <th>ソース</th>
+          <th>IR分析定量</th>
+          <th style="min-width:220px;">IR分析コメント</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for snap in snapshots %}
+        <tr>
+          <td><strong>{{ snap.date_yy_m }}</strong></td>
+          <td>
+            {% if snap.data_source == 'auto' %}
+            <span class="source-auto">auto</span>
+            {% elif snap.data_source == 'manual' %}
+            <span class="source-manual">manual</span>
+            {% elif snap.data_source == 'migration' %}
+            <span class="source-migration">migration</span>
+            {% else %}
+            <span>{{ snap.data_source or '' }}</span>
+            {% endif %}
+          </td>
+          <td style="white-space:pre-wrap;">{{ snap.ir_quant or '' }}</td>
+          <td><textarea class="editable-field" name="ir_comment_{{ snap.date_yy_m }}" rows="2" data-form="ir">{{ snap.ir_comment or '' }}</textarea></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  </form>
+  <div class="save-bar" id="save-bar-ir">
+    <span>未保存の変更があります</span>
+    <div class="btn-group">
+      <button class="outline secondary" style="padding:0.3em 0.8em;margin:0;" onclick="revertForm('ir')">元に戻す</button>
+      <button style="padding:0.3em 1em;margin:0;" onclick="document.getElementById('ir-comment-form').submit()">保存</button>
+    </div>
+  </div>
+</details>
+{% endif %}
+
+{# ===== 3. 指標スナップショット時系列 ===== #}
+{% set has_quality = snapshots|selectattr('quality_indicators')|list %}
+{% if has_quality %}
+<details open>
+  <summary><strong>指標スナップショット時系列</strong></summary>
+  <div style="overflow-x:auto;">
+    <table class="snapshot-table">
+      <thead>
+        <tr>
+          <th>日付</th>
+          <th>クォリティ指標</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for snap in snapshots %}
+        {% if snap.quality_indicators %}
+        <tr>
+          <td>{{ snap.date_yy_m }}</td>
+          <td style="white-space:pre-wrap;">{{ snap.quality_indicators }}</td>
+        </tr>
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</details>
+{% endif %}
+
+{# ===== 4. 理論株価乖離率時系列 ===== #}
+{% set has_kairi = snapshots|selectattr('rironkabuka_kairi')|list %}
+{% if has_kairi %}
+<details open>
+  <summary><strong>理論株価乖離率時系列</strong></summary>
+  <div style="overflow-x:auto;">
+    <table class="snapshot-table">
+      <thead>
+        <tr>
+          <th>日付</th>
+          <th>理論株価乖離</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for snap in snapshots %}
+        {% if snap.rironkabuka_kairi %}
+        <tr>
+          <td>{{ snap.date_yy_m }}</td>
+          <td>{{ snap.rironkabuka_kairi }}</td>
+        </tr>
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</details>
+{% endif %}
+
+{# ===== 5. 手動メモ（click-to-edit） ===== #}
+<div class="memo-section" id="memo-section">
+  <h3>手動メモ</h3>
+  <form id="memo-form" action="/stock/{{ record.code_s }}/memo" method="post">
+
+    <div class="memo-field">
+      <label>総合評価</label>
+      <select class="editable-select" name="overall_rating" data-form="memo">
+        <option value="">未評価</option>
+        {% for r in valid_ratings %}
+        <option value="{{ r }}" {{ 'selected' if record.overall_rating == r }}>{{ r }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div class="memo-field">
+      <label>機関投資家コメント</label>
+      <textarea class="editable-field" name="institutional_comment" rows="3" data-form="memo">{{ record.institutional_comment or '' }}</textarea>
+    </div>
+
+    <div class="memo-field">
+      <label>メモ・総括</label>
+      <textarea class="editable-field" name="memo" rows="6" data-form="memo">{{ record.memo or '' }}</textarea>
+    </div>
+
+    <div class="memo-field">
+      <label>OpenWork</label>
+      <input class="editable-field" type="text" name="openwork" value="{{ record.openwork or '' }}" data-form="memo" style="max-width:8em;">
+    </div>
+
+    <div class="memo-field">
+      <label>ジムクレイマー</label>
+      <textarea class="editable-field" name="cramer" rows="2" data-form="memo">{{ record.cramer or '' }}</textarea>
+    </div>
+
+  </form>
+  <div class="save-bar" id="save-bar-memo">
+    <span>未保存の変更があります</span>
+    <div class="btn-group">
+      <button class="outline secondary" style="padding:0.3em 0.8em;margin:0;" onclick="revertForm('memo')">元に戻す</button>
+      <button style="padding:0.3em 1em;margin:0;" onclick="document.getElementById('memo-form').submit()">保存</button>
+    </div>
+  </div>
+</div>
+
+{# ===== 6. 四季報（click-to-edit） ===== #}
+<div class="memo-section" id="shikiho-section">
+  <h3>四季報</h3>
+  <form id="shikiho-form" action="/stock/{{ record.code_s }}/shikiho" method="post">
+
+    <div class="memo-field">
+      <label>企業概要</label>
+      <textarea class="editable-field" name="overview" rows="3" data-form="shikiho">{{ record.overview or '' }}</textarea>
+    </div>
+
+    <div class="memo-field">
+      {% set shikiho = record.shikiho_comments or [] %}
+      <label>四季報コメント (<span id="shikiho-count">{{ shikiho|length }}</span>/5件)</label>
+      <div id="shikiho-edit-area">
+        {% for comment in shikiho %}
+        <div class="shikiho-entry" style="display:flex;align-items:start;gap:0.3em;margin-bottom:0.3em;">
+          <span style="font-size:0.8em;color:#888;width:1.5em;padding-top:0.6em;">{{ loop.index }}.</span>
+          <textarea class="editable-field" name="shikiho_comments_{{ loop.index0 }}" rows="2" style="flex:1;" data-form="shikiho">{{ comment }}</textarea>
+          <button type="button" class="outline secondary" style="padding:0.2em 0.5em;font-size:0.8em;margin:0;margin-top:0.4em;" onclick="removeShikiho(this)" title="削除">&times;</button>
+        </div>
+        {% endfor %}
+        <button type="button" id="btn-add-shikiho" class="outline" style="margin-top:0.3em;padding:0.2em 0.8em;font-size:0.85em;" onclick="addShikiho()"
+          {% if shikiho|length >= 5 %}style="display:none;"{% endif %}>+ 追加 (残り{{ 5 - shikiho|length }}件)</button>
+      </div>
+    </div>
+
+  </form>
+  <div class="save-bar" id="save-bar-shikiho">
+    <span>未保存の変更があります</span>
+    <div class="btn-group">
+      <button class="outline secondary" style="padding:0.3em 0.8em;margin:0;" onclick="revertForm('shikiho')">元に戻す</button>
+      <button style="padding:0.3em 1em;margin:0;" onclick="document.getElementById('shikiho-form').submit()">保存</button>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/scripts/webapp/templates/search.html
+++ b/scripts/webapp/templates/search.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+{% block title %}検索 | Shintakane Research{% endblock %}
+
+{% block content %}
+<h2>銘柄調査DB検索</h2>
+
+<form method="get" action="/" style="margin-bottom:1.5em;">
+  <div style="display:flex;gap:0.8em;flex-wrap:wrap;align-items:end;">
+    <div>
+      <label for="filter-code" style="font-size:0.85em;">銘柄コード</label>
+      <input id="filter-code" type="text" name="code_s" value="{{ filter_code_s }}"
+             placeholder="例: 3496" style="width:8em;padding:0.4em;margin:0;">
+    </div>
+    <div>
+      <label for="filter-rating" style="font-size:0.85em;">評価</label>
+      <select id="filter-rating" name="rating" style="padding:0.4em;margin:0;">
+        <option value="">全て</option>
+        {% for r in ["S","A","B","C","D","E"] %}
+        <option value="{{ r }}" {{ 'selected' if filter_rating == r }}>{{ r }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="filter-keyword" style="font-size:0.85em;">キーワード</label>
+      <input id="filter-keyword" type="text" name="keyword" value="{{ filter_keyword }}"
+             placeholder="銘柄名・メモ等" style="width:14em;padding:0.4em;margin:0;">
+    </div>
+    <div>
+      <button type="submit" style="padding:0.4em 1em;margin:0;">検索</button>
+    </div>
+  </div>
+</form>
+
+<p style="font-size:0.85em;color:#666;">{{ records|length }} 件</p>
+
+{% if records %}
+<div style="overflow-x:auto;">
+<table style="font-size:0.85em;">
+  <thead>
+    <tr>
+      <th>コード</th>
+      <th>評価</th>
+      <th>銘柄名</th>
+      <th>スナップ数</th>
+      <th>概要</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for rec in records %}
+    <tr>
+      <td><a href="/stock/{{ rec.code_s }}">{{ rec.code_s }}</a></td>
+      <td>
+        {% if rec.overall_rating %}
+        <span class="rating-badge rating-{{ rec.overall_rating }}">{{ rec.overall_rating }}</span>
+        {% else %}-{% endif %}
+      </td>
+      <td><a href="/stock/{{ rec.code_s }}">{{ rec.stock_name or '-' }}</a></td>
+      <td>{{ (rec.snapshots or [])|length }}</td>
+      <td>{{ (rec.overview or '')[:40] }}{% if (rec.overview or '')|length > 40 %}...{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</div>
+{% else %}
+<p>該当する銘柄がありません。</p>
+{% endif %}
+{% endblock %}

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1,0 +1,176 @@
+"""webapp/helpers.py のテスト (tmp_path で一時DBを作成)"""
+
+import os
+
+import pytest
+
+import research_shelve as rs
+from webapp import helpers
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """テスト用一時DBパスを返す"""
+    return str(tmp_path / "test_research_shelve")
+
+
+@pytest.fixture
+def populated_db(db_path, monkeypatch):
+    """テストデータ入りDBを準備し、helpers のDB参照先を差し替える"""
+    # research_shelve の RESEARCH_SHELVE を差し替え
+    monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+    monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+    monkeypatch.setattr("webapp.helpers.RESEARCH_SHELVE", db_path)
+    monkeypatch.setattr("webapp.helpers._LOCK_PATH", db_path + ".lock")
+
+    # テストデータ投入
+    rec = rs.create_research_record(
+        "3496", "アズーム",
+        overall_rating="A",
+        memo="テストメモ",
+        overview="駐車場サブリース",
+        institutional_comment="成長性高い",
+        openwork="3.72",
+        cramer="Buy推奨",
+        shikiho_comments=["最高益", "新規事業"],
+        analysis_date_raw="11/13",
+        kessan_date_raw="01/30",
+    )
+    rs.upsert_research_record(rec, db_path=db_path)
+
+    snap1 = rs.create_snapshot("26.4", ir_quant="[A]28%", ir_comment="好調", data_source="auto")
+    snap2 = rs.create_snapshot("26.1", ir_quant="[A]26%", ir_comment="順調", data_source="auto")
+    rs.upsert_snapshot("3496", snap1, db_path=db_path)
+    rs.upsert_snapshot("3496", snap2, db_path=db_path)
+
+    return db_path
+
+
+class TestGetResearchDetail:
+    """get_research_detail のテスト"""
+
+    def test_existing_record(self, populated_db):
+        rec = helpers.get_research_detail("3496")
+        assert rec is not None
+        assert rec["code_s"] == "3496"
+        assert rec["stock_name"] == "アズーム"
+
+    def test_nonexistent_record(self, populated_db):
+        rec = helpers.get_research_detail("9999")
+        assert rec is None
+
+
+class TestSearchRecords:
+    """search_records のテスト"""
+
+    def test_no_filter(self, populated_db):
+        results = helpers.search_records()
+        assert len(results) == 1
+        assert results[0]["code_s"] == "3496"
+
+    def test_rating_filter(self, populated_db):
+        results = helpers.search_records(rating="A")
+        assert len(results) == 1
+
+        results = helpers.search_records(rating="S")
+        assert len(results) == 0
+
+    def test_keyword_filter(self, populated_db):
+        results = helpers.search_records(keyword="駐車場")
+        assert len(results) == 1
+
+        results = helpers.search_records(keyword="存在しない")
+        assert len(results) == 0
+
+
+class TestSaveMemo:
+    """save_memo のテスト"""
+
+    def test_save_memo_updates_fields(self, populated_db):
+        form = {
+            "overall_rating": "S",
+            "institutional_comment": "更新コメント",
+            "memo": "更新メモ",
+            "openwork": "4.0",
+            "cramer": "Strong Buy",
+        }
+        helpers.save_memo("3496", form)
+
+        rec = helpers.get_research_detail("3496")
+        assert rec["overall_rating"] == "S"
+        assert rec["memo"] == "更新メモ"
+        assert rec["openwork"] == "4.0"
+        assert rec["cramer"] == "Strong Buy"
+        assert rec["institutional_comment"] == "更新コメント"
+
+    def test_save_memo_preserves_other_fields(self, populated_db):
+        form = {
+            "overall_rating": "B",
+            "institutional_comment": "",
+            "memo": "",
+            "openwork": "",
+            "cramer": "",
+        }
+        helpers.save_memo("3496", form)
+
+        rec = helpers.get_research_detail("3496")
+        # memo以外のフィールドが保持されている
+        assert rec["stock_name"] == "アズーム"
+        assert rec["overview"] == "駐車場サブリース"
+        assert len(rec["snapshots"]) == 2
+
+
+class TestSaveShikiho:
+    """save_shikiho のテスト"""
+
+    def test_save_shikiho_updates_fields(self, populated_db):
+        form = {
+            "overview": "更新概要",
+            "shikiho_comments_0": "コメント1",
+            "shikiho_comments_1": "コメント2",
+            "shikiho_comments_2": "コメント3",
+        }
+        helpers.save_shikiho("3496", form)
+
+        rec = helpers.get_research_detail("3496")
+        assert rec["overview"] == "更新概要"
+        assert rec["shikiho_comments"] == ["コメント1", "コメント2", "コメント3"]
+
+    def test_save_shikiho_empty_comments_skipped(self, populated_db):
+        form = {
+            "overview": "概要",
+            "shikiho_comments_0": "有効",
+            "shikiho_comments_1": "  ",  # 空白のみ → スキップ
+            "shikiho_comments_2": "有効2",
+        }
+        helpers.save_shikiho("3496", form)
+
+        rec = helpers.get_research_detail("3496")
+        assert rec["shikiho_comments"] == ["有効", "有効2"]
+
+
+class TestSaveIrComments:
+    """save_ir_comments のテスト"""
+
+    def test_save_ir_comments_updates(self, populated_db):
+        form = {
+            "ir_comment_26.4": "更新コメント26.4",
+            "ir_comment_26.1": "更新コメント26.1",
+        }
+        helpers.save_ir_comments("3496", form)
+
+        rec = helpers.get_research_detail("3496")
+        snaps = rec["snapshots"]
+        # 降順ソートなので 26.4 が先頭
+        assert snaps[0]["ir_comment"] == "更新コメント26.4"
+        assert snaps[1]["ir_comment"] == "更新コメント26.1"
+
+    def test_save_ir_comments_partial(self, populated_db):
+        """一部のスナップショットのみ更新"""
+        form = {"ir_comment_26.4": "26.4のみ更新"}
+        helpers.save_ir_comments("3496", form)
+
+        rec = helpers.get_research_detail("3496")
+        snaps = rec["snapshots"]
+        assert snaps[0]["ir_comment"] == "26.4のみ更新"
+        assert snaps[1]["ir_comment"] == "順調"  # 未変更

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -17,11 +17,8 @@ def db_path(tmp_path):
 @pytest.fixture
 def populated_db(db_path, monkeypatch):
     """テストデータ入りDBを準備し、helpers のDB参照先を差し替える"""
-    # research_shelve の RESEARCH_SHELVE を差し替え
     monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
     monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
-    monkeypatch.setattr("webapp.helpers.RESEARCH_SHELVE", db_path)
-    monkeypatch.setattr("webapp.helpers._LOCK_PATH", db_path + ".lock")
 
     # テストデータ投入
     rec = rs.create_research_record(

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1,0 +1,157 @@
+"""webapp ルートの統合テスト (Flaskテストクライアント使用)"""
+
+import os
+
+import pytest
+
+import research_shelve as rs
+from webapp import create_app
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_research_shelve")
+
+
+@pytest.fixture
+def app(db_path, monkeypatch):
+    """テスト用Flaskアプリ (DBパス差し替え済み)"""
+    monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+    monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+    monkeypatch.setattr("webapp.helpers.RESEARCH_SHELVE", db_path)
+    monkeypatch.setattr("webapp.helpers._LOCK_PATH", db_path + ".lock")
+
+    # テストデータ投入
+    rec = rs.create_research_record(
+        "3496", "アズーム",
+        overall_rating="A",
+        memo="テストメモ",
+        overview="駐車場サブリース",
+        shikiho_comments=["最高益"],
+    )
+    rs.upsert_research_record(rec, db_path=db_path)
+    snap = rs.create_snapshot("26.4", ir_quant="[A]28%", ir_comment="好調", data_source="auto")
+    rs.upsert_snapshot("3496", snap, db_path=db_path)
+
+    app = create_app()
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestSearchRoute:
+    """GET / のテスト"""
+
+    def test_index_returns_200(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+    def test_index_shows_records(self, client):
+        resp = client.get("/")
+        assert "3496" in resp.data.decode()
+        assert "アズーム" in resp.data.decode()
+
+    def test_index_filter_by_rating(self, client):
+        resp = client.get("/?rating=A")
+        html = resp.data.decode()
+        assert "アズーム" in html
+
+        resp = client.get("/?rating=S")
+        html = resp.data.decode()
+        assert "アズーム" not in html
+        assert "0 件" in html
+
+    def test_index_filter_by_code(self, client):
+        resp = client.get("/?code_s=3496")
+        assert "アズーム" in resp.data.decode()
+
+        resp = client.get("/?code_s=9999")
+        assert "アズーム" not in resp.data.decode()
+
+
+class TestDetailRoute:
+    """GET /stock/<code_s> のテスト"""
+
+    def test_detail_returns_200(self, client):
+        resp = client.get("/stock/3496")
+        assert resp.status_code == 200
+
+    def test_detail_shows_record_info(self, client):
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "アズーム" in html
+        assert "3496" in html
+        assert "テストメモ" in html
+
+    def test_detail_404_for_unknown(self, client):
+        resp = client.get("/stock/9999")
+        assert resp.status_code == 404
+
+
+class TestMemoPostRoutes:
+    """POST /stock/<code_s>/memo のテスト"""
+
+    def test_memo_post_redirects(self, client):
+        resp = client.post("/stock/3496/memo", data={
+            "overall_rating": "S",
+            "institutional_comment": "",
+            "memo": "新メモ",
+            "openwork": "",
+            "cramer": "",
+        })
+        assert resp.status_code == 302
+        assert "/stock/3496" in resp.headers["Location"]
+
+    def test_memo_post_persists(self, client):
+        client.post("/stock/3496/memo", data={
+            "overall_rating": "B",
+            "institutional_comment": "更新",
+            "memo": "更新メモ",
+            "openwork": "4.0",
+            "cramer": "Sell",
+        })
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "更新メモ" in html
+
+
+class TestShikihoPostRoutes:
+    """POST /stock/<code_s>/shikiho のテスト"""
+
+    def test_shikiho_post_redirects(self, client):
+        resp = client.post("/stock/3496/shikiho", data={
+            "overview": "新概要",
+            "shikiho_comments_0": "コメント1",
+        })
+        assert resp.status_code == 302
+
+    def test_shikiho_post_persists(self, client):
+        client.post("/stock/3496/shikiho", data={
+            "overview": "更新概要",
+            "shikiho_comments_0": "更新コメント",
+        })
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "更新概要" in html
+
+
+class TestIrCommentPostRoutes:
+    """POST /stock/<code_s>/ir_comment のテスト"""
+
+    def test_ir_comment_post_redirects(self, client):
+        resp = client.post("/stock/3496/ir_comment", data={
+            "ir_comment_26.4": "更新IR",
+        })
+        assert resp.status_code == 302
+
+    def test_ir_comment_post_persists(self, client):
+        client.post("/stock/3496/ir_comment", data={
+            "ir_comment_26.4": "IR更新済み",
+        })
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "IR更新済み" in html

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -18,8 +18,6 @@ def app(db_path, monkeypatch):
     """テスト用Flaskアプリ (DBパス差し替え済み)"""
     monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
     monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
-    monkeypatch.setattr("webapp.helpers.RESEARCH_SHELVE", db_path)
-    monkeypatch.setattr("webapp.helpers._LOCK_PATH", db_path + ".lock")
 
     # テストデータ投入
     rec = rs.create_research_record(


### PR DESCRIPTION
## Summary
- research_shelveのデータをブラウザで閲覧・編集するFlask Webアプリを追加
- click-to-editによるメモ・四季報・IR分析コメントの編集UI（変更検知+保存バー付き）
- fcntl.flockによるプロセス間排他制御でバッチ処理との安全な共存を保証
- helpers単体テスト11件 + ルート統合テスト13件 = 計24テスト追加（既存452テスト全合格）

## 追加ファイル
- `scripts/webapp/` — Flask app factory, ルート3つ (search, detail, memo), テンプレート3つ, CSS/JS
- `tests/test_webapp_helpers.py`, `tests/test_webapp_routes.py`
- `requirements.txt` に `flask>=3.0` 追加

## 起動方法
```bash
source ../../.venv/bin/activate && cd scripts && python -m webapp.app
# http://localhost:5001
```

## Test plan
- [x] `pytest tests/test_webapp_helpers.py tests/test_webapp_routes.py -v` — 24テスト全合格
- [x] 全テスト (`pytest tests/`) — 452テスト全合格、リグレッションなし
- [x] ブラウザで http://localhost:5001 → 検索 → 銘柄詳細 → メモ編集・保存を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)