### PR TITLE
issue #154: 決算反応に PTS 騰落率を追加

### DIFF
--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1623,7 +1623,7 @@ def update_research_snapshots(*, db_path=None, code_filter=None):
     return watch_set
 
 
-def update_pts_reactions(watch_set, today_date, *, stocks=None, db_path=None):
+def update_pts_reactions(watch_set, today_date, *, stocks=None):
     """当日決算銘柄の kessan_comments に PTS 騰落率を追記する。
 
     - today_date: datetime.date (get_price_day の戻り値)

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1516,7 +1516,7 @@ def update_research_snapshots(*, db_path=None, code_filter=None):
         log_warning(
             "[research] my_watch_list.txt が見つからないためスナップショット自動追記をスキップ"
         )
-        return
+        return set()
     watch_set = set(watch_codes) | set(possess_codes)
     if code_filter is not None:
         filter_set = set(code_filter)
@@ -1620,6 +1620,52 @@ def update_research_snapshots(*, db_path=None, code_filter=None):
         + (f", {skipped_existing} 件スキップ(既存)" if skipped_existing else "")
     )
 
+    return watch_set
+
+
+def update_pts_reactions(watch_set, today_date, *, stocks=None, db_path=None):
+    """当日決算銘柄の kessan_comments に PTS 騰落率を追記する。
+
+    - today_date: datetime.date (get_price_day の戻り値)
+    - PTS CSV の日付と today_date が一致する場合のみ書き込み
+      (load_pts_changes_for_date が日付一致を保証)
+    - watch_set 制限で research_shelve 汚染を防ぐ
+    - stocks=None なら自前で load_stock_db() を呼ぶ (呼び出し側の重複ロード回避)
+    - PTS CSV 不在 / watch_set 空のときは warning + スキップ
+    """
+    import pts_data
+    from webapp.helpers import upsert_kessan_pts_change
+
+    if not watch_set:
+        log_warning("[pts] watch_set が空のため PTS 反応の追記をスキップ")
+        return
+
+    pts_changes = pts_data.load_pts_changes_for_date(today_date)
+    if not pts_changes:
+        log_warning("[pts] 当日 PTS CSV が見つからないため PTS 反応の追記をスキップ")
+        return
+
+    if stocks is None:
+        stocks = load_stock_db()
+
+    today_str = today_date.strftime("%Y/%m/%d")
+    written = 0
+    # PTS データ件数は当日決算 ~10件、watch_set は ~325件。
+    # 積を取って先に絞り込む方が走査件数が少なく意図が明確になる。
+    for code_s in watch_set & pts_changes.keys():
+        stock = stocks.get(code_s)
+        if not stock or stock.get("kessanbi") != today_str:
+            continue
+        quarter = int(stock.get("kessan_quarter") or 0)
+        try:
+            upsert_kessan_pts_change(
+                code_s, today_str, quarter, pts_changes[code_s]
+            )
+            written += 1
+        except Exception as e:
+            log_warning(f"[pts] PTS 反応の追記失敗: {code_s} {e}")
+    log_print(f"[pts] PTS 反応を当日決算銘柄 {written} 件に追記")
+
 
 # ==================================================
 # main
@@ -1682,7 +1728,9 @@ def main():
         )  # UPD_FORCE/UPD_REEVAL/UPD_INTERVAL
         if args.snapshot:
             # update 対象の銘柄に絞ってスナップショットを追記する
-            update_research_snapshots(code_filter=code_list)
+            watch_set = update_research_snapshots(code_filter=code_list)
+            today_date = get_price_day(datetime.today())
+            update_pts_reactions(watch_set or set(), today_date)
     elif command == "list":
         # DB内銘柄情報表示
         if args.codes:
@@ -1697,7 +1745,9 @@ def main():
         UPLOAD_CSV = True  # True/False
         UPDATE_PORTFOLIO = True
         list_all_db(UPLOAD_CSV, UPDATE_PORTFOLIO)
-        update_research_snapshots()
+        watch_set = update_research_snapshots()
+        today_date = get_price_day(datetime.today())
+        update_pts_reactions(watch_set or set(), today_date)
     elif command == "edit":
         edit_db()
     elif command == "backup":

--- a/scripts/pts_data.py
+++ b/scripts/pts_data.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""PTS (夜間取引) CSV のロード用ユーティリティ。
+
+shintakane.py の `search_fromcsv_pts()` から CSV パース部を抽出し、
+make_stock_db / research 系から呼べる純粋関数として提供する。
+"""
+
+import csv
+import datetime as _datetime
+import os
+from typing import Dict, Optional
+
+from ks_util import DATA_DIR, log_warning
+
+
+def get_pts_csv_path_for_date(date_obj):
+    """指定日 (datetime.date) の pts_YYMMDD.csv パスを返す。
+
+    存在チェックはしない。命名規則は `shintakane.py:208` の
+    `get_pts_day_txtname()` と一致させる: `pts_YYMMDD.csv`。
+    """
+    if not isinstance(date_obj, _datetime.date):
+        raise TypeError(f"date_obj は datetime.date 型: got {type(date_obj).__name__}")
+    fname = "pts_%02d%02d%02d.csv" % (
+        date_obj.year - 2000,
+        date_obj.month,
+        date_obj.day,
+    )
+    return os.path.join(DATA_DIR, "today_stocks", fname)
+
+
+def load_pts_changes_for_date(date_obj) -> Dict[str, str]:
+    """指定日の PTS CSV を読み、`{code_s: zenjitsuhi_per_str}` の dict を返す。
+
+    - 引数: 必須の `date_obj` (datetime.date)。日付一致を必須化
+    - 戻り値の値は ``"+2.5"`` 形式 (% 記号を除去、符号は保持)
+    - 指定日 CSV 不在時は空 dict
+    - 「最新CSVフォールバック」は実装しない (古い CSV を当日扱いする誤適用防止)
+    """
+    csv_path = get_pts_csv_path_for_date(date_obj)
+    if not os.path.exists(csv_path):
+        return {}
+
+    result: Dict[str, str] = {}
+    try:
+        with open(csv_path, "r", encoding="utf-8") as f:
+            for row in csv.reader(f):
+                if not row or len(row) < 7:
+                    continue
+                code_field = row[1].split()
+                if not code_field:
+                    continue
+                code_s = code_field[0]
+                raw = row[6] or ""
+                normalized = _normalize_pts_change_str(raw)
+                if normalized:
+                    result[code_s] = normalized
+    except (OSError, csv.Error) as e:
+        log_warning(f"PTS CSV 読み込み失敗: {csv_path}: {e}")
+        return {}
+    return result
+
+
+def _normalize_pts_change_str(raw: str) -> Optional[str]:
+    """CSV の zenjitsuhi_per ("+2.5%") を保存形式 ("+2.5") に正規化。
+
+    - 末尾の "%" を除去
+    - 符号 ("+" / "-") は保持
+    - 空文字や数値変換不能なら None
+    """
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    if s.endswith("%"):
+        s = s[:-1]
+    s = s.strip()
+    if not s:
+        return None
+    body = s.lstrip("+-")
+    if not body:
+        return None
+    try:
+        float(body)
+    except ValueError:
+        return None
+    return s

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -115,6 +115,7 @@ def normalize_kessan_post_price_changes(entry: Dict[str, Any]) -> Dict[str, str]
     """決算コメントエントリの post_price_changes を正規化する。
 
     - 新形式 dict があれば各期間キーを str に正規化して返す
+    - dict に "pts" キー (PTS ナイトセッション前日比) があれば保持する
     - 無ければ旧 post_price_change を {"1d": <値>, "5d": ""} に補完
     - どちらも無ければ全期間 "" を返す
     """
@@ -124,6 +125,10 @@ def normalize_kessan_post_price_changes(entry: Dict[str, Any]) -> Dict[str, str]
         for key, _ in KESSAN_REACTION_PERIODS:
             v = raw.get(key, "")
             result[key] = str(v) if v else ""
+        # PTS は KESSAN_REACTION_PERIODS とは別系統 (時間軸が違う) なので個別に扱う
+        pts_v = raw.get("pts", "")
+        if pts_v:
+            result["pts"] = str(pts_v)
         return result
     legacy = entry.get("post_price_change", "") or ""
     if legacy:

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -14,6 +14,7 @@ import make_stock_db as stock_db
 import make_market_db
 
 import kessan
+import pts_data
 from ks_util import *
 
 
@@ -206,10 +207,15 @@ def search_fromcsv_pts(fname):
 
 
 def get_pts_day_txtname(today):
-    """datetime からPTS日付CSVファイルパスを生成"""
-    txt_template = os.path.join(DATA_DIR, "today_stocks", "pts_%02d%02d%02d")
-    today_txt = txt_template % (today.year - 2000, today.month, today.day)
-    return today_txt
+    """datetime からPTS日付CSVファイルパス (拡張子なし) を生成
+
+    pts_data.get_pts_csv_path_for_date() に委譲。戻り値は ``.csv`` を含まない
+    既存契約を維持する。
+    """
+    csv_path = pts_data.get_pts_csv_path_for_date(today.date() if isinstance(today, datetime) else today)
+    if csv_path.endswith(".csv"):
+        return csv_path[:-4]
+    return csv_path
 
 
 def get_latest_pts_fname():

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -906,7 +906,9 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
             # （旧 post_price_change のみ持つレコードでも 1d 値を引き継ぐ）
             existing = comments[target_idx]
             existing_changes = normalize_kessan_post_price_changes(existing)
-            merged_changes: Dict[str, str] = {}
+            # 未知キー (例: "pts" — 別経路で書き込まれる) を保持するため
+            # 既存 dict をベースに 1d/5d だけ上書きマージする
+            merged_changes: Dict[str, str] = dict(existing_changes)
             for key, _ in KESSAN_REACTION_PERIODS:
                 new_v = post_price_changes.get(key, "")
                 old_v = existing_changes.get(key, "")
@@ -917,6 +919,87 @@ def save_kessan_comment(code_s: str, form_data: dict) -> Dict[str, Any]:
             comments.append(new_entry)
 
         # 昇順ソート + 12件超の最古を削除
+        comments = _sort_kessan_comments(comments)
+        if len(comments) > MAX_KESSAN_COMMENTS:
+            comments = comments[-MAX_KESSAN_COMMENTS:]
+
+        record["kessan_comments"] = comments
+        upsert_research_record(record)
+
+    return new_entry
+
+
+def upsert_kessan_pts_change(
+    code_s: str,
+    kessanbi: str,
+    quarter: int,
+    pts_value: str,
+) -> Dict[str, Any]:
+    """当日決算銘柄の kessan_comments に PTS 騰落率を upsert する。
+
+    - 既存 (kessanbi, quarter) エントリがあれば post_price_changes['pts'] のみ更新
+    - 無ければ最小限のエントリを新規作成
+    - レコード自体が無ければ add_stock() で先行登録
+    - quarter は make_stock_db 側で stock['kessan_quarter'] から渡される
+
+    Args:
+        code_s: 銘柄コード
+        kessanbi: YYYY/MM/DD 形式
+        quarter: 1〜4 (0 は未取得扱い)
+        pts_value: "+2.5" 形式 (% 記号は除去済み、符号は保持)
+
+    Returns:
+        upsert したエントリ dict
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    if _parse_kessanbi(kessanbi) is None:
+        raise ValueError(f"kessanbi は YYYY/MM/DD 形式: got {kessanbi!r}")
+    pts_str = str(pts_value) if pts_value is not None else ""
+
+    # add_stock は内部で _flock を取るため _flock 外で呼ぶ
+    if get_research_record(normalized) is None:
+        try:
+            add_stock(normalized)
+        except ValueError:
+            # 競合で先に登録されたケースは続行 (再取得時に拾える)
+            pass
+
+    with _flock():
+        record = get_research_record(normalized)
+        if record is None:
+            raise ValueError(f"レコード登録失敗: {normalized}")
+
+        comments: List[Dict[str, Any]] = list(record.get("kessan_comments") or [])
+        target_idx = None
+        for i, entry in enumerate(comments):
+            if (
+                entry.get("kessanbi") == kessanbi
+                and int(entry.get("quarter", 0) or 0) == int(quarter or 0)
+            ):
+                target_idx = i
+                break
+
+        if target_idx is not None:
+            existing = comments[target_idx]
+            ppc = dict(existing.get("post_price_changes") or {})
+            ppc["pts"] = pts_str
+            existing["post_price_changes"] = ppc
+            new_entry = existing
+        else:
+            new_entry = {
+                "kessanbi": kessanbi,
+                "quarter": int(quarter or 0),
+                "pre_expectation": "",
+                "pre_outlook": "",
+                "post_price_changes": {"pts": pts_str},
+                "post_comment": "",
+                "kessan_matagi": False,
+                "held_before_kessan": False,
+                "held_after_kessan": False,
+            }
+            comments.append(new_entry)
+
         comments = _sort_kessan_comments(comments)
         if len(comments) > MAX_KESSAN_COMMENTS:
             comments = comments[-MAX_KESSAN_COMMENTS:]

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -229,6 +229,16 @@ nav .quick-search {
   font-weight: bold;
   margin-left: 4px;
 }
+.kessan-pts-label {
+  display: inline-block;
+  background: #34495e;
+  color: #fff;
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-size: 0.75em;
+  font-weight: bold;
+  margin-right: 3px;
+}
 .kessan-expectation-badge {
   display: inline-block;
   padding: 0 5px;

--- a/scripts/webapp/templates/market.html
+++ b/scripts/webapp/templates/market.html
@@ -75,13 +75,17 @@
       <a href="/stock/{{ s.code_s }}">{{ s.stock_name or '-' }}</a>
       {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}
       {% if s.pre_expectation %}<span class="kessan-expectation-badge exp-{{ s.pre_expectation }}">{{ s.pre_expectation }}</span>{% endif %}
-      {% if is_past and (s.post_price_changes['1d'] or s.post_price_changes['5d']) %}
+      {% if is_past and (s.post_price_changes['pts'] or s.post_price_changes['1d'] or s.post_price_changes['5d']) %}
+        {% set pcp = s.post_price_changes['pts'] %}
         {% set pc1 = s.post_price_changes['1d'] %}
         {% set pc5 = s.post_price_changes['5d'] %}
         <span class="kessan-price-change">
-          {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-          /
-          {% if pc5 %}<span class="{% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% else %}<span>-</span>{% endif %}
+          {% if pcp %}<span class="kessan-pts-label">PTS</span><span class="{% if pcp.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pcp }}%</span>{% endif %}
+          {% if pc1 or pc5 %}
+            {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
+            /
+            {% if pc5 %}<span class="{% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% else %}<span>-</span>{% endif %}
+          {% endif %}
         </span>
       {% endif %}
       {% if s.pre_outlook or s.post_comment %}

--- a/tests/test_append_research_snapshots.py
+++ b/tests/test_append_research_snapshots.py
@@ -479,3 +479,200 @@ class TestUpdateResearchSnapshots:
 
         loaded = rs.get_research_record("9999", db_path=db_path)
         assert len(loaded["snapshots"]) == 0
+
+
+class TestUpdatePtsReactions:
+    """update_pts_reactions のユニットテスト (issue #154)"""
+
+    @pytest.fixture
+    def setup_db(self, db_path, monkeypatch):
+        """research_shelve のパスを差し替え"""
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        from webapp import helpers as _helpers
+        monkeypatch.setattr(_helpers, "RESEARCH_SHELVE", db_path, raising=False)
+        return db_path
+
+    def test_writes_pts_for_today_kessan_in_watch_set(self, setup_db, monkeypatch):
+        """watch_set ∩ 当日決算 ∩ PTS データありの銘柄に PTS が書き込まれる"""
+        from datetime import datetime as _dt
+        today = _dt.today().date()
+        today_str = today.strftime("%Y/%m/%d")
+
+        stock = _make_stock("3496", kessanbi=today_str, stock_name="アズーム")
+        stock["kessan_quarter"] = 4
+        stocks = {"3496": stock}
+
+        monkeypatch.setattr(
+            "pts_data.load_pts_changes_for_date",
+            lambda d: {"3496": "+2.5"},
+        )
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        make_stock_db.update_pts_reactions({"3496"}, today, stocks=stocks)
+
+        loaded = rs.get_research_record("3496", db_path=setup_db)
+        assert len(loaded["kessan_comments"]) == 1
+        entry = loaded["kessan_comments"][0]
+        assert entry["kessanbi"] == today_str
+        assert entry["quarter"] == 4
+        assert entry["post_price_changes"]["pts"] == "+2.5"
+
+    def test_skips_when_kessanbi_is_not_today(self, setup_db, monkeypatch):
+        """kessanbi != today の銘柄には PTS を書き込まない"""
+        from datetime import datetime as _dt
+        today = _dt.today().date()
+        yesterday = _today_str(-1)
+
+        stock = _make_stock("3496", kessanbi=yesterday, stock_name="アズーム")
+        stock["kessan_quarter"] = 4
+        stocks = {"3496": stock}
+
+        monkeypatch.setattr(
+            "pts_data.load_pts_changes_for_date",
+            lambda d: {"3496": "+2.5"},
+        )
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        make_stock_db.update_pts_reactions({"3496"}, today, stocks=stocks)
+
+        loaded = rs.get_research_record("3496", db_path=setup_db)
+        assert loaded["kessan_comments"] == []
+
+    def test_skips_when_not_in_watch_set(self, setup_db, monkeypatch):
+        """watch_set 外の銘柄は PTS が書き込まれない (research DB 汚染防止)"""
+        from datetime import datetime as _dt
+        today = _dt.today().date()
+        today_str = today.strftime("%Y/%m/%d")
+
+        stock = _make_stock("3496", kessanbi=today_str, stock_name="アズーム")
+        stock["kessan_quarter"] = 4
+        stocks = {"3496": stock}
+
+        monkeypatch.setattr(
+            "pts_data.load_pts_changes_for_date",
+            lambda d: {"3496": "+2.5"},
+        )
+
+        # 事前レコードなし。watch_set にも含めない
+        make_stock_db.update_pts_reactions({"9999"}, today, stocks=stocks)
+
+        # 自動登録もされない (research DB 汚染なし)
+        assert rs.get_research_record("3496", db_path=setup_db) is None
+
+    def test_skips_when_pts_csv_missing(self, setup_db, monkeypatch):
+        """PTS CSV 不在 (空 dict) ならスキップ、書き込みなし"""
+        from datetime import datetime as _dt
+        today = _dt.today().date()
+        today_str = today.strftime("%Y/%m/%d")
+
+        stock = _make_stock("3496", kessanbi=today_str, stock_name="アズーム")
+        stock["kessan_quarter"] = 4
+        stocks = {"3496": stock}
+
+        # 空 dict (CSV 不在の擬似)
+        monkeypatch.setattr(
+            "pts_data.load_pts_changes_for_date",
+            lambda d: {},
+        )
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        make_stock_db.update_pts_reactions({"3496"}, today, stocks=stocks)
+
+        loaded = rs.get_research_record("3496", db_path=setup_db)
+        assert loaded["kessan_comments"] == []
+
+    def test_skips_when_pts_dict_lacks_code(self, setup_db, monkeypatch):
+        """PTS dict に当該銘柄のエントリが無ければスキップ"""
+        from datetime import datetime as _dt
+        today = _dt.today().date()
+        today_str = today.strftime("%Y/%m/%d")
+
+        stock = _make_stock("3496", kessanbi=today_str, stock_name="アズーム")
+        stock["kessan_quarter"] = 4
+        stocks = {"3496": stock}
+
+        monkeypatch.setattr(
+            "pts_data.load_pts_changes_for_date",
+            lambda d: {"7203": "+0.5"},  # 別銘柄しかない
+        )
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        make_stock_db.update_pts_reactions({"3496"}, today, stocks=stocks)
+
+        loaded = rs.get_research_record("3496", db_path=setup_db)
+        assert loaded["kessan_comments"] == []
+
+    def test_creates_kessan_entry_when_missing(self, setup_db, monkeypatch):
+        """kessan_comments が空でも PTS 用に新規エントリが作られる"""
+        from datetime import datetime as _dt
+        today = _dt.today().date()
+        today_str = today.strftime("%Y/%m/%d")
+
+        stock = _make_stock("3496", kessanbi=today_str, stock_name="アズーム")
+        stock["kessan_quarter"] = 4
+        stocks = {"3496": stock}
+
+        monkeypatch.setattr(
+            "pts_data.load_pts_changes_for_date",
+            lambda d: {"3496": "+1.2"},
+        )
+
+        # research_shelve は登録済みだが kessan_comments は空
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        make_stock_db.update_pts_reactions({"3496"}, today, stocks=stocks)
+
+        loaded = rs.get_research_record("3496", db_path=setup_db)
+        assert len(loaded["kessan_comments"]) == 1
+        entry = loaded["kessan_comments"][0]
+        assert entry["post_price_changes"]["pts"] == "+1.2"
+
+    def test_updates_pts_only_on_existing_entry(self, setup_db, monkeypatch):
+        """既存 (kessanbi, quarter) エントリの PTS のみ更新、他キーは保持"""
+        from datetime import datetime as _dt
+        today = _dt.today().date()
+        today_str = today.strftime("%Y/%m/%d")
+
+        stock = _make_stock("3496", kessanbi=today_str, stock_name="アズーム")
+        stock["kessan_quarter"] = 4
+        stocks = {"3496": stock}
+
+        monkeypatch.setattr(
+            "pts_data.load_pts_changes_for_date",
+            lambda d: {"3496": "+1.2"},
+        )
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": today_str,
+                "quarter": 4,
+                "pre_expectation": "◎",
+                "pre_outlook": "強気",
+                "post_price_changes": {"1d": "", "5d": ""},
+                "post_comment": "",
+                "kessan_matagi": False,
+                "held_before_kessan": False,
+                "held_after_kessan": False,
+            },
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        make_stock_db.update_pts_reactions({"3496"}, today, stocks=stocks)
+
+        loaded = rs.get_research_record("3496", db_path=setup_db)
+        entry = loaded["kessan_comments"][0]
+        assert entry["post_price_changes"]["pts"] == "+1.2"
+        # 他フィールドは保持
+        assert entry["pre_expectation"] == "◎"
+        assert entry["pre_outlook"] == "強気"

--- a/tests/test_pts_data.py
+++ b/tests/test_pts_data.py
@@ -1,0 +1,127 @@
+"""pts_data.py のユニットテスト。
+
+- get_pts_csv_path_for_date: pts_YYMMDD.csv 形式
+- load_pts_changes_for_date:
+  - 日付一致時のみ dict 返却
+  - 指定日 CSV 不在で空 dict
+  - "+2.5%" → "+2.5" の % 除去
+  - "-3.0%" の符号保持
+  - 数値パース不能/空欄はスキップ
+"""
+
+import os
+from datetime import date
+
+import pytest
+
+import pts_data
+
+
+@pytest.fixture
+def isolated_data_dir(monkeypatch, tmp_path):
+    """pts_data の DATA_DIR を tmp_path に差し替え、today_stocks/ を作る"""
+    today_stocks = tmp_path / "today_stocks"
+    today_stocks.mkdir()
+    monkeypatch.setattr(pts_data, "DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _write_pts_csv(data_dir, dt, rows):
+    """pts_YYMMDD.csv をテスト用に書き出す。rows は list[list[str]]"""
+    fname = "pts_%02d%02d%02d.csv" % (dt.year - 2000, dt.month, dt.day)
+    path = data_dir / "today_stocks" / fname
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(",".join(row) + "\n")
+    return path
+
+
+class TestGetPtsCsvPathForDate:
+    """get_pts_csv_path_for_date のテスト"""
+
+    def test_basic_naming(self, isolated_data_dir):
+        path = pts_data.get_pts_csv_path_for_date(date(2026, 4, 30))
+        assert path.endswith(os.path.join("today_stocks", "pts_260430.csv"))
+
+    def test_zero_padded_month_day(self, isolated_data_dir):
+        path = pts_data.get_pts_csv_path_for_date(date(2026, 1, 5))
+        assert path.endswith("pts_260105.csv")
+
+    def test_rejects_non_date(self, isolated_data_dir):
+        with pytest.raises(TypeError):
+            pts_data.get_pts_csv_path_for_date("2026-04-30")
+
+    def test_does_not_check_existence(self, isolated_data_dir):
+        # 存在しなくてもパスは返す
+        path = pts_data.get_pts_csv_path_for_date(date(2030, 1, 1))
+        assert "pts_300101.csv" in path
+
+
+class TestLoadPtsChangesForDate:
+    """load_pts_changes_for_date のテスト"""
+
+    def test_empty_dict_when_csv_missing(self, isolated_data_dir):
+        # CSV が無い日付を指定 → 空 dict
+        result = pts_data.load_pts_changes_for_date(date(2030, 1, 1))
+        assert result == {}
+
+    def test_strips_percent_keeps_sign(self, isolated_data_dir):
+        # "+2.5%" → "+2.5", "-3.0%" → "-3.0"
+        target = date(2026, 4, 30)
+        _write_pts_csv(
+            isolated_data_dir, target,
+            [
+                ["1", "6501 日立", "東P", "電機", "1531", "+300", "+2.5%", "16800"],
+                ["2", "7203 トヨタ", "東P", "輸送機", "2900", "-90", "-3.0%", "10000"],
+            ],
+        )
+        result = pts_data.load_pts_changes_for_date(target)
+        assert result == {"6501": "+2.5", "7203": "-3.0"}
+
+    def test_skips_invalid_or_empty(self, isolated_data_dir):
+        target = date(2026, 4, 30)
+        _write_pts_csv(
+            isolated_data_dir, target,
+            [
+                ["1", "6501 日立", "東P", "電機", "1531", "+300", "+2.5%", "16800"],
+                ["2", "9999 テスト", "東G", "情報", "100", "0", "", "1000"],   # 空
+                ["3", "0001 不正", "東G", "情報", "100", "0", "abc%", "1000"],  # 数値不能
+            ],
+        )
+        result = pts_data.load_pts_changes_for_date(target)
+        assert result == {"6501": "+2.5"}
+
+    def test_no_fallback_to_latest_csv(self, isolated_data_dir):
+        """日付一致が必須。古い CSV が残っていても指定日の CSV が無ければ空 dict。"""
+        # 1 日前の CSV を作るが、当日の CSV は作らない
+        yesterday = date(2026, 4, 29)
+        _write_pts_csv(
+            isolated_data_dir, yesterday,
+            [["1", "6501 日立", "東P", "電機", "1531", "+300", "+2.5%", "16800"]],
+        )
+        # 当日を指定 → 空 dict (フォールバックしない)
+        today = date(2026, 4, 30)
+        result = pts_data.load_pts_changes_for_date(today)
+        assert result == {}
+
+    def test_handles_missing_columns_gracefully(self, isolated_data_dir):
+        target = date(2026, 4, 30)
+        _write_pts_csv(
+            isolated_data_dir, target,
+            [
+                ["1", "6501 日立", "東P", "電機"],  # カラム不足
+                ["2", "7203 トヨタ", "東P", "輸送機", "2900", "-90", "-1.5%", "10000"],
+            ],
+        )
+        result = pts_data.load_pts_changes_for_date(target)
+        assert result == {"7203": "-1.5"}
+
+    def test_handles_code_field_with_only_code(self, isolated_data_dir):
+        """code+name の name が無くても code_s だけは取れる"""
+        target = date(2026, 4, 30)
+        _write_pts_csv(
+            isolated_data_dir, target,
+            [["1", "215A", "東G", "情報", "1000", "+50", "+5.0%", "1000"]],
+        )
+        result = pts_data.load_pts_changes_for_date(target)
+        assert result == {"215A": "+5.0"}

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -328,6 +328,40 @@ class TestCrud:
         entry = loaded["kessan_comments"][0]
         assert entry["post_price_changes"] == {"1d": "+3.2", "5d": "+5.1"}
 
+    def test_get_research_record_preserves_pts_key(self, db_path):
+        """PTS キー (issue #154) は normalize 後も保持される"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/04/30",
+            "quarter": 4,
+            "pre_expectation": "○",
+            "pre_outlook": "",
+            "post_price_changes": {"pts": "+2.5", "1d": "", "5d": ""},
+            "post_comment": "",
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        entry = loaded["kessan_comments"][0]
+        assert entry["post_price_changes"].get("pts") == "+2.5"
+        assert entry["post_price_changes"].get("1d") == ""
+        assert entry["post_price_changes"].get("5d") == ""
+
+    def test_normalize_does_not_inject_pts_for_legacy_entries(self, db_path):
+        """旧形式 (post_price_change のみ) からの正規化では PTS は付与しない"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/03/11",
+            "quarter": 3,
+            "pre_expectation": "○",
+            "pre_outlook": "",
+            "post_price_change": "-15",
+            "post_comment": "",
+        }]
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("5032", db_path=db_path)
+        entry = loaded["kessan_comments"][0]
+        assert "pts" not in entry["post_price_changes"]
+
 
 # ==================================================
 # スナップショット層: upsert_snapshot

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -244,6 +244,49 @@ class TestGetMarketKessanData:
         # 当日決算は today_entries に分類される
         assert "2026/04/27" in today_keys
 
+    def test_today_kessan_includes_pts_in_post_price_changes(
+        self, kessan_env, db_path
+    ):
+        """当日決算エントリの post_price_changes に PTS キーが含まれる (issue #154)"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 4, 27, 19, 0)
+        pf_dict = {
+            "6501": {
+                "code_s": "6501",
+                "stock_name": "日立製作所",
+                "kessanbi": "2026/04/27",
+                "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        # research_shelve に PTS 入りの kessan_comments を予め登録
+        rec = rs.create_research_record("6501", "日立製作所")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/04/27",
+            "quarter": 4,
+            "pre_expectation": "",
+            "pre_outlook": "",
+            "post_price_changes": {"pts": "+2.5", "1d": "", "5d": ""},
+            "post_comment": "",
+            "kessan_matagi": False,
+            "held_before_kessan": False,
+            "held_after_kessan": False,
+        }]
+        rs.upsert_research_record(rec)
+
+        result = helpers.get_market_kessan_data()
+        today_entries = result["today_entries"]
+        # 4/27 のエントリがあり、その中の 6501 が PTS を持つ
+        found = False
+        for kessanbi, stocks in today_entries:
+            if kessanbi != "2026/04/27":
+                continue
+            for s in stocks:
+                if s["code_s"] == "6501":
+                    assert s["post_price_changes"].get("pts") == "+2.5"
+                    found = True
+        assert found, "6501 のエントリが today_entries に見つからない"
+
 
 class TestSearchRecords:
     """search_records のテスト"""
@@ -810,3 +853,127 @@ class TestSaveKessanCommentMultiPeriod:
         entry = helpers.save_kessan_comment("5032", self._form(pre_outlook="updated"))
         assert entry["post_price_changes"]["1d"] == "-7.5"
         assert entry["post_price_changes"]["5d"] == ""
+
+    def test_overwrite_preserves_pts_key(self, setup_db, monkeypatch):
+        """既存エントリに PTS キーがある状態で save_kessan_comment しても消えない (issue #154)"""
+        # 既存に PTS 入りで 1 件
+        rec = rs.get_research_record("5032")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/03/11",
+                "quarter": 3,
+                "pre_expectation": "○",
+                "pre_outlook": "init",
+                "post_price_changes": {"pts": "+2.5", "1d": "+3.2", "5d": ""},
+                "post_comment": "",
+                "kessan_matagi": False,
+                "held_before_kessan": False,
+                "held_after_kessan": False,
+            },
+        ]
+        rs.upsert_research_record(rec)
+        # webapp で再保存 (calc_price_reactions は 1d/5d だけ返す)
+        monkeypatch.setattr(
+            helpers, "calc_price_reactions",
+            lambda c, k: {"1d": "+4.0", "5d": "+5.1"},
+        )
+        entry = helpers.save_kessan_comment("5032", self._form(pre_outlook="updated"))
+        # 1d/5d は新値で更新、PTS キーは既存値を維持
+        assert entry["post_price_changes"]["1d"] == "+4.0"
+        assert entry["post_price_changes"]["5d"] == "+5.1"
+        assert entry["post_price_changes"]["pts"] == "+2.5"
+
+
+class TestUpsertKessanPtsChange:
+    """upsert_kessan_pts_change のテスト (issue #154)"""
+
+    @pytest.fixture
+    def setup_db(self, db_path, monkeypatch):
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr(helpers, "RESEARCH_SHELVE", db_path, raising=False)
+        return db_path
+
+    def test_creates_new_entry_when_no_kessan_comment(self, setup_db, monkeypatch):
+        """既存 kessan_comments が空の銘柄に PTS を upsert → 新規エントリ作成"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rs.upsert_research_record(rec)
+        entry = helpers.upsert_kessan_pts_change("5032", "2026/04/30", 4, "+2.5")
+        assert entry["kessanbi"] == "2026/04/30"
+        assert entry["quarter"] == 4
+        assert entry["post_price_changes"] == {"pts": "+2.5"}
+        # 永続化されていること
+        loaded = rs.get_research_record("5032")
+        assert loaded["kessan_comments"][0]["post_price_changes"]["pts"] == "+2.5"
+
+    def test_updates_existing_entry_pts_only(self, setup_db, monkeypatch):
+        """既存 (kessanbi, quarter) エントリの PTS のみ更新、他キーは保持"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/04/30",
+                "quarter": 4,
+                "pre_expectation": "◎",
+                "pre_outlook": "強気",
+                "post_price_changes": {"1d": "", "5d": ""},
+                "post_comment": "",
+                "kessan_matagi": False,
+                "held_before_kessan": False,
+                "held_after_kessan": False,
+            },
+        ]
+        rs.upsert_research_record(rec)
+        entry = helpers.upsert_kessan_pts_change("5032", "2026/04/30", 4, "-1.8")
+        assert entry["post_price_changes"]["pts"] == "-1.8"
+        # 他フィールドは保持
+        assert entry["pre_expectation"] == "◎"
+        assert entry["pre_outlook"] == "強気"
+
+    def test_creates_record_when_research_record_missing(
+        self, setup_db, monkeypatch
+    ):
+        """research_shelve に未登録 → add_stock 経由で先行登録される"""
+        # add_stock の中身は stocks_shelve に依存するためモック
+        called = {"add_stock": 0}
+
+        def fake_add_stock(code_s):
+            # add_stock が呼ばれたら、空レコードを直接作る
+            r = rs.create_research_record(code_s, "TEST")
+            rs.upsert_research_record(r)
+            called["add_stock"] += 1
+            return code_s
+
+        monkeypatch.setattr(helpers, "add_stock", fake_add_stock)
+        entry = helpers.upsert_kessan_pts_change("5032", "2026/04/30", 4, "+2.5")
+        assert called["add_stock"] == 1
+        assert entry["post_price_changes"]["pts"] == "+2.5"
+
+    def test_rejects_invalid_kessanbi(self, setup_db):
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rs.upsert_research_record(rec)
+        with pytest.raises(ValueError):
+            helpers.upsert_kessan_pts_change("5032", "2026-04-30", 4, "+2.5")
+
+    def test_separate_quarter_creates_new_entry(self, setup_db):
+        """同じ kessanbi でも quarter が違えば別エントリ"""
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/04/30",
+                "quarter": 4,
+                "pre_expectation": "",
+                "pre_outlook": "",
+                "post_price_changes": {"pts": "+2.5"},
+                "post_comment": "",
+                "kessan_matagi": False,
+                "held_before_kessan": False,
+                "held_after_kessan": False,
+            },
+        ]
+        rs.upsert_research_record(rec)
+        helpers.upsert_kessan_pts_change("5032", "2026/04/30", 1, "+5.0")
+        loaded = rs.get_research_record("5032")
+        # 2 エントリある (q=4 と q=1)
+        assert len(loaded["kessan_comments"]) == 2
+        quarters = sorted(int(e["quarter"]) for e in loaded["kessan_comments"])
+        assert quarters == [1, 4]


### PR DESCRIPTION
Closes #154

## Summary
- 当日決算銘柄の「反応」を PTS (夜間取引) 騰落率で表示。`post_price_changes` に `"pts"` キーを別系統で追加し、当日カードに「PTS +X.X%」バッジを描画する
- 1d/5d は営業日ベースで当日値が出ないため、PTS で代替する設計 (案B: 新キー追加)
- 18:00 cron 後に `update_pts_reactions()` が watch_set ∩ 当日決算銘柄に PTS 反応を upsert する

## 主な変更
- **新規** `scripts/pts_data.py`: 当日 PTS CSV のロード用ユーティリティ。日付一致必須、最新CSVフォールバックなし (古い CSV を当日扱いする誤適用を防ぐため)
- **新規** `webapp/helpers.upsert_kessan_pts_change()`: 当日決算エントリの `post_price_changes['pts']` のみ upsert
- `make_stock_db.update_pts_reactions()` を追加し、`list_all_db` / `update --snapshot` 両パスから cron 後に呼ぶ
- `research_shelve.normalize_kessan_post_price_changes()`: `pts` キー保持の分岐追加 (KESSAN_REACTION_PERIODS は変更なし)
- `webapp/helpers.save_kessan_comment()`: `merged_changes` を未知キー保持型に (人間が反応コメ手修正時に PTS が消えないよう保証)
- `webapp/templates/market.html` + `static/style.css`: PTS バッジ表示 (紺背景・白文字)

## simplify レビュー対応
- **load_stock_db 多重呼び出し**: `update_pts_reactions(stocks=None)` で自前ロードに変更し main 側の重複ロードを削除
- **watch_set 全走査 → 積で絞り込み**: `watch_set & pts_changes.keys()` で意図明確化
- **watch_set 空ケースのログレベル**: log_print → log_warning (異常系のため)

## Test plan
- [x] `pytest tests/ -m "not local_db and not live_html"` 全 839 件 pass
- [x] `pytest tests/test_pts_data.py tests/test_research_shelve.py tests/test_webapp_helpers.py tests/test_append_research_snapshots.py tests/test_webapp_routes.py` 関連 222 件 pass
- [x] webapp 起動 + Playwright で `/market` を実機検証 (3496 アズーム当日カードに `PTS +2.5%` バッジ描画を確認)
- [x] 実 PTS CSV (4/29) を `pts_data.load_pts_changes_for_date()` でパースし 9 件取得確認 (符号保持・%除去 OK)
- [x] `shintakane.py` 既存 `search_fromcsv_pts` の互換動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)