### PR TITLE
四季報コメントに時期情報追加 + 8件対応

### DIFF
--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -352,6 +352,47 @@ def _validate_record_for_upsert(record: Dict[str, Any]) -> None:
         )
 
 
+def _normalize_shikiho_comments(comments):
+    """四季報コメントを List[dict] に正規化する（後方互換）。
+
+    各要素を個別に判定し、str なら {"period": "", "comment": str} に変換。
+    dict はそのまま保持。混在データにも対応。
+    """
+    if not comments:
+        return []
+    result = []
+    for item in comments:
+        if isinstance(item, str):
+            result.append({"period": "", "comment": item})
+        elif isinstance(item, dict):
+            result.append(item)
+    return result
+
+
+def current_shikiho_period() -> str:
+    """現在月から四季報の発行時期を返す。
+
+    発売月の翌月までがその号:
+    12月・1月・2月 → X.12（新春号）
+     3月・4月・5月 → X.3 （春号）
+     6月・7月・8月 → X.6 （夏号）
+     9月・10月・11月 → X.9 （秋号）
+    """
+    from datetime import date as _date
+    today = _date.today()
+    yy = today.year % 100
+    m = today.month
+    if m <= 2:
+        return f"{yy - 1}.12"
+    if m <= 5:
+        return f"{yy}.3"
+    if m <= 8:
+        return f"{yy}.6"
+    if m <= 11:
+        return f"{yy}.9"
+    return f"{yy}.12"
+
+
 def get_research_record(
     code_s: str,
     *,
@@ -360,12 +401,18 @@ def get_research_record(
     """1銘柄の調査レコードを取得する。
 
     存在しなければ None。code_s は内部で正規化される。
+    shikiho_comments は List[dict] に自動正規化される（後方互換）。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
     path = _resolve_db_path(db_path)
     with ShelveDB(path) as db:
-        return db.get(normalized)
+        record = db.get(normalized)
+    if record is not None:
+        record["shikiho_comments"] = _normalize_shikiho_comments(
+            record.get("shikiho_comments", [])
+        )
+    return record
 
 
 def upsert_research_record(
@@ -681,10 +728,14 @@ def format_record_full(record: Dict[str, Any]) -> str:
     lines.append(f"ジムクレイマー : {_indent_multiline(cramer, ' ' * 17)}")
     if shikiho:
         lines.append(f"四季報コメント ({len(shikiho)}件):")
-        for i, comment in enumerate(shikiho, start=1):
-            # 1 セル内に 【タイトル】... が複数ブロック連結されている場合があるので、
-            # 全文を改行インデント付きで表示する
-            lines.append(f"  [{i}] {_indent_multiline(comment, ' ' * 6)}")
+        for item in shikiho:
+            if isinstance(item, dict):
+                period = item.get("period", "") or "-"
+                comment = item.get("comment", "")
+            else:
+                period = "-"
+                comment = str(item)
+            lines.append(f"  [{period}] {_indent_multiline(comment, ' ' * 8)}")
     else:
         lines.append(f"四季報コメント : {_EMPTY_MARK}")
     lines.append("")

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -61,11 +61,7 @@ def add_stock(code_s: str) -> str:
     code_s = normalize_code_s(code_s)
     validate_code_s(code_s)
 
-    # 既存チェック
-    if get_research_record(code_s) is not None:
-        raise ValueError(f"{code_s} は既に登録されています")
-
-    # stocks_shelve から取得
+    # stocks_shelve から取得（ロック外で読み取り専用）
     stock = get_stock_data(code_s)
     if not stock:
         raise ValueError(f"{code_s} は株式DBに未登録です（先に make_stock_db.py で登録してください）")
@@ -96,8 +92,12 @@ def add_stock(code_s: str) -> str:
     except Exception as e:
         log_warning(f"[research] 銘柄追加時スナップショット生成失敗: {code_s} {e}")
 
-    record = create_research_record(code_s, stock_name, snapshots=snapshots)
-    upsert_research_record(record)
+    # 既存チェック + 書き込みをアトミックに実行
+    with _flock():
+        if get_research_record(code_s) is not None:
+            raise ValueError(f"{code_s} は既に登録されています")
+        record = create_research_record(code_s, stock_name, snapshots=snapshots)
+        upsert_research_record(record)
     return code_s
 
 
@@ -203,7 +203,7 @@ def save_memo(code_s: str, form_data: dict) -> None:
 def save_shikiho(code_s: str, form_data: dict) -> None:
     """四季報フィールドを更新する。
 
-    対象: overview, shikiho_comments (最大5件)
+    対象: overview, shikiho_comments (最大8件、List[dict])
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
@@ -215,14 +215,12 @@ def save_shikiho(code_s: str, form_data: dict) -> None:
 
         record["overview"] = form_data.get("overview", "")
 
-        comments: List[str] = []
-        for i in range(5):
-            key = f"shikiho_comments_{i}"
-            val = form_data.get(key)
-            if val is not None:
-                stripped = val.strip()
-                if stripped:
-                    comments.append(stripped)
+        comments: List[Dict[str, str]] = []
+        for i in range(8):
+            comment = form_data.get(f"shikiho_comments_{i}", "").strip()
+            period = form_data.get(f"shikiho_periods_{i}", "").strip()
+            if comment:
+                comments.append({"period": period, "comment": comment})
         record["shikiho_comments"] = comments
 
         upsert_research_record(record)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -12,9 +12,12 @@ from typing import Any, Dict, List, Optional
 
 from db_shelve import STOCKS_SHELVE, ShelveDB
 from html_sanitizer import sanitize_html
+from ks_util import get_price_day, log_warning
 from research_shelve import (
     get_research_record,
     upsert_research_record,
+    create_research_record,
+    create_snapshot,
     list_research_records,
     validate_code_s,
     normalize_code_s,
@@ -40,6 +43,62 @@ def get_stock_data(code_s: str) -> Dict[str, Any]:
     normalized = normalize_code_s(code_s)
     with ShelveDB(STOCKS_SHELVE) as db:
         return db.get(normalized) or {}
+
+
+def add_stock(code_s: str) -> str:
+    """銘柄を research_shelve に追加する。
+
+    stocks_shelve からデータを取得し、スナップショット付きでレコードを作成する。
+
+    Args:
+        code_s: 銘柄コード
+    Returns:
+        正規化された code_s
+    Raises:
+        ValueError: 入力不正、stocks_shelve に未登録、既に登録済み
+    """
+    from datetime import datetime
+    code_s = normalize_code_s(code_s)
+    validate_code_s(code_s)
+
+    # 既存チェック
+    if get_research_record(code_s) is not None:
+        raise ValueError(f"{code_s} は既に登録されています")
+
+    # stocks_shelve から取得
+    stock = get_stock_data(code_s)
+    if not stock:
+        raise ValueError(f"{code_s} は株式DBに未登録です（先に make_stock_db.py で登録してください）")
+
+    stock_name = stock.get("stock_name", "")
+
+    # スナップショット生成（失敗してもレコード作成は続行）
+    snapshots = []
+    try:
+        import gyoseki
+        import shihyou
+        import rironkabuka
+
+        progress_expr, growth_expr = gyoseki.get_gyoseki_expr(stock)
+        ir_quant = growth_expr + progress_expr
+
+        today = get_price_day(datetime.today())
+        date_yy_m = f"{today.year % 100}.{today.month}.{today.day}"
+
+        snapshot = create_snapshot(
+            date_yy_m,
+            ir_quant=ir_quant,
+            quality_indicators=shihyou.get_shihyo_expr(stock),
+            rironkabuka_kairi=rironkabuka.get_rironkabuka_expr(stock),
+            data_source="auto",
+        )
+        snapshots = [snapshot]
+    except Exception as e:
+        log_warning(f"[research] 銘柄追加時スナップショット生成失敗: {code_s} {e}")
+
+    record = create_research_record(code_s, stock_name, snapshots=snapshots)
+    upsert_research_record(record)
+    return code_s
 
 
 def get_disclosures(code_s: str) -> List[tuple]:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -216,11 +216,14 @@ def save_shikiho(code_s: str, form_data: dict) -> None:
         record["overview"] = form_data.get("overview", "")
 
         comments: List[Dict[str, str]] = []
-        for i in range(8):
+        for i in range(10):
             comment = form_data.get(f"shikiho_comments_{i}", "").strip()
             period = form_data.get(f"shikiho_periods_{i}", "").strip()
             if comment:
                 comments.append({"period": period, "comment": comment})
+        # 8件超は古い順（先頭）を切り詰め、新しいもの（末尾）を残す
+        if len(comments) > 8:
+            comments = comments[-8:]
         record["shikiho_comments"] = comments
 
         upsert_research_record(record)

--- a/scripts/webapp/routes/search.py
+++ b/scripts/webapp/routes/search.py
@@ -4,9 +4,9 @@
 GET / : 銘柄コード/名前/評価でフィルタし一覧表示
 """
 
-from flask import Blueprint, render_template, request
+from flask import Blueprint, render_template, request, redirect, url_for, flash
 
-from webapp.helpers import search_records
+from webapp.helpers import search_records, add_stock
 
 search_bp = Blueprint("search", __name__)
 
@@ -33,3 +33,15 @@ def index():
         filter_keyword=keyword or "",
         filter_code_s=code_s,
     )
+
+
+@search_bp.route("/stock/add", methods=["POST"])
+def add_stock_route():
+    """銘柄追加。"""
+    code_s = request.form.get("add_code_s", "").strip()
+    try:
+        code_s = add_stock(code_s)
+        return redirect(url_for("detail.stock_detail", code_s=code_s))
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return redirect(url_for("search.index"))

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -92,7 +92,8 @@ function revertShikiho() {
 /* --- 非同期フォーム送信（ページリロードなし） --- */
 function submitFormAsync(form) {
   var formData = new FormData(form);
-  fetch(form.action, { method: 'POST', body: formData }).then(function() {
+  fetch(form.action, { method: 'POST', body: formData }).then(function(response) {
+    if (!response.ok) return;
     /* 保存完了: dirty フラグをリセットして初期値を更新 */
     form.querySelectorAll('.editable-field, .editable-select').forEach(function(el) {
       initialValues[el.name] = el.value;
@@ -176,11 +177,6 @@ function addShikiho() {
   var area = document.getElementById('shikiho-edit-area');
   if (!area) return;
   var entries = area.querySelectorAll('.shikiho-entry');
-  /* 8件を超える場合は古い順（末尾）を削除 */
-  while (entries.length >= MAX_SHIKIHO) {
-    entries[entries.length - 1].remove();
-    entries = area.querySelectorAll('.shikiho-entry');
-  }
   var idx = entries.length;
   var period = currentShikihoPeriod();
   var div = document.createElement('div');

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -89,19 +89,22 @@ function revertShikiho() {
   updateSaveBar('shikiho');
 }
 
-/* --- 非同期フォーム送信（ページリロードなし） --- */
+/* --- 非同期フォーム送信（直列化でリクエスト順序を保証） --- */
+var _saveQueue = Promise.resolve();
 function submitFormAsync(form) {
   var formData = new FormData(form);
-  fetch(form.action, { method: 'POST', body: formData }).then(function(response) {
-    if (!response.ok) return;
-    /* 保存完了: dirty フラグをリセットして初期値を更新 */
-    form.querySelectorAll('.editable-field, .editable-select').forEach(function(el) {
-      initialValues[el.name] = el.value;
-      el.classList.remove('dirty');
+  _saveQueue = _saveQueue.then(function() {
+    return fetch(form.action, { method: 'POST', body: formData }).then(function(response) {
+      if (!response.ok) return;
+      /* 保存完了: dirty フラグをリセットして初期値を更新 */
+      form.querySelectorAll('.editable-field, .editable-select').forEach(function(el) {
+        initialValues[el.name] = el.value;
+        el.classList.remove('dirty');
+      });
+      var formName = (form.querySelector('[data-form]') || {}).dataset;
+      if (formName && formName.form) updateSaveBar(formName.form);
     });
-    var formName = (form.querySelector('[data-form]') || {}).dataset;
-    if (formName && formName.form) updateSaveBar(formName.form);
-  });
+  }).catch(function() { /* ネットワークエラー時もキューを継続 */ });
 }
 
 /* --- フォーカスアウト時の自動保存 --- */
@@ -148,7 +151,8 @@ function currentShikihoPeriod() {
 }
 
 /* --- 四季報コメント: 追加/削除 --- */
-function updateShikihoState() {
+function updateShikihoState(opts) {
+  var save = (opts && opts.save !== undefined) ? opts.save : true;
   var entries = document.querySelectorAll('#shikiho-edit-area .shikiho-entry');
   var count = entries.length;
   var countEl = document.getElementById('shikiho-count');
@@ -168,9 +172,11 @@ function updateShikihoState() {
     btn.style.display = '';
     btn.textContent = '+ 追加';
   }
-  /* 件数変更時は非同期で自動保存 */
-  var form = document.getElementById('shikiho-form');
-  if (form) submitFormAsync(form);
+  /* 件数変更時は非同期で自動保存（save=false で抑制可能） */
+  if (save) {
+    var form = document.getElementById('shikiho-form');
+    if (form) submitFormAsync(form);
+  }
 }
 
 function addShikiho() {
@@ -188,7 +194,8 @@ function addShikiho() {
     '<textarea class="editable-field" name="shikiho_comments_' + idx + '" rows="4" style="flex:1;" data-form="shikiho" placeholder="四季報コメントを入力..."></textarea>';
   area.insertBefore(div, document.getElementById('btn-add-shikiho'));
   var ta = div.querySelector('textarea');
-  updateShikihoState();
+  /* UI更新のみ、保存はしない（空のtextareaで保存するとデータロスになる） */
+  updateShikihoState({ save: false });
   ta.focus();
 }
 

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -89,6 +89,20 @@ function revertShikiho() {
   updateSaveBar('shikiho');
 }
 
+/* --- 非同期フォーム送信（ページリロードなし） --- */
+function submitFormAsync(form) {
+  var formData = new FormData(form);
+  fetch(form.action, { method: 'POST', body: formData }).then(function() {
+    /* 保存完了: dirty フラグをリセットして初期値を更新 */
+    form.querySelectorAll('.editable-field, .editable-select').forEach(function(el) {
+      initialValues[el.name] = el.value;
+      el.classList.remove('dirty');
+    });
+    var formName = (form.querySelector('[data-form]') || {}).dataset;
+    if (formName && formName.form) updateSaveBar(formName.form);
+  });
+}
+
 /* --- フォーカスアウト時の自動保存 --- */
 var _autoSaveFormIds = {
   'ir': 'ir-comment-form',
@@ -115,7 +129,7 @@ document.addEventListener('focusout', function(e) {
     var formId = _autoSaveFormIds[formName];
     if (!formId) return;
     var form = document.getElementById(formId);
-    if (form) form.submit();
+    if (form) submitFormAsync(form);
   }, 100);
 });
 
@@ -136,9 +150,9 @@ function updateShikihoState() {
     btn.style.display = remaining <= 0 ? 'none' : '';
     btn.textContent = '+ 追加 (残り' + remaining + '件)';
   }
-  /* 件数変更時は即座に自動保存 */
+  /* 件数変更時は非同期で自動保存 */
   var form = document.getElementById('shikiho-form');
-  if (form) form.submit();
+  if (form) submitFormAsync(form);
 }
 
 function addShikiho() {
@@ -155,8 +169,9 @@ function addShikiho() {
     '<textarea class="editable-field" name="shikiho_comments_' + idx + '" rows="2" style="flex:1;" data-form="shikiho" placeholder="四季報コメントを入力..."></textarea>' +
     '<button type="button" class="outline secondary" style="padding:0.2em 0.5em;font-size:0.8em;margin:0;margin-top:0.4em;" onclick="removeShikiho(this)" title="削除">&times;</button>';
   area.insertBefore(div, document.getElementById('btn-add-shikiho'));
+  var ta = div.querySelector('textarea');
   updateShikihoState();
-  div.querySelector('textarea').focus();
+  ta.focus();
 }
 
 function removeShikiho(btn) {

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -1,6 +1,6 @@
 /* 銘柄詳細ビュー: click-to-edit + 変更検知 + 四季報追加/削除 */
 
-var MAX_SHIKIHO = 5;
+var MAX_SHIKIHO = 8;
 
 /* --- リッチテキスト表示 → 編集モード切替 (issue #115) --- */
 function switchToEdit(displayEl) {
@@ -133,6 +133,19 @@ document.addEventListener('focusout', function(e) {
   }, 100);
 });
 
+/* --- 四季報: 時期自動判定 --- */
+function currentShikihoPeriod() {
+  var now = new Date();
+  var yy = now.getFullYear() % 100;
+  var m = now.getMonth() + 1;
+  /* 発売月の翌月まで: 12-2月→X.12, 3-5月→X.3, 6-8月→X.6, 9-11月→X.9 */
+  if (m <= 2) return (yy - 1) + '.12';
+  if (m <= 5) return yy + '.3';
+  if (m <= 8) return yy + '.6';
+  if (m <= 11) return yy + '.9';
+  return yy + '.12';
+}
+
 /* --- 四季報コメント: 追加/削除 --- */
 function updateShikihoState() {
   var entries = document.querySelectorAll('#shikiho-edit-area .shikiho-entry');
@@ -140,15 +153,19 @@ function updateShikihoState() {
   var countEl = document.getElementById('shikiho-count');
   if (countEl) countEl.textContent = count;
   entries.forEach(function(entry, i) {
-    entry.querySelector('span').textContent = (i + 1) + '.';
+    var hidden = entry.querySelector('input[type=hidden]');
+    var span = entry.querySelector('span');
+    if (hidden) {
+      span.textContent = hidden.value || '-';
+      hidden.name = 'shikiho_periods_' + i;
+    }
     var ta = entry.querySelector('textarea');
     ta.name = 'shikiho_comments_' + i;
   });
   var btn = document.getElementById('btn-add-shikiho');
   if (btn) {
-    var remaining = MAX_SHIKIHO - count;
-    btn.style.display = remaining <= 0 ? 'none' : '';
-    btn.textContent = '+ 追加 (残り' + remaining + '件)';
+    btn.style.display = '';
+    btn.textContent = '+ 追加';
   }
   /* 件数変更時は非同期で自動保存 */
   var form = document.getElementById('shikiho-form');
@@ -159,15 +176,20 @@ function addShikiho() {
   var area = document.getElementById('shikiho-edit-area');
   if (!area) return;
   var entries = area.querySelectorAll('.shikiho-entry');
-  if (entries.length >= MAX_SHIKIHO) return;
+  /* 8件を超える場合は古い順（末尾）を削除 */
+  while (entries.length >= MAX_SHIKIHO) {
+    entries[entries.length - 1].remove();
+    entries = area.querySelectorAll('.shikiho-entry');
+  }
   var idx = entries.length;
+  var period = currentShikihoPeriod();
   var div = document.createElement('div');
   div.className = 'shikiho-entry';
   div.style.cssText = 'display:flex;align-items:start;gap:0.3em;margin-bottom:0.3em;';
   div.innerHTML =
-    '<span style="font-size:0.8em;color:#888;width:1.5em;padding-top:0.6em;">' + (idx + 1) + '.</span>' +
-    '<textarea class="editable-field" name="shikiho_comments_' + idx + '" rows="2" style="flex:1;" data-form="shikiho" placeholder="四季報コメントを入力..."></textarea>' +
-    '<button type="button" class="outline secondary" style="padding:0.2em 0.5em;font-size:0.8em;margin:0;margin-top:0.4em;" onclick="removeShikiho(this)" title="削除">&times;</button>';
+    '<span style="font-size:0.8em;color:#888;min-width:3em;padding-top:0.6em;">' + period + '</span>' +
+    '<input type="hidden" name="shikiho_periods_' + idx + '" value="' + period + '">' +
+    '<textarea class="editable-field" name="shikiho_comments_' + idx + '" rows="4" style="flex:1;" data-form="shikiho" placeholder="四季報コメントを入力..."></textarea>';
   area.insertBefore(div, document.getElementById('btn-add-shikiho'));
   var ta = div.querySelector('textarea');
   updateShikihoState();

--- a/scripts/webapp/templates/base.html
+++ b/scripts/webapp/templates/base.html
@@ -16,10 +16,22 @@
   <ul>
     <li class="quick-search">
       <form action="/" method="get" style="display:flex;align-items:center;gap:0.4em;margin:0;">
-        <input type="text" name="code_s" placeholder="銘柄コード" aria-label="銘柄コード検索"
+        <input id="nav-code" type="text" name="code_s" placeholder="銘柄コード" aria-label="銘柄コード検索"
                style="width:8em;padding:0.3em 0.5em;margin:0;font-size:0.9em;height:auto;">
         <button type="submit" class="outline" style="padding:0.3em 0.7em;margin:0;font-size:0.9em;">Go</button>
+        <button type="button" class="outline" style="padding:0.3em 0.7em;margin:0;font-size:0.9em;white-space:nowrap;" onclick="navAddStock()">+ 追加</button>
       </form>
+      <form id="nav-add-form" method="post" action="/stock/add" style="display:none;">
+        <input type="hidden" name="add_code_s" id="nav-add-code">
+      </form>
+      <script>
+      function navAddStock() {
+        var code = document.getElementById('nav-code').value.trim();
+        if (!code) { alert('銘柄コードを入力してください'); return; }
+        document.getElementById('nav-add-code').value = code;
+        document.getElementById('nav-add-form').submit();
+      }
+      </script>
     </li>
   </ul>
 </nav>

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -12,10 +12,11 @@
       <small style="color:#888;font-size:0.5em;">{{ record.code_s }}</small>
       {{ record.stock_name or '' }}
     </h1>
+    {% if stock.overview %}<div style="color:#555;font-size:0.85em;margin-bottom:0.2em;">{{ stock.overview }}</div>{% endif %}
     <div class="meta">
       分析日: <input class="editable-field inline-date" type="text" name="analysis_date_raw" value="{{ record.analysis_date_raw or '' }}" data-form="memo" form="memo-form" placeholder="MM/DD" style="width:5em;display:inline;padding:0.1em 0.3em;font-size:0.9em;">
       {% if stock.kessanbi %} | 決算日: {{ stock.kessanbi[2:] }}{% endif %}
-      <div style="margin-top:0.2em;">
+      <div>
         <a href="https://kabutan.jp/stock/chart?code={{ record.code_s }}&time=w" target="_blank" rel="noopener noreferrer">チャート</a>
         | <a href="https://kabutan.jp/stock/finance?code={{ record.code_s }}" target="_blank" rel="noopener noreferrer">業績</a>
         | <a href="https://finance.yahoo.co.jp/quote/{{ record.code_s }}.T/forum" target="_blank" rel="noopener noreferrer">掲示板</a>
@@ -167,17 +168,17 @@
 
     <div class="memo-field">
       {% set shikiho = record.shikiho_comments or [] %}
-      <label>四季報コメント (<span id="shikiho-count">{{ shikiho|length }}</span>/5件)</label>
+      <label>四季報コメント (<span id="shikiho-count">{{ shikiho|length }}</span>/8件)</label>
       <div id="shikiho-edit-area">
-        {% for comment in shikiho %}
+        {% for item in shikiho %}
         <div class="shikiho-entry" style="display:flex;align-items:start;gap:0.3em;margin-bottom:0.3em;">
-          <span style="font-size:0.8em;color:#888;width:1.5em;padding-top:0.6em;">{{ loop.index }}.</span>
-          <textarea class="editable-field" name="shikiho_comments_{{ loop.index0 }}" rows="2" style="flex:1;" data-form="shikiho">{{ comment }}</textarea>
-          <button type="button" class="outline secondary" style="padding:0.2em 0.5em;font-size:0.8em;margin:0;margin-top:0.4em;" onclick="removeShikiho(this)" title="削除">&times;</button>
+          <span style="font-size:0.8em;color:#888;min-width:3em;padding-top:0.6em;">{{ item.period or '-' }}</span>
+          <input type="hidden" name="shikiho_periods_{{ loop.index0 }}" value="{{ item.period or '' }}">
+          <textarea class="editable-field" name="shikiho_comments_{{ loop.index0 }}" rows="4" style="flex:1;" data-form="shikiho">{{ item.comment }}</textarea>
+          {# 削除ボタンは非表示（基本的に消さないため） #}
         </div>
         {% endfor %}
-        <button type="button" id="btn-add-shikiho" class="outline" style="margin-top:0.3em;padding:0.2em 0.8em;font-size:0.85em;" onclick="addShikiho()"
-          {% if shikiho|length >= 5 %}style="display:none;"{% endif %}>+ 追加 (残り{{ 5 - shikiho|length }}件)</button>
+        <button type="button" id="btn-add-shikiho" class="outline" style="margin-top:0.3em;padding:0.2em 0.8em;font-size:0.85em;" onclick="addShikiho()">+ 追加</button>
       </div>
     </div>
 

--- a/scripts/webapp/templates/search.html
+++ b/scripts/webapp/templates/search.html
@@ -31,6 +31,14 @@
   </div>
 </form>
 
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+  {% for category, message in messages %}
+  <div style="padding:0.5em 1em;margin-bottom:1em;border-radius:4px;font-size:0.9em;{% if category == 'error' %}background:#ffeaea;color:#c00;border:1px solid #fcc;{% else %}background:#eaffea;color:#060;border:1px solid #cfc;{% endif %}">{{ message }}</div>
+  {% endfor %}
+{% endif %}
+{% endwith %}
+
 <p style="font-size:0.85em;color:#666;">{{ records|length }} 件</p>
 
 {% if records %}

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -455,8 +455,8 @@ class TestFormat:
             openwork="3.72",
             cramer="独自ビジネス",
             shikiho_comments=[
-                "【最高益】駐車場借り上げが順調",
-                "【連続最高益】主力事業続伸",
+                {"period": "26.3", "comment": "【最高益】駐車場借り上げが順調"},
+                {"period": "25.12", "comment": "【連続最高益】主力事業続伸"},
             ],
             snapshots=[
                 rs.create_snapshot(

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -124,26 +124,39 @@ class TestSaveShikiho:
         form = {
             "overview": "更新概要",
             "shikiho_comments_0": "コメント1",
+            "shikiho_periods_0": "26.3",
             "shikiho_comments_1": "コメント2",
+            "shikiho_periods_1": "25.12",
             "shikiho_comments_2": "コメント3",
+            "shikiho_periods_2": "25.9",
         }
         helpers.save_shikiho("3496", form)
 
         rec = helpers.get_research_detail("3496")
         assert rec["overview"] == "更新概要"
-        assert rec["shikiho_comments"] == ["コメント1", "コメント2", "コメント3"]
+        assert rec["shikiho_comments"] == [
+            {"period": "26.3", "comment": "コメント1"},
+            {"period": "25.12", "comment": "コメント2"},
+            {"period": "25.9", "comment": "コメント3"},
+        ]
 
     def test_save_shikiho_empty_comments_skipped(self, populated_db):
         form = {
             "overview": "概要",
             "shikiho_comments_0": "有効",
+            "shikiho_periods_0": "26.3",
             "shikiho_comments_1": "  ",  # 空白のみ → スキップ
+            "shikiho_periods_1": "25.12",
             "shikiho_comments_2": "有効2",
+            "shikiho_periods_2": "25.9",
         }
         helpers.save_shikiho("3496", form)
 
         rec = helpers.get_research_detail("3496")
-        assert rec["shikiho_comments"] == ["有効", "有効2"]
+        assert rec["shikiho_comments"] == [
+            {"period": "26.3", "comment": "有効"},
+            {"period": "25.9", "comment": "有効2"},
+        ]
 
 
 class TestSaveIrComments:

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -124,6 +124,7 @@ class TestShikihoPostRoutes:
         resp = client.post("/stock/3496/shikiho", data={
             "overview": "新概要",
             "shikiho_comments_0": "コメント1",
+            "shikiho_periods_0": "26.3",
         })
         assert resp.status_code == 302
 
@@ -131,6 +132,7 @@ class TestShikihoPostRoutes:
         client.post("/stock/3496/shikiho", data={
             "overview": "更新概要",
             "shikiho_comments_0": "更新コメント",
+            "shikiho_periods_0": "26.3",
         })
         resp = client.get("/stock/3496")
         html = resp.data.decode()


### PR DESCRIPTION
## Summary
- 四季報コメントのデータ構造を `List[str]` → `List[dict]` に変更（`{"period": "26.3", "comment": "..."}`）
- 既存データは読み込み時に後方互換で自動変換
- 最大件数を5→8件に拡張、8件超は古い順を自動削除
- 追加時に現在月から時期を自動判定（3-5月→X.3, 6-8月→X.6, 9-11月→X.9, 12-2月→X.12）
- 番号表示（1. 2. 3.）を時期表示（26.3, 25.12）に変更
- 削除ボタン非表示、企業概要をヘッダーに表示、add_stockのアトミック化

## Test plan
- [x] `pytest tests/test_research_shelve.py tests/test_webapp_helpers.py tests/test_webapp_routes.py` 全105テスト通過
- [x] 既存コメントが時期なし（-）で表示されること確認
- [x] 追加時に時期が自動設定されること確認
- [ ] CI通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)