### PR TITLE
適宜開示テストの日付を動的化し期限切れ失敗を解消

### DIFF
--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -472,10 +472,11 @@ class TestHtmlDisclosure:
 
     def test_hyperlink_parse(self):
         """=HYPERLINK()パターンが<a>タグに変換される"""
+        today_str = make_market_db.get_price_day(datetime.today()).strftime("%Y%m%d")
         disc_csv = [
             ["日付", "銘柄コード", "銘柄名", "種類", "本文"],
             [
-                "20260315",
+                today_str,
                 '=HYPERLINK("https://kabutan.jp/stock/chart?code=1234","1234")',
                 "テスト銘柄",
                 "開示",
@@ -488,10 +489,11 @@ class TestHtmlDisclosure:
 
     def test_html_escape(self):
         """銘柄名の特殊文字がエスケープされる"""
+        today_str = make_market_db.get_price_day(datetime.today()).strftime("%Y%m%d")
         disc_csv = [
             ["日付", "銘柄コード", "銘柄名", "種類", "本文"],
             [
-                "20260315",
+                today_str,
                 '=HYPERLINK("https://example.com","1234")',
                 "A&B<C>",
                 "開示",
@@ -532,9 +534,10 @@ class TestHtmlDisclosure:
 
     def test_gyoseki_row_class(self):
         """決算・修正行にdisc-row-gyosekiクラスが付く"""
+        today_str = make_market_db.get_price_day(datetime.today()).strftime("%Y%m%d")
         disc_csv = [
             ["日付", "銘柄コード", "銘柄名", "種類", "本文"],
-            ["20260315", "1234", "テスト", "決算", "決算発表"],
+            [today_str, "1234", "テスト", "決算", "決算発表"],
         ]
         result = make_market_db._html_disclosure(disc_csv)
         assert 'disc-row-gyoseki' in result


### PR DESCRIPTION
## Summary
- `tests/test_make_market_db.py::TestHtmlDisclosure` 3件（`test_hyperlink_parse` / `test_html_escape` / `test_gyoseki_row_class`）が main でも失敗していた
- 原因: テストが固定日 `"20260315"` を使っており、`_html_disclosure` の「30日以上前のデータは除外」ロジックで対象行が全てドロップされ、アサートするHTMLが出力されなくなっていた
- 修正: 3テストの日付を `get_price_day(datetime.today())` ベースの動的値に置換（同ファイル内の `test_recent_details_open` と同じスタイル）

## Test plan
- [x] `pytest tests/test_make_market_db.py tests/test_functional_market.py -v -m "not local_db and not live_html"` → 61 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)