### PR TITLE
決算日セクション: 当日決算を past 扱いにして反応コメ入力を可能に

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1133,7 +1133,13 @@ def get_market_kessan_data() -> Dict[str, Any]:
                 updates,
             ))
 
-        groups = past_groups if dt < base_day else future_groups
+        # 表示振り分けはカレンダー上の今日基準。当日決算は past 扱いとし、
+        # 株価変動率枠・反応コメ・決算またぎフィールドを当日中に編集できるようにする
+        # (株価変動率の値は当日中は空欄でも、引け後の手動入力は可能)。
+        # held_before/after の判定はこれより上の base_day ベースを維持
+        # (当日中の保有は「決算前保有」として扱うため)。
+        today_cal = datetime.today().date()
+        groups = past_groups if dt <= today_cal else future_groups
         groups.setdefault(kessanbi, []).append(entry)
 
     if persist_targets:

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -131,6 +131,115 @@ class TestGetResearchDetail:
         assert entry["post_price_changes"] == {"1d": "", "5d": ""}
 
 
+class TestGetMarketKessanData:
+    """get_market_kessan_data の振り分けロジックテスト"""
+
+    @pytest.fixture
+    def kessan_env(self, populated_db, monkeypatch):
+        """pf_kessan_shelve / portfolio / 価格ログ等を共通モック"""
+        # 当日決算/過去/未来をテストごとに pf_dict で渡せるよう、
+        # load_pf_kessan_db は外側から指定可能なヘルパとして組み立てる
+        from datetime import datetime as _dt
+
+        def setup(pf_dict, today_dt):
+            # kessan.load_pf_kessan_db
+            import kessan as _k
+            monkeypatch.setattr(_k, "load_pf_kessan_db", lambda: pf_dict)
+            # portfolio.parse_my_portforio (ウォッチ・保有なしで全銘柄通す)
+            import portfolio as _p
+            monkeypatch.setattr(
+                _p, "parse_my_portforio", lambda: ([], [])
+            )
+            # 価格ログ (反応率計算で使われるが、当日扱いの検証では不要)
+            monkeypatch.setattr(helpers, "_bulk_price_logs", lambda codes: {})
+            # datetime.today() を固定
+            class FrozenDateTime(_dt):
+                @classmethod
+                def today(cls):
+                    return today_dt
+                @classmethod
+                def now(cls, tz=None):
+                    return today_dt
+            monkeypatch.setattr(helpers, "datetime", FrozenDateTime)
+            # get_price_day も同じ datetime を参照するため、helpers 経由で暗黙にカバーされる
+        return setup
+
+    def test_today_kessan_goes_to_recent_past(self, kessan_env):
+        """当日決算は recent_past_entries に振り分けられる (issue: 当日反応コメ入力)"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 4, 27, 10, 0)  # 4/27 朝
+        pf_dict = {
+            "6501": {
+                "code_s": "6501",
+                "stock_name": "日立製作所",
+                "kessanbi": "2026/04/27",
+                "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        result = helpers.get_market_kessan_data()
+        # 当日 (4/27) は past 側 (recent_past_entries) に入る
+        past_keys = [k for k, _ in result["recent_past_entries"]]
+        future_keys = [k for k, _ in result["future_entries"]]
+        assert "2026/04/27" in past_keys
+        assert "2026/04/27" not in future_keys
+
+    def test_yesterday_kessan_in_recent_past(self, kessan_env):
+        """前日決算は従来通り recent_past_entries"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 4, 27, 10, 0)
+        pf_dict = {
+            "6501": {
+                "code_s": "6501",
+                "stock_name": "日立製作所",
+                "kessanbi": "2026/04/26",
+                "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        result = helpers.get_market_kessan_data()
+        past_keys = [k for k, _ in result["recent_past_entries"]]
+        assert "2026/04/26" in past_keys
+
+    def test_tomorrow_kessan_in_future(self, kessan_env):
+        """翌日以降の決算は future_entries"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 4, 27, 10, 0)
+        pf_dict = {
+            "6501": {
+                "code_s": "6501",
+                "stock_name": "日立製作所",
+                "kessanbi": "2026/04/28",
+                "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        result = helpers.get_market_kessan_data()
+        future_keys = [k for k, _ in result["future_entries"]]
+        past_keys = [k for k, _ in result["recent_past_entries"]]
+        assert "2026/04/28" in future_keys
+        assert "2026/04/28" not in past_keys
+
+    def test_today_kessan_morning_before_18(self, kessan_env):
+        """18 時前 (base_day=前日) でも当日決算は past 側に入る (本修正の核心)"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 4, 27, 9, 0)  # 9 時 = base_day は 4/26
+        pf_dict = {
+            "6501": {
+                "code_s": "6501",
+                "stock_name": "日立製作所",
+                "kessanbi": "2026/04/27",
+                "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        result = helpers.get_market_kessan_data()
+        past_keys = [k for k, _ in result["recent_past_entries"]]
+        # 修正前: base_day=4/26 で dt(4/27) >= base_day(4/26) → future へ落ちる
+        # 修正後: today_cal=4/27 で dt(4/27) <= today_cal(4/27) → past
+        assert "2026/04/27" in past_keys
+
+
 class TestSearchRecords:
     """search_records のテスト"""
 


### PR DESCRIPTION
## Summary

\`/market\` の決算日セクションで、当日決算銘柄 (例: 4/27 当日アクセス時の 6501 日立製作所) が future 側に振り分けられていたため、株価変動率枠・反応コメ・決算またぎチェックが表示されず、当日中に反応コメを入力できなかった問題を修正。

## 原因

\`get_market_kessan_data\` の振り分けロジックが \`get_price_day(datetime.today())\` (18 時前は前日扱い) を基準にしており、\`dt < base_day\` のものだけを past、それ以外を future にしていた。

- 4/27 朝アクセス → \`base_day = 4/26\` → 4/27 決算 \`dt(4/27) >= base_day(4/26)\` で **future**
- 4/27 18 時以降 → \`base_day = 4/27\` → 4/27 決算 \`dt(4/27) >= base_day(4/27)\` で **future** (\`>=\` だから当日も future)

つまり当日決算は時刻によらず **常に future 扱い**で、当日中の反応コメ入力が不可能だった。

## 修正

振り分けを **カレンダー上の今日 (today_cal)** ベースに変更:

\`\`\`python
today_cal = datetime.today().date()
groups = past_groups if dt <= today_cal else future_groups
\`\`\`

- 当日決算 (dt == today_cal) → past 側 (recent_past_entries) に入る
- 翌日以降 (dt > today_cal) → future 側
- 過去 (dt < today_cal) → past 側 (従来通り)

\`held_before_kessan\` / \`held_after_kessan\` の判定は **従来通り base_day ベース**を維持 (当日中の保有は「決算前保有」として扱うのが正しいため)。

## Test plan

- [x] \`pytest tests/ -m "not local_db and not live_html"\` — 756 passed (前回 752 + 新規 4)
- [x] \`TestGetMarketKessanData\` 新設 (4 ケース):
  - 当日決算が recent_past_entries に振り分けられる
  - 前日決算は従来通り recent_past_entries
  - 翌日決算は future_entries
  - 18 時前 (base_day=前日) でも当日決算は past 側 (本修正の核心)
- [x] WebApp で 4/27 アクセス時、保有銘柄 6501 日立製作所が \`04/27 (済)\` カードに表示されることを Playwright で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)