### PR TITLE
決算コメントに決算またぎフィールド追加 + ログ再インポートで☆取込 (#138)

### DIFF
--- a/scripts/migrate_kessan_comments_from_log.py
+++ b/scripts/migrate_kessan_comments_from_log.py
@@ -653,12 +653,15 @@ def _upsert_kessan_comment_local(
         else:
             if target_idx is not None:
                 # 通常モードの既存上書き:
-                # webapp が学習した held_before_kessan / held_after_kessan は
-                # ログには情報が無いため、既存の True を退行させない。
-                # ただし True は下げない一方向更新 (新規側が True ならそれを採用)。
+                # webapp が学習した / 手動編集された保有系フラグ
+                # (held_before_kessan / held_after_kessan / kessan_matagi) は、
+                # ログ側には十分な情報が無いため退行させない (True → False させない)。
+                # 新規側が True ならそれを採用する一方向更新。
                 existing = comments[target_idx]
                 new_entry = dict(full_entry)
-                for key in ("held_before_kessan", "held_after_kessan"):
+                for key in (
+                    "held_before_kessan", "held_after_kessan", "kessan_matagi",
+                ):
                     if existing.get(key) and not new_entry.get(key):
                         new_entry[key] = True
                 comments[target_idx] = new_entry

--- a/scripts/migrate_kessan_comments_from_log.py
+++ b/scripts/migrate_kessan_comments_from_log.py
@@ -652,10 +652,20 @@ def _upsert_kessan_comment_local(
             saved_entry = merged
         else:
             if target_idx is not None:
-                comments[target_idx] = full_entry
+                # 通常モードの既存上書き:
+                # webapp が学習した held_before_kessan / held_after_kessan は
+                # ログには情報が無いため、既存の True を退行させない。
+                # ただし True は下げない一方向更新 (新規側が True ならそれを採用)。
+                existing = comments[target_idx]
+                new_entry = dict(full_entry)
+                for key in ("held_before_kessan", "held_after_kessan"):
+                    if existing.get(key) and not new_entry.get(key):
+                        new_entry[key] = True
+                comments[target_idx] = new_entry
+                saved_entry = new_entry
             else:
                 comments.append(full_entry)
-            saved_entry = full_entry
+                saved_entry = full_entry
 
         # 昇順ソート + 12 件超の最古削除
         comments = _sort_kessan_comments(comments)

--- a/scripts/migrate_kessan_comments_from_log.py
+++ b/scripts/migrate_kessan_comments_from_log.py
@@ -166,6 +166,7 @@ class StockToken:
     quarter: int           # 0〜4
     pre_outlook: str       # ": xxx" 部分。なければ ""
     line_no: int
+    had_holding_mark: bool = False  # ☆/⭐/⭐︎ が先頭に付いていたか (決算またぎの痕跡)
 
 
 @dataclass
@@ -208,16 +209,19 @@ def _normalize_expectation(ch: Optional[str]) -> str:
     return ch
 
 
-def _strip_leading_markers(text: str) -> Tuple[str, str]:
+def _strip_leading_markers(text: str) -> Tuple[str, bool, str]:
     """銘柄行先頭の保有マーク (☆/⭐/異体字セレクタ) と期待度マーカーを剥がす。
 
     順不同: 保有マーク → 期待度、または期待度 → 保有マーク のどちらも対応。
     保有マークの直後の全角空白・半角空白は食う ("☆ ◯4783..." → "◯4783...")。
 
     Returns:
-        (pre_expectation, rest)  pre_expectation は "" または VALID_EXPECTATIONS 相当
+        (pre_expectation, had_holding_mark, rest)
+        pre_expectation: "" または VALID_EXPECTATIONS 相当
+        had_holding_mark: ☆/⭐/⭐︎ を検出したら True (決算またぎの痕跡)
     """
     pre_exp = ""
+    had_holding_mark = False
     rest = text
     # 最大 4 回ループ: 保有マーク/期待度マーカー/空白/異体字セレクタを順に剥がす
     for _ in range(4):
@@ -227,6 +231,7 @@ def _strip_leading_markers(text: str) -> Tuple[str, str]:
         rest = VARIATION_SELECTOR_RE.sub("", rest, count=1) if rest and "\ufe00" <= rest[0] <= "\ufe0f" else rest
         head = rest[0] if rest else ""
         if head in HOLDING_MARKERS:
+            had_holding_mark = True
             rest = rest[1:]
             # 直後の空白 (全角 U+3000 / 半角) を食う
             rest = rest.lstrip(" \u3000")
@@ -237,7 +242,7 @@ def _strip_leading_markers(text: str) -> Tuple[str, str]:
             rest = rest.lstrip(" \u3000")
             continue
         break
-    return pre_exp, rest
+    return pre_exp, had_holding_mark, rest
 
 
 def tokenize_lines(lines: List[str]) -> Tuple[List[Token], List[Dict[str, Any]]]:
@@ -315,7 +320,7 @@ def tokenize_lines(lines: List[str]) -> Tuple[List[Token], List[Dict[str, Any]]]
             continue
 
         # 銘柄行: 先頭マーカー (保有/期待度) を剥がしてから STOCK_HEAD にかける
-        pre_exp, rest = _strip_leading_markers(normalized)
+        pre_exp, had_holding_mark, rest = _strip_leading_markers(normalized)
         m_stock = STOCK_HEAD.match(rest)
         quarter: Optional[int] = None
         tail_raw = ""
@@ -352,6 +357,7 @@ def tokenize_lines(lines: List[str]) -> Tuple[List[Token], List[Dict[str, Any]]]
                 quarter=quarter,
                 pre_outlook=pre_outlook,
                 line_no=idx,
+                had_holding_mark=had_holding_mark,
             ))
             continue
 
@@ -378,6 +384,7 @@ class ParsedEntry:
     pre_outlook: str
     post_price_change: str  # 符号付き文字列、% なし。post なしは ""
     post_comment: str       # post なしは ""
+    kessan_matagi: bool = False  # 決算日をまたいで保有していたか (ログ上の ☆ 由来)
     source_line_no: int = 0  # 診断用
 
 
@@ -481,6 +488,7 @@ def build_entries_from_tokens(
             pre_outlook=pending.pre_outlook,
             post_price_change=post_price_change,
             post_comment=post_comment,
+            kessan_matagi=pending.had_holding_mark,
             source_line_no=pending.line_no,
         ))
         pending = None
@@ -552,7 +560,8 @@ def _upsert_kessan_comment_local(
     entry: ParsedEntry,
     *,
     db_path: Optional[str] = None,
-) -> Dict[str, Any]:
+    update_fields: Optional[List[str]] = None,
+) -> Optional[Dict[str, Any]]:
     """entry を research_shelve に upsert する (本スクリプト専用のローカル実装)。
 
     排他制御: `_flock(db_path)` で read-modify-write 全体を囲む。
@@ -568,23 +577,45 @@ def _upsert_kessan_comment_local(
         最小レコード (stock_name="") を作って当該 db_path に登録する。
         検証 (--db-path /tmp/...) やテスト時に本番 DB が影響を受けない。
 
+    update_fields が指定された場合:
+      - 既存エントリに (kessanbi, quarter) マッチする行だけを対象に、
+        指定フィールドのみを更新する (他フィールドは既存値を保持)。
+      - マッチしないエントリは新規追加せずスキップし、戻り値は None。
+        (12件キャップによる既存履歴の追い出しを防ぐ安全策)
+      - update_fields の値は KESSAN_COMMENT_FIELDS の部分集合でなければ ValueError。
+
     Returns:
-        保存したエントリ dict。
+        保存したエントリ dict。update_fields 指定で未マッチスキップ時は None。
     """
     normalized = rs.normalize_code_s(entry.code_s)
 
-    saved_entry: Dict[str, Any] = {
+    full_entry: Dict[str, Any] = {
         "kessanbi": entry.kessanbi,
         "quarter": entry.quarter,
         "pre_expectation": entry.pre_expectation,
         "pre_outlook": entry.pre_outlook,
         "post_price_change": entry.post_price_change,
         "post_comment": entry.post_comment,
+        "kessan_matagi": bool(entry.kessan_matagi),
+        # ログには決算前後の保有履歴情報が含まれないため False 固定。
+        # 後日 webapp 側で is_possess を見て昇格される。
+        "held_before_kessan": False,
+        "held_after_kessan": False,
     }
+
+    if update_fields:
+        unknown = set(update_fields) - set(rs.KESSAN_COMMENT_FIELDS)
+        if unknown:
+            raise ValueError(
+                f"update_fields に未知フィールド: {sorted(unknown)}"
+            )
 
     with _flock(db_path):
         record = rs.get_research_record(normalized, db_path=db_path)
         if record is None:
+            if update_fields:
+                # 既存のみ更新モードではレコード自体が無ければスキップ
+                return None
             if db_path is None:
                 # 本番 DB: webapp の save_kessan_comment と同じパターン
                 # add_stock は内部で _flock() を取るがリエントラントなので OK
@@ -610,10 +641,21 @@ def _upsert_kessan_comment_local(
                 target_idx = i
                 break
 
-        if target_idx is not None:
-            comments[target_idx] = saved_entry
+        if update_fields:
+            # 既存エントリに一致したときだけ、指定フィールドのみを上書き
+            if target_idx is None:
+                return None
+            merged = dict(comments[target_idx])
+            for field in update_fields:
+                merged[field] = full_entry[field]
+            comments[target_idx] = merged
+            saved_entry = merged
         else:
-            comments.append(saved_entry)
+            if target_idx is not None:
+                comments[target_idx] = full_entry
+            else:
+                comments.append(full_entry)
+            saved_entry = full_entry
 
         # 昇順ソート + 12 件超の最古削除
         comments = _sort_kessan_comments(comments)
@@ -646,6 +688,7 @@ def migrate_log_to_research_shelve(
     dry_run: bool = False,
     default_year: Optional[int] = None,
     show_codes: Optional[List[str]] = None,
+    update_fields: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """ログファイル全体を研究DBに移行する。
 
@@ -654,6 +697,7 @@ def migrate_log_to_research_shelve(
         2. dry_run=False ならバックアップ
         3. 各エントリを _upsert_kessan_comment_local で upsert
            - 失敗時は log_warning + failed_entries に追加、継続
+           - update_fields 指定時は未マッチのエントリをスキップ集計
         4. show_codes が指定されたら format_record_full で stdout に出力
         5. サマリ dict を返す
     """
@@ -667,6 +711,10 @@ def migrate_log_to_research_shelve(
 
     total = len(entries)
     log_print(f"[migrate_kessan] 有効エントリ: {total}")
+    if update_fields:
+        log_print(
+            f"[migrate_kessan] update_fields モード: {update_fields} のみ既存エントリに反映"
+        )
 
     # バックアップ
     backup_paths: List[str] = []
@@ -686,13 +734,19 @@ def migrate_log_to_research_shelve(
     # 実行
     failed_entries: List[Dict[str, Any]] = []
     succeeded = 0
+    skipped_unmatched = 0
 
     log_print("[migrate_kessan] 移行開始...")
     for idx, entry in enumerate(entries, start=1):
         try:
             _validate_entry(entry)
             if not dry_run:
-                _upsert_kessan_comment_local(entry, db_path=db_path)
+                result = _upsert_kessan_comment_local(
+                    entry, db_path=db_path, update_fields=update_fields,
+                )
+                if update_fields and result is None:
+                    skipped_unmatched += 1
+                    continue
             succeeded += 1
         except (ValueError, TypeError) as e:
             log_warning(
@@ -712,6 +766,10 @@ def migrate_log_to_research_shelve(
         f"[migrate_kessan] 完了: 成功 {succeeded} 件、失敗 {len(failed_entries)} 件"
         f" (パース warning {len(parse_warnings)} 件)"
     )
+    if update_fields:
+        log_print(
+            f"[migrate_kessan] update_fields モードの未マッチスキップ: {skipped_unmatched} 件"
+        )
 
     if failed_entries:
         log_print("[migrate_kessan] 失敗エントリ一覧:")
@@ -756,6 +814,8 @@ def migrate_log_to_research_shelve(
         "parse_warnings": parse_warnings,
         "dry_run": dry_run,
         "backup_paths": backup_paths,
+        "skipped_unmatched": skipped_unmatched,
+        "update_fields": update_fields,
     }
 
 
@@ -801,11 +861,26 @@ def main() -> int:
         default=None,
         help="<YYYY年> ヘッダが先頭に無い場合の default 年 (edge case)",
     )
+    parser.add_argument(
+        "--update-fields",
+        default=None,
+        help=(
+            "既存エントリに対して指定フィールドのみ更新するモード。"
+            "カンマ区切りで複数可 (例: --update-fields kessan_matagi)。"
+            "未マッチのエントリは新規追加せずスキップする (既存履歴の追い出し防止)。"
+        ),
+    )
     args = parser.parse_args()
 
     show_codes: Optional[List[str]] = None
     if args.show:
         show_codes = [c.strip() for c in args.show.split(",") if c.strip()]
+
+    update_fields: Optional[List[str]] = None
+    if args.update_fields:
+        update_fields = [
+            f.strip() for f in args.update_fields.split(",") if f.strip()
+        ]
 
     summary = migrate_log_to_research_shelve(
         args.log_path,
@@ -813,6 +888,7 @@ def main() -> int:
         dry_run=args.dry_run,
         default_year=args.year,
         show_codes=show_codes,
+        update_fields=update_fields,
     )
 
     return 1 if summary["failed"] > 0 else 0

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -90,12 +90,16 @@ RECORD_FIELDS = frozenset(
 # 決算コメントエントリの既知フィールド
 KESSAN_COMMENT_FIELDS = frozenset(
     {
-        "kessanbi",          # YYYY/MM/DD
-        "quarter",           # 1-4 (int)
-        "pre_expectation",   # ◎/○/△/× or ""
-        "pre_outlook",       # 事前見通し (フリーテキスト)
-        "post_price_change", # 決算反応の株価変動率 (%) スナップショット
-        "post_comment",      # 決算後コメント (フリーテキスト)
+        "kessanbi",             # YYYY/MM/DD
+        "quarter",              # 1-4 (int)
+        "pre_expectation",      # ◎/○/△/× or ""
+        "pre_outlook",          # 事前見通し (フリーテキスト)
+        "post_price_change",    # 決算反応の株価変動率 (%) スナップショット
+        "post_comment",         # 決算後コメント (フリーテキスト)
+        "held_before_kessan",   # 決算前に保有中だったか (bool, 未来エントリで永続化)
+        "held_after_kessan",    # 決算後に保有中だったか (bool, 過去エントリで永続化)
+        "kessan_matagi",        # 決算日をまたいで保有していたか (bool)
+                                # 自動判定: held_before AND held_after / ログ☆由来 / UI手動
     }
 )
 
@@ -448,6 +452,8 @@ def get_research_record(
     存在しなければ None。code_s は内部で正規化される。
     shikiho_comments は List[dict] に自動正規化される（後方互換）。
     kessan_comments は未設定の旧レコードに対し空リストで補完する（後方互換）。
+    kessan_comments の各エントリに kessan_matagi / held_before_kessan /
+    held_after_kessan が無ければ False で補完する（後方互換）。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
@@ -460,6 +466,14 @@ def get_research_record(
         )
         if not isinstance(record.get("kessan_comments"), list):
             record["kessan_comments"] = []
+        for entry in record["kessan_comments"]:
+            if not isinstance(entry, dict):
+                continue
+            for key in (
+                "kessan_matagi", "held_before_kessan", "held_after_kessan",
+            ):
+                if key not in entry:
+                    entry[key] = False
     return record
 
 
@@ -798,7 +812,10 @@ def format_record_full(record: Dict[str, Any]) -> str:
             pre = entry.get("pre_outlook", "")
             price_change = entry.get("post_price_change", "") or "-"
             post = entry.get("post_comment", "")
-            lines.append(f"  [{kessanbi} {quarter}Q 期待度:{pre_exp} 反応:{price_change}%]")
+            matagi_mark = "◆" if entry.get("kessan_matagi") else ""
+            lines.append(
+                f"  [{kessanbi} {quarter}Q 期待度:{pre_exp} 反応:{price_change}% {matagi_mark}]"
+            )
             lines.append(f"    事前    : {_indent_multiline(pre, ' ' * 14)}")
             lines.append(f"    事後    : {_indent_multiline(post, ' ' * 14)}")
     else:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -498,11 +498,113 @@ def _sort_kessan_comments(comments: List[Dict[str, Any]]) -> List[Dict[str, Any]
     return sorted(comments, key=_key)
 
 
-def _validate_kessan_comment_input(form_data: dict) -> Tuple[str, int, str, str, str]:
+_FORM_TRUE_VALUES = frozenset({"1", "true", "True", "on", "yes"})
+_FORM_FALSE_VALUES = frozenset({"0", "false", "False", "off", "no"})
+
+
+def _is_possess_now(code_s: str) -> bool:
+    """code_s が現在の保有リスト (my_watch_list.txt の H プレフィックス) に含まれるか。
+
+    parse 失敗時は False (kessan_matagi を誤って立てない安全側に倒す)。
+    """
+    try:
+        import portfolio
+        _, possess_list = portfolio.parse_my_portforio()
+        return code_s in set(possess_list)
+    except Exception as e:
+        log_warning(f"[kessan_matagi] parse_my_portforio 失敗: {e}")
+        return False
+
+
+def _persist_kessan_held_flags(
+    targets: List[Tuple[str, str, int, Dict[str, bool]]],
+) -> None:
+    """指定された (code_s, kessanbi, quarter) の保有系フラグを True に永続化する。
+
+    updates dict は {"held_before_kessan": True, ...} のような True 立ち上げ指示。
+    True は False に下げない (True だけを追記する一方向更新)。
+
+    並行書き込み安全対応:
+      - ロック下で get_research_record() による **再取得** を行い、
+        呼び出し元が保持していた可能性のある stale な record は使わない。
+      - updates の指定キー以外には触らない (他フィールドの並行編集は温存)。
+      - 該当エントリが見つからない / 全指定キーが既に True ならスキップ。
+
+    同一 code_s の複数 (kessanbi, quarter) を 1 回の lock にまとめる。
+    """
+    # code_s 単位でまとめる
+    grouped: Dict[str, List[Tuple[str, int, Dict[str, bool]]]] = {}
+    for code_s, kessanbi, quarter, updates in targets:
+        grouped.setdefault(code_s, []).append((kessanbi, quarter, updates))
+
+    for code_s, items in grouped.items():
+        try:
+            with _flock():
+                record = get_research_record(code_s)
+                if record is None:
+                    continue
+                comments = list(record.get("kessan_comments") or [])
+                changed = False
+                for kessanbi, quarter, updates in items:
+                    for existing in comments:
+                        if (
+                            existing.get("kessanbi") == kessanbi
+                            and int(existing.get("quarter", 0) or 0) == quarter
+                        ):
+                            for key, new_val in updates.items():
+                                # True のみ追記 (False 降格しない)
+                                if new_val and not existing.get(key):
+                                    existing[key] = True
+                                    changed = True
+                            # AND 判定を permanent 側でも保証
+                            if (
+                                existing.get("held_before_kessan")
+                                and existing.get("held_after_kessan")
+                                and not existing.get("kessan_matagi")
+                            ):
+                                existing["kessan_matagi"] = True
+                                changed = True
+                            break
+                if changed:
+                    record["kessan_comments"] = comments
+                    upsert_research_record(record)
+        except Exception as e:
+            log_warning(f"[kessan_matagi] 永続化失敗 code={code_s}: {e}")
+
+
+def _parse_form_tristate_bool(raw: Any) -> Optional[bool]:
+    """フォーム値を bool / None (=未指定) に正規化する。
+
+    - True/False をそのまま受理
+    - "1"/"true"/"on"/"yes" → True、"0"/"false"/"off"/"no" → False
+    - None, "" は未指定として None を返す
+    - それ以外は ValueError
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        s = raw.strip()
+        if s == "":
+            return None
+        if s in _FORM_TRUE_VALUES:
+            return True
+        if s in _FORM_FALSE_VALUES:
+            return False
+    raise ValueError(f"bool として解釈不能: {raw!r}")
+
+
+def _validate_kessan_comment_input(
+    form_data: dict,
+) -> Tuple[str, int, str, str, str, Optional[bool]]:
     """フォーム入力を検証し、正規化した値を返す。
 
     Returns:
-        (kessanbi, quarter, pre_expectation, pre_outlook, post_comment)
+        (kessanbi, quarter, pre_expectation, pre_outlook, post_comment,
+         kessan_matagi_override)
+        kessan_matagi_override は None / True / False。
+        None は「フォームに指定なし」で、save 側の自動判定を使う。
     Raises:
         ValueError: 入力不正
     """
@@ -525,7 +627,21 @@ def _validate_kessan_comment_input(form_data: dict) -> Tuple[str, int, str, str,
     pre_outlook = form_data.get("pre_outlook", "") or ""
     post_comment = form_data.get("post_comment", "") or ""
 
-    return kessanbi, quarter, pre_expectation, pre_outlook, post_comment
+    kessan_matagi_override: Optional[bool]
+    if "kessan_matagi" in form_data:
+        try:
+            kessan_matagi_override = _parse_form_tristate_bool(
+                form_data.get("kessan_matagi")
+            )
+        except ValueError as e:
+            raise ValueError(f"kessan_matagi 不正: {e}")
+    else:
+        kessan_matagi_override = None
+
+    return (
+        kessanbi, quarter, pre_expectation, pre_outlook, post_comment,
+        kessan_matagi_override,
+    )
 
 
 def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
@@ -543,12 +659,16 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
 
-    kessanbi, quarter, pre_expectation, pre_outlook, post_comment = (
-        _validate_kessan_comment_input(form_data)
-    )
+    (
+        kessanbi, quarter, pre_expectation, pre_outlook, post_comment,
+        kessan_matagi_override,
+    ) = _validate_kessan_comment_input(form_data)
 
     # 変動率をスナップショット算出
     post_price_change = calc_price_reaction(normalized, kessanbi)
+
+    # 現在保有中か (kessan_matagi 初期値判定用)
+    is_possess_now = _is_possess_now(normalized)
 
     with _flock():
         record = get_research_record(normalized)
@@ -570,6 +690,38 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
                 target_idx = i
                 break
 
+        # 既存 held フラグを引き継ぐ (True は下げない)
+        existing_held_before = False
+        existing_held_after = False
+        existing_matagi = False
+        if target_idx is not None:
+            existing = comments[target_idx]
+            existing_held_before = bool(existing.get("held_before_kessan", False))
+            existing_held_after = bool(existing.get("held_after_kessan", False))
+            existing_matagi = bool(existing.get("kessan_matagi", False))
+
+        # 決算前後の切り分け: kessanbi と現在日の比較で held_before/after を更新
+        kessanbi_dt = _parse_kessanbi(kessanbi)
+        today = get_price_day(datetime.today())
+        held_before = existing_held_before
+        held_after = existing_held_after
+        if is_possess_now and kessanbi_dt is not None:
+            if kessanbi_dt >= today:
+                held_before = True
+            else:
+                held_after = True
+
+        # kessan_matagi の確定:
+        #   1. form_data に明示指定があればそれを優先 (手動トグル)
+        #   2. 既存エントリが True ならそれを維持
+        #   3. held_before AND held_after なら True (AND 判定)
+        if kessan_matagi_override is not None:
+            kessan_matagi = kessan_matagi_override
+        elif existing_matagi:
+            kessan_matagi = True
+        else:
+            kessan_matagi = bool(held_before and held_after)
+
         new_entry: Dict[str, Any] = {
             "kessanbi": kessanbi,
             "quarter": quarter,
@@ -577,6 +729,9 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
             "pre_outlook": pre_outlook,
             "post_price_change": post_price_change,
             "post_comment": post_comment,
+            "kessan_matagi": kessan_matagi,
+            "held_before_kessan": held_before,
+            "held_after_kessan": held_after,
         }
         if target_idx is not None:
             # 既存エントリ上書き。post_price_change はリアルタイム計算失敗時は既存値を優先
@@ -685,6 +840,9 @@ def get_market_kessan_data() -> Dict[str, Any]:
             "post_comment": "",
             "has_comment": False,
             "is_possess": code_s in possess_set,
+            "kessan_matagi": False,
+            "held_before_kessan": False,
+            "held_after_kessan": False,
         }
 
     # research_shelve のコメント済みエントリをマージ
@@ -725,6 +883,9 @@ def get_market_kessan_data() -> Dict[str, Any]:
                     or entry.get("pre_expectation")
                 ),
                 "is_possess": code_s in possess_set,
+                "kessan_matagi": bool(entry.get("kessan_matagi", False)),
+                "held_before_kessan": bool(entry.get("held_before_kessan", False)),
+                "held_after_kessan": bool(entry.get("held_after_kessan", False)),
             }
 
     # 過去エントリで post_price_change 未保存のものだけ一括で price_log 取得
@@ -741,6 +902,11 @@ def get_market_kessan_data() -> Dict[str, Any]:
     # 日付ごとにグループ化
     future_groups: Dict[str, List[Dict[str, Any]]] = {}
     past_groups: Dict[str, List[Dict[str, Any]]] = {}
+    # kessan_matagi 関連フィールドで新たに True 化した per-entry を記録し、
+    # ループ後に専用関数で shelve に永続化する。
+    # (stale rec を直接 upsert すると並行編集を上書きするため、lock 下で再取得する)
+    # targets: [(code_s, kessanbi, quarter, {"held_before_kessan": True, ...}), ...]
+    persist_targets: List[Tuple[str, str, int, Dict[str, bool]]] = []
     for entry in merged.values():
         kessanbi = entry["kessanbi"]
         dt = _parse_kessanbi(kessanbi)
@@ -750,8 +916,42 @@ def get_market_kessan_data() -> Dict[str, Any]:
         if dt < base_day and not entry.get("post_price_change"):
             log = price_logs_cache.get(entry["code_s"], [])
             entry["post_price_change"] = _price_reaction_from_log(log, dt)
+
+        # 前後保有フラグのスナップショット化
+        # - 未来エントリ (dt >= base_day): is_possess=True なら held_before_kessan=True
+        # - 過去エントリ (dt <  base_day): is_possess=True なら held_after_kessan=True
+        # True は False に下げない (過去の保有痕跡は不可逆保持)
+        updates: Dict[str, bool] = {}
+        if entry.get("is_possess"):
+            if dt >= base_day and not entry.get("held_before_kessan"):
+                entry["held_before_kessan"] = True
+                updates["held_before_kessan"] = True
+            elif dt < base_day and not entry.get("held_after_kessan"):
+                entry["held_after_kessan"] = True
+                updates["held_after_kessan"] = True
+
+        # AND 判定: 決算前保有 & 決算後保有 の両方満たせば kessan_matagi=True 確定
+        if (
+            entry.get("held_before_kessan")
+            and entry.get("held_after_kessan")
+            and not entry.get("kessan_matagi")
+        ):
+            entry["kessan_matagi"] = True
+            updates["kessan_matagi"] = True
+
+        if updates:
+            persist_targets.append((
+                entry["code_s"],
+                entry["kessanbi"],
+                int(entry.get("quarter", 0) or 0),
+                updates,
+            ))
+
         groups = past_groups if dt < base_day else future_groups
         groups.setdefault(kessanbi, []).append(entry)
+
+    if persist_targets:
+        _persist_kessan_held_flags(persist_targets)
 
     # 銘柄コード順にカード内ソート
     for d in list(future_groups.values()) + list(past_groups.values()):

--- a/scripts/webapp/routes/market.py
+++ b/scripts/webapp/routes/market.py
@@ -50,6 +50,7 @@ def get_kessan_comment_api(code_s: str):
             "pre_outlook": "",
             "post_price_change": "",
             "post_comment": "",
+            "kessan_matagi": False,
         }
     return jsonify(entry)
 

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -326,8 +326,15 @@ function saveKessanFromEditor(li) {
   formData.append('pre_expectation', preExp ? preExp.value : '');
   formData.append('pre_outlook', preOut ? preOut.value : '');
   formData.append('post_comment', postCom ? postCom.value : '');
+  /* kessan_matagi は checkbox が初期値と変わった時のみ送信する。
+     (未操作で常に送ると save_kessan_comment 側で override 扱いになり、
+      held_before && held_after による自動昇格が効かなくなる) */
   if (matagi) {
-    formData.append('kessan_matagi', matagi.checked ? '1' : '0');
+    var initial = matagi.dataset.initial || '0';
+    var current = matagi.checked ? '1' : '0';
+    if (current !== initial) {
+      formData.append('kessan_matagi', current);
+    }
   }
 
   var url = '/api/kessan_comment/' + encodeURIComponent(code);

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -271,9 +271,11 @@ function openKessanEditor(li) {
       var preOut = editor.querySelector('.kessan-pre-outlook');
       var postCom = editor.querySelector('.kessan-post-comment');
       var postPc = editor.querySelector('.kessan-post-price-change');
+      var matagi = editor.querySelector('.kessan-matagi');
       if (preExp) preExp.value = data.pre_expectation || '';
       if (preOut) preOut.value = data.pre_outlook || '';
       if (postCom) postCom.value = data.post_comment || '';
+      if (matagi) matagi.checked = !!data.kessan_matagi;
       if (postPc && data.post_price_change) {
         postPc.textContent = data.post_price_change;
       }
@@ -288,14 +290,19 @@ function openKessanEditor(li) {
 
 function rememberKessanInitialValues(editor) {
   editor.querySelectorAll('.kessan-field').forEach(function(el) {
-    el.dataset.initial = el.value;
+    if (el.type === 'checkbox') {
+      el.dataset.initial = el.checked ? '1' : '0';
+    } else {
+      el.dataset.initial = el.value;
+    }
   });
 }
 
 function isKessanDirty(editor) {
   var dirty = false;
   editor.querySelectorAll('.kessan-field').forEach(function(el) {
-    if (el.value !== (el.dataset.initial || '')) dirty = true;
+    var current = el.type === 'checkbox' ? (el.checked ? '1' : '0') : el.value;
+    if (current !== (el.dataset.initial || '')) dirty = true;
   });
   return dirty;
 }
@@ -311,6 +318,7 @@ function saveKessanFromEditor(li) {
   var preExp = editor.querySelector('.kessan-pre-expectation');
   var preOut = editor.querySelector('.kessan-pre-outlook');
   var postCom = editor.querySelector('.kessan-post-comment');
+  var matagi = editor.querySelector('.kessan-matagi');
 
   var formData = new FormData();
   formData.append('kessanbi', kessanbi);
@@ -318,6 +326,9 @@ function saveKessanFromEditor(li) {
   formData.append('pre_expectation', preExp ? preExp.value : '');
   formData.append('pre_outlook', preOut ? preOut.value : '');
   formData.append('post_comment', postCom ? postCom.value : '');
+  if (matagi) {
+    formData.append('kessan_matagi', matagi.checked ? '1' : '0');
+  }
 
   var url = '/api/kessan_comment/' + encodeURIComponent(code);
   _saveQueue = _saveQueue.then(function() {
@@ -345,9 +356,25 @@ function saveKessanFromEditor(li) {
   }).catch(function() { /* エラー時もキュー継続 */ });
 }
 
-/* 保存成功後、li 内の表示用 DOM（見通し・反応・期待度バッジ）を更新 */
+/* 保存成功後、li 内の表示用 DOM（見通し・反応・期待度バッジ・決算またぎ）を更新 */
 function updateKessanViewDOM(li, data) {
   var isPast = li.dataset.isPast === '1';
+
+  /* 決算またぎ ◆ マーク */
+  var matagiMark = li.querySelector('.kessan-matagi-mark');
+  if (data.kessan_matagi) {
+    if (!matagiMark) {
+      matagiMark = document.createElement('span');
+      matagiMark.className = 'kessan-matagi-mark';
+      matagiMark.title = '決算またぎ保有';
+      matagiMark.textContent = '◆';
+      var possessMark = li.querySelector('.kessan-possess-mark');
+      var refNode = possessMark ? possessMark.nextSibling : li.firstChild;
+      li.insertBefore(matagiMark, refNode);
+    }
+  } else if (matagiMark) {
+    matagiMark.remove();
+  }
 
   /* 期待度バッジ */
   var badge = li.querySelector('.kessan-expectation-badge');

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -297,6 +297,14 @@ nav .quick-search {
   background: #fff9ed;
 }
 
+/* 決算またぎ (決算日をまたいで保有) マーク */
+.kessan-matagi-mark {
+  color: #c49b2d;
+  font-weight: bold;
+  margin-right: 2px;
+  font-size: 0.9em;
+}
+
 /* 決算コメント常時表示 (編集中以外でも見える) */
 .kessan-comment-view {
   margin: 2px 0 2px 14px;

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -232,7 +232,10 @@
       <tbody onclick="toggleKessanRow(event)">
         {% for entry in kessan_hist | reverse %}
         <tr>
-          <td class="col-date">{{ entry.kessanbi }}</td>
+          <td class="col-date">
+            {{ entry.kessanbi }}
+            {% if entry.kessan_matagi %}<span class="kessan-matagi-mark" title="決算またぎ保有">◆</span>{% endif %}
+          </td>
           <td class="col-q">{% if entry.quarter %}{{ entry.quarter }}Q{% endif %}</td>
           <td class="col-exp">
             {% if entry.pre_expectation %}

--- a/scripts/webapp/templates/market.html
+++ b/scripts/webapp/templates/market.html
@@ -47,6 +47,10 @@
         <label>反応コメ:</label>
         <textarea class="kessan-field kessan-post-comment" rows="2" placeholder="決算後の反応・コメント"></textarea>
       </div>
+      <div class="kessan-editor-row">
+        <label>決算またぎ:</label>
+        <input type="checkbox" class="kessan-field kessan-matagi">
+      </div>
       {% endif %}
     </div>
   {%- endmacro %}
@@ -62,6 +66,7 @@
         onclick="handleKessanRowClick(event, this)"
         title="クリックでコメント編集">
       {% if s.is_possess %}<span class="kessan-possess-mark" title="保有銘柄">☆</span>{% endif %}
+      {% if s.kessan_matagi %}<span class="kessan-matagi-mark" title="決算またぎ保有">◆</span>{% endif %}
       <a href="https://kabutan.jp/stock/chart?code={{ s.code_s }}" target="_blank">{{ s.code_s }}</a>
       <a href="/stock/{{ s.code_s }}">{{ s.stock_name or '-' }}</a>
       {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}

--- a/tests/test_migrate_kessan_comments_from_log.py
+++ b/tests/test_migrate_kessan_comments_from_log.py
@@ -786,6 +786,37 @@ class TestLocalUpsert:
         assert entry["held_before_kessan"] is True
         assert entry["held_after_kessan"] is True
 
+    def test_normal_upsert_preserves_existing_kessan_matagi_true(self, db_path):
+        """通常モードで既存の kessan_matagi=True を ☆なしログで False に下げない
+
+        webapp の自動昇格や手動トグルで True になっていたエントリは、
+        ログ側に ☆ が無くても True を保持する (PR レビュー P2 追加分)。
+        """
+        _preregister(db_path, "5032")
+        rec = rs.get_research_record("5032", db_path=db_path)
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/03/11",
+            "quarter": 3,
+            "pre_expectation": "○",
+            "pre_outlook": "既存見通し",
+            "post_price_change": "-15",
+            "post_comment": "[E] -15% x",
+            "kessan_matagi": True,          # 既存 True (webapp 由来)
+            "held_before_kessan": False,
+            "held_after_kessan": True,
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        # ログ側 ☆なし (kessan_matagi=False) で通常保存
+        mig._upsert_kessan_comment_local(
+            self._entry(kessan_matagi=False),
+            db_path=db_path,
+        )
+
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        entry = loaded["kessan_comments"][0]
+        assert entry["kessan_matagi"] is True  # 退行しない
+
     def test_normal_upsert_accepts_new_true_flags(self, db_path):
         """True 側の更新は反映される (片方だけ True に立てるケース)"""
         _preregister(db_path, "5032")

--- a/tests/test_migrate_kessan_comments_from_log.py
+++ b/tests/test_migrate_kessan_comments_from_log.py
@@ -752,6 +752,68 @@ class TestLocalUpsert:
                 update_fields=["kessan_matagi", "nonexistent_field"],
             )
 
+    def test_normal_upsert_preserves_existing_held_flags(self, db_path):
+        """通常モードの既存上書きで held_before/after の True を退行させない
+
+        webapp 側が学習した保有痕跡 (held_before_kessan / held_after_kessan)
+        をログ由来の全上書きで消してはいけない (PR レビュー P2)。
+        """
+        _preregister(db_path, "5032")
+        # 事前に True 状態のエントリを直接 DB に入れる (webapp 学習済み状態を模擬)
+        rec = rs.get_research_record("5032", db_path=db_path)
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/03/11",
+            "quarter": 3,
+            "pre_expectation": "○",
+            "pre_outlook": "既存見通し",
+            "post_price_change": "-15",
+            "post_comment": "[E] -15% x",
+            "kessan_matagi": True,
+            "held_before_kessan": True,
+            "held_after_kessan": True,
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        # ログから同じ (kessanbi, quarter) を通常モードで upsert
+        mig._upsert_kessan_comment_local(
+            self._entry(kessan_matagi=False),  # ログ由来は False だが
+            db_path=db_path,
+        )
+
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        entry = loaded["kessan_comments"][0]
+        # 既存の True を保持
+        assert entry["held_before_kessan"] is True
+        assert entry["held_after_kessan"] is True
+
+    def test_normal_upsert_accepts_new_true_flags(self, db_path):
+        """True 側の更新は反映される (片方だけ True に立てるケース)"""
+        _preregister(db_path, "5032")
+        # 既存は held_* 両方 False
+        rec = rs.get_research_record("5032", db_path=db_path)
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/03/11",
+            "quarter": 3,
+            "pre_expectation": "○",
+            "pre_outlook": "x",
+            "post_price_change": "",
+            "post_comment": "",
+            "kessan_matagi": False,
+            "held_before_kessan": False,
+            "held_after_kessan": False,
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        # ログ側から通常保存 (ログは常に held_* を False でくるが、
+        # もし将来的に True 化されたエントリで呼び出された場合も退行しないこと)
+        mig._upsert_kessan_comment_local(self._entry(), db_path=db_path)
+
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        entry = loaded["kessan_comments"][0]
+        # 既存が False なので False のままで問題ない
+        assert entry["held_before_kessan"] is False
+        assert entry["held_after_kessan"] is False
+
 
 # ==================================================
 # 6. TestMigrateLogToResearchShelve

--- a/tests/test_migrate_kessan_comments_from_log.py
+++ b/tests/test_migrate_kessan_comments_from_log.py
@@ -65,6 +65,49 @@ class TestReadLogLines:
 
 
 # ==================================================
+# 2-pre. TestStripLeadingMarkers
+# ==================================================
+class TestStripLeadingMarkers:
+    """_strip_leading_markers の直接テスト (戻り値 3-tuple)"""
+
+    def test_no_markers(self):
+        pre, held, rest = mig._strip_leading_markers("5032あ[3Q]")
+        assert pre == ""
+        assert held is False
+        assert rest == "5032あ[3Q]"
+
+    def test_holding_mark_only(self):
+        pre, held, rest = mig._strip_leading_markers("☆5032あ[3Q]")
+        assert pre == ""
+        assert held is True
+        assert rest == "5032あ[3Q]"
+
+    def test_expectation_only(self):
+        pre, held, rest = mig._strip_leading_markers("◯5032あ[3Q]")
+        assert pre == "○"  # 正規化
+        assert held is False
+        assert rest == "5032あ[3Q]"
+
+    def test_holding_then_expectation(self):
+        pre, held, rest = mig._strip_leading_markers("☆◯5032あ[3Q]")
+        assert pre == "○"
+        assert held is True
+        assert rest == "5032あ[3Q]"
+
+    def test_expectation_then_holding(self):
+        pre, held, rest = mig._strip_leading_markers("◯☆5032あ[3Q]")
+        assert pre == "○"
+        assert held is True
+        assert rest == "5032あ[3Q]"
+
+    def test_emoji_star_with_vs15(self):
+        """⭐︎ (U+2B50+U+FE0E) は held=True"""
+        pre, held, rest = mig._strip_leading_markers("⭐\ufe0e6324")
+        assert held is True
+        assert rest == "6324"
+
+
+# ==================================================
 # 2. TestTokenizer
 # ==================================================
 class TestTokenizer:
@@ -96,7 +139,7 @@ class TestTokenizer:
         assert t.pre_outlook == ""
 
     def test_stock_with_holding_mark(self):
-        """☆ は holding marker で pre_expectation にしない"""
+        """☆ は holding marker で pre_expectation にしない + had_holding_mark=True"""
         tokens, _ = mig.tokenize_lines(["☆5032ＡＮＹＣＯＬＯＲ[3Q]"])
         t = tokens[0]
         assert isinstance(t, mig.StockToken)
@@ -104,6 +147,14 @@ class TestTokenizer:
         assert t.code_s == "5032"
         assert t.quarter == 3
         assert t.pre_outlook == ""
+        assert t.had_holding_mark is True
+
+    def test_stock_without_holding_mark(self):
+        """☆ 無しでは had_holding_mark=False"""
+        tokens, _ = mig.tokenize_lines(["◯9556ＩＮＴＬＯＯＰ[2Q]"])
+        t = tokens[0]
+        assert isinstance(t, mig.StockToken)
+        assert t.had_holding_mark is False
 
     def test_stock_with_pre_expectation_marui(self):
         """◯ (U+25EF) は ○ (U+25CB) に正規化される"""
@@ -314,7 +365,7 @@ class TestBuildEntries:
     """エントリ組立層のテスト"""
 
     def test_stock_with_post_full_attach(self):
-        """stock + post 行がアタッチされて 1 エントリ生成"""
+        """stock + post 行がアタッチされて 1 エントリ生成 + ☆ が kessan_matagi=True に反映"""
         tokens, _ = mig.tokenize_lines([
             "<2026年>",
             "[03/11]",
@@ -331,6 +382,19 @@ class TestBuildEntries:
         assert e.pre_outlook == ""
         assert e.post_price_change == "-15"
         assert e.post_comment == "[E] -15% 棚卸資産グッズ？評価損"
+        assert e.kessan_matagi is True
+
+    def test_stock_without_holding_mark_kessan_matagi_false(self):
+        """☆ 無しの銘柄行は kessan_matagi=False"""
+        tokens, _ = mig.tokenize_lines([
+            "<2026年>",
+            "[03/12]",
+            "◯9556ＩＮＴＬＯＯＰ[2Q]: かなり安く",
+            "\u3000←E: -18% ほげ",
+        ])
+        entries, _ = mig.build_entries_from_tokens(tokens)
+        assert len(entries) == 1
+        assert entries[0].kessan_matagi is False
 
     def test_stock_with_outlook_no_post(self):
         """見通しあり・事後なし → エントリ生成 (post フィールドは空)"""
@@ -624,6 +688,69 @@ class TestLocalUpsert:
         # db_path が渡っていること
         assert calls[0][0] == (db_path,) or calls[0][1].get("db_path") == db_path \
             or (len(calls[0][0]) > 0 and calls[0][0][0] == db_path)
+
+    def test_kessan_matagi_saved_by_default(self, db_path):
+        """通常 upsert で kessan_matagi が保存される"""
+        _preregister(db_path, "5032")
+        mig._upsert_kessan_comment_local(
+            self._entry(kessan_matagi=True), db_path=db_path,
+        )
+        rec = rs.get_research_record("5032", db_path=db_path)
+        assert rec["kessan_comments"][0]["kessan_matagi"] is True
+
+    def test_update_fields_only_modifies_target_field(self, db_path):
+        """--update-fields kessan_matagi: 他フィールドは既存値を保持"""
+        _preregister(db_path, "5032")
+        # 初回: kessan_matagi=False で通常保存
+        mig._upsert_kessan_comment_local(
+            self._entry(
+                pre_outlook="手動修正後の内容",
+                post_comment="[C] -3% 手動追記",
+                kessan_matagi=False,
+            ),
+            db_path=db_path,
+        )
+        # update_fields モードで kessan_matagi のみ True 化
+        result = mig._upsert_kessan_comment_local(
+            self._entry(
+                pre_outlook="古いログの内容",     # これは反映されないはず
+                post_comment="古いログ post",    # これも反映されないはず
+                kessan_matagi=True,
+            ),
+            db_path=db_path,
+            update_fields=["kessan_matagi"],
+        )
+        assert result is not None
+        rec = rs.get_research_record("5032", db_path=db_path)
+        entry = rec["kessan_comments"][0]
+        assert entry["kessan_matagi"] is True
+        # 他フィールドは既存値保持
+        assert entry["pre_outlook"] == "手動修正後の内容"
+        assert entry["post_comment"] == "[C] -3% 手動追記"
+
+    def test_update_fields_unmatched_is_skipped(self, db_path):
+        """--update-fields 指定でマッチなしなら新規追加せずスキップ (None を返す)"""
+        _preregister(db_path, "5032")
+        # マッチするエントリ無しで update_fields 呼び出し
+        result = mig._upsert_kessan_comment_local(
+            self._entry(kessanbi="2099/01/01", kessan_matagi=True),
+            db_path=db_path,
+            update_fields=["kessan_matagi"],
+        )
+        assert result is None
+        rec = rs.get_research_record("5032", db_path=db_path)
+        # 新規追加されていないこと
+        assert rec["kessan_comments"] == []
+
+    def test_update_fields_rejects_unknown_field(self, db_path):
+        """update_fields に KESSAN_COMMENT_FIELDS 外のキーが入ると ValueError"""
+        _preregister(db_path, "5032")
+        with pytest.raises(ValueError):
+            mig._upsert_kessan_comment_local(
+                self._entry(),
+                db_path=db_path,
+                update_fields=["kessan_matagi", "nonexistent_field"],
+            )
 
 
 # ==================================================

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -259,6 +259,43 @@ class TestCrud:
         loaded = rs.get_research_record("135A", db_path=db_path)
         assert loaded["code_s"] == "135A"
 
+    # --- kessan_matagi スキーマ拡張 (issue #138) ---
+    def test_kessan_comment_fields_includes_kessan_matagi(self):
+        """KESSAN_COMMENT_FIELDS に kessan_matagi が含まれる"""
+        assert "kessan_matagi" in rs.KESSAN_COMMENT_FIELDS
+
+    def test_get_research_record_backfills_kessan_matagi_false(self, db_path):
+        """旧形式 (kessan_matagi 無) のエントリは読み込み時に False で補完される"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        # kessan_matagi なしの旧エントリを直接埋め込み
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/03/11",
+            "quarter": 3,
+            "pre_expectation": "○",
+            "pre_outlook": "見通し",
+            "post_price_change": "-15",
+            "post_comment": "[E] -15% x",
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        assert loaded["kessan_comments"][0]["kessan_matagi"] is False
+
+    def test_get_research_record_preserves_kessan_matagi_true(self, db_path):
+        """True で保存されたエントリは読み込み時も True"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/03/11",
+            "quarter": 3,
+            "pre_expectation": "○",
+            "pre_outlook": "見通し",
+            "post_price_change": "-15",
+            "post_comment": "[E] -15% x",
+            "kessan_matagi": True,
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        assert loaded["kessan_comments"][0]["kessan_matagi"] is True
+
 
 # ==================================================
 # スナップショット層: upsert_snapshot

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -250,3 +250,175 @@ class TestHasRecentDisclosure:
         # 12/28 は昨年扱いで6日前 → True
         disclosures = [("12/28", "決算", "昨年末", "http://example.com")]
         assert helpers.has_recent_disclosure(disclosures, days=7) is True
+
+
+class TestSaveKessanCommentMatagi:
+    """save_kessan_comment の held_before/after + kessan_matagi AND 判定 (issue #138)"""
+
+    @pytest.fixture
+    def setup_db(self, db_path, monkeypatch):
+        """RESEARCH_SHELVE を tmp_path に差し替えて初期レコードを 1 件入れる"""
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr(helpers, "RESEARCH_SHELVE", db_path, raising=False)
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rs.upsert_research_record(rec, db_path=db_path)
+        # price_log は未登録でOK (calc_price_reaction は空文字を返す)
+        monkeypatch.setattr(helpers, "calc_price_reaction", lambda c, k: "")
+        return db_path
+
+    @pytest.fixture
+    def today_2026_03_15(self, monkeypatch):
+        """テスト用に get_price_day を 2026/3/15 に固定"""
+        from datetime import date as _date
+        monkeypatch.setattr(helpers, "get_price_day", lambda _: _date(2026, 3, 15))
+
+    def _form(self, **overrides):
+        base = {
+            "kessanbi": "2026/03/11",  # today より前 → 決算後
+            "quarter": "3",
+            "pre_expectation": "○",
+            "pre_outlook": "事前",
+            "post_comment": "",
+        }
+        base.update(overrides)
+        return base
+
+    def test_past_entry_with_possess_sets_held_after_only(
+        self, setup_db, today_2026_03_15, monkeypatch
+    ):
+        """過去の決算 + 現在保有 → held_after_kessan のみ True (before は False のまま)"""
+        monkeypatch.setattr(helpers, "_is_possess_now", lambda c: True)
+        entry = helpers.save_kessan_comment("5032", self._form())
+        assert entry["held_before_kessan"] is False
+        assert entry["held_after_kessan"] is True
+        # AND 判定なので kessan_matagi は False
+        assert entry["kessan_matagi"] is False
+
+    def test_future_entry_with_possess_sets_held_before_only(
+        self, setup_db, today_2026_03_15, monkeypatch
+    ):
+        """未来の決算 + 現在保有 → held_before_kessan のみ True"""
+        monkeypatch.setattr(helpers, "_is_possess_now", lambda c: True)
+        form = self._form(kessanbi="2026/04/20")
+        entry = helpers.save_kessan_comment("5032", form)
+        assert entry["held_before_kessan"] is True
+        assert entry["held_after_kessan"] is False
+        assert entry["kessan_matagi"] is False
+
+    def test_new_entry_without_possess_sets_both_false(
+        self, setup_db, today_2026_03_15, monkeypatch
+    ):
+        """新規作成時、保有してなければ held フラグは両方 False"""
+        monkeypatch.setattr(helpers, "_is_possess_now", lambda c: False)
+        entry = helpers.save_kessan_comment("5032", self._form())
+        assert entry["held_before_kessan"] is False
+        assert entry["held_after_kessan"] is False
+        assert entry["kessan_matagi"] is False
+
+    def test_two_phase_save_flips_matagi_by_and(
+        self, setup_db, today_2026_03_15, monkeypatch
+    ):
+        """
+        決算前に保有で保存 → held_before=True、
+        時間を進めて決算後に保有で再保存 → held_after=True で AND で kessan_matagi=True
+        """
+        monkeypatch.setattr(helpers, "_is_possess_now", lambda c: True)
+        # フェーズ1: today=2026/3/15, kessanbi=2026/4/20 (未来)
+        from datetime import date as _date
+        monkeypatch.setattr(helpers, "get_price_day", lambda _: _date(2026, 3, 15))
+        form = self._form(kessanbi="2026/04/20")
+        helpers.save_kessan_comment("5032", form)
+
+        # フェーズ2: 時計進行、today=2026/4/25 で同じ kessanbi は過去に変わる
+        monkeypatch.setattr(helpers, "get_price_day", lambda _: _date(2026, 4, 25))
+        entry = helpers.save_kessan_comment("5032", form)
+        assert entry["held_before_kessan"] is True
+        assert entry["held_after_kessan"] is True
+        assert entry["kessan_matagi"] is True
+
+    def test_existing_true_is_not_downgraded(
+        self, setup_db, today_2026_03_15, monkeypatch
+    ):
+        """既存 held_after=True / kessan_matagi=True は現在非保有でも下げない"""
+        monkeypatch.setattr(helpers, "_is_possess_now", lambda c: True)
+        # 1回目: 保有中で held_after を立てる
+        helpers.save_kessan_comment("5032", self._form(pre_outlook="init"))
+        # matagi を手動で True にしておく (二相統合の代用)
+        monkeypatch.setattr(helpers, "_is_possess_now", lambda c: False)
+        entry2 = helpers.save_kessan_comment(
+            "5032", self._form(pre_outlook="update"),
+        )
+        # held_after が False に下がっていないこと
+        assert entry2["held_after_kessan"] is True
+
+    def test_form_override_wins(self, setup_db, today_2026_03_15, monkeypatch):
+        """form 明示の kessan_matagi が最優先"""
+        monkeypatch.setattr(helpers, "_is_possess_now", lambda c: True)
+        form = self._form(kessan_matagi="1")
+        entry = helpers.save_kessan_comment("5032", form)
+        # held_after しか True にならないが、form override で kessan_matagi=True
+        assert entry["kessan_matagi"] is True
+
+
+class TestPersistKessanHeldFlags:
+    """_persist_kessan_held_flags の挙動 (並行書き込み安全対応)"""
+
+    @pytest.fixture
+    def setup_db(self, db_path, monkeypatch):
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/03/11",
+                "quarter": 3,
+                "pre_expectation": "○",
+                "pre_outlook": "既存見通し",
+                "post_price_change": "-15",
+                "post_comment": "[E] -15% x",
+                "kessan_matagi": False,
+                "held_before_kessan": False,
+                "held_after_kessan": False,
+            },
+        ]
+        rs.upsert_research_record(rec, db_path=db_path)
+        return db_path
+
+    def test_promotes_held_after_only(self, setup_db):
+        """held_after=True のみ指定すれば後側だけが True 化、matagi は False"""
+        helpers._persist_kessan_held_flags([
+            ("5032", "2026/03/11", 3, {"held_after_kessan": True}),
+        ])
+        loaded = rs.get_research_record("5032")
+        entry = loaded["kessan_comments"][0]
+        assert entry["held_after_kessan"] is True
+        assert entry["held_before_kessan"] is False
+        assert entry["kessan_matagi"] is False
+        # 他フィールドは温存
+        assert entry["pre_outlook"] == "既存見通し"
+
+    def test_and_promotion_activates_matagi(self, setup_db):
+        """held_before=True と held_after=True が両方立てば kessan_matagi も True"""
+        # 先に held_before を立て、
+        helpers._persist_kessan_held_flags([
+            ("5032", "2026/03/11", 3, {"held_before_kessan": True}),
+        ])
+        # 次に held_after を立てる → AND で kessan_matagi=True
+        helpers._persist_kessan_held_flags([
+            ("5032", "2026/03/11", 3, {"held_after_kessan": True}),
+        ])
+        loaded = rs.get_research_record("5032")
+        entry = loaded["kessan_comments"][0]
+        assert entry["held_before_kessan"] is True
+        assert entry["held_after_kessan"] is True
+        assert entry["kessan_matagi"] is True
+
+    def test_noop_when_no_match(self, setup_db):
+        """未マッチのターゲットは黙ってスキップ"""
+        helpers._persist_kessan_held_flags([
+            ("5032", "2099/01/01", 1, {"held_after_kessan": True}),
+        ])
+        loaded = rs.get_research_record("5032")
+        assert loaded["kessan_comments"][0]["held_after_kessan"] is False
+        assert len(loaded["kessan_comments"]) == 1


### PR DESCRIPTION
## Summary
- 決算コメントの per-entry スキーマに `kessan_matagi` / `held_before_kessan` / `held_after_kessan` を追加し、「決算日に保有していたか」を現在 `is_possess` と別概念として管理できるようにした
- `/market` を開くたびに、保有中の銘柄は決算日と現在日の前後で `held_before_kessan` / `held_after_kessan` を永続化。両方 True になれば AND 判定で `kessan_matagi` が自動確定する（ロック下で再取得→マージ→upsert により並行編集を破壊しない）
- 過去ログ `kessan_comments_log.txt` の ☆/⭐/⭐︎ マークを取り込む `--update-fields kessan_matagi` モードを migrate スクリプトに追加。未マッチエントリは新規追加せずスキップし、既存手動修正と 12件キャップによる履歴追い出しを保護
- UI: detail.html 履歴テーブルと market.html の過去決算カードに `◆` マークを表示（`is_possess` の ☆ とは別記号）。market のエディタに「決算またぎ」チェックボックスを追加して手動トグルも可能

関連: #138

## Test plan
- [x] `pytest tests/test_research_shelve.py tests/test_migrate_kessan_comments_from_log.py tests/test_webapp_helpers.py tests/test_webapp_routes.py -v` で 202 passed
- [x] `migrate_kessan_comments_from_log.py --dry-run` で 582 エントリ・failed 0
- [x] 本番 backup 後に `--update-fields kessan_matagi` を実行、218A など ☆付きエントリで `kessan_matagi=True` が立ち他フィールド非破壊を確認
- [x] `/stock/218A` で決算コメント履歴に ◆ 表示を確認
- [x] `/market` で保有銘柄 3496 アズーム (2026/04/30 Q2) の事前見通しを入力 → 新規エントリに `held_before_kessan=True` のみ立ち、`held_after_kessan=False` / `kessan_matagi=False` になることを確認 (仕様通り)