### PR TITLE
決算カレンダー機能を webapp に追加 (closes #127)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ oauth2client==4.1.3
 httplib2==0.22.0
 yfinance>=0.2.31
 flask>=3.0
+beautifulsoup4>=4.12

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -61,6 +61,10 @@ DATE_YY_M_PATTERN = re.compile(r"^(\d{2})\.(\d{1,2})(?:\.(\d{1,2}))?$")
 # 総合評価の許容値
 VALID_RATINGS = frozenset({"", "S", "A", "B", "C", "D", "E"})
 
+# 決算コメントの期待度許容値 (◎/○/▲/△/× または未設定)
+# 順序: ◎ > ○ > ▲ > △ > × (期待度が高い順)
+VALID_EXPECTATIONS = frozenset({"", "◎", "○", "▲", "△", "×"})
+
 # スナップショットのデータソース区分
 VALID_DATA_SOURCES = frozenset({"manual", "migration", "auto"})
 
@@ -76,11 +80,27 @@ RECORD_FIELDS = frozenset(
         "openwork",
         "cramer",
         "shikiho_comments",
+        "kessan_comments",
         "snapshots",
         "analysis_date_raw",
         "kessan_date_raw",
     }
 )
+
+# 決算コメントエントリの既知フィールド
+KESSAN_COMMENT_FIELDS = frozenset(
+    {
+        "kessanbi",          # YYYY/MM/DD
+        "quarter",           # 1-4 (int)
+        "pre_expectation",   # ◎/○/△/× or ""
+        "pre_outlook",       # 事前見通し (フリーテキスト)
+        "post_price_change", # 決算反応の株価変動率 (%) スナップショット
+        "post_comment",      # 決算後コメント (フリーテキスト)
+    }
+)
+
+# 決算コメントの最大件数 (四半期12回分 ≒ 3年)
+MAX_KESSAN_COMMENTS = 12
 
 # スナップショットの既知フィールド
 SNAPSHOT_FIELDS = frozenset(
@@ -193,6 +213,7 @@ def create_research_record(
     openwork: str = "",
     cramer: str = "",
     shikiho_comments: Optional[List[str]] = None,
+    kessan_comments: Optional[List[Dict[str, Any]]] = None,
     snapshots: Optional[List[Dict[str, Any]]] = None,
     analysis_date_raw: str = "",
     kessan_date_raw: str = "",
@@ -201,7 +222,7 @@ def create_research_record(
 
     - code_s は normalize_code_s で大文字化される
     - overall_rating は空/S〜E のみ許容
-    - shikiho_comments と snapshots はリストでない場合に空リストで補完
+    - shikiho_comments / kessan_comments / snapshots はリストでない場合に空リストで補完
     - analysis_date_raw / kessan_date_raw はスプシ原文保持用(例: "11/13",
       "22四季報春" などの異形も許容。形式バリデーションはしない。型チェックのみ)
     - 返却した dict は upsert_research_record にそのまま渡せる
@@ -221,6 +242,7 @@ def create_research_record(
         )
 
     shikiho = list(shikiho_comments) if shikiho_comments else []
+    kessan = list(kessan_comments) if kessan_comments else []
     snaps = list(snapshots) if snapshots else []
 
     return {
@@ -233,6 +255,7 @@ def create_research_record(
         "openwork": openwork,
         "cramer": cramer,
         "shikiho_comments": shikiho,
+        "kessan_comments": kessan,
         "snapshots": snaps,
         "analysis_date_raw": analysis_date_raw,
         "kessan_date_raw": kessan_date_raw,
@@ -402,6 +425,7 @@ def get_research_record(
 
     存在しなければ None。code_s は内部で正規化される。
     shikiho_comments は List[dict] に自動正規化される（後方互換）。
+    kessan_comments は未設定の旧レコードに対し空リストで補完する（後方互換）。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
@@ -412,6 +436,8 @@ def get_research_record(
         record["shikiho_comments"] = _normalize_shikiho_comments(
             record.get("shikiho_comments", [])
         )
+        if not isinstance(record.get("kessan_comments"), list):
+            record["kessan_comments"] = []
     return record
 
 
@@ -704,6 +730,7 @@ def format_record_full(record: Dict[str, Any]) -> str:
     openwork = record.get("openwork", "")
     cramer = record.get("cramer", "")
     shikiho = record.get("shikiho_comments") or []
+    kessan_comments = record.get("kessan_comments") or []
     snapshots = record.get("snapshots") or []
     analysis_date_raw = record.get("analysis_date_raw", "")
     kessan_date_raw = record.get("kessan_date_raw", "")
@@ -738,6 +765,22 @@ def format_record_full(record: Dict[str, Any]) -> str:
             lines.append(f"  [{period}] {_indent_multiline(comment, ' ' * 8)}")
     else:
         lines.append(f"四季報コメント : {_EMPTY_MARK}")
+    if kessan_comments:
+        lines.append(f"決算コメント ({len(kessan_comments)}件):")
+        for entry in kessan_comments:
+            if not isinstance(entry, dict):
+                continue
+            kessanbi = entry.get("kessanbi", "-") or "-"
+            quarter = entry.get("quarter", "-")
+            pre_exp = entry.get("pre_expectation", "") or "-"
+            pre = entry.get("pre_outlook", "")
+            price_change = entry.get("post_price_change", "") or "-"
+            post = entry.get("post_comment", "")
+            lines.append(f"  [{kessanbi} {quarter}Q 期待度:{pre_exp} 反応:{price_change}%]")
+            lines.append(f"    事前    : {_indent_multiline(pre, ' ' * 14)}")
+            lines.append(f"    事後    : {_indent_multiline(post, ' ' * 14)}")
+    else:
+        lines.append(f"決算コメント   : {_EMPTY_MARK}")
     lines.append("")
 
     # --- スナップショットブロック ---

--- a/scripts/webapp/__init__.py
+++ b/scripts/webapp/__init__.py
@@ -23,9 +23,11 @@ def create_app() -> Flask:
     from webapp.routes.search import search_bp
     from webapp.routes.detail import detail_bp
     from webapp.routes.memo import memo_bp
+    from webapp.routes.market import market_bp
 
     app.register_blueprint(search_bp)
     app.register_blueprint(detail_bp)
     app.register_blueprint(memo_bp)
+    app.register_blueprint(market_bp)
 
     return app

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -572,9 +572,14 @@ def get_kessan_comment(code_s: str, kessanbi: str) -> Optional[Dict[str, Any]]:
 def get_market_kessan_data() -> Dict[str, Any]:
     """決算カレンダー表示用データを構築する。
 
+    用語定義（本モジュール共通）:
+      - ウォッチリスト: my_watch_list.txt 上の未保有銘柄
+      - 保有銘柄: my_watch_list.txt 上の H プレフィックス付き銘柄
+      - ポートフォリオ: ウォッチリスト ∪ 保有銘柄（= 日常的に追跡する対象）
+
     - pf_kessan_shelve から全ポートフォリオ銘柄の kessanbi (YYYY/MM/DD) を取得
-    - research_shelve の kessan_comments をマージ（ただし現在のポートフォリオ
-      内の銘柄のみ。ウォッチリスト/保有から外した銘柄のコメントは /market には
+    - research_shelve の kessan_comments をマージ（ただし現在のポートフォリオに
+      含まれる銘柄のみ。ポートフォリオから外した銘柄のコメントは /market には
       表示せず、銘柄詳細ページ側で閲覧する想定）
     - 基準日は get_price_day() で判定し、過去/未来に分類
     - 未来は (date_str, [stock dict, ...]) のリスト、日付昇順
@@ -598,10 +603,7 @@ def get_market_kessan_data() -> Dict[str, Any]:
         log_warning(f"[market] load_pf_kessan_db 失敗: {e}")
         pf_dict = {}
 
-    # ポートフォリオ銘柄セットを取得
-    # - watch_list: ウォッチリスト銘柄
-    # - possess_list: 保有銘柄 (H プレフィックス付き)
-    # - portfolio_set: 両者の和集合 = /market 表示対象
+    # ポートフォリオ (= ウォッチリスト ∪ 保有銘柄) を取得
     possess_set: set = set()
     portfolio_set: set = set()
     try:
@@ -621,8 +623,8 @@ def get_market_kessan_data() -> Dict[str, Any]:
         code_s = (v.get("code_s") or key or "").strip()
         if not code_s:
             continue
-        # pf_kessan_shelve には卒業銘柄が残留しているケースがあるため、
-        # 現在のポートフォリオ (ウォッチリスト + 保有) でフィルタする。
+        # pf_kessan_shelve にはポートフォリオ外の卒業銘柄が残留している
+        # ケースがあるため、現在のポートフォリオでフィルタする。
         # portfolio_set が空（parse 失敗時）はフィルタしない安全側に倒す。
         if portfolio_set and code_s not in portfolio_set:
             continue

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -6,9 +6,10 @@ research_shelve のデータ取得・更新をWebアプリ用にラップする�
 同じロックファイルを取ることでプロセス間の安全な共存を保証する。
 """
 
+import os
 import re
-from datetime import date
-from typing import Any, Dict, List, Optional
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
 
 from db_shelve import STOCKS_SHELVE, ShelveDB
 from html_sanitizer import sanitize_html
@@ -24,6 +25,8 @@ from research_shelve import (
     validate_rating,
     _flock,
     VALID_RATINGS,
+    VALID_EXPECTATIONS,
+    MAX_KESSAN_COMMENTS,
 )
 
 
@@ -251,3 +254,472 @@ def save_ir_comments(code_s: str, form_data: dict) -> None:
 
         record["snapshots"] = snapshots
         upsert_research_record(record)
+
+
+# =======================================================
+# 市場データ / 決算カレンダー用ヘルパー (issue #127)
+# =======================================================
+
+_KESSANBI_PATTERN = re.compile(r"^\d{4}/\d{1,2}/\d{1,2}$")
+
+
+def _parse_kessanbi(kessanbi: str) -> Optional[date]:
+    """YYYY/MM/DD 文字列を date に変換する。形式不正時は None。"""
+    if not isinstance(kessanbi, str) or not _KESSANBI_PATTERN.match(kessanbi):
+        return None
+    try:
+        return datetime.strptime(kessanbi, "%Y/%m/%d").date()
+    except ValueError:
+        return None
+
+
+def get_market_html_parts() -> Dict[str, str]:
+    """market_data.html を読み込み、決算セクション以外のパーツを dict で返す。
+
+    返り値のキー:
+      - "available": bool 相当の "1" or "" （ファイル存在判定）
+      - "css": <style> タグの中身
+      - "header": <h1> の HTML
+      - "body_without_kessan": <body> 内のコンテンツのうち、
+         <h2>決算日</h2> 以下のブロック（次の <h2> 直前まで、または
+         <details><summary>▶ 済の決算を表示...</summary> 含む）を除去したもの。
+         <h1> は除外し、決算セクションのあった位置にプレースホルダ
+         "<!--KESSAN_PLACEHOLDER-->" を挿入。
+      - "footer": <footer> タグ
+
+    ファイル未存在時は {"available": ""} を返す。
+    BeautifulSoup が未インストールの場合も {"available": ""} を返す。
+    """
+    try:
+        from ks_util import DATA_DIR
+        data_dir = DATA_DIR
+    except Exception:
+        data_dir = os.environ.get("KS_DATA_DIR", "")
+    html_path = os.path.join(data_dir, "code_rank_data", "market_data.html")
+    if not os.path.exists(html_path):
+        return {"available": ""}
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError:
+        log_warning("[market] BeautifulSoup 未インストールのため market_data.html を読み込めません")
+        return {"available": ""}
+
+    try:
+        with open(html_path, "r", encoding="utf-8") as f:
+            html_content = f.read()
+    except OSError as e:
+        log_warning(f"[market] market_data.html 読み込み失敗: {e}")
+        return {"available": ""}
+
+    soup = BeautifulSoup(html_content, "html.parser")
+
+    # CSS
+    style_tag = soup.find("style")
+    css = style_tag.string if style_tag and style_tag.string else ""
+
+    # h1
+    h1_tag = soup.find("h1")
+    header_html = str(h1_tag) if h1_tag else ""
+
+    # 決算セクションを除去してプレースホルダ挿入
+    # 構造: <h2>決算日</h2> の直後に <div class="kessan-grid"> と <details>
+    # （過去決算折りたたみ）が続く。次の <h2> までを対象にする。
+    body = soup.find("body")
+    if body is None:
+        return {"available": ""}
+
+    kessan_h2 = None
+    for h2 in body.find_all("h2"):
+        if h2.get_text(strip=True) == "決算日":
+            kessan_h2 = h2
+            break
+
+    if kessan_h2 is not None:
+        to_remove = []
+        # h2決算日 から 次の h2 or footer or 末尾までを削除対象に
+        sibling = kessan_h2
+        while sibling is not None:
+            next_sib = sibling.next_sibling
+            # 次要素が <h2>（決算以外）または <footer> なら停止
+            if sibling is not kessan_h2 and hasattr(sibling, "name"):
+                if sibling.name == "h2" or sibling.name == "footer":
+                    break
+            to_remove.append(sibling)
+            sibling = next_sib
+        # プレースホルダを h2決算日 の位置に挿入
+        placeholder = soup.new_tag("div", id="kessan-placeholder-mark")
+        placeholder.string = "__KESSAN_PLACEHOLDER__"
+        kessan_h2.insert_before(placeholder)
+        for el in to_remove:
+            el.extract()
+
+    # h1 も body から除く（テンプレート側で header として別途描画）
+    if h1_tag is not None:
+        h1_tag.extract()
+
+    # footer 抽出
+    footer_tag = body.find("footer")
+    footer_html = str(footer_tag) if footer_tag else ""
+    if footer_tag is not None:
+        footer_tag.extract()
+
+    body_html = body.decode_contents()
+
+    return {
+        "available": "1",
+        "css": css or "",
+        "header": header_html,
+        "body_without_kessan": body_html,
+        "footer": footer_html,
+    }
+
+
+def _price_reaction_from_log(price_log: List, kessanbi_dt: date) -> str:
+    """price_log と決算日 date から変動率を算出する内部関数。
+
+    price_log: [(date, int終値), ...]
+    kessanbi_dt: 決算日の date
+    """
+    if not price_log:
+        return ""
+    try:
+        sorted_log = sorted(price_log, key=lambda x: x[0], reverse=True)
+    except (TypeError, IndexError):
+        return ""
+
+    before_price: Optional[int] = None
+    after_price: Optional[int] = None
+    for entry in sorted_log:
+        try:
+            entry_dt, entry_pr = entry[0], entry[1]
+        except (IndexError, TypeError):
+            continue
+        if not isinstance(entry_dt, date):
+            continue
+        if entry_dt <= kessanbi_dt and before_price is None:
+            before_price = entry_pr
+        if entry_dt > kessanbi_dt:
+            after_price = entry_pr
+
+    if before_price is None or after_price is None or before_price == 0:
+        return ""
+    try:
+        change = (float(after_price) / float(before_price) - 1.0) * 100.0
+    except (ValueError, ZeroDivisionError):
+        return ""
+    sign = "+" if change >= 0 else ""
+    return f"{sign}{change:.1f}"
+
+
+def calc_price_reaction(code_s: str, kessanbi: str) -> str:
+    """決算日前営業日終値と翌営業日終値から株価変動率を算出する。
+
+    Args:
+        code_s: 銘柄コード
+        kessanbi: YYYY/MM/DD 形式
+
+    Returns:
+        "+3.2" / "-1.5" 形式。取得不可時は "".
+    """
+    kessanbi_dt = _parse_kessanbi(kessanbi)
+    if kessanbi_dt is None:
+        return ""
+
+    stock = get_stock_data(code_s)
+    return _price_reaction_from_log(stock.get("price_log") or [], kessanbi_dt)
+
+
+def _bulk_price_logs(code_list: List[str]) -> Dict[str, List]:
+    """stocks_shelve を1回だけ開いて複数銘柄の price_log を dict で返す。"""
+    if not code_list:
+        return {}
+    result: Dict[str, List] = {}
+    normalized_codes = set()
+    for c in code_list:
+        try:
+            normalized_codes.add(normalize_code_s(c))
+        except Exception:
+            continue
+    with ShelveDB(STOCKS_SHELVE) as db:
+        for code in normalized_codes:
+            rec = db.get(code)
+            if rec:
+                result[code] = rec.get("price_log") or []
+    return result
+
+
+def _sort_kessan_comments(comments: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """kessan_comments を kessanbi 昇順に安定ソート。"""
+    def _key(entry):
+        dt = _parse_kessanbi(entry.get("kessanbi", ""))
+        return dt or date.min
+    return sorted(comments, key=_key)
+
+
+def _validate_kessan_comment_input(form_data: dict) -> Tuple[str, int, str, str, str]:
+    """フォーム入力を検証し、正規化した値を返す。
+
+    Returns:
+        (kessanbi, quarter, pre_expectation, pre_outlook, post_comment)
+    Raises:
+        ValueError: 入力不正
+    """
+    kessanbi = (form_data.get("kessanbi") or "").strip()
+    if _parse_kessanbi(kessanbi) is None:
+        raise ValueError(f"kessanbi は YYYY/MM/DD 形式: got {kessanbi!r}")
+
+    quarter_raw = form_data.get("quarter", "")
+    try:
+        quarter = int(quarter_raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"quarter は整数: got {quarter_raw!r}")
+    if quarter < 0 or quarter > 4:
+        raise ValueError(f"quarter は 0〜4: got {quarter}")
+
+    pre_expectation = (form_data.get("pre_expectation") or "").strip()
+    if pre_expectation not in VALID_EXPECTATIONS:
+        raise ValueError(f"pre_expectation 不正: {pre_expectation!r}")
+
+    pre_outlook = form_data.get("pre_outlook", "") or ""
+    post_comment = form_data.get("post_comment", "") or ""
+
+    return kessanbi, quarter, pre_expectation, pre_outlook, post_comment
+
+
+def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
+    """決算コメントを1件 upsert する。
+
+    - 同じ (kessanbi, quarter) のエントリが既にあれば上書き
+    - なければ追加
+    - 12件超過時は最古（kessanbi 昇順の先頭）を削除
+    - research_shelve 未登録なら add_stock() で自動登録
+    - post_price_change は price_log から自動計算してスナップショット化
+
+    Returns:
+        保存したエントリ dict
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+
+    kessanbi, quarter, pre_expectation, pre_outlook, post_comment = (
+        _validate_kessan_comment_input(form_data)
+    )
+
+    # 変動率をスナップショット算出
+    post_price_change = calc_price_reaction(normalized, kessanbi)
+
+    with _flock():
+        record = get_research_record(normalized)
+        if record is None:
+            # 自動登録（_flock を再入しないよう add_stock の内部ロックに依存）
+            add_stock(normalized)
+            record = get_research_record(normalized)
+            if record is None:
+                raise ValueError(f"レコード登録失敗: {normalized}")
+
+        comments: List[Dict[str, Any]] = list(record.get("kessan_comments") or [])
+        # 同一 (kessanbi, quarter) を探す
+        target_idx = None
+        for i, entry in enumerate(comments):
+            if (
+                entry.get("kessanbi") == kessanbi
+                and int(entry.get("quarter", 0) or 0) == quarter
+            ):
+                target_idx = i
+                break
+
+        new_entry: Dict[str, Any] = {
+            "kessanbi": kessanbi,
+            "quarter": quarter,
+            "pre_expectation": pre_expectation,
+            "pre_outlook": pre_outlook,
+            "post_price_change": post_price_change,
+            "post_comment": post_comment,
+        }
+        if target_idx is not None:
+            # 既存エントリ上書き。post_price_change はリアルタイム計算失敗時は既存値を優先
+            existing = comments[target_idx]
+            if not post_price_change and existing.get("post_price_change"):
+                new_entry["post_price_change"] = existing["post_price_change"]
+            comments[target_idx] = new_entry
+        else:
+            comments.append(new_entry)
+
+        # 昇順ソート + 12件超の最古を削除
+        comments = _sort_kessan_comments(comments)
+        if len(comments) > MAX_KESSAN_COMMENTS:
+            comments = comments[-MAX_KESSAN_COMMENTS:]
+
+        record["kessan_comments"] = comments
+        upsert_research_record(record)
+
+    return new_entry
+
+
+def get_kessan_comment(code_s: str, kessanbi: str) -> Optional[Dict[str, Any]]:
+    """特定の (code_s, kessanbi) のコメントエントリを返す。未登録/未存在は None。"""
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    record = get_research_record(normalized)
+    if record is None:
+        return None
+    for entry in record.get("kessan_comments") or []:
+        if entry.get("kessanbi") == kessanbi:
+            return entry
+    return None
+
+
+def get_market_kessan_data() -> Dict[str, Any]:
+    """決算カレンダー表示用データを構築する。
+
+    - pf_kessan_shelve から全ポートフォリオ銘柄の kessanbi (YYYY/MM/DD) を取得
+    - research_shelve の kessan_comments でコメント済みエントリをマージ
+    - 基準日は get_price_day() で判定し、過去/未来に分類
+    - 未来は (date_str, [stock dict, ...]) のリスト、日付昇順
+    - 過去は (date_str, [stock dict, ...]) のリスト、日付降順
+
+    Returns:
+        {
+          "base_day": date,
+          "future_entries": [(kessanbi_str, [stock dict]), ...],
+          "past_entries":  [(kessanbi_str, [stock dict]), ...],
+        }
+        各 stock dict:
+          code_s, stock_name, kessanbi, quarter,
+          pre_expectation, pre_outlook, post_price_change, post_comment,
+          has_comment (bool)
+    """
+    import kessan  # 遅延 import (sys.path 解決後)
+    try:
+        pf_dict = kessan.load_pf_kessan_db() or {}
+    except Exception as e:
+        log_warning(f"[market] load_pf_kessan_db 失敗: {e}")
+        pf_dict = {}
+
+    # 保有銘柄セットを取得 (H プレフィックス付きの銘柄)
+    possess_set: set = set()
+    try:
+        import portfolio
+        _, possess_list = portfolio.parse_my_portforio()
+        possess_set = set(possess_list)
+    except Exception as e:
+        log_warning(f"[market] parse_my_portforio 失敗: {e}")
+
+    base_day = get_price_day(datetime.today())
+
+    # (code_s, kessanbi) をキーに統合
+    merged: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+    for key, v in pf_dict.items():
+        code_s = (v.get("code_s") or key or "").strip()
+        if not code_s:
+            continue
+        kessanbi = (v.get("kessanbi") or "").strip()
+        if not kessanbi or _parse_kessanbi(kessanbi) is None:
+            continue
+        merged_key = (code_s, kessanbi)
+        merged[merged_key] = {
+            "code_s": code_s,
+            "stock_name": v.get("stock_name", ""),
+            "kessanbi": kessanbi,
+            "quarter": v.get("kessan_quarter", 0) or 0,
+            "pre_expectation": "",
+            "pre_outlook": "",
+            "post_price_change": "",
+            "post_comment": "",
+            "has_comment": False,
+            "is_possess": code_s in possess_set,
+        }
+
+    # research_shelve のコメント済みエントリをマージ
+    try:
+        records = list_research_records()
+    except Exception as e:
+        log_warning(f"[market] list_research_records 失敗: {e}")
+        records = []
+
+    for rec in records:
+        code_s = rec.get("code_s", "")
+        if not code_s:
+            continue
+        for entry in rec.get("kessan_comments") or []:
+            kessanbi = entry.get("kessanbi", "")
+            if not kessanbi:
+                continue
+            merged_key = (code_s, kessanbi)
+            quarter = entry.get("quarter", 0) or 0
+            base = merged.get(merged_key)
+            stock_name = (base or {}).get("stock_name") or rec.get("stock_name", "")
+            merged[merged_key] = {
+                "code_s": code_s,
+                "stock_name": stock_name,
+                "kessanbi": kessanbi,
+                "quarter": quarter if quarter else (base or {}).get("quarter", 0),
+                "pre_expectation": entry.get("pre_expectation", "") or "",
+                "pre_outlook": entry.get("pre_outlook", "") or "",
+                "post_price_change": entry.get("post_price_change", "") or "",
+                "post_comment": entry.get("post_comment", "") or "",
+                "has_comment": bool(
+                    entry.get("pre_outlook") or entry.get("post_comment")
+                    or entry.get("pre_expectation")
+                ),
+                "is_possess": code_s in possess_set,
+            }
+
+    # 過去エントリで post_price_change 未保存のものだけ一括で price_log 取得
+    past_codes_need_calc = set()
+    for entry in merged.values():
+        dt = _parse_kessanbi(entry["kessanbi"])
+        if dt is None:
+            continue
+        if dt < base_day and not entry.get("post_price_change"):
+            past_codes_need_calc.add(entry["code_s"])
+
+    price_logs_cache = _bulk_price_logs(list(past_codes_need_calc)) if past_codes_need_calc else {}
+
+    # 日付ごとにグループ化
+    future_groups: Dict[str, List[Dict[str, Any]]] = {}
+    past_groups: Dict[str, List[Dict[str, Any]]] = {}
+    for entry in merged.values():
+        kessanbi = entry["kessanbi"]
+        dt = _parse_kessanbi(kessanbi)
+        if dt is None:
+            continue
+        # 過去の変動率を計算できれば補完（保存済み値が無い場合のみ、キャッシュ利用）
+        if dt < base_day and not entry.get("post_price_change"):
+            log = price_logs_cache.get(entry["code_s"], [])
+            entry["post_price_change"] = _price_reaction_from_log(log, dt)
+        groups = past_groups if dt < base_day else future_groups
+        groups.setdefault(kessanbi, []).append(entry)
+
+    # 銘柄コード順にカード内ソート
+    for d in list(future_groups.values()) + list(past_groups.values()):
+        d.sort(key=lambda e: e["code_s"])
+
+    future_entries = sorted(
+        future_groups.items(),
+        key=lambda kv: _parse_kessanbi(kv[0]) or date.max,
+    )
+    past_entries_all = sorted(
+        past_groups.items(),
+        key=lambda kv: _parse_kessanbi(kv[0]) or date.min,
+        reverse=True,
+    )
+    # 過去7日間は常時表示、それ以前は details で折りたたみ
+    recent_cutoff = base_day - timedelta(days=7)
+    recent_past_entries: List = []
+    older_past_entries: List = []
+    for kv in past_entries_all:
+        dt = _parse_kessanbi(kv[0]) or date.min
+        if dt >= recent_cutoff:
+            recent_past_entries.append(kv)
+        else:
+            older_past_entries.append(kv)
+
+    return {
+        "base_day": base_day,
+        "future_entries": future_entries,
+        "past_entries": past_entries_all,  # 後方互換
+        "recent_past_entries": recent_past_entries,
+        "older_past_entries": older_past_entries,
+    }

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -573,7 +573,9 @@ def get_market_kessan_data() -> Dict[str, Any]:
     """決算カレンダー表示用データを構築する。
 
     - pf_kessan_shelve から全ポートフォリオ銘柄の kessanbi (YYYY/MM/DD) を取得
-    - research_shelve の kessan_comments でコメント済みエントリをマージ
+    - research_shelve の kessan_comments をマージ（ただし現在のポートフォリオ
+      内の銘柄のみ。ウォッチリスト/保有から外した銘柄のコメントは /market には
+      表示せず、銘柄詳細ページ側で閲覧する想定）
     - 基準日は get_price_day() で判定し、過去/未来に分類
     - 未来は (date_str, [stock dict, ...]) のリスト、日付昇順
     - 過去は (date_str, [stock dict, ...]) のリスト、日付降順
@@ -596,12 +598,17 @@ def get_market_kessan_data() -> Dict[str, Any]:
         log_warning(f"[market] load_pf_kessan_db 失敗: {e}")
         pf_dict = {}
 
-    # 保有銘柄セットを取得 (H プレフィックス付きの銘柄)
+    # ポートフォリオ銘柄セットを取得
+    # - watch_list: ウォッチリスト銘柄
+    # - possess_list: 保有銘柄 (H プレフィックス付き)
+    # - portfolio_set: 両者の和集合 = /market 表示対象
     possess_set: set = set()
+    portfolio_set: set = set()
     try:
         import portfolio
-        _, possess_list = portfolio.parse_my_portforio()
+        watch_list, possess_list = portfolio.parse_my_portforio()
         possess_set = set(possess_list)
+        portfolio_set = set(watch_list) | set(possess_list)
     except Exception as e:
         log_warning(f"[market] parse_my_portforio 失敗: {e}")
 
@@ -613,6 +620,11 @@ def get_market_kessan_data() -> Dict[str, Any]:
     for key, v in pf_dict.items():
         code_s = (v.get("code_s") or key or "").strip()
         if not code_s:
+            continue
+        # pf_kessan_shelve には卒業銘柄が残留しているケースがあるため、
+        # 現在のポートフォリオ (ウォッチリスト + 保有) でフィルタする。
+        # portfolio_set が空（parse 失敗時）はフィルタしない安全側に倒す。
+        if portfolio_set and code_s not in portfolio_set:
             continue
         kessanbi = (v.get("kessanbi") or "").strip()
         if not kessanbi or _parse_kessanbi(kessanbi) is None:
@@ -641,6 +653,11 @@ def get_market_kessan_data() -> Dict[str, Any]:
     for rec in records:
         code_s = rec.get("code_s", "")
         if not code_s:
+            continue
+        # ポートフォリオ外の銘柄コメントは /market に表示しない
+        # （銘柄詳細ページ側で過去ログとして閲覧する想定 — issue #131）
+        # portfolio_set が空（parse 失敗時）はフィルタしない安全側に倒す
+        if portfolio_set and code_s not in portfolio_set:
             continue
         for entry in rec.get("kessan_comments") or []:
             kessanbi = entry.get("kessanbi", "")

--- a/scripts/webapp/routes/market.py
+++ b/scripts/webapp/routes/market.py
@@ -1,0 +1,65 @@
+"""
+市場データ・決算カレンダー ルート。
+
+GET  /market                         : 市場データページ (market_data.html を取り込み + 動的決算セクション)
+GET  /api/kessan_comment/<code_s>    : 指定銘柄・決算日のコメントを JSON で返す
+POST /api/kessan_comment/<code_s>    : 決算コメントを保存 (新規 or 上書き)
+"""
+
+from flask import Blueprint, jsonify, render_template, request
+
+from webapp.helpers import (
+    get_kessan_comment,
+    get_market_html_parts,
+    get_market_kessan_data,
+    save_kessan_comment,
+)
+from research_shelve import VALID_EXPECTATIONS
+
+market_bp = Blueprint("market", __name__)
+
+
+@market_bp.route("/market", methods=["GET"])
+def market_page():
+    """市場データページ。静的 market_data.html を取り込み、決算セクションを動的版に差し替える。"""
+    market_parts = get_market_html_parts()
+    kessan_data = get_market_kessan_data()
+
+    expectation_options = sorted(VALID_EXPECTATIONS, key=lambda x: ("", "◎", "○", "▲", "△", "×").index(x))
+
+    return render_template(
+        "market.html",
+        market_parts=market_parts,
+        kessan_data=kessan_data,
+        expectation_options=expectation_options,
+    )
+
+
+@market_bp.route("/api/kessan_comment/<code_s>", methods=["GET"])
+def get_kessan_comment_api(code_s: str):
+    """指定銘柄・決算日のコメントを JSON で返す。未登録時は空エントリ。"""
+    kessanbi = request.args.get("kessanbi", "").strip()
+    if not kessanbi:
+        return jsonify({"error": "kessanbi required"}), 400
+    entry = get_kessan_comment(code_s, kessanbi)
+    if entry is None:
+        entry = {
+            "kessanbi": kessanbi,
+            "quarter": 0,
+            "pre_expectation": "",
+            "pre_outlook": "",
+            "post_price_change": "",
+            "post_comment": "",
+        }
+    return jsonify(entry)
+
+
+@market_bp.route("/api/kessan_comment/<code_s>", methods=["POST"])
+def post_kessan_comment_api(code_s: str):
+    """決算コメントを保存。成功時は保存後エントリを返す。"""
+    form = request.form if request.form else (request.get_json(silent=True) or {})
+    try:
+        entry = save_kessan_comment(code_s, form)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    return jsonify(entry)

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -16,7 +16,18 @@ document.addEventListener('keydown', function(e) {
   if (e.key === 'Escape') {
     var el = document.activeElement;
     if (el && (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT' || el.tagName === 'SELECT')) {
-      el.blur();
+      /* 決算エディタ内の field ならその場で保存してからアコーディオン閉じる */
+      if (el.classList && el.classList.contains('kessan-field')) {
+        var editor = el.closest('.kessan-editor');
+        var li = editor ? editor.closest('.kessan-stock') : null;
+        el.blur();
+        if (li) {
+          saveKessanFromEditor(li);
+          if (editor) editor.style.display = 'none';
+        }
+      } else {
+        el.blur();
+      }
     }
   }
 });
@@ -208,3 +219,140 @@ function removeShikiho(btn) {
   btn.closest('.shikiho-entry').remove();
   updateShikihoState();
 }
+
+/* ==========================================================
+ * 決算カレンダー (issue #127)
+ *   インラインアコーディオン: クリックで入力欄を展開
+ *   blur で自動保存 (_saveQueue 経由で直列化)
+ * ========================================================== */
+
+/* 銘柄行クリック: リンク・エディタ内クリックは除外して編集UIを展開 */
+function handleKessanRowClick(e, li) {
+  /* 親要素を辿って、クリック起点が除外対象（リンク・エディタ内）か判定 */
+  var target = e.target;
+  while (target && target !== li) {
+    if (target.tagName === 'A') return;
+    if (target.classList && target.classList.contains('kessan-editor')) return;
+    if (target.classList && target.classList.contains('kessan-comment-view')) return;
+    target = target.parentNode;
+  }
+  openKessanEditor(li);
+}
+
+function openKessanEditor(li) {
+  var editor = li.querySelector('.kessan-editor');
+  if (!editor) return;
+
+  var isOpen = editor.style.display !== 'none';
+  if (isOpen) {
+    editor.style.display = 'none';
+    return;
+  }
+
+  editor.style.display = '';
+  if (editor.dataset.loaded === '0') {
+    var code = li.dataset.code;
+    var kessanbi = li.dataset.kessanbi;
+    var url = '/api/kessan_comment/' + encodeURIComponent(code) +
+              '?kessanbi=' + encodeURIComponent(kessanbi);
+    fetch(url).then(function(res) {
+      return res.ok ? res.json() : null;
+    }).then(function(data) {
+      if (!data) return;
+      var preExp = editor.querySelector('.kessan-pre-expectation');
+      var preOut = editor.querySelector('.kessan-pre-outlook');
+      var postCom = editor.querySelector('.kessan-post-comment');
+      var postPc = editor.querySelector('.kessan-post-price-change');
+      if (preExp) preExp.value = data.pre_expectation || '';
+      if (preOut) preOut.value = data.pre_outlook || '';
+      if (postCom) postCom.value = data.post_comment || '';
+      if (postPc && data.post_price_change) {
+        postPc.textContent = data.post_price_change;
+      }
+      editor.dataset.loaded = '1';
+      rememberKessanInitialValues(editor);
+    }).catch(function() { /* ネットワーク失敗時は静かに無視 */ });
+  }
+
+  var preOutEl = editor.querySelector('.kessan-pre-outlook');
+  if (preOutEl) preOutEl.focus();
+}
+
+function rememberKessanInitialValues(editor) {
+  editor.querySelectorAll('.kessan-field').forEach(function(el) {
+    el.dataset.initial = el.value;
+  });
+}
+
+function isKessanDirty(editor) {
+  var dirty = false;
+  editor.querySelectorAll('.kessan-field').forEach(function(el) {
+    if (el.value !== (el.dataset.initial || '')) dirty = true;
+  });
+  return dirty;
+}
+
+function saveKessanFromEditor(li) {
+  var editor = li.querySelector('.kessan-editor');
+  if (!editor) return;
+  if (!isKessanDirty(editor)) return;
+
+  var code = li.dataset.code;
+  var kessanbi = li.dataset.kessanbi;
+  var quarter = li.dataset.quarter || '0';
+  var preExp = editor.querySelector('.kessan-pre-expectation');
+  var preOut = editor.querySelector('.kessan-pre-outlook');
+  var postCom = editor.querySelector('.kessan-post-comment');
+
+  var formData = new FormData();
+  formData.append('kessanbi', kessanbi);
+  formData.append('quarter', quarter);
+  formData.append('pre_expectation', preExp ? preExp.value : '');
+  formData.append('pre_outlook', preOut ? preOut.value : '');
+  formData.append('post_comment', postCom ? postCom.value : '');
+
+  var url = '/api/kessan_comment/' + encodeURIComponent(code);
+  _saveQueue = _saveQueue.then(function() {
+    return fetch(url, { method: 'POST', body: formData }).then(function(res) {
+      if (!res.ok) return null;
+      return res.json();
+    }).then(function(data) {
+      if (!data) return;
+      /* 初期値リセット */
+      rememberKessanInitialValues(editor);
+      /* post_price_change 表示更新 */
+      var postPc = editor.querySelector('.kessan-post-price-change');
+      if (postPc && data.post_price_change) {
+        postPc.textContent = data.post_price_change;
+      }
+      /* has-comment クラス付与で左縁に色がつく */
+      if (data.pre_outlook || data.post_comment || data.pre_expectation) {
+        li.classList.add('has-comment');
+      }
+    });
+  }).catch(function() { /* エラー時もキュー継続 */ });
+}
+
+/* フォーカスアウトで保存。kessan-field からのフォーカス遷移先が
+   同じエディタ内なら保存しない（タブ移動対応） */
+document.addEventListener('focusout', function(e) {
+  var el = e.target;
+  if (!el.classList || !el.classList.contains('kessan-field')) return;
+  var editor = el.closest('.kessan-editor');
+  if (!editor) return;
+
+  setTimeout(function() {
+    var next = document.activeElement;
+    if (next && editor.contains(next)) return;
+    var li = editor.closest('.kessan-stock');
+    if (li) saveKessanFromEditor(li);
+  }, 100);
+});
+
+/* Enter 押下でセレクトを確定させた時にもフォーカスアウトを促す（select は change で明示的に） */
+document.addEventListener('change', function(e) {
+  var el = e.target;
+  if (!el.classList || !el.classList.contains('kessan-pre-expectation')) return;
+  var li = el.closest('.kessan-stock');
+  if (li) saveKessanFromEditor(li);
+});

--- a/scripts/webapp/static/favicon.svg
+++ b/scripts/webapp/static/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#ffffff"/>
+  <line x1="8" y1="40" x2="56" y2="40" stroke="#2c3e50" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 12 48 L 24 36 L 34 44 L 52 18" fill="none" stroke="#c0392b" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M 44 18 L 54 16 L 52 26 Z" fill="#c0392b"/>
+  <circle cx="24" cy="36" r="3" fill="#2c3e50"/>
+  <circle cx="34" cy="44" r="3" fill="#2c3e50"/>
+</svg>

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -136,6 +136,16 @@ nav .brand {
   font-size: 1.1em;
   text-decoration: none;
 }
+nav .nav-link {
+  padding: 0.25em 0.6em;
+  color: #2c3e50;
+  text-decoration: none;
+  border-radius: 4px;
+  font-size: 0.95em;
+}
+nav .nav-link:hover {
+  background: #ecf0f1;
+}
 nav .quick-search {
   display: flex;
   align-items: center;
@@ -184,4 +194,124 @@ nav .quick-search {
 .rich-display a {
   color: #3498db;
   text-decoration: underline;
+}
+
+/* =========================================================
+ * 決算カレンダー (issue #127)
+ * market_data.html から取り込んだ .kessan-grid / .kessan-card
+ * のベーススタイルに、webapp 固有の拡張を重ねる。
+ * ========================================================= */
+
+.kessan-stock {
+  padding: 2px 0;
+  border-left: 3px solid transparent;
+  padding-left: 6px;
+  margin-left: -6px;
+  cursor: pointer;
+}
+.kessan-stock:hover {
+  background: #f5faff;
+}
+.kessan-stock.has-comment {
+  border-left-color: #f39c12;
+  background: #fffcf4;
+}
+.kessan-stock.has-comment:hover {
+  background: #fff5e3;
+}
+.kessan-q-label {
+  color: #888;
+  font-size: 0.85em;
+  margin-left: 2px;
+}
+.kessan-price-change {
+  font-size: 0.85em;
+  font-weight: bold;
+  margin-left: 4px;
+}
+.kessan-expectation-badge {
+  display: inline-block;
+  padding: 0 5px;
+  margin-left: 3px;
+  border-radius: 3px;
+  font-size: 0.8em;
+  font-weight: bold;
+  background: #f5f5f5;
+  color: #333;
+  border: 1px solid #ddd;
+}
+.kessan-expectation-badge.exp-◎ { background: #e74c3c; color: #fff; border-color: #c0392b; }
+.kessan-expectation-badge.exp-○ { background: #f39c12; color: #fff; border-color: #d68910; }
+.kessan-expectation-badge.exp-▲ { background: #f1c40f; color: #333; border-color: #d4ac0d; }
+.kessan-expectation-badge.exp-△ { background: #bdc3c7; color: #333; border-color: #95a5a6; }
+.kessan-expectation-badge.exp-× { background: #3498db; color: #fff; border-color: #2874a6; }
+
+.kessan-editor {
+  margin: 4px 0 6px 14px;
+  padding: 6px 8px;
+  border-left: 2px solid #bbb;
+  background: #fafafa;
+  font-size: 0.85em;
+}
+.kessan-editor-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.kessan-editor-row label {
+  flex: 0 0 6em;
+  color: #555;
+  font-size: 0.9em;
+  padding-top: 2px;
+  margin: 0;
+}
+.kessan-editor-row textarea,
+.kessan-editor-row select {
+  flex: 1;
+  margin: 0;
+  padding: 3px 5px;
+  font-size: 0.95em;
+  min-height: auto;
+}
+.kessan-editor-row select {
+  flex: 0 0 5em;
+}
+.kessan-editor-row textarea {
+  resize: vertical;
+}
+.kessan-field-display {
+  padding: 3px 5px;
+  font-family: monospace;
+  font-size: 0.95em;
+  color: #333;
+}
+
+/* 保有銘柄マーク */
+.kessan-possess-mark {
+  color: #e67e22;
+  font-weight: bold;
+  margin-right: 2px;
+}
+.kessan-stock.is-possess {
+  background: #fff9ed;
+}
+
+/* 決算コメント常時表示 (編集中以外でも見える) */
+.kessan-comment-view {
+  margin: 2px 0 2px 14px;
+  font-size: 0.82em;
+  color: #555;
+  line-height: 1.4;
+}
+.kessan-pre-view,
+.kessan-post-view {
+  padding: 1px 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.kessan-view-label {
+  color: #888;
+  font-weight: bold;
+  margin-right: 3px;
 }

--- a/scripts/webapp/templates/base.html
+++ b/scripts/webapp/templates/base.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{% block title %}Shintakane Research{% endblock %}</title>
+<link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
 <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
@@ -12,6 +13,7 @@
 <nav class="container-fluid">
   <ul>
     <li><a href="/" class="brand">Shintakane Research</a></li>
+    <li><a href="/market" class="nav-link">市場データ</a></li>
   </ul>
   <ul>
     <li class="quick-search">

--- a/scripts/webapp/templates/market.html
+++ b/scripts/webapp/templates/market.html
@@ -1,0 +1,141 @@
+{% extends "base.html" %}
+{% block title %}市場データ - Shintakane Research{% endblock %}
+{% block content %}
+
+{% if market_parts.available %}
+<style>
+/* market_data.html から取り込んだ scoped CSS */
+{{ market_parts.css | safe }}
+</style>
+{{ market_parts.header | safe }}
+{% else %}
+<div style="padding:12px;margin:12px 0;background:#fef3e6;border:1px solid #f5c37c;border-radius:6px;">
+  市場データ (<code>market_data.html</code>) が未生成です。<br>
+  <small>scripts/make_market_db.py を実行すると生成されます。決算カレンダーは以下の通り利用できます。</small>
+</div>
+{% endif %}
+
+{# 市場データ本文: 決算セクションはプレースホルダに置き換え済み #}
+{% set body_parts = market_parts.get('body_without_kessan', '').split('<div id="kessan-placeholder-mark">__KESSAN_PLACEHOLDER__</div>') %}
+{% if body_parts[0] %}
+{{ body_parts[0] | safe }}
+{% endif %}
+
+{# ここから動的決算セクション #}
+<h2>決算日</h2>
+<div id="kessan-section">
+  {% macro render_kessan_editor(s, is_past) -%}
+    <div class="kessan-editor" style="display:none;" data-loaded="0">
+      <div class="kessan-editor-row">
+        <label>期待度:</label>
+        <select class="kessan-field kessan-pre-expectation">
+          {% for opt in expectation_options %}
+            <option value="{{ opt }}">{{ opt or '—' }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="kessan-editor-row">
+        <label>事前見通し:</label>
+        <textarea class="kessan-field kessan-pre-outlook" rows="2" placeholder="決算前の見通し"></textarea>
+      </div>
+      {% if is_past %}
+      <div class="kessan-editor-row">
+        <label>株価変動率:</label>
+        <span class="kessan-field-display kessan-post-price-change">{{ s.post_price_change or '-' }}</span>
+      </div>
+      <div class="kessan-editor-row">
+        <label>反応コメ:</label>
+        <textarea class="kessan-field kessan-post-comment" rows="2" placeholder="決算後の反応・コメント"></textarea>
+      </div>
+      {% endif %}
+    </div>
+  {%- endmacro %}
+
+  {% macro render_stock_li(s, is_past) -%}
+    {% set li_class = 'kessan-4q' if (s.quarter|string) == '4' else '' %}
+    {% set possess_class = ' is-possess' if s.is_possess else '' %}
+    <li class="{{ li_class }} kessan-stock{% if s.has_comment %} has-comment{% endif %}{{ possess_class }}"
+        data-code="{{ s.code_s }}"
+        data-kessanbi="{{ s.kessanbi }}"
+        data-quarter="{{ s.quarter }}"
+        data-is-past="{{ '1' if is_past else '0' }}"
+        onclick="handleKessanRowClick(event, this)"
+        title="クリックでコメント編集">
+      {% if s.is_possess %}<span class="kessan-possess-mark" title="保有銘柄">☆</span>{% endif %}
+      <a href="https://kabutan.jp/stock/chart?code={{ s.code_s }}" target="_blank">{{ s.code_s }}</a>
+      <a href="/stock/{{ s.code_s }}">{{ s.stock_name or '-' }}</a>
+      {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}
+      {% if s.pre_expectation %}<span class="kessan-expectation-badge exp-{{ s.pre_expectation }}">{{ s.pre_expectation }}</span>{% endif %}
+      {% if is_past and s.post_price_change %}
+        {% set pc = s.post_price_change %}
+        <span class="kessan-price-change {% if pc.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc }}%</span>
+      {% endif %}
+      {% if s.pre_outlook or s.post_comment %}
+      <div class="kessan-comment-view">
+        {% if s.pre_outlook %}<div class="kessan-pre-view"><span class="kessan-view-label">見通し:</span> {{ s.pre_outlook }}</div>{% endif %}
+        {% if is_past and s.post_comment %}<div class="kessan-post-view"><span class="kessan-view-label">反応:</span> {{ s.post_comment }}</div>{% endif %}
+      </div>
+      {% endif %}
+      {{ render_kessan_editor(s, is_past) }}
+    </li>
+  {%- endmacro %}
+
+  {# 直近1週間の過去決算: 常時表示（未来決算の前に配置） #}
+  {% if kessan_data.recent_past_entries %}
+  <div class="kessan-grid">
+    {% for kessanbi, stocks in kessan_data.recent_past_entries %}
+    <div class="kessan-card past">
+      <div class="card-date">{{ kessanbi[5:] }} (済)</div>
+      <ul class="stock-list">
+        {% for s in stocks %}{{ render_stock_li(s, true) }}{% endfor %}
+      </ul>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if kessan_data.future_entries %}
+  <div class="kessan-grid">
+    {% for kessanbi, stocks in kessan_data.future_entries %}
+    <div class="kessan-card future">
+      <div class="card-date">{{ kessanbi[5:] }}</div>
+      <ul class="stock-list">
+        {% for s in stocks %}{{ render_stock_li(s, false) }}{% endfor %}
+      </ul>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {# それ以前の過去決算: 折りたたみ #}
+  {% if kessan_data.older_past_entries %}
+  <details>
+    <summary style="cursor:pointer; color:#666; margin:8px 0;">▶ さらに前の決算を表示 ({{ kessan_data.older_past_entries|length }}件)</summary>
+    <div class="kessan-grid">
+      {% for kessanbi, stocks in kessan_data.older_past_entries %}
+      <div class="kessan-card past">
+        <div class="card-date">{{ kessanbi[5:] }} (済)</div>
+        <ul class="stock-list">
+          {% for s in stocks %}{{ render_stock_li(s, true) }}{% endfor %}
+        </ul>
+      </div>
+      {% endfor %}
+    </div>
+  </details>
+  {% endif %}
+
+  {% if not kessan_data.future_entries and not kessan_data.past_entries %}
+  <div style="color:#888;padding:12px;">決算予定の銘柄がありません（ポートフォリオ設定を確認してください）。</div>
+  {% endif %}
+</div>
+
+{# 決算以降の本文 (適時開示など) #}
+{% if body_parts|length > 1 and body_parts[1] %}
+{{ body_parts[1] | safe }}
+{% endif %}
+
+{% if market_parts.available %}
+{{ market_parts.footer | safe }}
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
## Summary

- 静的 `market_data.html` を `/market` ルートで取り込み、決算セクションを動的版に差し替えて決算メモ管理を webapp 内で完結させる
- ポートフォリオ銘柄の決算前後に、期待度・見通し・株価反応・コメントを一元管理（研究DBに最大12件=3年分蓄積）
- ナビバーに「市場データ」リンク追加、browser favicon も新規追加

## 主な変更

| ファイル | 変更 |
|---|---|
| `scripts/research_shelve.py` | `kessan_comments` フィールド、`VALID_EXPECTATIONS` (◎○▲△×)、`MAX_KESSAN_COMMENTS=12`、`KESSAN_COMMENT_FIELDS` を追加 |
| `scripts/webapp/routes/market.py` | **新規**: `GET /market` + `GET/POST /api/kessan_comment/<code_s>` |
| `scripts/webapp/helpers.py` | `get_market_html_parts` / `get_market_kessan_data` / `save_kessan_comment` / `calc_price_reaction` / `_bulk_price_logs` を追加 |
| `scripts/webapp/templates/market.html` | **新規**: BeautifulSoup で `market_data.html` から決算セクションを除去、動的版を描画 |
| `scripts/webapp/templates/base.html` | ナビに「市場データ」リンク + favicon.svg 参照 |
| `scripts/webapp/static/app.js` | 銘柄行クリックでアコーディオン展開、Esc で保存＋閉じる、blur で自動保存 |
| `scripts/webapp/static/style.css` | 期待度バッジ・アコーディオン・保有☆マーク・コメント常時表示のスタイル |
| `scripts/webapp/static/favicon.svg` | **新規**: ブラウザタブ用ファビコン |

## UI 機能

- ポートフォリオ銘柄の決算日を日付別カードで表示
- 銘柄行クリックでアコーディオン展開（リンクは除外）→ 期待度セレクタ・見通し入力
- 決算済の銘柄は株価反応率(自動算出)と反応コメント欄
- 保有銘柄には ☆ マーク
- コメント済み銘柄は編集画面を開かなくても常時表示
- **表示順**: 直近1週間の過去決算 → 未来決算 → さらに前の決算（折りたたみ）

## データフロー

- `pf_kessan_shelve` がメインのデータソース（全ポートフォリオ銘柄の現在の決算日）
- `research_shelve.kessan_comments` でコメント済みエントリをマージ（`kessanbi` は `YYYY/MM/DD` で永続化）
- 株価反応率は `stocks_shelve.price_log`（直近10営業日）から算出し、保存時にスナップショット化
- 保存時に未登録銘柄は `add_stock()` で自動登録

## パフォーマンス

初期実装 `/market` ロード 4.1秒 → `stocks_shelve` の bulk 取得で **0.8秒**に改善（`_bulk_price_logs` で shelve 開閉回数を削減）。

## Test plan

- [x] `pytest tests/test_research_shelve.py tests/test_webapp_helpers.py tests/test_webapp_routes.py` 全 105 件合格
- [x] `curl /market` でテーマランク・市場表・適時開示の静的コンテンツが保持されることを確認
- [x] `GET/POST /api/kessan_comment` で保存→再取得→DB永続化を確認
- [x] ブラウザで `/market` を表示し、銘柄行クリックでアコーディオン展開、Esc で保存＋閉じることを確認
- [x] 保有銘柄の ☆ 表示、コメント済銘柄の常時表示を確認
- [x] 直近1週間過去決算 → 未来決算 → さらに前の決算（折りたたみ）の表示順を確認

## 関連

- Closes #127
- 関連: #129（BeautifulSoup 採用を機に既存HTMLパースの段階的リファクタを別issueで管理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)