### PR TITLE
決算修正パーサの取りこぼし修正 + make_stock_db.py の銘柄指定CLI化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,13 @@ cd scripts && python shintakane.py analyze
 # DB全銘柄のランキング更新 + CSV出力
 cd scripts && python make_stock_db.py list_all_db
 
-# 特定銘柄の更新（main()内のcode_listを編集して実行）
-cd scripts && python make_stock_db.py update
+# 特定銘柄の更新 (引数で指定可。未指定時はソース内デフォルト)
+cd scripts && python make_stock_db.py update 6324             # 単一銘柄
+cd scripts && python make_stock_db.py update 6324 7203 215A   # 複数銘柄
+cd scripts && python make_stock_db.py update 6324 --snapshot  # 更新後にスナップショットも自動追記
 
-# 特定銘柄データの表示
-cd scripts && python make_stock_db.py list
+# 特定銘柄データの表示 (引数で指定可)
+cd scripts && python make_stock_db.py list 6324
 
 # 上場廃止銘柄のクリーンアップ
 cd scripts && python make_stock_db.py reflesh

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1294,7 +1294,7 @@ def _collect_trigger_dates(stock, today):
     return [c[1] for c in candidates]
 
 
-def update_research_snapshots(*, db_path=None):
+def update_research_snapshots(*, db_path=None, code_filter=None):
     """ウォッチ銘柄のうち決算更新があったものにスナップショットを自動追記する。
 
     対象は `my_watch_list.txt` 記載のコード (通常 + H付き保有) の union に限定。
@@ -1303,6 +1303,11 @@ def update_research_snapshots(*, db_path=None):
     空レコードを自動登録してから同一実行内でスナップショットも追記する。
     ウィンドウ外の未登録ウォッチ銘柄は登録しない (research DB を汚染しないため)。
     同じ date_yy_m のスナップショットが既にあればスキップ。
+
+    Args:
+        db_path: research_shelve の DB パス上書き (テスト用)
+        code_filter: 銘柄コード集合を渡すと、ウォッチ集合との積に限定する。
+                     None の場合はウォッチ集合全体が対象。
     """
     import research_shelve
     import portfolio
@@ -1316,6 +1321,14 @@ def update_research_snapshots(*, db_path=None):
         )
         return
     watch_set = set(watch_codes) | set(possess_codes)
+    if code_filter is not None:
+        filter_set = set(code_filter)
+        not_in_watch = filter_set - watch_set
+        if not_in_watch:
+            log_warning(
+                f"[research] code_filter にウォッチ外銘柄が含まれるためスキップ: {sorted(not_in_watch)}"
+            )
+        watch_set = watch_set & filter_set
 
     stocks = load_stock_db()
     today = get_price_day(datetime.today())
@@ -1415,6 +1428,18 @@ def main():
     parser.add_argument(
         "command", type=str, nargs="?", default="list_all_db", help="実行するコマンド"
     )
+    parser.add_argument(
+        "codes",
+        type=str,
+        nargs="*",
+        default=[],
+        help="update / list に渡す銘柄コード（複数可）。未指定時はソース内のデフォルトを使用",
+    )
+    parser.add_argument(
+        "--snapshot",
+        action="store_true",
+        help="update 後にウォッチ銘柄のスナップショット自動追記を実行",
+    )
     args = parser.parse_args()
     log_print("=" * 30)
     log_print("make_stock_db.pyを実行します", args)
@@ -1430,9 +1455,12 @@ def main():
     # command = "reflesh"
     # command = "test"
     if command == "update":
-        code_list = "471A"
-        # code_list = "2979 3226 4384 4434 4443 4448 4449 4475 4477 4478 4479 4480 4483 4485 4488 4490 4493 4599 6835 7071"
-        code_list = code_list.split()
+        if args.codes:
+            code_list = list(args.codes)
+        else:
+            code_list = "471A"
+            # code_list = "2979 3226 4384 4434 4443 4448 4449 4475 4477 4478 4479 4480 4483 4485 4488 4490 4493 4599 6835 7071"
+            code_list = code_list.split()
         # f = open("update_code_list.txt")
         # lines = f.readlines()
         # code_list = [l.strip() for l in lines]
@@ -1446,11 +1474,17 @@ def main():
         update_db_rows(
             code_list, upd=UPD_FORCE, tables=tables
         )  # UPD_FORCE/UPD_REEVAL/UPD_INTERVAL
+        if args.snapshot:
+            # update 対象の銘柄に絞ってスナップショットを追記する
+            update_research_snapshots(code_filter=code_list)
     elif command == "list":
         # DB内銘柄情報表示
-        code_list = "4483"
-        # code_list = "3242 3686 6058 6432 7435"
-        code_list = code_list.split()
+        if args.codes:
+            code_list = list(args.codes)
+        else:
+            code_list = "4483"
+            # code_list = "3242 3686 6058 6432 7435"
+            code_list = code_list.split()
         list_db(code_list)
     elif command == "list_all_db":
         # DBの情報をランキングで表示する

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -1307,10 +1307,12 @@ def parse_kessan_html(html):
             log_warning("決算ページフォーマット変更?")
         return kessan_list
 
-    # htmlから、決算情報が含まれば箇所を取得(正規表現にコストかかるため高速化)
-    body_html = re.search(
-        r'<table class="s_news_list mgbt0">(.*?)</table>', html, re.S
-    ).group(1)
+    # 決算情報のテーブルは1ページに `s_news_list mgbt0` と `s_news_list mgt0` の
+    # 2つに分かれている。両方を連結して対象にしないと後半テーブルの記事が漏れる
+    bodies = re.findall(
+        r'<table class="s_news_list[^"]*">(.*?)</table>', html, re.S
+    )
+    body_html = "".join(bodies)
     mod_lst = re_search_kessan("ctg3_ks", body_html)
     log_print("決算修正:", [item[:2] for item in mod_lst])
 

--- a/tests/test_append_research_snapshots.py
+++ b/tests/test_append_research_snapshots.py
@@ -389,3 +389,47 @@ class TestUpdateResearchSnapshots:
         assert isinstance(snap["ir_quant"], str)
         assert isinstance(snap["quality_indicators"], str)
         assert isinstance(snap["rironkabuka_kairi"], str)
+
+    def test_code_filter_limits_targets(self, db_path, monkeypatch):
+        """code_filter を渡すと指定銘柄だけが処理される (他銘柄は触らない)"""
+        today = _today_str()
+        stock_a = _make_stock("3496", kessanbi=today, stock_name="アズーム")
+        stock_b = _make_stock("6324", kessanbi=today, stock_name="ハーモニック")
+        monkeypatch.setattr(
+            make_stock_db, "load_stock_db",
+            lambda: {"3496": stock_a, "6324": stock_b},
+        )
+        monkeypatch.setattr(
+            portfolio, "parse_my_portforio", lambda: (["3496", "6324"], [])
+        )
+
+        for code_s, name in [("3496", "アズーム"), ("6324", "ハーモニック")]:
+            rec = rs.create_research_record(code_s, name)
+            rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(
+            db_path=db_path, code_filter=["6324"]
+        )
+
+        # 6324 だけスナップショットが追記され、3496 は触られない
+        rec_a = rs.get_research_record("3496", db_path=db_path)
+        rec_b = rs.get_research_record("6324", db_path=db_path)
+        assert len(rec_a["snapshots"]) == 0
+        assert len(rec_b["snapshots"]) == 1
+
+    def test_code_filter_outside_watchlist_skipped(self, db_path, monkeypatch):
+        """code_filter にウォッチ外の銘柄を指定すると何もしない (汚染防止)"""
+        today = _today_str()
+        stock = _make_stock("9999", kessanbi=today, stock_name="ウォッチ外")
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"9999": stock})
+        monkeypatch.setattr(portfolio, "parse_my_portforio", lambda: (["3496"], []))
+
+        rec = rs.create_research_record("9999", "ウォッチ外")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(
+            db_path=db_path, code_filter=["9999"]
+        )
+
+        loaded = rs.get_research_record("9999", db_path=db_path)
+        assert len(loaded["snapshots"]) == 0

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -350,3 +350,97 @@ class TestUpdateDbSignalKeys:
         stock_data = {"code_s": "1234", "breakout": []}
         make_stock_db.update_db(stocks, stock_data)
         assert stocks["1234"]["breakout"] == []
+
+
+# ==================================================
+# main() の CLI 引数 (update / list の銘柄指定)
+# ==================================================
+class TestMainCLIArgs:
+    """`make_stock_db.py update 6324` のように銘柄を引数指定できることのテスト"""
+
+    def _patch_common(self, monkeypatch):
+        import googledrive
+        monkeypatch.setattr(googledrive, "wait_all_uploads", lambda: None)
+
+    def test_update_with_codes(self, monkeypatch):
+        """update に銘柄コードを渡すと code_list がそれになる"""
+        called = {}
+
+        def fake_update_db_rows(code_list, upd=None, tables=None):
+            called["code_list"] = code_list
+
+        monkeypatch.setattr(make_stock_db, "update_db_rows", fake_update_db_rows)
+        monkeypatch.setattr(make_stock_db, "update_research_snapshots", lambda: None)
+        self._patch_common(monkeypatch)
+
+        monkeypatch.setattr("sys.argv", ["make_stock_db.py", "update", "6324"])
+        make_stock_db.main()
+        assert called["code_list"] == ["6324"]
+
+    def test_update_with_multiple_codes(self, monkeypatch):
+        """複数銘柄も渡せる"""
+        called = {}
+
+        def fake_update_db_rows(code_list, upd=None, tables=None):
+            called["code_list"] = code_list
+
+        monkeypatch.setattr(make_stock_db, "update_db_rows", fake_update_db_rows)
+        monkeypatch.setattr(make_stock_db, "update_research_snapshots", lambda: None)
+        self._patch_common(monkeypatch)
+
+        monkeypatch.setattr(
+            "sys.argv", ["make_stock_db.py", "update", "6324", "7203", "215A"]
+        )
+        make_stock_db.main()
+        assert called["code_list"] == ["6324", "7203", "215A"]
+
+    def test_update_without_codes_uses_default(self, monkeypatch):
+        """codes 未指定時はソース内デフォルトが使われる (既存挙動維持)"""
+        called = {}
+
+        def fake_update_db_rows(code_list, upd=None, tables=None):
+            called["code_list"] = code_list
+
+        monkeypatch.setattr(make_stock_db, "update_db_rows", fake_update_db_rows)
+        monkeypatch.setattr(make_stock_db, "update_research_snapshots", lambda: None)
+        self._patch_common(monkeypatch)
+
+        monkeypatch.setattr("sys.argv", ["make_stock_db.py", "update"])
+        make_stock_db.main()
+        assert called["code_list"] == ["471A"]
+
+    def test_update_snapshot_flag(self, monkeypatch):
+        """--snapshot フラグで update_research_snapshots が指定銘柄に絞って呼ばれる"""
+        called = {"update_db_rows": False, "snapshot_kwargs": None}
+
+        def fake_update_db_rows(code_list, upd=None, tables=None):
+            called["update_db_rows"] = True
+
+        def fake_snapshots(*, db_path=None, code_filter=None):
+            called["snapshot_kwargs"] = {"db_path": db_path, "code_filter": code_filter}
+
+        monkeypatch.setattr(make_stock_db, "update_db_rows", fake_update_db_rows)
+        monkeypatch.setattr(make_stock_db, "update_research_snapshots", fake_snapshots)
+        self._patch_common(monkeypatch)
+
+        monkeypatch.setattr(
+            "sys.argv", ["make_stock_db.py", "update", "6324", "7203", "--snapshot"]
+        )
+        make_stock_db.main()
+        assert called["update_db_rows"] is True
+        # update 対象銘柄だけがフィルタに渡る (ウォッチ全銘柄を走らせない)
+        assert called["snapshot_kwargs"]["code_filter"] == ["6324", "7203"]
+
+    def test_list_with_codes(self, monkeypatch):
+        """list に銘柄コードを渡すと code_list がそれになる"""
+        called = {}
+
+        def fake_list_db(code_list):
+            called["code_list"] = code_list
+
+        monkeypatch.setattr(make_stock_db, "list_db", fake_list_db)
+        self._patch_common(monkeypatch)
+
+        monkeypatch.setattr("sys.argv", ["make_stock_db.py", "list", "6324"])
+        make_stock_db.main()
+        assert called["code_list"] == ["6324"]

--- a/tests/test_shintakane.py
+++ b/tests/test_shintakane.py
@@ -331,6 +331,24 @@ class TestParseKessanHtml:
         mod_lst, _ = shintakane.parse_kessan_html(html)
         assert len(mod_lst[0]) == 4
 
+    def test_2つのテーブル両方からパースする(self):
+        """株探の決算速報ページは `s_news_list mgbt0` と `s_news_list mgt0`
+        の2テーブル構成。後半テーブルの記事も拾える必要がある (regression)"""
+        rows_front = _build_kessan_row(
+            "2026-04-24", "ctg3_ks", "7774", "/news/a", "前期経常を上方修正"
+        )
+        rows_back = _build_kessan_row(
+            "2026-04-24", "ctg3_ks", "6324", "/news/b", "ハーモニック、前期経常を67％上方修正"
+        )
+        html = (
+            f'<table class="s_news_list mgbt0">{rows_front}</table>'
+            f'<table class="s_news_list mgt0">{rows_back}</table>'
+        )
+        mod_lst, _ = shintakane.parse_kessan_html(html)
+        codes = [item[0] for item in mod_lst]
+        assert "7774" in codes
+        assert "6324" in codes
+
 
 # ==================================================
 # convert_kabutan_pts_html（株探・PTSナイトランキング）


### PR DESCRIPTION
## Summary

- kabutan 決算速報ページの **2テーブル構造** に対応し、後半テーブル（`s_news_list mgt0`）の記事の取りこぼしを解消
- `make_stock_db.py update <code>... --snapshot` で特定銘柄の強制再評価＋スナップショット追記を一発で実行可能に
- `update_research_snapshots` に `code_filter` 引数を追加（ウォッチ集合との積を取るため DB 汚染防止は維持）

## 背景：何が起きていたか

ユーザーが「6324 ハーモニックの 4/24 上方修正後にスナップショットが取れていない」と報告。調査の結果、以下が判明:

- 6324 の `kessan_mod_date` が **1年前の `2025/04/24` のまま**で、`update_research_snapshots` の14日ウィンドウから外れていた
- 個別銘柄の `disclosure`（適時開示）には `('04/24', '修正', 'ハーモニック、前期経常を67％上方修正', ...)` で正常に出ている
- `update_todays_kessan` が読みに行く kabutan 決算速報ページのキャッシュHTMLには **6324 が確かに存在**するが、パーサが拾えていなかった
- HTML 構造は `<table class="s_news_list mgbt0">` と `<table class="s_news_list mgt0">` の **2テーブル分割**で、現行コードは前者のみを抽出範囲にしていた
- 実 HTML キャッシュ（4/25 19:00 取得分、page1〜8）で検証すると **4/24 修正の取得件数が約半分**（17件→33件）に増加し、6324 を含むこれまで取り逃していた銘柄を全て拾えるようになる

## 主な変更

### 1. `scripts/shintakane.py`: パーサ修正

```python
# Before: 1つ目のテーブルのみ対象
body_html = re.search(
    r'<table class="s_news_list mgbt0">(.*?)</table>', html, re.S
).group(1)

# After: s_news_list クラスの全テーブルを連結
bodies = re.findall(
    r'<table class="s_news_list[^"]*">(.*?)</table>', html, re.S
)
body_html = "".join(bodies)
```

### 2. `scripts/make_stock_db.py`: CLI 引数化

`update`/`list` コマンドに銘柄コード可変長引数を追加（従来はソース内 `code_list` を編集する運用）。

```bash
# 単一銘柄
python make_stock_db.py update 6324
# 複数銘柄
python make_stock_db.py update 6324 7203 215A
# 強制更新 + スナップショット追記
python make_stock_db.py update 6324 --snapshot
# 表示
python make_stock_db.py list 6324
```

引数省略時は従来通りソース内デフォルトを使う（後方互換）。

### 3. `update_research_snapshots(code_filter=...)`

ウォッチ集合との積に絞る実装。`code_filter` にウォッチ外銘柄を渡すと警告ログを出してスキップ（既存の DB 汚染防止規約を維持）。

### 4. ドキュメント

`CLAUDE.md` の開発コマンド一覧を新CLIの使い方に更新。

## 影響範囲

- 過去から一貫して決算修正・発表記事の **約半数を取り逃していた**ため、本修正により今後の `kessan_mod_date` 更新精度が大幅に向上
- 統合テスト導入（issue #145）のフィクスチャ更新フローでも活用可能（[#145 にコメント済](https://github.com/nasumiso/KSKInvestSystem/issues/145#issuecomment-4319608830)）

## Test plan

- [x] `pytest tests/test_shintakane.py tests/test_make_stock_db.py tests/test_append_research_snapshots.py -v` → **86 件全 PASS**
- [x] 新規テスト追加: 8件
  - `TestParseKessanHtml::test_2つのテーブル両方からパースする` (回帰)
  - `TestMainCLIArgs::*` 5件（CLI 引数）
  - `TestUpdateResearchSnapshots::test_code_filter_*` 2件
- [x] 実 HTML キャッシュでの動作確認: 4/24 修正取得件数 17件 → **33件**（6324 含む）
- [x] 6324 で実DBに対しエンドツーエンド動作確認:
  - `update_todays_kessan()` で `kessan_mod_date` が `2026/04/24` に更新
  - `update_research_snapshots(code_filter=['6324'])` でスナップショット 4件 → **5件** (`26.4.24 source=auto` 追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)