### PR TITLE
issue #117 Part A: O'Neil Market State Machine 実装

### DIFF
--- a/doc/requirements/market_state_machine_requirements.md
+++ b/doc/requirements/market_state_machine_requirements.md
@@ -1,0 +1,341 @@
+# Market State Machine 要件定義 (issue #117 Part A)
+
+> 既存の市場方向シグナル (`scripts/price.py:266-351 _calc_daily_indicators()` 内のDD/FTD判定 + `direction_signal`) を、O'Neil/IBD原典に準拠した3状態の State Machine に置き換える。
+>
+> 関連 issue: #117
+
+---
+
+## 1. 背景
+
+### 現状の direction_signal 計算
+
+`_calc_daily_indicators()` で以下を計算:
+
+1. 直近20日の日足から DD (ディストリビューションデイ) と FTD (フォロースルーデイ) を検出
+2. `direction_signal = "sell"` if `len(distribution_day) >= 5` else `"neutral"`
+3. `market_db[index_name]` に `distribution_days` / `followthrough_days` / `direction_signal` として保存
+4. `make_market_db.py:_html_market()` で表示
+
+### 課題
+
+#### 課題1: DD/FTD 判定が原典準拠でない
+
+- DD閾値: `dr <= -0.1 and pr_pos >= 0.5` (前日比 -0.1% 以下 + 引け値が安値から半分以下)
+  - O'Neil 原典は **「前日比 -0.2% 以下 + 出来高が前日より増加」** が標準
+- FTD: `dr >= 1.7 and dv >= avg_vol`
+  - O'Neil 原典は **「ラリーアテンプト Day 4 以降に +1.0% 以上の上昇 + 出来高増」**。ラリーアテンプトという概念自体が現状未実装
+- Stalling Day (新高値付近で上昇率小・出来高増・下半分引け) 未検出
+
+#### 課題2: DD の有効期限管理がない
+
+原典では DD は以下のいずれかで失効する:
+- 発生から 25 取引日経過
+- 指数が DD の終値から 5% 以上上昇
+
+現状は単純に直近 20 日窓でカウントしているのみで、失効ロジックがない。
+
+#### 課題3: 2状態モデルしかない
+
+現状 `neutral` / `sell` の 2状態のみ。原典は **3状態モデル** (Confirmed Uptrend / Uptrend Under Pressure / Market in Correction) で、各状態への遷移条件が明確に定義されている。2状態では Correction → Confirmed Uptrend の復帰判定ができない。
+
+#### 課題4: シグナル連動の完全欠落
+
+`make_stock_db.py:802-` の `make_signal()` は `direction_signal` を**一切参照していない**。Correction 中でもブレイクアウト/ポケットピボットのタグが出る。
+
+### 課題4 の取り扱い
+
+課題4 (シグナル連動) は本要件 (Part A) では対応せず、後続の Part B (issue #117 Part B) で扱う。Part A はあくまで **「market_state を計算して market_db に保存し、HTMLに表示する」** ところまで。`make_signal()` 改修は後続。
+
+---
+
+## 2. ゴール
+
+1. **3状態 State Machine の導入**: confirmed_uptrend / uptrend_under_pressure / market_in_correction の3状態を計算・永続化する
+2. **原典準拠の DD/FTD 判定**: O'Neil 原典に整合する通常 DD 検出 (Stalling Day はデータ拡張PRで対応) と、ラリーアテンプト追跡付き FTD 判定を実装する
+3. **DD の有効期限管理**: 25取引日経過 + 5% 上昇による DD 失効を実装する
+4. **後方互換**: 既存の `direction_signal` フィールドを廃止せず、新3値 (`confirmed_uptrend` / `uptrend_under_pressure` / `market_in_correction`) を入れて互換維持。HTML表示も合わせて更新する
+
+---
+
+## 3. アーキテクチャ方針
+
+### モジュール分離
+
+| モジュール | 責務 |
+|---|---|
+| `scripts/price.py` の `_calc_daily_indicators()` | **DD/FTD 候補の生検出**のみ。今日 + 直近の日足から「DD 候補日」「FTD 候補日」を検出する純関数 |
+| `scripts/market_state.py` (新設) | **State 遷移計算と永続化用ヘルパー**。前日の state_meta を入力に、新state と新meta を返す純関数 |
+| `scripts/make_market_db.py` の `make_db_common()` | 両者の**結線**。前日 state_meta を market_db から読み出し、`market_state.py` に渡し、結果を market_db に書き戻す |
+
+`market_state.py` は I/O を持たない純関数の集まりとし、テスト容易性を確保する。
+
+### State の永続化
+
+各指数の `market_db[index_name]` に以下を追加:
+
+```
+market_state: str  # "confirmed_uptrend" | "uptrend_under_pressure" | "market_in_correction"
+state_meta: {
+    rally_attempt_start_date: str | None,
+    rally_attempt_start_low: float | None,
+    distribution_days_with_close: [(YYMMDD, close), ...],
+    last_ftd_date: str | None,
+}
+state_history: [(YYMMDD, state, trigger), ...]  # 直近30件のみ保持
+```
+
+既存の `distribution_days` / `followthrough_days` フィールドは**削除せず維持** (HTML表示でも引き続き使用)。新たな (date, close) タプル形式は `state_meta.distribution_days_with_close` に持つ。
+
+### direction_signal の取り扱い
+
+既存の `direction_signal` フィールドは**削除せず**、新3値の文字列 + 日付の形式 (`"confirmed_uptrend,YYMMDD"` 等) で書き続ける。
+
+- 旧値 (`"sell,YYMMDD"`, `"neutral,YYMMDD"`) → 新値 (`"market_in_correction,YYMMDD"`, `"uptrend_under_pressure,YYMMDD"` 等) に**完全置換**
+- HTML表示も新値に合わせて更新 (`make_market_db.py:_html_market()` の signal 列、CSSクラスも刷新)
+
+シグナル連動 (Part B) は本要件のスコープ外。`make_signal()` は Part A では改修しない。
+
+---
+
+## 4. 基本設計
+
+### 4.1 DD 判定 (原典準拠)
+
+`_calc_daily_indicators()` 内のDD判定ロジックを書き換える。
+
+#### 通常 DD
+
+```
+DD成立条件:
+  pct_change <= -0.2  (前日比 -0.2% 以下)
+  AND
+  volume > prev_volume  (出来高が前日より増加)
+```
+
+成立した DD は `distribution_days_with_close` に `(date, close)` のタプルで記録される。
+
+#### Stalling Day (Part A では実装しない)
+
+Stalling Day (新高値付近で上昇率小・出来高増・下半分引け) は、52週高値データを必要とする。現行のデータ取得長 (Kabutan 1ページ ≈ 60営業日 / yfinance `period="3mo"` 90日) では 52週 (250営業日) を満たせず、要件として実装不能。
+
+→ Stalling Day は **データ拡張PR (yfinance period延長 + Kabutan ページング)** と同時に追加実装する。Part A スコープから外す。
+
+### 4.2 DD 失効
+
+`market_state.py:expire_distribution_days(dd_list, today_close, daily_history) -> dd_list`
+
+- **25 取引日経過**した DD は失効
+- 当日終値が DD 発生日終値の **1.05倍以上** に達した DD は失効
+
+#### 25取引日経過の判定方法
+
+`daily_history` (直近の日付リスト) を引数として渡し、その中で DD の日付がどの位置にあるかをカウントする。具体的には:
+
+```
+days_passed = daily_history.index(today_date) - daily_history.index(dd_date)
+expired = days_passed >= 25
+```
+
+#### 境界条件: daily_history に該当 DD 日がない場合
+
+DD の日付が `daily_history` に含まれない場合 (= データ取得窓を逸脱) は、**失効扱い**にする。これは:
+
+- 取引日窓自体が現行 90日 (yfinance) / 60日 (Kabutan) であり、25日制限を確実に超えるため安全側
+- 実装複雑度を抑える (DD自身に経過日数カウンタを持たせる代わりに、毎日 daily_history から計算するシンプル方式)
+- 古いDDが永続残留してstateが張り付くリスクを避ける
+
+将来データ拡張PR後は daily_history が長くなるので、この境界処理に当たるDDは出にくくなる。
+
+### 4.3 ラリーアテンプト追跡
+
+Correction 状態のとき、以下を追跡:
+
+| メタ | 説明 |
+|---|---|
+| `rally_attempt_start_date` | Correction 中に最初に「前日より高引け」した日 (Day 1) |
+| `rally_attempt_start_low` | Day 1 の安値 |
+
+#### Day 1 の検出
+
+```
+Correction中で rally_attempt_start_date が None のとき:
+  当日終値 > 前日終値 → Day 1 確定 (start_date, start_low を保存)
+```
+
+#### Day 1 の安値割れによるリセット
+
+```
+Day 1 設定済みの状態で:
+  当日安値 < rally_attempt_start_low → ラリーアテンプト破綻、start_date を None にリセット
+```
+
+### 4.4 FTD 判定 (固定閾値)
+
+`market_state.py:check_follow_through_day(today, prev, rally_meta) -> bool`
+
+```
+FTD成立条件:
+  rally_attempt_start_date is not None  (ラリーアテンプト追跡中)
+  AND
+  Day 4 以降 (start_date から数えて 3 取引日経過後)
+  AND
+  当日安値 >= rally_attempt_start_low  (リセット条件を満たしていない)
+  AND
+  pct_change >= 1.0  (固定閾値、IBD中央値)
+  AND
+  volume > prev_volume
+```
+
+ボラティリティ連動閾値 (200日HV ベースで 0.7%〜1.245%) は本要件では**実装しない**。理由: 200日HV計算には日足データの大幅拡張が必要で、実装規模に見合う効果が得られない。固定 1.0% で運用継続。
+
+### 4.5 状態遷移ルール (Part A)
+
+```
+[market_in_correction] ─[FTD成立]→ [confirmed_uptrend]
+
+[confirmed_uptrend] ─[直近25取引日内の有効DD ≥ 4]→ [uptrend_under_pressure]
+[confirmed_uptrend] ─[直近25取引日内の有効DD ≥ 6]→ [market_in_correction]
+
+[uptrend_under_pressure] ─[直近25取引日内の有効DD ≥ 6]→ [market_in_correction]
+[uptrend_under_pressure] ─[直近25取引日内の有効DD < 4]→ [confirmed_uptrend]
+```
+
+50日MA 割れによる遷移 (S9 など) は Part A スコープ外 (50日MA計算が前提のため、データ拡張PR後に追加)。
+
+### 4.6 初期状態の扱い
+
+`market_state` フィールドが market_db にない指数 (初回計算時) は、現在のDD数で初期判定:
+
+```
+DD数 ≥ 5  → market_in_correction
+それ以外 → confirmed_uptrend  (デフォルト楽観)
+```
+
+初期状態判定後は通常の遷移ロジックに乗る。
+
+---
+
+## 5. 対象指数
+
+TOPIX / マザーズ (東証グロース) / 日経225 / NASDAQ / SP500 の **全5指数** で State Machine を計算する。
+
+各指数は独立に状態を持ち、独立に遷移する。Part B (シグナル連動) で参照する主指数は TOPIX / マザーズだが、Part A では全指数で計算 + 表示する (情報量を確保)。
+
+---
+
+## 6. HTML表示
+
+`make_market_db.py:_html_market()` の改修:
+
+| 列 | Part A 前 | Part A 後 |
+|---|---|---|
+| シグナル | `direction_signal` (`sell` / `neutral` / `buy` を `signal-sell` / `signal-buy` クラスで色分け) | `market_state` (3値) を `state-confirmed` (緑) / `state-pressure` (黄) / `state-correction` (赤) で色分け表示 |
+
+CSSクラスは `make_market_db.py:605-` の市場テーブルCSSブロックに追加:
+
+```
+.state-confirmed { background: #eafaf1; color: #27ae60; font-weight: bold; }
+.state-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
+.state-correction { background: #fdedec; color: #c0392b; font-weight: bold; }
+```
+
+旧 `.signal-sell` / `.signal-buy` は他用途で残るため**削除しない**が、市場テーブルでは新クラスを使う。
+
+---
+
+## 7. テスト戦略
+
+### 7.1 単体テスト (`tests/test_market_state.py` 新設)
+
+最低限カバーするケース:
+
+- **DD 判定**:
+  - 通常 DD (-0.5% + 出来高増) → 検出
+  - -0.1% + 出来高増 → 非検出 (閾値 -0.2% に届かない)
+  - 出来高減 → 非検出
+- **DD 失効**:
+  - 26取引日経過 → 失効
+  - 5%上昇 → 失効
+  - daily_history に DD 日が含まれない (窓外) → 失効扱い
+- **ラリーアテンプト**:
+  - Correction中に Day 1 設定
+  - Day 1 安値割れでリセット
+- **FTD 判定**:
+  - Day 4、+1.5% + 出来高増 → 検出
+  - Day 3 (早すぎ) → 非検出
+  - Day 4、+0.9% (閾値未達) → 非検出
+- **状態遷移**:
+  - market_in_correction → confirmed_uptrend (FTD)
+  - confirmed_uptrend → uptrend_under_pressure (有効DD ≥ 4)
+  - confirmed_uptrend → market_in_correction (有効DD ≥ 6)
+  - uptrend_under_pressure → confirmed_uptrend (有効DD < 4 復帰)
+  - uptrend_under_pressure → market_in_correction (有効DD ≥ 6)
+
+### 7.2 既存テストの更新
+
+- `tests/test_price.py:443-457`: `direction_signal` 形式テスト更新 (新3値の文字列を expects)
+- `tests/test_make_market_db.py:358-396`: 各指数の `market_state` テスト追加。`direction_signal` の値が新3値になることを確認
+
+### 7.3 統合テスト
+
+- 実DB再計算: `make_market_db.update_market_db()` を実行し、5指数すべてに `market_state` が入ることを確認
+- 実DB値が直感に整合するかを目視: 「直近DDが多い相場なら correction」など
+
+---
+
+## 8. スコープ外 (Part A で扱わないもの)
+
+- **Stalling Day 検出**: 52週高値データが必要だが、現行データ取得長で確保できない (データ拡張PRで追加)
+- ボラティリティ連動FTD閾値 (200日HV計算が必要、効果は限定的)
+- 6ヶ月分日足データ取得 (Kabutanページング、yfinance period延長) — 別PR
+- 日足50日MA (`pr>ma50` 遷移ルール用) — データ拡張PR後
+- シグナル連動 (`make_signal()` 改修) — Part B
+- Minervini Breadth (トレンドテンプレート通過銘柄数) — Part C
+- 過去データバックテスト
+- `make_signal()` の `direction_signal` 参照対応 (Part B)
+
+---
+
+## 9. 実装順序
+
+1. **要件定義書コミット** (本ドキュメント)
+2. **`scripts/market_state.py` 新設**:
+   - 状態定数、`derive_state()`, `expire_distribution_days()`, `check_follow_through_day()`, ラリーアテンプト管理関数
+3. **`tests/test_market_state.py` 新設** (TDD的に最低限カバー)
+4. **`scripts/price.py` 改修**:
+   - `_calc_daily_indicators()` の通常 DD ロジックを原典準拠 (`pct_change <= -0.2 and volume > prev_volume`) に置換
+   - 戻り値に `(date, close)` タプル形式の `distribution_days_with_close` を追加 (既存 `distribution_days` も維持)
+   - Stalling Day はスコープ外 (データ拡張PRで実装)
+5. **`scripts/make_market_db.py` 改修**:
+   - `make_db_common()` で前日 state_meta を読んで `market_state.py` に渡し、新state/meta を保存
+   - `_html_market()` で signal 列を `market_state` 表示に変更、CSSクラス追加
+6. **既存テスト更新**:
+   - `tests/test_price.py` の direction_signal 形式テスト
+   - `tests/test_make_market_db.py` の state テスト追加
+7. **統合テスト**: 実DB再計算 + WebApp /market 目視確認 (Playwright)
+8. **PR作成** (Closes は使わない: Part B/C 残るため)
+
+---
+
+## 10. 後方互換性
+
+| 項目 | 互換 | 備考 |
+|---|---|---|
+| `distribution_days` フィールド | ◯ 維持 | 形式変えず、表示でも使う |
+| `followthrough_days` フィールド | ◯ 維持 | 形式変えず、表示でも使う |
+| `direction_signal` フィールド形式 | ◯ 維持 | `"<state>,YYMMDD"` 形式を継続 |
+| `direction_signal` フィールド値 | ✗ 変更 | `sell`/`neutral`/`buy` → `confirmed_uptrend`/`uptrend_under_pressure`/`market_in_correction` |
+| `make_signal()` の挙動 | ◯ 維持 | Part B で改修するため、Part A では既存挙動のまま (`direction_signal` 参照していないので影響なし) |
+| `market_state` フィールド | (新規) | 既存DBに無くてもデフォルト遷移ロジックで初期化される |
+
+`direction_signal` の値を依存している外部があれば影響を受ける。grep で確認: `grep -rn "direction_signal" scripts/ tests/`。現在の grep 結果では `make_market_db.py:_html_market()` の表示と、`tests/test_price.py`/`tests/test_make_market_db.py` のテストアサーションのみが該当。すべて Part A 内で更新する。
+
+---
+
+## 11. 関連
+
+- 本要件は issue #117 の Part A の実装仕様を定義する
+- Part B: シグナル連動 (`make_signal()` 改修) — `direction_signal` または `market_state` を参照する別要件
+- Part C: Minervini Breadth (トレンドテンプレート通過銘柄数による市場健全性評価) — 別要件
+- 関連ドキュメント: `doc/ARCHITECTURE.md` の市場DB構造 (`market_state` 追加で更新が必要)

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -398,6 +398,118 @@ def _save_market_db(market_db):
         db.import_from_dict(market_db)
 
 
+def _update_index_market_state(prev_index_db, new_index_db):
+    """指数 dict に market_state / state_meta / state_history / direction_signal を計算して書き込む。
+
+    issue #117 Part A: 前日 state_meta を引き継ぎ、当日の DD/FTD 候補から
+    market_state.py の純関数群で新state を導出する。
+
+    Args:
+        prev_index_db: 前日の market_db[index_name] dict (なければ {})
+        new_index_db: 当日の指数 dict (mutate される)
+    """
+    import market_state
+
+    # 1. 前日 state_meta を取得 (なければ空)
+    prev_meta = prev_index_db.get("state_meta", {}) or {}
+    prev_state = prev_index_db.get("market_state")
+    prev_history = prev_index_db.get("state_history", []) or []
+
+    # 2. 当日のDD候補を前日のDDリストにマージ
+    today_dd_with_close = list(prev_meta.get("distribution_days_with_close", []))
+    new_dd_with_close = new_index_db.get("distribution_days_with_close", []) or []
+    # 重複を排除しつつ新しいDDを追加
+    existing_dates = {d for d, _ in today_dd_with_close}
+    for dd_date, dd_close in new_dd_with_close:
+        if dd_date not in existing_dates:
+            today_dd_with_close.append((dd_date, dd_close))
+            existing_dates.add(dd_date)
+
+    # 3. 当日終値・履歴で DD を失効処理
+    daily_history = new_index_db.get("daily_history", []) or []
+    today_close = float(new_index_db.get("price", 0) or 0)
+    valid_dd = market_state.expire_distribution_days(
+        today_dd_with_close, today_close=today_close, daily_history=daily_history,
+    )
+
+    # 4. ラリーアテンプト追跡 (Correction 状態のときのみ)
+    rally_meta = {
+        "rally_attempt_start_date": prev_meta.get("rally_attempt_start_date"),
+        "rally_attempt_start_low": prev_meta.get("rally_attempt_start_low"),
+    }
+    today_low = float(new_index_db.get("low", 0) or 0)
+    today_high = float(new_index_db.get("high", 0) or 0)
+    today_volume = int(new_index_db.get("volume", 0) or 0)
+    # 当日と前日の close/low/volume を取得 (price_log[0] が当日、[1] が前日のはず)
+    price_log = new_index_db.get("price_log", []) or []
+    today_date = daily_history[0] if daily_history else (
+        price_log[0][0] if price_log else ""
+    )
+    prev_close = 0.0
+    prev_volume = 0
+    prev_low = 0.0
+    if len(price_log) >= 2:
+        prev_close = float(price_log[1][1] or 0)
+    # price_log には close のみ。low/volume は当日分しか new_index_db に残らない
+    # daily_history と組み合わせて 1日前の low/volume が必要だが、現状取れない
+    # ラリー判定は close 基準 (前日 close) で十分動く。low/volume は当日分のみ参照
+    today_dict = {
+        "date": today_date,
+        "close": today_close,
+        "low": today_low,
+        "high": today_high,
+        "volume": today_volume,
+    }
+    prev_dict = {
+        "close": prev_close,
+        "volume": int(prev_meta.get("prev_volume", 0) or 0),
+        "low": prev_low,
+    }
+
+    if prev_state == market_state.MARKET_IN_CORRECTION:
+        rally_meta = market_state.update_rally_attempt(rally_meta, today_dict, prev_dict)
+    else:
+        # Correction 以外ではラリー追跡は不要 (リセット)
+        rally_meta = {"rally_attempt_start_date": None, "rally_attempt_start_low": None}
+
+    # 5. FTD 判定 (Correction 状態 + ラリー追跡中のみ)
+    ftd_today = False
+    if prev_state == market_state.MARKET_IN_CORRECTION:
+        # FTD 判定には今日の出来高 vs 前日出来高が必要
+        # prev_meta に prev_volume が無くても、price_log から推定できないので簡易判定
+        # 当日の出来高は new_index_db['volume']、前日は state_meta に保存しておく
+        if prev_dict["volume"] > 0 and today_dict["volume"] > 0:
+            ftd_today = market_state.check_follow_through_day(
+                today_dict, prev_dict, rally_meta, daily_history,
+            )
+
+    # 6. 状態遷移
+    new_state, trigger = market_state.derive_state(
+        prev_state=prev_state,
+        valid_dd_count=len(valid_dd),
+        ftd_today=ftd_today,
+    )
+
+    # 7. state_history 更新
+    new_history = market_state.append_state_history(
+        prev_history, today_date or "", new_state, trigger,
+    )
+
+    # 8. 結果を new_index_db に書き戻し
+    new_index_db["market_state"] = new_state
+    new_index_db["state_meta"] = {
+        "rally_attempt_start_date": rally_meta.get("rally_attempt_start_date"),
+        "rally_attempt_start_low": rally_meta.get("rally_attempt_start_low"),
+        "distribution_days_with_close": valid_dd,
+        "last_ftd_date": today_date if ftd_today else prev_meta.get("last_ftd_date"),
+        "prev_volume": today_volume,  # 次回呼び出し用に保存
+    }
+    new_index_db["state_history"] = new_history
+    new_index_db["direction_signal"] = market_state.to_direction_signal(
+        new_state, today_date or "",
+    )
+
+
 def update_market_db():
     """マーケットDBを読み込んで最新に更新"""
     market_db = get_market_db()
@@ -419,17 +531,25 @@ def update_market_db():
     theme_db = make_theme_data(prev_momentum_rank)
     market_db.update(theme_db)
 
-    topix_db = make_topix_db()
-    market_db.update(topix_db)
-
-    mothers_db = make_mothers_db()
-    market_db.update(mothers_db)
-    nikkei_db = make_nikkei_db()
-    market_db.update(nikkei_db)
-    nasdaq_db = make_nasdaq_db()
-    market_db.update(nasdaq_db)
-    sp500_db = make_sp500_db()
-    market_db.update(sp500_db)
+    # 各指数を更新 (まず DD/FTD 候補と当日価格を取得)
+    index_makers = [
+        ("topix", make_topix_db),
+        ("mothers", make_mothers_db),
+        ("nikkei225", make_nikkei_db),
+        ("nasdaq", make_nasdaq_db),
+        ("sp500", make_sp500_db),
+    ]
+    for index_name, maker in index_makers:
+        prev_index_db = market_db.get(index_name, {}) or {}
+        new_data = maker()  # {index_name: {...}}
+        new_index_db = new_data.get(index_name, {})
+        if new_index_db:
+            # 市場状態の計算 (issue #117 Part A)
+            try:
+                _update_index_market_state(prev_index_db, new_index_db)
+            except Exception as e:
+                log_warning("[market_state] %s の State 計算失敗: %s" % (index_name, e))
+        market_db[index_name] = new_index_db
 
     _save_market_db(market_db)
     log_print("MarketDB保存:", list(market_db.keys()))
@@ -609,6 +729,10 @@ tr:hover { background: #f5f5f5; }
 .trend-good { color: #27ae60; font-weight: bold; }
 .rs-strong { color: #27ae60; font-weight: bold; }
 .rs-weak { color: #c0392b; font-weight: bold; }
+/* market_state (issue #117 Part A) */
+.state-confirmed { background: #eafaf1; color: #27ae60; font-weight: bold; }
+.state-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
+.state-correction { background: #fdedec; color: #c0392b; font-weight: bold; }
 
 /* 決算 */
 .kessan-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
@@ -821,11 +945,20 @@ def _html_market(market_db):
             diff = db.get("spr_buygagher", 0) - db.get("spr_20", 0)
             spr_eval = step_func(diff, [-10, -5, 0, 5, 10], ["E", "D", "C", "B", "A"])
 
-            # シグナルのCSSクラス
+            # シグナルのCSSクラス (issue #117 Part A: market_state ベース)
+            # signal の値は "<state>,YYMMDD" 形式 (例: "confirmed_uptrend,26/04/30")
+            signal_str = str(signal).lower()
             signal_class = ""
-            if "sell" in str(signal).lower():
+            if "market_in_correction" in signal_str:
+                signal_class = ' class="state-correction"'
+            elif "uptrend_under_pressure" in signal_str:
+                signal_class = ' class="state-pressure"'
+            elif "confirmed_uptrend" in signal_str:
+                signal_class = ' class="state-confirmed"'
+            # 後方互換: 旧 sell/buy にもフォールバック
+            elif "sell" in signal_str:
                 signal_class = ' class="signal-sell"'
-            elif "buy" in str(signal).lower():
+            elif "buy" in signal_str:
                 signal_class = ' class="signal-buy"'
 
             # トレンドのCSSクラス

--- a/scripts/market_state.py
+++ b/scripts/market_state.py
@@ -1,0 +1,264 @@
+"""市場状態 State Machine (issue #117 Part A)
+
+O'Neil/IBD原典に準拠した3状態モデル + 原典準拠DD/FTD判定 + ラリーアテンプト追跡を実装する。
+
+3状態:
+- confirmed_uptrend: 上昇トレンド確定
+- uptrend_under_pressure: 上昇トレンドだが圧力下 (DD増加)
+- market_in_correction: 調整相場
+
+I/O は持たない純関数の集まり。market_db への永続化は make_market_db.py 側で行う。
+詳細仕様は doc/requirements/market_state_machine_requirements.md を参照。
+"""
+
+# ==================================================
+# 状態定数
+# ==================================================
+CONFIRMED_UPTREND = "confirmed_uptrend"
+UPTREND_UNDER_PRESSURE = "uptrend_under_pressure"
+MARKET_IN_CORRECTION = "market_in_correction"
+
+ALL_STATES = (CONFIRMED_UPTREND, UPTREND_UNDER_PRESSURE, MARKET_IN_CORRECTION)
+
+# ==================================================
+# 判定パラメータ (将来差し替え可能にするためモジュール定数化)
+# ==================================================
+
+# DD 失効
+DD_EXPIRY_DAYS = 25  # 25取引日経過で失効
+DD_RECOVERY_RATIO = 1.05  # DD発生日終値の1.05倍以上に達したら失効
+
+# 状態遷移しきい値
+DD_THRESHOLD_TO_PRESSURE = 4  # confirmed → pressure: 直近25日内 DD ≥ 4
+DD_THRESHOLD_TO_CORRECTION = 6  # confirmed/pressure → correction: DD ≥ 6
+DD_THRESHOLD_TO_CONFIRMED_FROM_PRESSURE = 4  # pressure → confirmed: DD < 4 復帰
+
+# FTD 判定 (固定閾値、IBD中央値)
+FTD_GAIN_THRESHOLD = 1.0  # %、ラリー Day 4 以降の最低上昇率
+FTD_MIN_DAYS_FROM_RALLY_START = 3  # Day 1 から3取引日後 = Day 4
+
+# state_history 保持件数
+STATE_HISTORY_MAX = 30
+
+
+# ==================================================
+# DD 失効
+# ==================================================
+def expire_distribution_days(dd_list, today_close, daily_history):
+    """有効な DD のみを返す (純関数)。
+
+    失効ルール:
+    - 25取引日経過: daily_history で DD 日と当日のインデックス差 >= 25
+    - 5%上昇: 当日終値 >= DD発生日終値 * 1.05
+    - 境界: DD 日が daily_history に含まれない (窓外) → 失効扱い
+
+    Args:
+        dd_list: [(date_str, close_float), ...] DD のリスト
+        today_close: float 当日終値
+        daily_history: [date_str, ...] 直近の取引日リスト (新しい日が先頭)
+
+    Returns:
+        list: 失効していない DD のリスト (順序は元のまま)
+    """
+    if not dd_list or not daily_history:
+        return []
+
+    # daily_history の date → index の dict (新しい日 = index 0)
+    history_index = {date: i for i, date in enumerate(daily_history)}
+    today_idx = history_index.get(daily_history[0])  # 0 のはず
+
+    valid = []
+    for dd_date, dd_close in dd_list:
+        # 5%上昇で失効
+        if dd_close > 0 and today_close >= dd_close * DD_RECOVERY_RATIO:
+            continue
+        # daily_history に含まれない (窓外) → 失効扱い
+        if dd_date not in history_index:
+            continue
+        # 25取引日経過で失効
+        days_passed = history_index[dd_date] - today_idx
+        if days_passed >= DD_EXPIRY_DAYS:
+            continue
+        valid.append((dd_date, dd_close))
+    return valid
+
+
+# ==================================================
+# ラリーアテンプト追跡
+# ==================================================
+def update_rally_attempt(rally_meta, today, prev):
+    """ラリーアテンプトの開始/リセット/維持を判定する (純関数)。
+
+    Correction 状態のときに呼ばれることを想定。
+    Confirmed/Pressure 状態では rally_meta はクリアする (呼び出し側で処理)。
+
+    Args:
+        rally_meta: dict {rally_attempt_start_date: str|None, rally_attempt_start_low: float|None}
+        today: dict {date, close, low}
+        prev: dict {date, close, low}
+
+    Returns:
+        dict: 更新後の rally_meta
+    """
+    start_date = rally_meta.get("rally_attempt_start_date")
+    start_low = rally_meta.get("rally_attempt_start_low")
+
+    # まだラリー開始していない: 当日 close > 前日 close で Day 1 確定
+    if start_date is None:
+        if today["close"] > prev["close"]:
+            return {
+                "rally_attempt_start_date": today["date"],
+                "rally_attempt_start_low": today["low"],
+            }
+        return rally_meta
+
+    # ラリー追跡中: 当日安値が start_low を下回ったらリセット
+    if today["low"] < start_low:
+        # リセット後、同日に新たな Day 1 を判定するかは仕様外 (次の取引日に再判定)
+        return {
+            "rally_attempt_start_date": None,
+            "rally_attempt_start_low": None,
+        }
+
+    # 継続
+    return rally_meta
+
+
+# ==================================================
+# FTD 判定
+# ==================================================
+def check_follow_through_day(today, prev, rally_meta, daily_history):
+    """FTD (Follow-Through Day) 成立判定 (純関数)。
+
+    成立条件:
+    - rally_attempt_start_date is not None (ラリー追跡中)
+    - Day 4 以降 (start から3取引日経過)
+    - 当日安値 >= rally_attempt_start_low (リセット未発動)
+    - 前日比 >= FTD_GAIN_THRESHOLD (固定 1.0%)
+    - 当日出来高 > 前日出来高
+
+    Args:
+        today: dict {date, close, low, volume}
+        prev: dict {close, volume}
+        rally_meta: dict
+        daily_history: [date_str, ...] 新しい日が先頭
+
+    Returns:
+        bool: FTD成立か
+    """
+    start_date = rally_meta.get("rally_attempt_start_date")
+    start_low = rally_meta.get("rally_attempt_start_low")
+    if not start_date or start_low is None:
+        return False
+
+    # 安値割れチェック
+    if today["low"] < start_low:
+        return False
+
+    # Day 4 以降か
+    history_index = {date: i for i, date in enumerate(daily_history)}
+    if today["date"] not in history_index or start_date not in history_index:
+        return False
+    days_since_start = history_index[start_date] - history_index[today["date"]]
+    if days_since_start < FTD_MIN_DAYS_FROM_RALLY_START:
+        return False
+
+    # 上昇率チェック
+    if prev["close"] <= 0:
+        return False
+    pct_change = (today["close"] / prev["close"] - 1) * 100
+    if pct_change < FTD_GAIN_THRESHOLD:
+        return False
+
+    # 出来高増チェック
+    if today["volume"] <= prev["volume"]:
+        return False
+
+    return True
+
+
+# ==================================================
+# 状態遷移
+# ==================================================
+def derive_state(prev_state, valid_dd_count, ftd_today):
+    """前日 state と当日の DD 数 / FTD成立から、新 state を計算する (純関数)。
+
+    遷移ルール:
+    - market_in_correction → confirmed_uptrend: FTD成立
+    - confirmed_uptrend → uptrend_under_pressure: 有効DD ≥ 4 (かつ < 6)
+    - confirmed_uptrend → market_in_correction: 有効DD ≥ 6
+    - uptrend_under_pressure → market_in_correction: 有効DD ≥ 6
+    - uptrend_under_pressure → confirmed_uptrend: 有効DD < 4
+    - それ以外: 状態維持
+
+    Args:
+        prev_state: 前日の state (None の場合は初期判定)
+        valid_dd_count: 有効DD数
+        ftd_today: bool 当日 FTD 成立か
+
+    Returns:
+        tuple: (new_state, trigger_reason)
+            trigger_reason: 遷移理由文字列 ("ftd" / "dd>=4" / "dd>=6" / "dd<4_recover" / "init" / "stay")
+    """
+    # 初回 (prev_state なし) は遷移ルールと同じ閾値で判定
+    if prev_state is None or prev_state not in ALL_STATES:
+        if valid_dd_count >= DD_THRESHOLD_TO_CORRECTION:
+            return MARKET_IN_CORRECTION, "init"
+        if valid_dd_count >= DD_THRESHOLD_TO_PRESSURE:
+            return UPTREND_UNDER_PRESSURE, "init"
+        return CONFIRMED_UPTREND, "init"
+
+    if prev_state == MARKET_IN_CORRECTION:
+        if ftd_today:
+            return CONFIRMED_UPTREND, "ftd"
+        return MARKET_IN_CORRECTION, "stay"
+
+    if prev_state == CONFIRMED_UPTREND:
+        if valid_dd_count >= DD_THRESHOLD_TO_CORRECTION:
+            return MARKET_IN_CORRECTION, "dd>=6"
+        if valid_dd_count >= DD_THRESHOLD_TO_PRESSURE:
+            return UPTREND_UNDER_PRESSURE, "dd>=4"
+        return CONFIRMED_UPTREND, "stay"
+
+    if prev_state == UPTREND_UNDER_PRESSURE:
+        if valid_dd_count >= DD_THRESHOLD_TO_CORRECTION:
+            return MARKET_IN_CORRECTION, "dd>=6"
+        if valid_dd_count < DD_THRESHOLD_TO_CONFIRMED_FROM_PRESSURE:
+            return CONFIRMED_UPTREND, "dd<4_recover"
+        return UPTREND_UNDER_PRESSURE, "stay"
+
+    # 想定外
+    return prev_state, "stay"
+
+
+# ==================================================
+# 状態履歴
+# ==================================================
+def append_state_history(history, today_date, new_state, trigger):
+    """state_history に1件追加。直近 STATE_HISTORY_MAX 件のみ保持。
+
+    Args:
+        history: 既存の履歴 [(date, state, trigger), ...] (新しいが先頭)
+        today_date: str
+        new_state: str
+        trigger: str
+
+    Returns:
+        list: 更新後の履歴
+    """
+    if not isinstance(history, list):
+        history = []
+    # 同じ日の既存エントリは置き換え (1日複数回計算される場合)
+    history = [h for h in history if h[0] != today_date]
+    history.insert(0, (today_date, new_state, trigger))
+    return history[:STATE_HISTORY_MAX]
+
+
+# ==================================================
+# direction_signal 互換変換
+# ==================================================
+def to_direction_signal(state, today_date):
+    """state と日付から direction_signal 文字列を生成する。
+    既存形式 "<value>,YYMMDD" を継続、value のみ変更。
+    """
+    return "%s,%s" % (state, today_date)

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -267,88 +267,66 @@ def _calc_daily_indicators(daily_price_list):
     """daily_price_listから日次指標を計算する
     parse_price_d_html_kabutanから指標計算部分を分離。
     Kabutan HTML パスと yfinance パス共通で使用する。
+
+    DD/FTD 判定は O'Neil 原典準拠 (issue #117 Part A):
+    - 通常DD: 前日比 -0.2% 以下 + 出来高が前日より増加
+    - FTD候補: 前日比 +1.0% 以上 + 出来高が前日より増加
+      (ラリーアテンプト Day 4 以降の判定は market_state.py 側で行うため、ここでは候補日のみ拾う)
+
+    direction_signal の最終値は make_market_db.py が market_state を計算してから上書きする。
+    本関数では空文字をデフォルトとして入れておく (フィールド自体は後方互換で維持)。
+
+    Stalling Day はデータ拡張PRで対応 (52週高値が必要)。
+
     Args:
         daily_price_list: 8要素タプル(文字列)のリスト
             [0]日付, [1]始値, [2]高値, [3]安値, [4]終値, [5]前日比, [6]前日比%, [7]売買高
             カンマ区切り数値文字列、新しい日付が先頭
     Returns:
-        dict: distribution_days / followthrough_days / direction_signal /
-              spr_20 / spr_5 / spr_buygagher / rv_20 / rv_5
+        dict: distribution_days / distribution_days_with_close / followthrough_days /
+              daily_history / direction_signal / spr_20 / spr_5 / spr_buygagher / rv_20 / rv_5
     """
-    # ---- ディストリビューション
-    distribution_day = []  # 日付のリスト
+    # ---- ディストリビューション / フォロースルー候補
+    distribution_day = []  # 日付のリスト (後方互換)
+    distribution_day_with_close = []  # (date, close) タプルのリスト (新規、State Machine 用)
     followthrough_day = []
-    # 前日より安く、出来高が増える日
-    # 　前日より0.1%以下で上半分で引ける場合はカウントしない[モラレス]
-    # 前日よりわずかに高くても下で引けていけばカウント[モラレス]
-    # 　例：0.1%上昇で25%以下で引ける
     count_day = 20
     target_days = list(
         reversed(daily_price_list[: count_day + 1])
     )  # インデックスが若いほど前の日にする
-    # 平均出来高
-    avg_vol = 0
-    avg_len = 0
-    for d in target_days:
-        try:
-            dv = int(d[7].replace(",", ""))  # 売買高
-            avg_vol += dv
-            avg_len += 1
-        except ValueError:
-            pass
-    if avg_len == 0:
+    if len(target_days) < 2:
         log_warning(" デイリー価格解析できず")
         return {}
-    avg_vol = avg_vol / avg_len
     current_day = target_days[-1][0]
     log_debug(current_day, "のディストリビューションカウント")
     for d, pd in zip(target_days[1:], target_days[:-1]):
         try:
             dp = float(d[4].replace(",", ""))  # 終値
-            pdp = float(pd[4].replace(",", ""))
             dv = int(d[7].replace(",", ""))  # 売買高
             pdv = int(pd[7].replace(",", ""))
-            dph = float(d[2].replace(",", ""))  # 高値
-            dpl = float(d[3].replace(",", ""))  # 安値
             dr = float(d[6].replace(",", ""))  # 前日比パーセント
         except ValueError:
             log_debug("%sはデータ取得できず" % d[0])
             continue
-        if dph == dpl:
-            # 高値=安値で値幅ゼロのケース (休場日や寄らずなど) は除外
-            continue
-        pr_pos = (dp - dpl) / (dph - dpl)
-        if dp < pdp:  # 前日より安く出来高が増える
-            if dv > pdv:
-                if dr >= -0.1 and pr_pos >= 0.5:
-                    log_debug("前日より0.1%以下で上半分で引ける場合はカウントしない", d[0])
-                else:
-                    distribution_day.append(d[0])
-        else:
-            if dv > pdv:
-                log_debug("dr", dr, "pr_pos", pr_pos)
-                if dr <= 0.1 and pr_pos <= 0.25:
-                    log_debug("前日よりわずかに高くても下で引けていけばカウント", d[0])
-                    distribution_day.append(d[0])
-        # フォロースルー: 反転から4~7日目で(ここは判定していない)
-        # 平均以上の出来高で1.7%以上の上昇
-        # 本当はその時から過去20日の出来高にしないといけないが取得できない・・
-        if dr >= 1.7 and dv >= avg_vol:
+        # 通常 DD (原典準拠)
+        if dr <= -0.2 and dv > pdv:
+            distribution_day.append(d[0])
+            distribution_day_with_close.append((d[0], dp))
+        # FTD候補 (ラリーアテンプト判定は market_state.py 側で行う)
+        if dr >= 1.0 and dv > pdv:
             followthrough_day.append(d[0])
     dic = {}
     dic["distribution_days"] = distribution_day
+    dic["distribution_days_with_close"] = distribution_day_with_close
     dic["followthrough_days"] = followthrough_day
+    # daily_history (新しい日が先頭) を State Machine の DD 失効判定で使う
+    dic["daily_history"] = [d[0] for d in daily_price_list[:count_day + 1]]
     log_debug("ディストリビューション:", distribution_day)
-    log_debug("フォロースルー:", followthrough_day)
+    log_debug("フォロースルー候補:", followthrough_day)
 
-    # ---- シグナル
-    signal = "neutral"
-    # TODO: とりあえず簡易
-    if len(distribution_day) >= 5:
-        signal = "sell"
-
-    dic["direction_signal"] = signal + "," + current_day
-    log_debug("シグナル:", dic["direction_signal"])
+    # direction_signal は make_market_db.py が market_state を計算してから上書きする。
+    # 計算前のデフォルト値として空文字を入れておく (後方互換のためフィールド自体は維持)。
+    dic["direction_signal"] = ""
 
     # ---- 売り圧力レシオ
     def to_numeric(str):

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -403,14 +403,35 @@ class TestHtmlMarket:
         }
 
     def test_signal_sell_class(self):
-        """sellシグナルにsignal-sellクラスが付く"""
+        """sellシグナルにsignal-sellクラスが付く (後方互換: 旧文字列でも動く)"""
         result = make_market_db._html_market(self._make_market_db())
         assert 'signal-sell' in result
 
     def test_signal_buy_class(self):
-        """buyシグナルにsignal-buyクラスが付く"""
+        """buyシグナルにsignal-buyクラスが付く (後方互換: 旧文字列でも動く)"""
         result = make_market_db._html_market(self._make_market_db())
         assert 'signal-buy' in result
+
+    def test_state_correction_class(self):
+        """direction_signal が market_in_correction なら state-correction クラス (issue #117 Part A)"""
+        db = self._make_market_db()
+        db["topix"]["direction_signal"] = "market_in_correction,26/04/30"
+        result = make_market_db._html_market(db)
+        assert 'state-correction' in result
+
+    def test_state_pressure_class(self):
+        """direction_signal が uptrend_under_pressure なら state-pressure クラス"""
+        db = self._make_market_db()
+        db["topix"]["direction_signal"] = "uptrend_under_pressure,26/04/30"
+        result = make_market_db._html_market(db)
+        assert 'state-pressure' in result
+
+    def test_state_confirmed_class(self):
+        """direction_signal が confirmed_uptrend なら state-confirmed クラス"""
+        db = self._make_market_db()
+        db["topix"]["direction_signal"] = "confirmed_uptrend,26/04/30"
+        result = make_market_db._html_market(db)
+        assert 'state-confirmed' in result
 
     def test_trend_good_class(self):
         """良好トレンド（◎/◯）にtrend-goodクラスが付く"""

--- a/tests/test_market_state.py
+++ b/tests/test_market_state.py
@@ -1,0 +1,306 @@
+"""market_state.py のテスト (issue #117 Part A)"""
+
+import pytest
+import market_state as ms
+
+
+# ==================================================
+# expire_distribution_days
+# ==================================================
+class TestExpireDistributionDays:
+    """DD 失効処理"""
+
+    def _history(self, n=30):
+        """直近 n 日のダミー履歴 (新しい日が先頭、YYMMDD)"""
+        # 26/04/30, 26/04/29, ..., で先頭に並べる (休日無視のシンプル形式)
+        return ["26/04/%02d" % (30 - i) for i in range(n)]
+
+    def test_recent_dd_kept(self):
+        """直近のDD (5日前) は維持される"""
+        history = self._history(30)
+        dd_list = [(history[5], 100.0)]  # 5日前のDD
+        valid = ms.expire_distribution_days(dd_list, today_close=99.0, daily_history=history)
+        assert valid == [(history[5], 100.0)]
+
+    def test_25_days_old_expires(self):
+        """25取引日経過したDDは失効"""
+        history = self._history(30)
+        dd_list = [(history[25], 100.0)]  # ちょうど25日前
+        valid = ms.expire_distribution_days(dd_list, today_close=99.0, daily_history=history)
+        assert valid == []
+
+    def test_24_days_old_kept(self):
+        """24取引日前のDDはまだ有効"""
+        history = self._history(30)
+        dd_list = [(history[24], 100.0)]
+        valid = ms.expire_distribution_days(dd_list, today_close=99.0, daily_history=history)
+        assert valid == [(history[24], 100.0)]
+
+    def test_5pct_recovery_expires(self):
+        """5%上昇で失効"""
+        history = self._history(30)
+        dd_list = [(history[3], 100.0)]
+        valid = ms.expire_distribution_days(dd_list, today_close=105.0, daily_history=history)
+        assert valid == []
+
+    def test_below_5pct_kept(self):
+        """5%未満の上昇では失効しない"""
+        history = self._history(30)
+        dd_list = [(history[3], 100.0)]
+        valid = ms.expire_distribution_days(dd_list, today_close=104.99, daily_history=history)
+        assert len(valid) == 1
+
+    def test_dd_outside_history_expires(self):
+        """daily_history に含まれないDDは失効扱い"""
+        history = self._history(30)
+        dd_list = [("25/01/01", 100.0)]  # 履歴範囲外
+        valid = ms.expire_distribution_days(dd_list, today_close=99.0, daily_history=history)
+        assert valid == []
+
+    def test_empty_dd_list(self):
+        """空リストは空のまま"""
+        history = self._history(30)
+        valid = ms.expire_distribution_days([], today_close=99.0, daily_history=history)
+        assert valid == []
+
+
+# ==================================================
+# update_rally_attempt
+# ==================================================
+class TestUpdateRallyAttempt:
+    """ラリーアテンプト追跡"""
+
+    def test_day1_starts_when_higher_close(self):
+        """前日より高引けで Day 1 開始"""
+        meta = {"rally_attempt_start_date": None, "rally_attempt_start_low": None}
+        today = {"date": "26/04/30", "close": 1000, "low": 990}
+        prev = {"date": "26/04/29", "close": 980, "low": 970}
+        result = ms.update_rally_attempt(meta, today, prev)
+        assert result["rally_attempt_start_date"] == "26/04/30"
+        assert result["rally_attempt_start_low"] == 990
+
+    def test_no_start_when_lower_close(self):
+        """前日より低引けでは Day 1 開始しない"""
+        meta = {"rally_attempt_start_date": None, "rally_attempt_start_low": None}
+        today = {"date": "26/04/30", "close": 970, "low": 960}
+        prev = {"date": "26/04/29", "close": 980, "low": 970}
+        result = ms.update_rally_attempt(meta, today, prev)
+        assert result["rally_attempt_start_date"] is None
+
+    def test_reset_on_low_break(self):
+        """ラリー追跡中に Day 1 安値割れでリセット"""
+        meta = {"rally_attempt_start_date": "26/04/25", "rally_attempt_start_low": 990}
+        today = {"date": "26/04/30", "close": 985, "low": 980}  # low < 990
+        prev = {"date": "26/04/29", "close": 988, "low": 985}
+        result = ms.update_rally_attempt(meta, today, prev)
+        assert result["rally_attempt_start_date"] is None
+        assert result["rally_attempt_start_low"] is None
+
+    def test_continue_when_low_holds(self):
+        """ラリー追跡中、Day 1 安値を保てば継続"""
+        meta = {"rally_attempt_start_date": "26/04/25", "rally_attempt_start_low": 990}
+        today = {"date": "26/04/30", "close": 1010, "low": 995}  # low >= 990
+        prev = {"date": "26/04/29", "close": 1005, "low": 1000}
+        result = ms.update_rally_attempt(meta, today, prev)
+        assert result["rally_attempt_start_date"] == "26/04/25"
+        assert result["rally_attempt_start_low"] == 990
+
+
+# ==================================================
+# check_follow_through_day
+# ==================================================
+class TestCheckFollowThroughDay:
+    """FTD 判定"""
+
+    def _history(self, n=30):
+        return ["26/04/%02d" % (30 - i) for i in range(n)]
+
+    def test_ftd_succeeds_on_day4(self):
+        """Day 4 (start から3日経過)、+1.5%、出来高増 → FTD成立"""
+        history = self._history(30)
+        rally_meta = {
+            "rally_attempt_start_date": history[3],  # 3日前 = Day 1
+            "rally_attempt_start_low": 990,
+        }
+        today = {"date": history[0], "close": 1015, "low": 1000, "volume": 1500}
+        prev = {"close": 1000, "volume": 1000}
+        assert ms.check_follow_through_day(today, prev, rally_meta, history) is True
+
+    def test_ftd_fails_too_early(self):
+        """Day 3 (まだ Day 4 に達していない) では成立しない"""
+        history = self._history(30)
+        rally_meta = {
+            "rally_attempt_start_date": history[2],  # 2日前
+            "rally_attempt_start_low": 990,
+        }
+        today = {"date": history[0], "close": 1015, "low": 1000, "volume": 1500}
+        prev = {"close": 1000, "volume": 1000}
+        assert ms.check_follow_through_day(today, prev, rally_meta, history) is False
+
+    def test_ftd_fails_below_threshold(self):
+        """Day 4、+0.9% (閾値1.0%未達) → 非成立"""
+        history = self._history(30)
+        rally_meta = {
+            "rally_attempt_start_date": history[3],
+            "rally_attempt_start_low": 990,
+        }
+        today = {"date": history[0], "close": 1009, "low": 1000, "volume": 1500}
+        prev = {"close": 1000, "volume": 1000}
+        assert ms.check_follow_through_day(today, prev, rally_meta, history) is False
+
+    def test_ftd_fails_volume_decrease(self):
+        """Day 4、上昇率十分でも出来高減なら非成立"""
+        history = self._history(30)
+        rally_meta = {
+            "rally_attempt_start_date": history[3],
+            "rally_attempt_start_low": 990,
+        }
+        today = {"date": history[0], "close": 1020, "low": 1000, "volume": 900}
+        prev = {"close": 1000, "volume": 1000}
+        assert ms.check_follow_through_day(today, prev, rally_meta, history) is False
+
+    def test_ftd_fails_when_low_break(self):
+        """Day 1 安値を割っていたら非成立"""
+        history = self._history(30)
+        rally_meta = {
+            "rally_attempt_start_date": history[3],
+            "rally_attempt_start_low": 990,
+        }
+        today = {"date": history[0], "close": 1015, "low": 985, "volume": 1500}  # low < 990
+        prev = {"close": 1000, "volume": 1000}
+        assert ms.check_follow_through_day(today, prev, rally_meta, history) is False
+
+    def test_ftd_fails_no_rally_attempt(self):
+        """ラリー追跡していなければ非成立"""
+        history = self._history(30)
+        rally_meta = {"rally_attempt_start_date": None, "rally_attempt_start_low": None}
+        today = {"date": history[0], "close": 1020, "low": 1000, "volume": 1500}
+        prev = {"close": 1000, "volume": 1000}
+        assert ms.check_follow_through_day(today, prev, rally_meta, history) is False
+
+
+# ==================================================
+# derive_state
+# ==================================================
+class TestDeriveState:
+    """状態遷移"""
+
+    def test_init_when_few_dd(self):
+        """初期状態: DD < 4 で confirmed_uptrend"""
+        state, trigger = ms.derive_state(prev_state=None, valid_dd_count=2, ftd_today=False)
+        assert state == ms.CONFIRMED_UPTREND
+        assert trigger == "init"
+
+    def test_init_when_4_dd(self):
+        """初期状態: DD = 4 で uptrend_under_pressure"""
+        state, trigger = ms.derive_state(prev_state=None, valid_dd_count=4, ftd_today=False)
+        assert state == ms.UPTREND_UNDER_PRESSURE
+        assert trigger == "init"
+
+    def test_init_when_6_dd(self):
+        """初期状態: DD >= 6 で market_in_correction"""
+        state, trigger = ms.derive_state(prev_state=None, valid_dd_count=6, ftd_today=False)
+        assert state == ms.MARKET_IN_CORRECTION
+        assert trigger == "init"
+
+    def test_correction_to_confirmed_via_ftd(self):
+        """Correction → Confirmed: FTD成立"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.MARKET_IN_CORRECTION, valid_dd_count=3, ftd_today=True
+        )
+        assert state == ms.CONFIRMED_UPTREND
+        assert trigger == "ftd"
+
+    def test_correction_stays(self):
+        """Correction → Correction: FTD 未成立"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.MARKET_IN_CORRECTION, valid_dd_count=3, ftd_today=False
+        )
+        assert state == ms.MARKET_IN_CORRECTION
+
+    def test_confirmed_to_pressure_at_4dd(self):
+        """Confirmed → Pressure: 有効DD = 4"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.CONFIRMED_UPTREND, valid_dd_count=4, ftd_today=False
+        )
+        assert state == ms.UPTREND_UNDER_PRESSURE
+        assert trigger == "dd>=4"
+
+    def test_confirmed_to_correction_at_6dd(self):
+        """Confirmed → Correction: 有効DD = 6"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.CONFIRMED_UPTREND, valid_dd_count=6, ftd_today=False
+        )
+        assert state == ms.MARKET_IN_CORRECTION
+        assert trigger == "dd>=6"
+
+    def test_confirmed_stays_at_3dd(self):
+        """Confirmed → Confirmed: 有効DD = 3 (4未満)"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.CONFIRMED_UPTREND, valid_dd_count=3, ftd_today=False
+        )
+        assert state == ms.CONFIRMED_UPTREND
+
+    def test_pressure_to_correction_at_6dd(self):
+        """Pressure → Correction: 有効DD = 6"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.UPTREND_UNDER_PRESSURE, valid_dd_count=6, ftd_today=False
+        )
+        assert state == ms.MARKET_IN_CORRECTION
+
+    def test_pressure_to_confirmed_recover(self):
+        """Pressure → Confirmed: 有効DD < 4 で復帰"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.UPTREND_UNDER_PRESSURE, valid_dd_count=3, ftd_today=False
+        )
+        assert state == ms.CONFIRMED_UPTREND
+        assert trigger == "dd<4_recover"
+
+    def test_pressure_stays_at_4dd(self):
+        """Pressure → Pressure: 有効DD = 4 (Correction にも復帰にも当たらない)"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.UPTREND_UNDER_PRESSURE, valid_dd_count=4, ftd_today=False
+        )
+        assert state == ms.UPTREND_UNDER_PRESSURE
+
+
+# ==================================================
+# append_state_history
+# ==================================================
+class TestAppendStateHistory:
+    """状態履歴管理"""
+
+    def test_append_to_empty(self):
+        """空履歴に追加"""
+        h = ms.append_state_history([], "26/04/30", ms.CONFIRMED_UPTREND, "init")
+        assert h == [("26/04/30", ms.CONFIRMED_UPTREND, "init")]
+
+    def test_caps_at_max(self):
+        """STATE_HISTORY_MAX 件で打ち切り"""
+        h = [("26/04/%02d" % i, ms.CONFIRMED_UPTREND, "stay") for i in range(35)]
+        h2 = ms.append_state_history(h, "26/05/01", ms.MARKET_IN_CORRECTION, "dd>=6")
+        assert len(h2) == ms.STATE_HISTORY_MAX
+        assert h2[0] == ("26/05/01", ms.MARKET_IN_CORRECTION, "dd>=6")
+
+    def test_replaces_same_date(self):
+        """同じ日付のエントリは置き換え"""
+        h = [("26/04/30", ms.CONFIRMED_UPTREND, "init")]
+        h2 = ms.append_state_history(h, "26/04/30", ms.MARKET_IN_CORRECTION, "dd>=6")
+        assert len(h2) == 1
+        assert h2[0] == ("26/04/30", ms.MARKET_IN_CORRECTION, "dd>=6")
+
+    def test_handles_none_history(self):
+        """history が None でも動く"""
+        h = ms.append_state_history(None, "26/04/30", ms.CONFIRMED_UPTREND, "init")
+        assert h == [("26/04/30", ms.CONFIRMED_UPTREND, "init")]
+
+
+# ==================================================
+# to_direction_signal
+# ==================================================
+class TestToDirectionSignal:
+    """direction_signal 文字列生成"""
+
+    def test_format(self):
+        s = ms.to_direction_signal(ms.CONFIRMED_UPTREND, "26/04/30")
+        assert s == "confirmed_uptrend,26/04/30"

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -440,7 +440,8 @@ class TestCalcDailyIndicators:
         rows = self._make_price_list(25)
         result = price._calc_daily_indicators(rows)
         for key in (
-            "distribution_days", "followthrough_days", "direction_signal",
+            "distribution_days", "distribution_days_with_close", "followthrough_days",
+            "daily_history", "direction_signal",
             "spr_20", "spr_5", "spr_buygagher", "rv_20", "rv_5",
         ):
             assert key in result
@@ -449,13 +450,32 @@ class TestCalcDailyIndicators:
         result = price._calc_daily_indicators([])
         assert result == {}
 
-    def test_direction_signal_format(self):
-        """direction_signal は '<sig>,<日付>' 形式"""
+    def test_direction_signal_default_empty(self):
+        """direction_signal は _calc_daily_indicators の段階では空文字。
+        最終値は make_market_db.py の State Machine 計算で上書きされる
+        (issue #117 Part A)"""
         rows = self._make_price_list(25)
         result = price._calc_daily_indicators(rows)
-        assert "," in result["direction_signal"]
-        sig, day = result["direction_signal"].split(",", 1)
-        assert sig in ("neutral", "sell")
+        assert result["direction_signal"] == ""
+
+    def test_distribution_days_with_close_format(self):
+        """distribution_days_with_close は (date, close) タプルのリスト"""
+        rows = self._make_price_list(25)
+        result = price._calc_daily_indicators(rows)
+        for entry in result["distribution_days_with_close"]:
+            assert len(entry) == 2
+            date, close = entry
+            assert isinstance(date, str)
+            assert isinstance(close, float)
+
+    def test_daily_history_newest_first(self):
+        """daily_history は新しい日付が先頭"""
+        rows = self._make_price_list(25)
+        result = price._calc_daily_indicators(rows)
+        history = result["daily_history"]
+        assert len(history) > 0
+        # rows[0] が最新日付なので history[0] と一致
+        assert history[0] == rows[0][0]
 
     def test_zero_range_day_does_not_crash(self):
         """高値=安値の日があってもZeroDivisionErrorにならない"""


### PR DESCRIPTION
## 概要

issue #117 Part A の実装。原典 (O'Neil/IBD) 準拠の **3状態 Market State Machine** を導入し、既存の2値モデル (`neutral`/`sell`) を `confirmed_uptrend` / `uptrend_under_pressure` / `market_in_correction` の3状態に置き換えた。

issue #117 は3 Part構成:
- Part A: **Market State Machine** ← 本PR
- Part B: シグナル連動 (`make_signal()` 改修) — 後続PR
- Part C: Minervini Breadth — 後続PR

Part B/C 残るため **`Closes` は使わない**。

要件定義書: `doc/requirements/market_state_machine_requirements.md` (前コミット、codex レビュー2回でクリティカル指摘解消済み)

## 実装

### `scripts/market_state.py` (新設)

純関数の集まりで State Machine を実装:

| 関数 | 責務 |
|---|---|
| `derive_state(prev_state, valid_dd_count, ftd_today)` | 状態遷移 |
| `expire_distribution_days(dd_list, today_close, daily_history)` | DD 失効処理 (25日経過 / 5%上昇 / 履歴外) |
| `update_rally_attempt(rally_meta, today, prev)` | ラリーアテンプト追跡 (Day 1 開始 / 安値割れリセット) |
| `check_follow_through_day(today, prev, rally_meta, daily_history)` | FTD 判定 (Day 4 以降 + 1.0% 以上 + 出来高増) |
| `append_state_history(history, today_date, new_state, trigger)` | 状態履歴管理 (直近30件) |
| `to_direction_signal(state, today_date)` | 既存形式 `<state>,YYMMDD` 互換変換 |

### `scripts/price.py` の DD/FTD ロジック書き換え

- 通常DD: `pct_change <= -0.2 and volume > prev_volume` (原典準拠)
- FTD候補: `pct_change >= 1.0 and volume > prev_volume` (ラリーアテンプト Day 4 判定は market_state.py に移譲)
- 新フィールド `distribution_days_with_close` (date, close) タプル / `daily_history` を出力
- `direction_signal` は空文字デフォルト (`make_market_db.py` 側で State 計算後に上書き)

### `scripts/make_market_db.py` 結線

- `_update_index_market_state(prev_index_db, new_index_db)` を新設
- `update_market_db()` で全5指数 (TOPIX/マザーズ/日経225/NASDAQ/SP500) を統一処理
- 前日 state_meta を market_db から読み出し、新stateを計算して書き戻す
- HTML 表示用の CSS クラス 3種追加 (`.state-confirmed` 緑 / `.state-pressure` 黄 / `.state-correction` 赤)
- 後方互換: 旧 `signal-sell`/`signal-buy` のフォールバックも残す

### 状態遷移ルール

```
[market_in_correction] ─[FTD]→ [confirmed_uptrend]
[confirmed_uptrend] ─[有効DD ≥ 4]→ [uptrend_under_pressure]
[confirmed_uptrend] ─[有効DD ≥ 6]→ [market_in_correction]
[uptrend_under_pressure] ─[有効DD ≥ 6]→ [market_in_correction]
[uptrend_under_pressure] ─[有効DD < 4]→ [confirmed_uptrend] (復帰)
```

## 主要設計判断

- **Stalling Day はスコープ外**: 52週高値データが必要だが現行データ取得長 (Kabutan 1ページ ≈ 60日) では不足。データ拡張PRで追加
- **FTD ボラティリティ連動閾値はスコープ外**: 200日HV計算が必要、効果は限定的。固定 1.0% (IBD中央値) で運用継続
- **DD 失効の境界条件**: `daily_history` に DD 日が含まれない場合は失効扱い (古い DD が永続残留する問題を回避)
- **direction_signal**: 形式互換 (`<state>,YYMMDD`) を維持しつつ値を3状態に置換

## テスト

### 新規 (`tests/test_market_state.py` 33件)

- DD 失効: 直近維持 / 25日経過失効 / 5%上昇失効 / 履歴外失効
- ラリーアテンプト: Day 1 開始 / 安値割れリセット / 継続
- FTD 判定: Day 4 成立 / Day 3 早すぎ / 閾値未達 / 出来高減 / 安値割れ / ラリー無し
- 状態遷移: 初期判定 (DD<4/=4/≥6) / Correction→Confirmed (FTD) / Confirmed→Pressure / Confirmed→Correction / Pressure→Correction / Pressure→Confirmed (復帰)
- 状態履歴: 追加 / 30件キャップ / 同日置換 / None耐性

### 既存テスト更新

- `tests/test_price.py`: `direction_signal` 形式テスト (空文字デフォルト) / 新フィールドのテスト追加
- `tests/test_make_market_db.py`: 3状態CSS表示テスト追加

### 全テスト
- 関連テスト 300件以上 全パス
- `pytest tests/test_market_state.py tests/test_price.py tests/test_make_market_db.py tests/test_make_stock_db.py tests/test_functional_market.py tests/test_append_research_snapshots.py`

## 動作確認

実DBで `make_market_db.update_market_db()` を実行後、各指数の `market_state` を確認:

| 指数 | 有効DD | State | 旧シグナル → 新シグナル |
|---|---|---|---|
| TOPIX | 4 | `uptrend_under_pressure` | sell → uptrend_under_pressure |
| マザーズ指数 | 2 | `confirmed_uptrend` | neutral → confirmed_uptrend |
| 日経225 | 4 | `uptrend_under_pressure` | neutral → uptrend_under_pressure (新ロジックでDD≥4) |
| NASDAQ | 1 | `confirmed_uptrend` | neutral → confirmed_uptrend |
| S&P 500 | 3 | `confirmed_uptrend` | neutral → confirmed_uptrend |

WebApp `/market` を Playwright で目視確認:
- TOPIX/日経225 は黄色 (state-pressure) 表示
- マザーズ/NASDAQ/SP500 は緑 (state-confirmed) 表示

## Test plan

- [x] 単体テスト 33件パス + 既存回帰全パス
- [x] 実DBで `make_market_db.update_market_db()` 実行 → state計算確認
- [x] WebApp `/market` 目視確認 (Playwright)
- [ ] 翌日以降のcron実行で state 遷移が正しく永続化されること
- [ ] 後続: Part B (`make_signal()` シグナル連動)
- [ ] 後続: Part C (Minervini Breadth)
- [ ] 後続: データ拡張PR (Stalling Day / 200日HV)

## 関連 issue

- #117 (親 issue, Part B/C 残るため open 継続)
- #109/#110/#111 (個別シグナル改善 — issue #117 後追い予定)
- #148 (market.html 再設計 — Part 1 は PR #163 で完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)