### PR TITLE
決算反応を1日後・5日後の複数期間に拡張 (#133)

### DIFF
--- a/scripts/price.py
+++ b/scripts/price.py
@@ -1278,7 +1278,7 @@ def parse_price_text_from_list(price_current, price_list):
     # print breaks
     # ---- 過去価格
     past_prices = []
-    LOG_DAY = 10
+    LOG_DAY = 20
     for ind in range(LOG_DAY):
         if ind >= len(price_list):
             continue

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -111,7 +111,7 @@ KESSAN_COMMENT_FIELDS = frozenset(
 )
 
 
-def _normalize_kessan_post_price_changes(entry: Dict[str, Any]) -> Dict[str, str]:
+def normalize_kessan_post_price_changes(entry: Dict[str, Any]) -> Dict[str, str]:
     """決算コメントエントリの post_price_changes を正規化する。
 
     - 新形式 dict があれば各期間キーを str に正規化して返す
@@ -503,7 +503,7 @@ def get_research_record(
             ):
                 if key not in entry:
                     entry[key] = False
-            entry["post_price_changes"] = _normalize_kessan_post_price_changes(entry)
+            entry["post_price_changes"] = normalize_kessan_post_price_changes(entry)
     return record
 
 
@@ -840,7 +840,7 @@ def format_record_full(record: Dict[str, Any]) -> str:
             quarter = entry.get("quarter", "-")
             pre_exp = entry.get("pre_expectation", "") or "-"
             pre = entry.get("pre_outlook", "")
-            changes = _normalize_kessan_post_price_changes(entry)
+            changes = normalize_kessan_post_price_changes(entry)
             reactions_parts = []
             for key, _ in KESSAN_REACTION_PERIODS:
                 v = changes.get(key, "")

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -87,6 +87,10 @@ RECORD_FIELDS = frozenset(
     }
 )
 
+# 決算コメントの反応率を計算する期間 (キー名, 営業日数) のタプル列
+# 表示・保存・後方互換正規化すべての場面でこの定数を参照する
+KESSAN_REACTION_PERIODS = (("1d", 1), ("5d", 5))
+
 # 決算コメントエントリの既知フィールド
 KESSAN_COMMENT_FIELDS = frozenset(
     {
@@ -94,7 +98,10 @@ KESSAN_COMMENT_FIELDS = frozenset(
         "quarter",              # 1-4 (int)
         "pre_expectation",      # ◎/○/△/× or ""
         "pre_outlook",          # 事前見通し (フリーテキスト)
-        "post_price_change",    # 決算反応の株価変動率 (%) スナップショット
+        "post_price_change",    # [旧形式・後方互換用] 決算反応の株価変動率 (%) スナップショット
+                                #   新規書込みでは使わない。読出時は post_price_changes に正規化される
+        "post_price_changes",   # 決算反応の株価変動率 (%) スナップショット (dict)
+                                #   {"1d": "+3.2", "5d": "+5.1"} 形式。取れない期間は空文字
         "post_comment",         # 決算後コメント (フリーテキスト)
         "held_before_kessan",   # 決算前に保有中だったか (bool, 未来エントリで永続化)
         "held_after_kessan",    # 決算後に保有中だったか (bool, 過去エントリで永続化)
@@ -102,6 +109,26 @@ KESSAN_COMMENT_FIELDS = frozenset(
                                 # 自動判定: held_before AND held_after / ログ☆由来 / UI手動
     }
 )
+
+
+def _normalize_kessan_post_price_changes(entry: Dict[str, Any]) -> Dict[str, str]:
+    """決算コメントエントリの post_price_changes を正規化する。
+
+    - 新形式 dict があれば各期間キーを str に正規化して返す
+    - 無ければ旧 post_price_change を {"1d": <値>, "5d": ""} に補完
+    - どちらも無ければ全期間 "" を返す
+    """
+    raw = entry.get("post_price_changes")
+    result: Dict[str, str] = {key: "" for key, _ in KESSAN_REACTION_PERIODS}
+    if isinstance(raw, dict):
+        for key, _ in KESSAN_REACTION_PERIODS:
+            v = raw.get(key, "")
+            result[key] = str(v) if v else ""
+        return result
+    legacy = entry.get("post_price_change", "") or ""
+    if legacy:
+        result["1d"] = str(legacy)
+    return result
 
 # 決算コメントの最大件数 (四半期12回分 ≒ 3年)
 MAX_KESSAN_COMMENTS = 12
@@ -454,6 +481,8 @@ def get_research_record(
     kessan_comments は未設定の旧レコードに対し空リストで補完する（後方互換）。
     kessan_comments の各エントリに kessan_matagi / held_before_kessan /
     held_after_kessan が無ければ False で補完する（後方互換）。
+    post_price_changes が無く旧 post_price_change のみがある場合、
+    {"1d": <旧値>, "5d": ""} に正規化する（後方互換）。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
@@ -474,6 +503,7 @@ def get_research_record(
             ):
                 if key not in entry:
                     entry[key] = False
+            entry["post_price_changes"] = _normalize_kessan_post_price_changes(entry)
     return record
 
 
@@ -810,11 +840,16 @@ def format_record_full(record: Dict[str, Any]) -> str:
             quarter = entry.get("quarter", "-")
             pre_exp = entry.get("pre_expectation", "") or "-"
             pre = entry.get("pre_outlook", "")
-            price_change = entry.get("post_price_change", "") or "-"
+            changes = _normalize_kessan_post_price_changes(entry)
+            reactions_parts = []
+            for key, _ in KESSAN_REACTION_PERIODS:
+                v = changes.get(key, "")
+                reactions_parts.append(f"{key}={v}%" if v else f"{key}=-")
+            reactions_str = " ".join(reactions_parts)
             post = entry.get("post_comment", "")
             matagi_mark = "◆" if entry.get("kessan_matagi") else ""
             lines.append(
-                f"  [{kessanbi} {quarter}Q 期待度:{pre_exp} 反応:{price_change}% {matagi_mark}]"
+                f"  [{kessanbi} {quarter}Q 期待度:{pre_exp} 反応:{reactions_str} {matagi_mark}]"
             )
             lines.append(f"    事前    : {_indent_multiline(pre, ' ' * 14)}")
             lines.append(f"    事後    : {_indent_multiline(post, ' ' * 14)}")

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -25,9 +25,11 @@ from research_shelve import (
     normalize_code_s,
     validate_rating,
     _flock,
+    _normalize_kessan_post_price_changes,
     VALID_RATINGS,
     VALID_EXPECTATIONS,
     MAX_KESSAN_COMMENTS,
+    KESSAN_REACTION_PERIODS,
 )
 
 
@@ -416,21 +418,31 @@ def get_market_html_parts() -> Dict[str, str]:
     }
 
 
-def _price_reaction_from_log(price_log: List, kessanbi_dt: date) -> str:
-    """price_log と決算日 date から変動率を算出する内部関数。
+def _price_reaction_from_log(
+    price_log: List,
+    kessanbi_dt: date,
+    *,
+    n_business_days: int = 1,
+) -> str:
+    """price_log と決算日 date から N 営業日後変動率を算出する内部関数。
 
     price_log: [(date, int終値), ...]
     kessanbi_dt: 決算日の date
+    n_business_days: 決算日より後の何営業日目の終値を見るか (>=1)
+
+    n=1 → 決算日翌営業日終値 / 決算日以下の最新営業日終値 - 1
+    n=5 → 5営業日後終値 / 決算日以下の最新営業日終値 - 1
+    log が不足する場合は "".
     """
-    if not price_log:
+    if not price_log or n_business_days < 1:
         return ""
     try:
-        sorted_log = sorted(price_log, key=lambda x: x[0], reverse=True)
+        sorted_log = sorted(price_log, key=lambda x: x[0])  # 昇順
     except (TypeError, IndexError):
         return ""
 
     before_price: Optional[int] = None
-    after_price: Optional[int] = None
+    after_entries: List[Tuple[date, int]] = []
     for entry in sorted_log:
         try:
             entry_dt, entry_pr = entry[0], entry[1]
@@ -438,13 +450,17 @@ def _price_reaction_from_log(price_log: List, kessanbi_dt: date) -> str:
             continue
         if not isinstance(entry_dt, date):
             continue
-        if entry_dt <= kessanbi_dt and before_price is None:
+        if entry_dt <= kessanbi_dt:
+            # 昇順なので最後に上書きされた値が「決算日以下の最新営業日」
             before_price = entry_pr
-        if entry_dt > kessanbi_dt:
-            after_price = entry_pr
+        else:
+            after_entries.append((entry_dt, entry_pr))
 
-    if before_price is None or after_price is None or before_price == 0:
+    if before_price is None or before_price == 0:
         return ""
+    if len(after_entries) < n_business_days:
+        return ""
+    after_price = after_entries[n_business_days - 1][1]
     try:
         change = (float(after_price) / float(before_price) - 1.0) * 100.0
     except (ValueError, ZeroDivisionError):
@@ -453,22 +469,34 @@ def _price_reaction_from_log(price_log: List, kessanbi_dt: date) -> str:
     return f"{sign}{change:.1f}"
 
 
-def calc_price_reaction(code_s: str, kessanbi: str) -> str:
-    """決算日前営業日終値と翌営業日終値から株価変動率を算出する。
+def calc_price_reactions(code_s: str, kessanbi: str) -> Dict[str, str]:
+    """決算日前営業日終値と複数期間後の終値から株価変動率を算出する。
 
     Args:
         code_s: 銘柄コード
         kessanbi: YYYY/MM/DD 形式
 
     Returns:
-        "+3.2" / "-1.5" 形式。取得不可時は "".
+        {"1d": "+3.2", "5d": "+5.1"} 形式。各期間で取得不可時は "" を入れる。
     """
     kessanbi_dt = _parse_kessanbi(kessanbi)
     if kessanbi_dt is None:
-        return ""
-
+        return {key: "" for key, _ in KESSAN_REACTION_PERIODS}
     stock = get_stock_data(code_s)
-    return _price_reaction_from_log(stock.get("price_log") or [], kessanbi_dt)
+    log = stock.get("price_log") or []
+    return {
+        key: _price_reaction_from_log(log, kessanbi_dt, n_business_days=n)
+        for key, n in KESSAN_REACTION_PERIODS
+    }
+
+
+def calc_price_reaction(code_s: str, kessanbi: str) -> str:
+    """[後方互換] 決算日翌営業日の変動率のみを返す。
+
+    新規呼び出しは calc_price_reactions を使うこと。
+    既存テスト・移行期コードからの呼び出しのため残置している。
+    """
+    return calc_price_reactions(code_s, kessanbi).get("1d", "")
 
 
 def _bulk_price_logs(code_list: List[str]) -> Dict[str, List]:
@@ -651,7 +679,7 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
     - なければ追加
     - 12件超過時は最古（kessanbi 昇順の先頭）を削除
     - research_shelve 未登録なら add_stock() で自動登録
-    - post_price_change は price_log から自動計算してスナップショット化
+    - post_price_changes は price_log から各期間 (1d/5d) を自動計算してスナップショット化
 
     Returns:
         保存したエントリ dict
@@ -664,8 +692,8 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
         kessan_matagi_override,
     ) = _validate_kessan_comment_input(form_data)
 
-    # 変動率をスナップショット算出
-    post_price_change = calc_price_reaction(normalized, kessanbi)
+    # 期間別変動率をスナップショット算出
+    post_price_changes = calc_price_reactions(normalized, kessanbi)
 
     # 現在保有中か (kessan_matagi 初期値判定用)
     is_possess_now = _is_possess_now(normalized)
@@ -727,17 +755,23 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
             "quarter": quarter,
             "pre_expectation": pre_expectation,
             "pre_outlook": pre_outlook,
-            "post_price_change": post_price_change,
+            "post_price_changes": dict(post_price_changes),
             "post_comment": post_comment,
             "kessan_matagi": kessan_matagi,
             "held_before_kessan": held_before,
             "held_after_kessan": held_after,
         }
         if target_idx is not None:
-            # 既存エントリ上書き。post_price_change はリアルタイム計算失敗時は既存値を優先
+            # 既存エントリ上書き。各期間ごとにリアルタイム計算失敗時は既存値を優先
+            # （旧 post_price_change のみ持つレコードでも 1d 値を引き継ぐ）
             existing = comments[target_idx]
-            if not post_price_change and existing.get("post_price_change"):
-                new_entry["post_price_change"] = existing["post_price_change"]
+            existing_changes = _normalize_kessan_post_price_changes(existing)
+            merged_changes: Dict[str, str] = {}
+            for key, _ in KESSAN_REACTION_PERIODS:
+                new_v = post_price_changes.get(key, "")
+                old_v = existing_changes.get(key, "")
+                merged_changes[key] = new_v if new_v else old_v
+            new_entry["post_price_changes"] = merged_changes
             comments[target_idx] = new_entry
         else:
             comments.append(new_entry)
@@ -790,8 +824,9 @@ def get_market_kessan_data() -> Dict[str, Any]:
         }
         各 stock dict:
           code_s, stock_name, kessanbi, quarter,
-          pre_expectation, pre_outlook, post_price_change, post_comment,
+          pre_expectation, pre_outlook, post_price_changes, post_comment,
           has_comment (bool)
+        post_price_changes は {"1d": str, "5d": str} の dict。取得不可期間は ""
     """
     import kessan  # 遅延 import (sys.path 解決後)
     try:
@@ -836,7 +871,7 @@ def get_market_kessan_data() -> Dict[str, Any]:
             "quarter": v.get("kessan_quarter", 0) or 0,
             "pre_expectation": "",
             "pre_outlook": "",
-            "post_price_change": "",
+            "post_price_changes": {key: "" for key, _ in KESSAN_REACTION_PERIODS},
             "post_comment": "",
             "has_comment": False,
             "is_possess": code_s in possess_set,
@@ -876,7 +911,7 @@ def get_market_kessan_data() -> Dict[str, Any]:
                 "quarter": quarter if quarter else (base or {}).get("quarter", 0),
                 "pre_expectation": entry.get("pre_expectation", "") or "",
                 "pre_outlook": entry.get("pre_outlook", "") or "",
-                "post_price_change": entry.get("post_price_change", "") or "",
+                "post_price_changes": _normalize_kessan_post_price_changes(entry),
                 "post_comment": entry.get("post_comment", "") or "",
                 "has_comment": bool(
                     entry.get("pre_outlook") or entry.get("post_comment")
@@ -888,13 +923,17 @@ def get_market_kessan_data() -> Dict[str, Any]:
                 "held_after_kessan": bool(entry.get("held_after_kessan", False)),
             }
 
-    # 過去エントリで post_price_change 未保存のものだけ一括で price_log 取得
+    # 過去エントリで post_price_changes のいずれかの期間が空のものだけ
+    # 一括で price_log を取得し補完計算する
     past_codes_need_calc = set()
     for entry in merged.values():
         dt = _parse_kessanbi(entry["kessanbi"])
         if dt is None:
             continue
-        if dt < base_day and not entry.get("post_price_change"):
+        if dt >= base_day:
+            continue
+        changes = entry.get("post_price_changes") or {}
+        if any(not changes.get(key) for key, _ in KESSAN_REACTION_PERIODS):
             past_codes_need_calc.add(entry["code_s"])
 
     price_logs_cache = _bulk_price_logs(list(past_codes_need_calc)) if past_codes_need_calc else {}
@@ -912,10 +951,18 @@ def get_market_kessan_data() -> Dict[str, Any]:
         dt = _parse_kessanbi(kessanbi)
         if dt is None:
             continue
-        # 過去の変動率を計算できれば補完（保存済み値が無い場合のみ、キャッシュ利用）
-        if dt < base_day and not entry.get("post_price_change"):
-            log = price_logs_cache.get(entry["code_s"], [])
-            entry["post_price_change"] = _price_reaction_from_log(log, dt)
+        # 過去の変動率を計算できれば補完（保存済み値が無い期間のみ、キャッシュ利用）
+        if dt < base_day:
+            existing_changes = entry.get("post_price_changes") or {}
+            if any(not existing_changes.get(key) for key, _ in KESSAN_REACTION_PERIODS):
+                log = price_logs_cache.get(entry["code_s"], [])
+                for key, n in KESSAN_REACTION_PERIODS:
+                    if existing_changes.get(key):
+                        continue
+                    calc = _price_reaction_from_log(log, dt, n_business_days=n)
+                    if calc:
+                        existing_changes[key] = calc
+                entry["post_price_changes"] = existing_changes
 
         # 前後保有フラグのスナップショット化
         # - 未来エントリ (dt >= base_day): is_possess=True なら held_before_kessan=True

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -38,6 +38,8 @@ def get_research_detail(code_s: str) -> Optional[Dict[str, Any]]:
 
     表示用に shikiho_comments を period 降順（新しい順）に並べ替える。
     period 空 / "-" は最古扱いで末尾に寄せ、同値同士は元リスト順を保つ。
+    過去の決算コメントで post_price_changes に欠損期間があれば
+    price_log から補完計算して in-memory で埋める（永続化はしない）。
     """
     validate_code_s(code_s)
     record = get_research_record(code_s)
@@ -45,7 +47,49 @@ def get_research_detail(code_s: str) -> Optional[Dict[str, Any]]:
         record["shikiho_comments"] = sort_shikiho_comments_desc(
             record.get("shikiho_comments") or []
         )
+        _backfill_post_price_changes_for_entries(
+            code_s,
+            record.get("kessan_comments") or [],
+        )
     return record
+
+
+def _backfill_post_price_changes_for_entries(
+    code_s: str,
+    entries: List[Dict[str, Any]],
+) -> None:
+    """過去エントリの post_price_changes に欠損期間があれば price_log から補完する。
+
+    永続化はせず、entry dict を in-place で更新する。
+    決算日が未来 (今日以降) のエントリは補完対象外。
+    """
+    if not entries:
+        return
+    base_day = get_price_day(datetime.today())
+
+    targets: List[Tuple[Dict[str, Any], date]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        dt = _parse_kessanbi(entry.get("kessanbi", ""))
+        if dt is None or dt >= base_day:
+            continue
+        changes = entry.get("post_price_changes") or {}
+        if any(not changes.get(key) for key, _ in KESSAN_REACTION_PERIODS):
+            targets.append((entry, dt))
+    if not targets:
+        return
+
+    log = _bulk_price_logs([code_s]).get(normalize_code_s(code_s), [])
+    if not log:
+        return
+    for entry, dt in targets:
+        existing = entry.get("post_price_changes") or {}
+        calculated = _price_reactions_from_log(log, dt)
+        for key, _ in KESSAN_REACTION_PERIODS:
+            if not existing.get(key) and calculated.get(key):
+                existing[key] = calculated[key]
+        entry["post_price_changes"] = existing
 
 
 def get_stock_data(code_s: str) -> Dict[str, Any]:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -25,7 +25,7 @@ from research_shelve import (
     normalize_code_s,
     validate_rating,
     _flock,
-    _normalize_kessan_post_price_changes,
+    normalize_kessan_post_price_changes,
     VALID_RATINGS,
     VALID_EXPECTATIONS,
     MAX_KESSAN_COMMENTS,
@@ -418,28 +418,20 @@ def get_market_html_parts() -> Dict[str, str]:
     }
 
 
-def _price_reaction_from_log(
+def _split_log_around_kessanbi(
     price_log: List,
     kessanbi_dt: date,
-    *,
-    n_business_days: int = 1,
-) -> str:
-    """price_log と決算日 date から N 営業日後変動率を算出する内部関数。
+) -> Tuple[Optional[int], List[Tuple[date, int]]]:
+    """price_log を「決算日以下の最新営業日終値」と「決算日より後の昇順タプル列」に分ける。
 
-    price_log: [(date, int終値), ...]
-    kessanbi_dt: 決算日の date
-    n_business_days: 決算日より後の何営業日目の終値を見るか (>=1)
-
-    n=1 → 決算日翌営業日終値 / 決算日以下の最新営業日終値 - 1
-    n=5 → 5営業日後終値 / 決算日以下の最新営業日終値 - 1
-    log が不足する場合は "".
+    複数期間の反応率計算でソート/分割を共有するための共通前処理。
     """
-    if not price_log or n_business_days < 1:
-        return ""
+    if not price_log:
+        return None, []
     try:
         sorted_log = sorted(price_log, key=lambda x: x[0])  # 昇順
     except (TypeError, IndexError):
-        return ""
+        return None, []
 
     before_price: Optional[int] = None
     after_entries: List[Tuple[date, int]] = []
@@ -455,18 +447,61 @@ def _price_reaction_from_log(
             before_price = entry_pr
         else:
             after_entries.append((entry_dt, entry_pr))
+    return before_price, after_entries
 
+
+def _format_reaction(before_price: Optional[int], after_price: int) -> str:
+    """前営業日終値 → N営業日後終値の変動率を符号付き文字列で返す。失敗時は ""。"""
     if before_price is None or before_price == 0:
         return ""
-    if len(after_entries) < n_business_days:
-        return ""
-    after_price = after_entries[n_business_days - 1][1]
     try:
         change = (float(after_price) / float(before_price) - 1.0) * 100.0
     except (ValueError, ZeroDivisionError):
         return ""
     sign = "+" if change >= 0 else ""
     return f"{sign}{change:.1f}"
+
+
+def _price_reaction_from_log(
+    price_log: List,
+    kessanbi_dt: date,
+    *,
+    n_business_days: int = 1,
+) -> str:
+    """price_log と決算日 date から N 営業日後変動率を算出する内部関数。
+
+    price_log: [(date, int終値), ...]
+    n=1 → 決算日翌営業日終値 / 決算日以下の最新営業日終値 - 1
+    n=5 → 5営業日後終値 / 決算日以下の最新営業日終値 - 1
+    log が不足する場合は "".
+
+    複数期間を一括計算する場合は _price_reactions_from_log を使うとソートを共有できる。
+    """
+    if n_business_days < 1:
+        return ""
+    before_price, after_entries = _split_log_around_kessanbi(price_log, kessanbi_dt)
+    if len(after_entries) < n_business_days:
+        return ""
+    return _format_reaction(before_price, after_entries[n_business_days - 1][1])
+
+
+def _price_reactions_from_log(
+    price_log: List,
+    kessanbi_dt: date,
+    periods: Tuple[Tuple[str, int], ...] = KESSAN_REACTION_PERIODS,
+) -> Dict[str, str]:
+    """price_log を1回だけソート/分割し、複数期間の反応率を一括算出する。
+
+    各期間で取得不可なら値は ""。
+    """
+    before_price, after_entries = _split_log_around_kessanbi(price_log, kessanbi_dt)
+    result: Dict[str, str] = {}
+    for key, n in periods:
+        if n < 1 or len(after_entries) < n:
+            result[key] = ""
+            continue
+        result[key] = _format_reaction(before_price, after_entries[n - 1][1])
+    return result
 
 
 def calc_price_reactions(code_s: str, kessanbi: str) -> Dict[str, str]:
@@ -484,10 +519,7 @@ def calc_price_reactions(code_s: str, kessanbi: str) -> Dict[str, str]:
         return {key: "" for key, _ in KESSAN_REACTION_PERIODS}
     stock = get_stock_data(code_s)
     log = stock.get("price_log") or []
-    return {
-        key: _price_reaction_from_log(log, kessanbi_dt, n_business_days=n)
-        for key, n in KESSAN_REACTION_PERIODS
-    }
+    return _price_reactions_from_log(log, kessanbi_dt)
 
 
 def calc_price_reaction(code_s: str, kessanbi: str) -> str:
@@ -765,7 +797,7 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
             # 既存エントリ上書き。各期間ごとにリアルタイム計算失敗時は既存値を優先
             # （旧 post_price_change のみ持つレコードでも 1d 値を引き継ぐ）
             existing = comments[target_idx]
-            existing_changes = _normalize_kessan_post_price_changes(existing)
+            existing_changes = normalize_kessan_post_price_changes(existing)
             merged_changes: Dict[str, str] = {}
             for key, _ in KESSAN_REACTION_PERIODS:
                 new_v = post_price_changes.get(key, "")
@@ -911,7 +943,7 @@ def get_market_kessan_data() -> Dict[str, Any]:
                 "quarter": quarter if quarter else (base or {}).get("quarter", 0),
                 "pre_expectation": entry.get("pre_expectation", "") or "",
                 "pre_outlook": entry.get("pre_outlook", "") or "",
-                "post_price_changes": _normalize_kessan_post_price_changes(entry),
+                "post_price_changes": normalize_kessan_post_price_changes(entry),
                 "post_comment": entry.get("post_comment", "") or "",
                 "has_comment": bool(
                     entry.get("pre_outlook") or entry.get("post_comment")
@@ -952,16 +984,15 @@ def get_market_kessan_data() -> Dict[str, Any]:
         if dt is None:
             continue
         # 過去の変動率を計算できれば補完（保存済み値が無い期間のみ、キャッシュ利用）
+        # 各銘柄の price_log は1回だけソート/分割して全期間で共有する
         if dt < base_day:
             existing_changes = entry.get("post_price_changes") or {}
             if any(not existing_changes.get(key) for key, _ in KESSAN_REACTION_PERIODS):
                 log = price_logs_cache.get(entry["code_s"], [])
-                for key, n in KESSAN_REACTION_PERIODS:
-                    if existing_changes.get(key):
-                        continue
-                    calc = _price_reaction_from_log(log, dt, n_business_days=n)
-                    if calc:
-                        existing_changes[key] = calc
+                calculated = _price_reactions_from_log(log, dt)
+                for key, _ in KESSAN_REACTION_PERIODS:
+                    if not existing_changes.get(key) and calculated.get(key):
+                        existing_changes[key] = calculated[key]
                 entry["post_price_changes"] = existing_changes
 
         # 前後保有フラグのスナップショット化

--- a/scripts/webapp/routes/market.py
+++ b/scripts/webapp/routes/market.py
@@ -6,6 +6,8 @@ GET  /api/kessan_comment/<code_s>    : 指定銘柄・決算日のコメント�
 POST /api/kessan_comment/<code_s>    : 決算コメントを保存 (新規 or 上書き)
 """
 
+from typing import Any, Dict
+
 from flask import Blueprint, jsonify, render_template, request
 
 from webapp.helpers import (
@@ -14,9 +16,41 @@ from webapp.helpers import (
     get_market_kessan_data,
     save_kessan_comment,
 )
-from research_shelve import VALID_EXPECTATIONS
+from research_shelve import (
+    KESSAN_REACTION_PERIODS,
+    VALID_EXPECTATIONS,
+    _normalize_kessan_post_price_changes,
+)
 
 market_bp = Blueprint("market", __name__)
+
+
+# API レスポンスに含める決算コメントエントリのキー集合
+# 旧 post_price_change は API 契約上含めない（_serialize_kessan_entry_for_api で除外）
+_API_ENTRY_KEYS = (
+    "kessanbi",
+    "quarter",
+    "pre_expectation",
+    "pre_outlook",
+    "post_comment",
+    "kessan_matagi",
+    "held_before_kessan",
+    "held_after_kessan",
+)
+
+
+def _serialize_kessan_entry_for_api(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """決算コメントエントリを API 用に整形する。
+
+    新スキーマ (post_price_changes) のみを返し、旧 post_price_change キーは含めない。
+    旧形式のみのデータを受け取った場合は post_price_changes に正規化して返す。
+    """
+    result: Dict[str, Any] = {}
+    for key in _API_ENTRY_KEYS:
+        if key in entry:
+            result[key] = entry[key]
+    result["post_price_changes"] = _normalize_kessan_post_price_changes(entry)
+    return result
 
 
 @market_bp.route("/market", methods=["GET"])
@@ -48,11 +82,12 @@ def get_kessan_comment_api(code_s: str):
             "quarter": 0,
             "pre_expectation": "",
             "pre_outlook": "",
-            "post_price_change": "",
+            "post_price_changes": {key: "" for key, _ in KESSAN_REACTION_PERIODS},
             "post_comment": "",
             "kessan_matagi": False,
         }
-    return jsonify(entry)
+        return jsonify(entry)
+    return jsonify(_serialize_kessan_entry_for_api(entry))
 
 
 @market_bp.route("/api/kessan_comment/<code_s>", methods=["POST"])
@@ -63,4 +98,4 @@ def post_kessan_comment_api(code_s: str):
         entry = save_kessan_comment(code_s, form)
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
-    return jsonify(entry)
+    return jsonify(_serialize_kessan_entry_for_api(entry))

--- a/scripts/webapp/routes/market.py
+++ b/scripts/webapp/routes/market.py
@@ -19,7 +19,7 @@ from webapp.helpers import (
 from research_shelve import (
     KESSAN_REACTION_PERIODS,
     VALID_EXPECTATIONS,
-    _normalize_kessan_post_price_changes,
+    normalize_kessan_post_price_changes,
 )
 
 market_bp = Blueprint("market", __name__)
@@ -49,7 +49,7 @@ def _serialize_kessan_entry_for_api(entry: Dict[str, Any]) -> Dict[str, Any]:
     for key in _API_ENTRY_KEYS:
         if key in entry:
             result[key] = entry[key]
-    result["post_price_changes"] = _normalize_kessan_post_price_changes(entry)
+    result["post_price_changes"] = normalize_kessan_post_price_changes(entry)
     return result
 
 

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -295,15 +295,17 @@ function rememberKessanInitialValues(editor) {
   });
 }
 
-/* 1d/5d 反応率を editor の post-price-change スパンに反映する */
+/* 1d/5d 反応率を editor の post-price-change スパンに反映する。
+   API が空文字を返したときは、テンプレ初期描画で入っている値を
+   上書きしない（market 側の補完計算結果が消えないようにするため）。 */
 function updatePostPriceChangeDisplay(editor, data) {
   var postPc = editor.querySelector('.kessan-post-price-change');
   if (!postPc) return;
   var changes = data.post_price_changes || {};
   var pc1Span = postPc.querySelector('.kessan-pc-1d');
   var pc5Span = postPc.querySelector('.kessan-pc-5d');
-  if (pc1Span) pc1Span.textContent = changes['1d'] || '-';
-  if (pc5Span) pc5Span.textContent = changes['5d'] || '-';
+  if (pc1Span && changes['1d']) pc1Span.textContent = changes['1d'];
+  if (pc5Span && changes['5d']) pc5Span.textContent = changes['5d'];
 }
 
 function isKessanDirty(editor) {

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -276,8 +276,12 @@ function openKessanEditor(li) {
       if (preOut) preOut.value = data.pre_outlook || '';
       if (postCom) postCom.value = data.post_comment || '';
       if (matagi) matagi.checked = !!data.kessan_matagi;
-      if (postPc && data.post_price_change) {
-        postPc.textContent = data.post_price_change;
+      if (postPc) {
+        var changes = data.post_price_changes || {};
+        var pc1Span = postPc.querySelector('.kessan-pc-1d');
+        var pc5Span = postPc.querySelector('.kessan-pc-5d');
+        if (pc1Span) pc1Span.textContent = changes['1d'] || '-';
+        if (pc5Span) pc5Span.textContent = changes['5d'] || '-';
       }
       editor.dataset.loaded = '1';
       rememberKessanInitialValues(editor);
@@ -346,10 +350,14 @@ function saveKessanFromEditor(li) {
       if (!data) return;
       /* 初期値リセット */
       rememberKessanInitialValues(editor);
-      /* post_price_change 表示更新 */
+      /* post_price_changes 表示更新 (1d/5d 併記) */
       var postPc = editor.querySelector('.kessan-post-price-change');
-      if (postPc && data.post_price_change) {
-        postPc.textContent = data.post_price_change;
+      if (postPc) {
+        var changes = data.post_price_changes || {};
+        var pc1Span = postPc.querySelector('.kessan-pc-1d');
+        var pc5Span = postPc.querySelector('.kessan-pc-5d');
+        if (pc1Span) pc1Span.textContent = changes['1d'] || '-';
+        if (pc5Span) pc5Span.textContent = changes['5d'] || '-';
       }
       /* 閲覧用 view DOM を再構築（リロード不要で反映） */
       updateKessanViewDOM(li, data);

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -270,19 +270,12 @@ function openKessanEditor(li) {
       var preExp = editor.querySelector('.kessan-pre-expectation');
       var preOut = editor.querySelector('.kessan-pre-outlook');
       var postCom = editor.querySelector('.kessan-post-comment');
-      var postPc = editor.querySelector('.kessan-post-price-change');
       var matagi = editor.querySelector('.kessan-matagi');
       if (preExp) preExp.value = data.pre_expectation || '';
       if (preOut) preOut.value = data.pre_outlook || '';
       if (postCom) postCom.value = data.post_comment || '';
       if (matagi) matagi.checked = !!data.kessan_matagi;
-      if (postPc) {
-        var changes = data.post_price_changes || {};
-        var pc1Span = postPc.querySelector('.kessan-pc-1d');
-        var pc5Span = postPc.querySelector('.kessan-pc-5d');
-        if (pc1Span) pc1Span.textContent = changes['1d'] || '-';
-        if (pc5Span) pc5Span.textContent = changes['5d'] || '-';
-      }
+      updatePostPriceChangeDisplay(editor, data);
       editor.dataset.loaded = '1';
       rememberKessanInitialValues(editor);
     }).catch(function() { /* ネットワーク失敗時は静かに無視 */ });
@@ -300,6 +293,17 @@ function rememberKessanInitialValues(editor) {
       el.dataset.initial = el.value;
     }
   });
+}
+
+/* 1d/5d 反応率を editor の post-price-change スパンに反映する */
+function updatePostPriceChangeDisplay(editor, data) {
+  var postPc = editor.querySelector('.kessan-post-price-change');
+  if (!postPc) return;
+  var changes = data.post_price_changes || {};
+  var pc1Span = postPc.querySelector('.kessan-pc-1d');
+  var pc5Span = postPc.querySelector('.kessan-pc-5d');
+  if (pc1Span) pc1Span.textContent = changes['1d'] || '-';
+  if (pc5Span) pc5Span.textContent = changes['5d'] || '-';
 }
 
 function isKessanDirty(editor) {
@@ -350,15 +354,7 @@ function saveKessanFromEditor(li) {
       if (!data) return;
       /* 初期値リセット */
       rememberKessanInitialValues(editor);
-      /* post_price_changes 表示更新 (1d/5d 併記) */
-      var postPc = editor.querySelector('.kessan-post-price-change');
-      if (postPc) {
-        var changes = data.post_price_changes || {};
-        var pc1Span = postPc.querySelector('.kessan-pc-1d');
-        var pc5Span = postPc.querySelector('.kessan-pc-5d');
-        if (pc1Span) pc1Span.textContent = changes['1d'] || '-';
-        if (pc5Span) pc5Span.textContent = changes['5d'] || '-';
-      }
+      updatePostPriceChangeDisplay(editor, data);
       /* 閲覧用 view DOM を再構築（リロード不要で反映） */
       updateKessanViewDOM(li, data);
       /* has-comment クラス付与で左縁に色がつく */

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -243,9 +243,12 @@
             {% endif %}
           </td>
           <td class="col-change">
-            {% if entry.post_price_change %}
-              {% set pc = entry.post_price_change %}
-              <span class="kessan-price-change {% if pc.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc }}%</span>
+            {% set pc1 = entry.post_price_changes['1d'] %}
+            {% set pc5 = entry.post_price_changes['5d'] %}
+            {% if pc1 or pc5 %}
+              {% if pc1 %}<span class="kessan-price-change {% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
+              /
+              {% if pc5 %}<span class="kessan-price-change {% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% else %}<span>-</span>{% endif %}
             {% else %}-{% endif %}
           </td>
           <td class="col-outlook kessan-ellipsis" title="{{ entry.pre_outlook or '' }}">{{ entry.pre_outlook or '' }}</td>

--- a/scripts/webapp/templates/market.html
+++ b/scripts/webapp/templates/market.html
@@ -41,7 +41,11 @@
       {% if is_past %}
       <div class="kessan-editor-row">
         <label>株価変動率:</label>
-        <span class="kessan-field-display kessan-post-price-change">{{ s.post_price_change or '-' }}</span>
+        <span class="kessan-field-display kessan-post-price-change">
+          <span class="kessan-pc-1d">{{ s.post_price_changes['1d'] or '-' }}</span>
+          /
+          <span class="kessan-pc-5d">{{ s.post_price_changes['5d'] or '-' }}</span>
+        </span>
       </div>
       <div class="kessan-editor-row">
         <label>反応コメ:</label>
@@ -71,9 +75,14 @@
       <a href="/stock/{{ s.code_s }}">{{ s.stock_name or '-' }}</a>
       {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}
       {% if s.pre_expectation %}<span class="kessan-expectation-badge exp-{{ s.pre_expectation }}">{{ s.pre_expectation }}</span>{% endif %}
-      {% if is_past and s.post_price_change %}
-        {% set pc = s.post_price_change %}
-        <span class="kessan-price-change {% if pc.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc }}%</span>
+      {% if is_past and (s.post_price_changes['1d'] or s.post_price_changes['5d']) %}
+        {% set pc1 = s.post_price_changes['1d'] %}
+        {% set pc5 = s.post_price_changes['5d'] %}
+        <span class="kessan-price-change">
+          {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
+          /
+          {% if pc5 %}<span class="{% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% else %}<span>-</span>{% endif %}
+        </span>
       {% endif %}
       {% if s.pre_outlook or s.post_comment %}
       <div class="kessan-comment-view">

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -633,3 +633,17 @@ class TestParsePriceTextFromList:
         price_list = self._make_price_list_7col()
         _, cur_prices = price.parse_price_text_from_list(1050, price_list)
         assert len(cur_prices) == 3
+
+    def test_price_log_capped_at_20(self):
+        """price_log は LOG_DAY=20 に揃う (issue #133 で 10→20 に拡張)"""
+        # 25 件入力 → 上限 20 件のみ保持
+        price_list = self._make_price_list_7col(count=25)
+        result_dict, _ = price.parse_price_text_from_list(1050, price_list)
+        assert len(result_dict["price_log"]) == 20
+
+    def test_price_log_handles_short_input(self):
+        """LOG_DAY より少ない入力でも安全に処理される (range の length ガード)"""
+        price_list = self._make_price_list_7col(count=5)
+        result_dict, _ = price.parse_price_text_from_list(1050, price_list)
+        # 入力が5件しかなければ price_log も最大5件
+        assert len(result_dict["price_log"]) <= 5

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -296,6 +296,38 @@ class TestCrud:
         loaded = rs.get_research_record("5032", db_path=db_path)
         assert loaded["kessan_comments"][0]["kessan_matagi"] is True
 
+    def test_get_research_record_normalizes_old_post_price_change(self, db_path):
+        """旧 post_price_change のみ持つエントリは post_price_changes に正規化される (issue #133)"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/03/11",
+            "quarter": 3,
+            "pre_expectation": "○",
+            "pre_outlook": "見通し",
+            "post_price_change": "-15",
+            "post_comment": "[E] -15% x",
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        entry = loaded["kessan_comments"][0]
+        assert entry["post_price_changes"] == {"1d": "-15", "5d": ""}
+
+    def test_get_research_record_preserves_post_price_changes_dict(self, db_path):
+        """新形式 post_price_changes は読出時もそのまま"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/03/11",
+            "quarter": 3,
+            "pre_expectation": "○",
+            "pre_outlook": "見通し",
+            "post_price_changes": {"1d": "+3.2", "5d": "+5.1"},
+            "post_comment": "",
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        entry = loaded["kessan_comments"][0]
+        assert entry["post_price_changes"] == {"1d": "+3.2", "5d": "+5.1"}
+
 
 # ==================================================
 # スナップショット層: upsert_snapshot

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -56,6 +56,80 @@ class TestGetResearchDetail:
         rec = helpers.get_research_detail("9999")
         assert rec is None
 
+    def test_backfills_missing_5d_from_price_log(
+        self, populated_db, monkeypatch
+    ):
+        """過去エントリで 5d が欠損していれば price_log から補完される (issue #133)"""
+        from datetime import date as _date, timedelta as _td
+        kessan = _date(2026, 4, 1)
+        # 決算日以下の終値 + 1d, 2d, ..., 6d 後の終値
+        log = [(kessan - _td(days=1), 1000)]
+        for i, pr in enumerate([1032, 1040, 1045, 1048, 1051], start=1):
+            log.append((kessan + _td(days=i), pr))
+        monkeypatch.setattr(
+            helpers,
+            "_bulk_price_logs",
+            lambda codes: {"3496": log} if "3496" in codes else {},
+        )
+        # today を決算後に固定 (補完対象は dt < base_day のもののみ)
+        monkeypatch.setattr(
+            helpers, "get_price_day", lambda _: _date(2026, 4, 25)
+        )
+        # 1d だけ持つエントリを直接挿入 (5d は欠損)
+        rec = rs.get_research_record("3496")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/04/01",
+            "quarter": 4,
+            "pre_expectation": "○",
+            "pre_outlook": "テスト",
+            "post_price_changes": {"1d": "+3.2", "5d": ""},
+            "post_comment": "",
+            "kessan_matagi": False,
+            "held_before_kessan": False,
+            "held_after_kessan": False,
+        }]
+        rs.upsert_research_record(rec)
+
+        detail = helpers.get_research_detail("3496")
+        entry = detail["kessan_comments"][0]
+        assert entry["post_price_changes"]["1d"] == "+3.2"
+        # 5d が補完されていること (1000 → 1051 = +5.1%)
+        assert entry["post_price_changes"]["5d"] == "+5.1"
+
+    def test_does_not_backfill_future_entries(
+        self, populated_db, monkeypatch
+    ):
+        """未来の決算エントリ (dt >= base_day) は補完対象外"""
+        from datetime import date as _date, timedelta as _td
+        kessan = _date(2026, 5, 1)  # 未来
+        log = [(kessan - _td(days=1), 1000), (kessan + _td(days=1), 1050)]
+        monkeypatch.setattr(
+            helpers,
+            "_bulk_price_logs",
+            lambda codes: {"3496": log},
+        )
+        monkeypatch.setattr(
+            helpers, "get_price_day", lambda _: _date(2026, 4, 25)
+        )
+        rec = rs.get_research_record("3496")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/05/01",
+            "quarter": 1,
+            "pre_expectation": "",
+            "pre_outlook": "",
+            "post_price_changes": {"1d": "", "5d": ""},
+            "post_comment": "",
+            "kessan_matagi": False,
+            "held_before_kessan": False,
+            "held_after_kessan": False,
+        }]
+        rs.upsert_research_record(rec)
+
+        detail = helpers.get_research_detail("3496")
+        entry = detail["kessan_comments"][0]
+        # 未来エントリなので補完されず空のまま
+        assert entry["post_price_changes"] == {"1d": "", "5d": ""}
+
 
 class TestSearchRecords:
     """search_records のテスト"""

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -511,16 +511,16 @@ class TestCalcPriceReactions:
 
 
 class TestNormalizePostPriceChanges:
-    """_normalize_kessan_post_price_changes の後方互換正規化 (issue #133)"""
+    """normalize_kessan_post_price_changes の後方互換正規化 (issue #133)"""
 
     def test_new_format_passthrough(self):
         entry = {"post_price_changes": {"1d": "+3", "5d": "+5"}}
-        result = rs._normalize_kessan_post_price_changes(entry)
+        result = rs.normalize_kessan_post_price_changes(entry)
         assert result == {"1d": "+3", "5d": "+5"}
 
     def test_old_format_lifts_to_1d(self):
         entry = {"post_price_change": "-15"}
-        result = rs._normalize_kessan_post_price_changes(entry)
+        result = rs.normalize_kessan_post_price_changes(entry)
         assert result == {"1d": "-15", "5d": ""}
 
     def test_both_present_prefers_new(self):
@@ -528,16 +528,16 @@ class TestNormalizePostPriceChanges:
             "post_price_change": "-15",
             "post_price_changes": {"1d": "+2", "5d": "+3"},
         }
-        result = rs._normalize_kessan_post_price_changes(entry)
+        result = rs.normalize_kessan_post_price_changes(entry)
         assert result == {"1d": "+2", "5d": "+3"}
 
     def test_neither_present_returns_empty(self):
-        result = rs._normalize_kessan_post_price_changes({})
+        result = rs.normalize_kessan_post_price_changes({})
         assert result == {"1d": "", "5d": ""}
 
     def test_partial_new_format_filled_with_empty(self):
         entry = {"post_price_changes": {"1d": "+3"}}  # 5d 欠落
-        result = rs._normalize_kessan_post_price_changes(entry)
+        result = rs.normalize_kessan_post_price_changes(entry)
         assert result == {"1d": "+3", "5d": ""}
 
 

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -263,8 +263,15 @@ class TestSaveKessanCommentMatagi:
         monkeypatch.setattr(helpers, "RESEARCH_SHELVE", db_path, raising=False)
         rec = rs.create_research_record("5032", "ANYCOLOR")
         rs.upsert_research_record(rec, db_path=db_path)
-        # price_log は未登録でOK (calc_price_reaction は空文字を返す)
+        # price_log は未登録でOK
+        # calc_price_reaction (旧API) と calc_price_reactions (新API) の両方を差し替え。
+        # 実コードは calc_price_reactions を呼ぶが、互換ラッパ経由を含めて空に固定する。
         monkeypatch.setattr(helpers, "calc_price_reaction", lambda c, k: "")
+        monkeypatch.setattr(
+            helpers,
+            "calc_price_reactions",
+            lambda c, k: {key: "" for key, _ in helpers.KESSAN_REACTION_PERIODS},
+        )
         return db_path
 
     @pytest.fixture
@@ -422,3 +429,196 @@ class TestPersistKessanHeldFlags:
         loaded = rs.get_research_record("5032")
         assert loaded["kessan_comments"][0]["held_after_kessan"] is False
         assert len(loaded["kessan_comments"]) == 1
+
+
+class TestPriceReactionFromLog:
+    """_price_reaction_from_log の N営業日後計算 (issue #133)"""
+
+    def _make_log(self, kessan_dt, before_pr, after_prs):
+        """決算日以下の終値 + 決算日より後の営業日終値リストから price_log を作る"""
+        from datetime import timedelta as _td
+        log = [(kessan_dt - _td(days=1), before_pr)]
+        for i, pr in enumerate(after_prs, start=1):
+            log.append((kessan_dt + _td(days=i), pr))
+        return log
+
+    def test_returns_1d_change_when_n_is_1(self):
+        from datetime import date
+        kessan = date(2026, 4, 1)
+        log = self._make_log(kessan, 1000, [1032])
+        assert helpers._price_reaction_from_log(log, kessan, n_business_days=1) == "+3.2"
+
+    def test_returns_5d_change_when_n_is_5(self):
+        from datetime import date
+        kessan = date(2026, 4, 1)
+        # 1000 → 1d後 1032, ..., 5d後 1051 (=+5.1%)
+        log = self._make_log(kessan, 1000, [1032, 1040, 1045, 1048, 1051])
+        assert helpers._price_reaction_from_log(log, kessan, n_business_days=5) == "+5.1"
+
+    def test_returns_empty_when_n5_not_enough_log(self):
+        from datetime import date
+        kessan = date(2026, 4, 1)
+        # 後ろが4本しか無い → n=5 で取得不可
+        log = self._make_log(kessan, 1000, [1010, 1020, 1030, 1040])
+        assert helpers._price_reaction_from_log(log, kessan, n_business_days=5) == ""
+
+    def test_returns_empty_when_no_before_price(self):
+        from datetime import date, timedelta
+        kessan = date(2026, 4, 1)
+        # 決算日以下の log が無い (全部 future)
+        log = [(kessan + timedelta(days=i), 1000 + i) for i in range(1, 6)]
+        assert helpers._price_reaction_from_log(log, kessan, n_business_days=1) == ""
+
+    def test_negative_change_format(self):
+        from datetime import date
+        kessan = date(2026, 4, 1)
+        log = self._make_log(kessan, 1000, [985])
+        assert helpers._price_reaction_from_log(log, kessan, n_business_days=1) == "-1.5"
+
+    def test_invalid_n_returns_empty(self):
+        from datetime import date
+        kessan = date(2026, 4, 1)
+        log = self._make_log(kessan, 1000, [1032])
+        assert helpers._price_reaction_from_log(log, kessan, n_business_days=0) == ""
+
+
+class TestCalcPriceReactions:
+    """calc_price_reactions の dict 返却 (issue #133)"""
+
+    def test_returns_dict_with_both_periods(self, monkeypatch):
+        from datetime import date, timedelta
+        kessan = date(2026, 4, 1)
+        log = [(kessan - timedelta(days=1), 1000)]
+        for i, pr in enumerate([1032, 1040, 1045, 1048, 1051], start=1):
+            log.append((kessan + timedelta(days=i), pr))
+        monkeypatch.setattr(helpers, "get_stock_data", lambda c: {"price_log": log})
+        result = helpers.calc_price_reactions("5032", "2026/04/01")
+        assert result == {"1d": "+3.2", "5d": "+5.1"}
+
+    def test_invalid_kessanbi_returns_empty_dict(self):
+        result = helpers.calc_price_reactions("5032", "invalid-date")
+        assert result == {"1d": "", "5d": ""}
+
+    def test_partial_log_returns_partial_dict(self, monkeypatch):
+        from datetime import date, timedelta
+        kessan = date(2026, 4, 1)
+        # 後ろ1本しか無い → 1d は取れて 5d は ""
+        log = [(kessan - timedelta(days=1), 1000), (kessan + timedelta(days=1), 1050)]
+        monkeypatch.setattr(helpers, "get_stock_data", lambda c: {"price_log": log})
+        result = helpers.calc_price_reactions("5032", "2026/04/01")
+        assert result["1d"] == "+5.0"
+        assert result["5d"] == ""
+
+
+class TestNormalizePostPriceChanges:
+    """_normalize_kessan_post_price_changes の後方互換正規化 (issue #133)"""
+
+    def test_new_format_passthrough(self):
+        entry = {"post_price_changes": {"1d": "+3", "5d": "+5"}}
+        result = rs._normalize_kessan_post_price_changes(entry)
+        assert result == {"1d": "+3", "5d": "+5"}
+
+    def test_old_format_lifts_to_1d(self):
+        entry = {"post_price_change": "-15"}
+        result = rs._normalize_kessan_post_price_changes(entry)
+        assert result == {"1d": "-15", "5d": ""}
+
+    def test_both_present_prefers_new(self):
+        entry = {
+            "post_price_change": "-15",
+            "post_price_changes": {"1d": "+2", "5d": "+3"},
+        }
+        result = rs._normalize_kessan_post_price_changes(entry)
+        assert result == {"1d": "+2", "5d": "+3"}
+
+    def test_neither_present_returns_empty(self):
+        result = rs._normalize_kessan_post_price_changes({})
+        assert result == {"1d": "", "5d": ""}
+
+    def test_partial_new_format_filled_with_empty(self):
+        entry = {"post_price_changes": {"1d": "+3"}}  # 5d 欠落
+        result = rs._normalize_kessan_post_price_changes(entry)
+        assert result == {"1d": "+3", "5d": ""}
+
+
+class TestSaveKessanCommentMultiPeriod:
+    """save_kessan_comment の dict 化 + 期間別ガード (issue #133)"""
+
+    @pytest.fixture
+    def setup_db(self, db_path, monkeypatch):
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr(helpers, "RESEARCH_SHELVE", db_path, raising=False)
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rs.upsert_research_record(rec, db_path=db_path)
+        from datetime import date as _date
+        monkeypatch.setattr(helpers, "get_price_day", lambda _: _date(2026, 4, 25))
+        monkeypatch.setattr(helpers, "_is_possess_now", lambda c: False)
+        return db_path
+
+    def _form(self, **overrides):
+        base = {
+            "kessanbi": "2026/03/11",
+            "quarter": "3",
+            "pre_expectation": "○",
+            "pre_outlook": "事前",
+            "post_comment": "",
+        }
+        base.update(overrides)
+        return base
+
+    def test_new_entry_saves_post_price_changes_dict(self, setup_db, monkeypatch):
+        """新規保存時、post_price_changes が dict で保存され post_price_change は含まれない"""
+        monkeypatch.setattr(
+            helpers, "calc_price_reactions",
+            lambda c, k: {"1d": "+3.2", "5d": "+5.1"},
+        )
+        entry = helpers.save_kessan_comment("5032", self._form())
+        assert entry["post_price_changes"] == {"1d": "+3.2", "5d": "+5.1"}
+        # 旧キーは新規エントリには含めない
+        assert "post_price_change" not in entry
+
+    def test_overwrite_keeps_existing_5d_when_new_calc_fails(self, setup_db, monkeypatch):
+        """既存に 5d=+5.1 がある状態で再計算が 5d="" を返したら、5d は既存値を保持"""
+        # フェーズ1: 両期間取れる
+        monkeypatch.setattr(
+            helpers, "calc_price_reactions",
+            lambda c, k: {"1d": "+3.2", "5d": "+5.1"},
+        )
+        helpers.save_kessan_comment("5032", self._form())
+        # フェーズ2: 5d だけ取れず "" になる
+        monkeypatch.setattr(
+            helpers, "calc_price_reactions",
+            lambda c, k: {"1d": "+4.0", "5d": ""},
+        )
+        entry = helpers.save_kessan_comment("5032", self._form())
+        assert entry["post_price_changes"]["1d"] == "+4.0"
+        # 既存の +5.1 が保持されている
+        assert entry["post_price_changes"]["5d"] == "+5.1"
+
+    def test_overwrite_legacy_record_lifts_1d_value(self, setup_db, monkeypatch):
+        """既存が旧 post_price_change のみ持つレコードを上書きする時、1d 既存値が保持される"""
+        # 旧形式のみのレコードを直接挿入
+        rec = rs.get_research_record("5032")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/03/11",
+                "quarter": 3,
+                "pre_expectation": "○",
+                "pre_outlook": "init",
+                "post_price_change": "-7.5",  # 旧形式のみ
+                "post_comment": "",
+                "kessan_matagi": False,
+                "held_before_kessan": False,
+                "held_after_kessan": False,
+            },
+        ]
+        rs.upsert_research_record(rec)
+        # 新計算が両方 "" を返す → 既存 1d="-7.5" が保持されるはず
+        monkeypatch.setattr(
+            helpers, "calc_price_reactions",
+            lambda c, k: {"1d": "", "5d": ""},
+        )
+        entry = helpers.save_kessan_comment("5032", self._form(pre_outlook="updated"))
+        assert entry["post_price_changes"]["1d"] == "-7.5"
+        assert entry["post_price_changes"]["5d"] == ""

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -239,3 +239,69 @@ class TestIrCommentPostRoutes:
         resp = client.get("/stock/3496")
         html = resp.data.decode()
         assert "IR更新済み" in html
+
+
+class TestKessanCommentApiContract:
+    """GET/POST /api/kessan_comment のレスポンス契約 (issue #133)
+
+    旧 post_price_change を返さず、新 post_price_changes のみ返すことを保証する。
+    """
+
+    def test_get_unregistered_returns_only_new_schema(self, client):
+        """未登録銘柄 GET → デフォルトレスポンスは post_price_changes のみで旧キー無し"""
+        resp = client.get("/api/kessan_comment/9999?kessanbi=2026/04/01")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "post_price_changes" in data
+        assert data["post_price_changes"] == {"1d": "", "5d": ""}
+        assert "post_price_change" not in data
+
+    def test_get_legacy_record_returns_normalized_dict(self, client):
+        """旧 post_price_change のみのレコード GET → post_price_changes に正規化、旧キー無し"""
+        # fixture の 2024/05/14 は post_price_change="-3.1" のみ
+        resp = client.get("/api/kessan_comment/3496?kessanbi=2024/05/14")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["post_price_changes"] == {"1d": "-3.1", "5d": ""}
+        assert "post_price_change" not in data
+
+    def test_get_new_format_record_passthrough(self, client, db_path):
+        """新形式 post_price_changes 持ちレコード GET → そのまま、旧キー無し"""
+        # 直接 shelve に新形式を書き込む
+        rec = rs.get_research_record("3496", db_path=db_path)
+        rec["kessan_comments"].append({
+            "kessanbi": "2026/03/15",
+            "quarter": 4,
+            "pre_expectation": "○",
+            "pre_outlook": "テスト",
+            "post_price_changes": {"1d": "+2.5", "5d": "+4.0"},
+            "post_comment": "新形式",
+            "kessan_matagi": False,
+            "held_before_kessan": False,
+            "held_after_kessan": False,
+        })
+        rs.upsert_research_record(rec, db_path=db_path)
+        resp = client.get("/api/kessan_comment/3496?kessanbi=2026/03/15")
+        data = resp.get_json()
+        assert data["post_price_changes"] == {"1d": "+2.5", "5d": "+4.0"}
+        assert "post_price_change" not in data
+
+    def test_post_response_returns_only_new_schema(self, client, monkeypatch):
+        """POST 後のレスポンスにも post_price_changes のみ含まれ、旧キー無し"""
+        from webapp import helpers as _helpers
+        monkeypatch.setattr(
+            _helpers, "calc_price_reactions",
+            lambda c, k: {"1d": "+1.0", "5d": "+2.0"},
+        )
+        monkeypatch.setattr(_helpers, "_is_possess_now", lambda c: False)
+        resp = client.post("/api/kessan_comment/3496", data={
+            "kessanbi": "2026/04/22",
+            "quarter": "1",
+            "pre_expectation": "○",
+            "pre_outlook": "API契約テスト",
+            "post_comment": "",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["post_price_changes"] == {"1d": "+1.0", "5d": "+2.0"}
+        assert "post_price_change" not in data


### PR DESCRIPTION
## Summary

issue #133: 決算反応の `post_price_change` (str) を `post_price_changes` (dict) に拡張し、1日後 / 5日後の両期間を保存・表示する。

- `scripts/price.py`: `LOG_DAY = 10 → 20` (5d 取得のためのバッファ)
- スキーマ拡張: `KESSAN_REACTION_PERIODS = (("1d", 1), ("5d", 5))` 定数で一元管理。`post_price_changes: {"1d": "+3.2", "5d": "+5.1"}` 形式で保存
- 後方互換: 旧 `post_price_change` のみのレコードは `get_research_record` で読出時に `{"1d": <旧値>, "5d": ""}` に正規化（移行スクリプトは作らない）
- API: `_serialize_kessan_entry_for_api` で GET/POST レスポンスから旧キーを除外
- UI: `market.html` / `detail.html` / `app.js` で `+3.2% / +5.1%` 併記表示
- 過去エントリの欠損期間は `get_market_kessan_data` と `get_research_detail` で `price_log` から in-memory 補完

## レビュー対応で含めた追加修正

- (codex) GET/POST レスポンスを `_serialize_kessan_entry_for_api` で明示整形 + API 契約回帰テスト 4 件追加
- (simplify) `_split_log_around_kessanbi` / `_format_reaction` 抽出で price_log のソート共有、`updatePostPriceChangeDisplay` で JS の重複ロジック集約、private 関数の rename
- (動作確認指摘) `/stock/<code>` 詳細ページでも 5d 補完計算を実施
- (P2 指摘) editor 展開時に空 API レスポンスでテンプレ補完値を上書きしないようガード

## Test plan

- [x] `pytest tests/ -v -m "not local_db and not live_html"` 721 passed
- [x] `python research_shelve.py show 5032` で `1d=-15% 5d=-` の併記表示確認
- [x] webapp 起動 → 6 銘柄 (1301/135A/215A/5032/247A/3496) で `/api/kessan_comment` レスポンスから旧 `post_price_change` キーが消えていることを確認 (24 通り leak 0 件)
- [x] `/stock/<code>` 詳細ページで履歴テーブルの 1d/5d 併記表示と 5d 補完を確認 (135A: `+17.2% / +25.0%`、3021: `-16.0% / -16.4%` 等)
- [x] `/market` で 317 銘柄、588 件の 1d/5d 表示が正常レンダリング
- [x] Playwright で editor 展開時に補完値が上書きされないことを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)