### PR TITLE
銘柄詳細ページに適時開示セクションを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ cd scripts && python research_shelve.py show 3496
 cd scripts && python research_shelve.py list --rating S,A --keyword 駐車場
 cd scripts && python research_shelve.py backup
 
-# 銘柄調査Webアプリ（research_shelveのブラウザUI）
+# Shintakane Research（銘柄調査WebApp）
 cd scripts && python -m webapp.app    # http://localhost:5001 で起動
 
 # スプシCSV → research_shelve 移行(issue #92)

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -114,7 +114,7 @@ stocks_shelve（日次更新の揮発性キャッシュ）とは別に、銘柄�
 | ファイル | 役割 |
 |---------|------|
 | `scripts/research_shelve.py` | 基盤（スキーマ・CRUD・バリデーション・CLI） |
-| `scripts/webapp/` | ブラウザUI（Flask、閲覧・編集） |
+| `scripts/webapp/` | Shintakane Research（銘柄調査WebApp、Flask） |
 | `scripts/migrate_research_from_csv.py` | スプレッドシートCSVからの移行（実行済み） |
 
 ### CLI
@@ -125,9 +125,9 @@ python research_shelve.py list [--rating S,A] [--keyword ...]    # フィルタ�
 python research_shelve.py backup                                 # DBバックアップ
 ```
 
-### Webアプリ (`scripts/webapp/`)
+### Shintakane Research (`scripts/webapp/`)
 
-research_shelveの閲覧・編集用ブラウザUI。Flask製、`http://localhost:5001` で起動。
+銘柄調査WebApp。research_shelveの閲覧・編集用。Flask製、`http://localhost:5001` で起動。
 
 **主な機能:**
 - 銘柄検索・フィルタ（評価ランク、キーワード、銘柄コード）

--- a/scripts/disclosure.py
+++ b/scripts/disclosure.py
@@ -352,6 +352,9 @@ def load_disclosure_for_code(code_s, days=30):
     """
     import csv
 
+    # 英字部分を大文字化して正規化（"135a" → "135A"）
+    code_s = code_s.strip().upper()
+
     if not os.path.exists(DISCLOSURE_CSV):
         log_debug("disclosure_db.csvが見つかりません: %s" % DISCLOSURE_CSV)
         return []

--- a/scripts/disclosure.py
+++ b/scripts/disclosure.py
@@ -341,6 +341,64 @@ def load_todays_news():
     return news_by_code
 
 
+def load_disclosure_for_code(code_s, days=30):
+    """disclosure_db.csvから指定銘柄の直近N日以内の開示を返す
+
+    Args:
+        code_s: 銘柄コード（文字列）
+        days: 何日以内の開示を返すか（デフォルト30日）
+    Returns:
+        list[tuple]: [(date_expr, type_expr, heading, url), ...] 日付降順
+    """
+    import csv
+
+    if not os.path.exists(DISCLOSURE_CSV):
+        log_debug("disclosure_db.csvが見つかりません: %s" % DISCLOSURE_CSV)
+        return []
+
+    today_date = get_price_day(datetime.today())
+    cutoff = today_date - timedelta(days=days)
+    cutoff_str = cutoff.strftime("%Y%m%d")
+
+    results = []
+    with open(DISCLOSURE_CSV, "r", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 5:
+                continue
+            # ヘッダー行・空行をスキップ
+            if row[0] == "日付" or not row[0].strip():
+                continue
+            # 銘柄コード: HYPERLINK式からcode_sを抽出
+            m_code = re.search(r'"(\d[0-9a-zA-Z]\d[0-9A-Z])"', row[1])
+            if not m_code:
+                continue
+            if m_code.group(1) != code_s:
+                continue
+            # 日付フィルタ
+            raw_date = row[0].strip()
+            if raw_date < cutoff_str:
+                continue
+            # 種類（「材料」はノイズが多いため除外）
+            type_expr = row[3].strip()
+            if type_expr == "材料":
+                continue
+            # 日付: YYYYMMDD → MM/DD
+            if len(raw_date) == 8 and raw_date.isdigit():
+                date_expr = "%s/%s" % (raw_date[4:6], raw_date[6:8])
+            else:
+                date_expr = raw_date
+            # 本文: HYPERLINK式からURLと見出しを抽出
+            m_link = re.search(r'=HYPERLINK\("(.+?)","(.+?)"\)', row[4])
+            if not m_link:
+                continue
+            url = m_link.group(1)
+            heading = m_link.group(2)
+            results.append((date_expr, type_expr, heading, url))
+
+    return results
+
+
 def main():
     # ロガーの初期化
     logger = setup_logger('shintakane')

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -42,6 +42,15 @@ def get_stock_data(code_s: str) -> Dict[str, Any]:
         return db.get(normalized) or {}
 
 
+def get_disclosures(code_s: str) -> List[tuple]:
+    """銘柄の直近適時開示リストを返す。CSVがなければ空リスト。"""
+    try:
+        import disclosure
+        return disclosure.load_disclosure_for_code(code_s)
+    except Exception:
+        return []
+
+
 def search_records(
     *,
     rating: Optional[str] = None,

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -6,7 +6,7 @@ GET /stock/<code_s> : 銘柄の全セクション表示
 
 from flask import Blueprint, render_template, abort
 
-from webapp.helpers import get_research_detail, get_stock_data
+from webapp.helpers import get_research_detail, get_stock_data, get_disclosures
 from research_shelve import VALID_RATINGS
 
 detail_bp = Blueprint("detail", __name__)
@@ -20,10 +20,12 @@ def stock_detail(code_s: str):
         abort(404)
 
     stock = get_stock_data(code_s)
+    disclosures = get_disclosures(code_s)
 
     return render_template(
         "detail.html",
         record=record,
         stock=stock,
+        disclosures=disclosures,
         valid_ratings=sorted(VALID_RATINGS - {""}),
     )

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -109,7 +109,7 @@
         {% if snap.quality_indicators %}
         <tr>
           <td>{{ snap.date_yy_m }}</td>
-          <td style="white-space:pre-wrap;">{{ snap.quality_indicators }}</td>
+          <td>{{ snap.quality_indicators|replace('\n', ' ') }}</td>
         </tr>
         {% endif %}
         {% endfor %}

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -19,6 +19,33 @@
   </div>
 </div>
 
+{# ===== 適時開示 ===== #}
+{% if disclosures %}
+<details>
+  <summary><strong>適時開示</strong> ({{ disclosures|length }}件)</summary>
+  <div style="overflow-x:auto;">
+    <table class="snapshot-table">
+      <thead>
+        <tr>
+          <th>日付</th>
+          <th>種類</th>
+          <th>内容</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for date, type, heading, url in disclosures %}
+        <tr>
+          <td>{{ date }}</td>
+          <td>{{ type }}</td>
+          <td><a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ heading }}</a></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</details>
+{% endif %}
+
 {# ===== 2. 業績スナップショット時系列 ===== #}
 {% set snapshots = record.snapshots or [] %}
 {% if snapshots %}


### PR DESCRIPTION
## Summary
- 銘柄詳細ページに直近30日の適時開示・決算関連リンクを折りたたみ表示するセクションを追加
- `disclosure_db.csv` から銘柄コードでフィルタし、「材料」種類は除外
- CSVが未生成/該当データなしの場合はセクション非表示

## Test plan
- [x] `pytest tests/test_disclosure.py tests/test_webapp_helpers.py tests/test_webapp_routes.py` 全42テスト通過
- [x] WebApp起動し銘柄詳細ページで適時開示の表示・リンク遷移を確認済み
- [ ] CI通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)