### PR TITLE
issue #148 Part 1: 市場指数RS表示の改善

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -607,6 +607,8 @@ tr:hover { background: #f5f5f5; }
 .signal-sell { background: #fdedec; color: #c0392b; font-weight: bold; }
 .signal-buy { background: #eafaf1; color: #27ae60; font-weight: bold; }
 .trend-good { color: #27ae60; font-weight: bold; }
+.rs-strong { color: #27ae60; font-weight: bold; }
+.rs-weak { color: #c0392b; font-weight: bold; }
 
 /* 決算 */
 .kessan-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
@@ -750,6 +752,44 @@ def _html_theme_rank(market_db, theme_rank_data=None):
     return '\n'.join(parts)
 
 
+# 指数向けトレンドテンプレート判定で「RS基準達成」とみなす rs_raw 閾値 (issue #148 Part 1)。
+# 銘柄向けの rs_rank>=75 は指数 (TOPIX 自身など) では常に未達となるため、
+# 直近1年で 5% 以上上昇していれば「RS基準達成」扱いとする緩い基準を採用。
+INDEX_RS_TREND_THRESHOLD = 1.05
+
+
+def _adjust_index_trend_template(db):
+    """指数向けに trend_template の RS 基準を補正する。
+
+    銘柄向けの rs_rank>=75 判定は指数では常に未達となるため、
+    rs_raw > INDEX_RS_TREND_THRESHOLD なら "RS" を未達リストから外す。
+
+    Args:
+        db: 指数DBの1指数分dict (rs_raw, trend_template を持つ)
+    Returns:
+        dict: trend_template だけ補正したコピー (元dictは破壊しない)
+    """
+    misses = list(db.get("trend_template", []))
+    if "RS" in misses and db.get("rs_raw", 0) > INDEX_RS_TREND_THRESHOLD:
+        misses.remove("RS")
+    adjusted = dict(db)
+    adjusted["trend_template"] = misses
+    return adjusted
+
+
+def _rs_class(rs_raw):
+    """rs_raw 値からCSSクラス名を返す。
+    >1.0=rs-strong (緑) / <1.0=rs-weak (赤) / =1.0 もしくは未取得 = クラスなし
+    """
+    if not rs_raw:
+        return ""
+    if rs_raw > 1.0:
+        return ' class="rs-strong"'
+    if rs_raw < 1.0:
+        return ' class="rs-weak"'
+    return ""
+
+
 def _html_market(market_db):
     """市場指標セクションのHTMLを生成する
 
@@ -772,7 +812,9 @@ def _html_market(market_db):
             continue
         try:
             db = market_db[db_name]
-            trend_expr = make_stock_db.get_trend_template_expr(db)
+            # 指数向けに trend_template の RS 基準を補正してから表示文字列を作る (issue #148 Part 1)
+            adjusted_db = _adjust_index_trend_template(db)
+            trend_expr = make_stock_db.get_trend_template_expr(adjusted_db)
             distribution_days = ", ".join([s[3:] for s in db.get("distribution_days", [])])
             followthrough_days = ", ".join([s[3:] for s in db.get("followthrough_days", [])])
             signal = db.get("direction_signal", "")
@@ -791,10 +833,13 @@ def _html_market(market_db):
             if trend_expr.startswith("◯") or trend_expr.startswith("◎"):
                 trend_class = ' class="trend-good"'
 
+            rs_raw = db.get("rs_raw", "")
+            rs_class = _rs_class(rs_raw)
+
             rows_html.append(
                 '<tr>\n'
                 '  <td><strong>%s</strong></td>\n'
-                '  <td>%s</td>\n'
+                '  <td%s>%s</td>\n'
                 '  <td%s>%s</td>\n'
                 '  <td>%s</td>\n'
                 '  <td>%s</td>\n'
@@ -803,7 +848,7 @@ def _html_market(market_db):
                 '  <td>%.1f, %.1f</td>\n'
                 '</tr>' % (
                     html_mod.escape(market_name),
-                    db.get("rs_raw", ""),
+                    rs_class, rs_raw,
                     trend_class, html_mod.escape(str(trend_expr)),
                     html_mod.escape(distribution_days),
                     html_mod.escape(followthrough_days),

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -449,6 +449,110 @@ class TestHtmlMarket:
         assert "NASDAQ" not in result
         assert "S&amp;P 500" not in result
 
+    def test_rs_strong_class_when_rs_raw_above_one(self):
+        """rs_raw > 1.0 で rs-strong クラスが付く (issue #148 Part 1)"""
+        result = make_market_db._html_market(self._make_market_db())
+        assert 'rs-strong' in result
+
+    def test_rs_weak_class_when_rs_raw_below_one(self):
+        """rs_raw < 1.0 で rs-weak クラスが付く (issue #148 Part 1)"""
+        db = self._make_market_db()
+        db["topix"]["rs_raw"] = 0.92
+        result = make_market_db._html_market(db)
+        assert 'rs-weak' in result
+
+    def test_rs_no_class_when_rs_raw_equals_one(self):
+        """rs_raw == 1.0 ではクラス付かない (デフォルト灰)"""
+        db = {
+            "topix": dict(self._make_market_db()["topix"], rs_raw=1.0)
+        }
+        result = make_market_db._html_market(db)
+        assert 'rs-strong' not in result
+        assert 'rs-weak' not in result
+
+    def test_index_rs_threshold_removes_RS_from_trend(self):
+        """rs_raw > 1.05 なら trend_template の "RS" 未達が除外される (issue #148 Part 1)"""
+        db = {
+            "mothers": dict(
+                self._make_market_db()["mothers"],
+                rs_raw=1.09,
+                trend_template=["ma30>ma40", "RS"],
+            )
+        }
+        result = make_market_db._html_market(db)
+        # "RS" が除外されたので残りは ma30>ma40 のみ → trend_template_expr は "◯ma30>ma40"
+        # "RS" だけの未達文字列が表示文字列に出てないことを確認
+        # (ma30>ma40 はタグとして残るので含まれる)
+        assert ',RS' not in result and 'RS,' not in result
+
+    def test_index_rs_threshold_below_does_not_remove_RS(self):
+        """rs_raw <= 1.05 なら "RS" 未達は除外されない"""
+        db = {
+            "mothers": dict(
+                self._make_market_db()["mothers"],
+                rs_raw=1.04,
+                trend_template=["ma30>ma40", "RS"],
+            )
+        }
+        result = make_market_db._html_market(db)
+        # 未達リストに "RS" が含まれて表示される (◯ma30>ma40,RS のような形)
+        assert 'RS' in result
+
+
+class TestAdjustIndexTrendTemplate:
+    """指数向け trend_template 補正のテスト (issue #148 Part 1)"""
+
+    def test_removes_RS_when_above_threshold(self):
+        """rs_raw > 1.05 で "RS" が除外される"""
+        db = {"rs_raw": 1.10, "trend_template": ["ma30>ma40", "RS"]}
+        result = make_market_db._adjust_index_trend_template(db)
+        assert "RS" not in result["trend_template"]
+        assert "ma30>ma40" in result["trend_template"]
+
+    def test_keeps_RS_at_threshold(self):
+        """rs_raw == 1.05 (境界値、strict >) では除外されない"""
+        db = {"rs_raw": 1.05, "trend_template": ["RS"]}
+        result = make_market_db._adjust_index_trend_template(db)
+        assert "RS" in result["trend_template"]
+
+    def test_keeps_RS_when_below_threshold(self):
+        """rs_raw < 1.05 では "RS" は除外されない"""
+        db = {"rs_raw": 1.02, "trend_template": ["RS"]}
+        result = make_market_db._adjust_index_trend_template(db)
+        assert "RS" in result["trend_template"]
+
+    def test_no_op_when_RS_not_in_misses(self):
+        """trend_template に "RS" がなければ何もしない"""
+        db = {"rs_raw": 1.20, "trend_template": ["ma30>ma40"]}
+        result = make_market_db._adjust_index_trend_template(db)
+        assert result["trend_template"] == ["ma30>ma40"]
+
+    def test_does_not_mutate_original(self):
+        """元のdictを破壊しない"""
+        original = {"rs_raw": 1.20, "trend_template": ["RS"]}
+        original_misses = list(original["trend_template"])
+        make_market_db._adjust_index_trend_template(original)
+        assert original["trend_template"] == original_misses
+
+
+class TestRsClass:
+    """rs_raw 値からCSSクラスを返すテスト (issue #148 Part 1)"""
+
+    def test_strong_when_above_one(self):
+        assert make_market_db._rs_class(1.15) == ' class="rs-strong"'
+
+    def test_weak_when_below_one(self):
+        assert make_market_db._rs_class(0.92) == ' class="rs-weak"'
+
+    def test_no_class_when_equal_one(self):
+        assert make_market_db._rs_class(1.0) == ""
+
+    def test_no_class_when_zero(self):
+        assert make_market_db._rs_class(0) == ""
+
+    def test_no_class_when_empty_string(self):
+        assert make_market_db._rs_class("") == ""
+
 
 class TestHtmlKessan:
     """決算HTML生成テスト"""


### PR DESCRIPTION
## 概要

issue #148 Part 1 の実装。`market.html` の市場サマリーテーブルで、銘柄向けロジックを流用していた RS表示・トレンド判定を**指数向けに修正**した。

issue #148 は4 Part構成:
- Part 1: **RS再計算/表示改善** ← 本PR
- Part 2: ディストリビューション/フォロースルー再定義 (#117 待ち、未着手)
- Part 3: シグナル再考 (#117 待ち、未着手)
- Part 4: NASDAQ/SP500 追加 (PR #149 で完了済み)

Part 2/3 が残るため **`Closes` は使わない**。

## 課題

調査の結果、以下の問題が判明した:

- **RS列**: `rs_raw` を生数値で表示するだけで、強弱が一目で分からない
- **トレンド列**: 銘柄向けの `get_trend_template_expr()` (トレンドテンプレート7基準を満たした数を表示) を流用しており、銘柄向けRS閾値 (`rs_rank>=75`) が**指数では常に未達** → 全指数で "RS" 未達が表示され、トレンド判定が機能しない

実DB値の確認:
| 指数 | rs_raw | trend_template (補正前) |
|---|---|---|
| TOPIX | 1.17 | RS |
| マザーズ | 1.07 | ma30>ma40, high(low)52, RS |
| 日経225 | 1.31 | RS |
| NASDAQ | 1.15 | ma10>ma30,40, RS |
| SP500 | 1.10 | ma10>ma30,40, RS |

すべての指数で「RS」だけが常に未達 → 銘柄向けロジックが指数に合っていない確証。

## 対応

`calc_rs()` の計算式そのものは触らず、**表示の改善** に絞る。

### 1. RS列の色付け (`_rs_class()` 追加)

- `rs_raw > 1.0` → `.rs-strong` (緑)
- `rs_raw < 1.0` → `.rs-weak` (赤)
- `rs_raw == 1.0` または未取得 → クラスなし (灰)

### 2. 指数向け trend_template 補正 (`_adjust_index_trend_template()` 追加)

- 閾値 `INDEX_RS_TREND_THRESHOLD = 1.05` を新設
- `rs_raw > 1.05` なら `trend_template` から "RS" 未達を除外
- 残り6基準 (MA関係・52週ポジション) は指数にもそのまま適用可能なので無変更

### 3. CSS追加

`.rs-strong` / `.rs-weak` を市場テーブル用CSSに追加。既存の `.signal-buy/sell`, `.trend-good` に色味を合わせる。

## 動作確認

実DBで `make_market_db.create_market_html(get_market_db())` を実行し、生成された `market_data.html` を WebApp 経由で Playwright で表示確認:

- 全指数の RS 列が緑表示 (`rs-strong`)
- TOPIX/日経225 → ◎ (RS未達が空になった)
- マザーズ → ◯ma30>ma40,high(low)52 (RS除外、他2基準残)
- NASDAQ/SP500 → ◯ma10>ma30,40 (RS除外)

スクリーンショット: ローカルの `market-issue148-after.png`

## テスト

- `pytest tests/test_make_market_db.py -v` → **79件全パス** (新規15件含む)
- 関連回帰: `tests/test_make_stock_db.py`, `tests/test_functional_market.py` → 75件全パス

新規テスト:
- `TestHtmlMarket` に5件追加 (RS色付け3 + トレンド差替え2)
- `TestAdjustIndexTrendTemplate` 5件 (補正ヘルパーの単体テスト)
- `TestRsClass` 5件 (CSS class判定の単体テスト)

## Test plan

- [x] 単体テスト 79件パス
- [x] 関連回帰テスト全パス
- [x] 実DBで market_data.html を再生成 → WebApp /market で目視確認
- [ ] cron 自動実行で生成されたHTMLでも意図通り表示されること (次回 19:00 cron 後に確認)

## 関連 issue

- #148 (親issue、Part 2/3 残るためopen継続)
- #117 (Market State Machine — Part 2/3 はこれ待ち)
- #149 (Part 4 = NASDAQ/SP500 追加、merge済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)