### PR TITLE
issue #117 Part B: 市場セクション表示を State Machine と統合

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -68,9 +68,21 @@
 | `prev_theme_rank` | list[str] | 前日のモメンタム順位（日付変更時に自動退避） |
 | `theme_momentum` | dict[str, tuple] | テーマ別騰落率 `(平均%, 銘柄数)` |
 | `access_date_theme_rank` | datetime | テーマランク最終取得日時 |
-| `topix`, `mothers`, `nikkei225`, `nasdaq` | dict | 各指数のprice/RS/トレンドデータ |
-| `distribution_days` | list | ディストリビューション・デイ |
-| `direction_signal` | str | 市場方向シグナル |
+| `topix`, `mothers`, `nikkei225`, `nasdaq`, `sp500` | dict | 各指数のprice/RS/トレンド/State Machine データ |
+
+各指数 dict が持つ主要キー (issue #117 Part A/B):
+
+| キー | 型 | 内容 |
+|------|---|------|
+| `market_state` | str | `confirmed_uptrend` / `uptrend_under_pressure` / `market_in_correction` |
+| `state_meta` | dict | `distribution_days_with_close` (有効DD), `last_ftd_date`, `rally_attempt_*` |
+| `state_history` | list | 直近30件の `(date, state, trigger)` 履歴 |
+| `high52_weekly` | float | 週足52本の最高値 (Stalling Day判定で参照) |
+| `price_kairi_wma10` | float | 現在価格の10週MA乖離率% (10MA明確割れ判定で参照) |
+| `direction_signal` | str | 後方互換、`<state>,YYMMDD` 形式 |
+| `distribution_days`, `followthrough_days` | list | 後方互換 (表示は state_meta から生成) |
+
+詳細仕様は [doc/requirements/market_state_machine_requirements.md](requirements/market_state_machine_requirements.md) を参照。
 
 ## 株式データベース（shelveベース）
 

--- a/doc/plan_market_data_html.md
+++ b/doc/plan_market_data_html.md
@@ -1,5 +1,9 @@
 # market_data HTML出力機能の追加
 
+> **注**: 本文書は HTML 出力機能を導入した時点の設計プラン (履歴) です。
+> 市場テーブルの列構成や `direction_signal` の値は issue #117 Part A/B で大きく変更されています。
+> 現在の仕様は [doc/requirements/market_state_machine_requirements.md](requirements/market_state_machine_requirements.md) を参照してください。
+
 ## Context
 
 market_data.csv をGoogleスプレッドシートにアップロードして閲覧しているが、CSVの可読性が低い（色分けなし、リンクが`=HYPERLINK()`関数表示、全データがフラットに並ぶ）。ブラウザで開くだけで見やすいHTMLファイルを並行生成する。プロトタイプ（`/tmp/market_data_prototype.html`）の方向性はユーザー承認済み。

--- a/doc/requirements/market_state_machine_requirements.md
+++ b/doc/requirements/market_state_machine_requirements.md
@@ -1,8 +1,11 @@
-# Market State Machine 要件定義 (issue #117 Part A)
+# Market State Machine 要件定義 (issue #117 Part A / Part B)
 
 > 既存の市場方向シグナル (`scripts/price.py:266-351 _calc_daily_indicators()` 内のDD/FTD判定 + `direction_signal`) を、O'Neil/IBD原典に準拠した3状態の State Machine に置き換える。
 >
 > 関連 issue: #117
+>
+> **本書は Part A 着手時点の仕様 (本文) + Part B で確定した変更点 (末尾の Addendum セクション) を併記している。**
+> 現在の実装は Part A + Part B の両方を反映している。Part A 本文で「スコープ外」「未実装」とされたもののうち Part B で実装されたものは Addendum を参照すること。
 
 ---
 
@@ -336,6 +339,62 @@ CSSクラスは `make_market_db.py:605-` の市場テーブルCSSブロックに
 ## 11. 関連
 
 - 本要件は issue #117 の Part A の実装仕様を定義する
-- Part B: シグナル連動 (`make_signal()` 改修) — `direction_signal` または `market_state` を参照する別要件
+- Part B: 市場セクション表示の State Machine 整合 + Stalling Day + 週足10MA補助遷移 — Addendum 参照
 - Part C: Minervini Breadth (トレンドテンプレート通過銘柄数による市場健全性評価) — 別要件
-- 関連ドキュメント: `doc/ARCHITECTURE.md` の市場DB構造 (`market_state` 追加で更新が必要)
+- 関連ドキュメント: `doc/ARCHITECTURE.md` の市場DB構造
+
+---
+
+## Addendum: Part B 完了時点の変更点 (issue #117 PR #166)
+
+Part B 着手時に当初想定していた「`make_signal()` のタグ干渉」(`[ブ]` → `[ブ?]`/`[ブ!]`) は **破棄**。代わりに以下を実装した。
+
+### 実装した変更
+
+#### 表示の State Machine 整合 (`_html_market`)
+
+- 列構成: 「シグナル」→「**市場状態**」、「ディストリビューション」→「**DD**」、「フォロースルー」→「**FTD/ラリー**」、「トレンド」は指数向け簡略表記
+- DD列: `数 / 6` (危険水準との比率)、詳細日付はホバー、4-5は黄、6+は赤
+- FTD/ラリー列: `confirmed`/`pressure` 時は `last_ftd_date`、`correction` 時は「ラリー Day N」
+- 市場状態列: 日本語ラベル + 遷移日 `(M/D〜)`、CSS で3色表示
+- トレンド列 (指数のみ): `◎ 7/7` / `◯ 5/7` / `▲ 3/7` / `△ 0/7` 形式、不通過項目はホバー (title属性)
+- 売り圧力レシオ列の買い集め指数 A-E 評価を削除
+- マザーズ指数 → グロース250 (DBキー `mothers` は維持)
+
+#### Stalling Day 検出 (本文 §1, §8 で「Part A 不可」とされていた)
+
+- 週足計算で 52週高値 (`high52_weekly`) を保存
+- `make_db_common` / `_make_us_index_db` で日足計算後 + 週足計算後に `add_stalling_days()` を呼び、通常DDに追加検出
+- 判定条件: 52週高値の97%以上 + 微増 (0% < dr < 0.4%) + 出来高増 + 終値が日足の下半分
+- 通常DDと重複する日は除外
+- データ拡張PRを待たずに既存データで実装可能になった (週足52本 = 52週分が既に取得済)
+
+#### 週足10MA 補助遷移 (本文 §6 注で「データ拡張PR後」とされていた)
+
+- 週足10MA = 日足50MA とほぼ同義 (10週 ≈ 50営業日) なので、`price_kairi_wma10` を使って実装
+- 定数 `WEEKLY_10MA_BREAK_THRESHOLD = -1.0` (% を超える明確な割れを判定)
+- 純関数 `is_below_10ma_clearly(kairi)` を追加
+- `derive_state` に `below_10ma=False` 引数追加 (後方互換)、補助遷移ルール:
+  - `confirmed → correction`: DD ≥ 4 かつ 10MA明確割れ (correction優先)
+  - `confirmed → pressure`: DD < 4 でも 10MA明確割れ
+  - `pressure → confirmed`: DD < 4 **かつ** NOT 10MA明確割れ (10MA下なら復帰しない)
+  - `correction → confirmed`: FTD成立 (10MA関係なく現状維持)
+
+### 残スコープ外 (本文の §8 から変更なし or 当面保留)
+
+- ボラティリティ連動FTD閾値 (200日HV計算が必要、効果限定的、保留)
+- Minervini Breadth (Part C、別 issue で対応予定だが優先度低)
+- 過去期間バックテスト検証 (運用しながら確認)
+- 個別銘柄シグナルとの連動 (`[ブ?]`/`[ブ!]` 等) — 当初の Part B 案だが、ユーザー判断で**実装しない**ことに変更
+
+### 当初の本文との差分要約
+
+| 項目 | 本文 (Part A 時点) | Part B 完了後 |
+|---|---|---|
+| Stalling Day | スコープ外 | **実装済** |
+| 50日MA 状態遷移 | データ拡張PR後 | **週足10MAで代替実装済** |
+| 「シグナル」列の値 | 英文字 `<state>,YYMMDD` | 日本語ラベル + 遷移日 |
+| DD列の表示 | 日付列挙 `02/13, 02/20, ...` | `2 / 6` 形式 + ホバー詳細 |
+| FTD列の表示 | 強い陽線リスト | 真のFTD or ラリー Day N |
+| マザーズ指数表記 | 「マザーズ指数」 | 「グロース250」 |
+| `make_signal()` 連動 (Part B) | 当初: タグ干渉案 | **実装しない** (市場表示精度向上に振り替え) |

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -312,6 +312,11 @@ def make_db_common(code_s):
     pricew_dict = price.get_weekly_price_data(code_s, upd=UPD_INTERVAL, prices=[pr, pr, pr])
     log_print("RS_RAW=", pricew_dict.get("rs_raw", 0))
     db.update(pricew_dict)
+    # Stalling Day 後付け検出 (issue #117 Part B): 週足の high52_weekly を使う
+    high52 = db.get("high52_weekly")
+    raw = db.pop("_daily_price_list_raw", None)
+    if high52 and raw:
+        price.add_stalling_days(db, raw, high52)
     return db
 
 
@@ -358,6 +363,11 @@ def _make_us_index_db(code_s, ticker_symbol, key):
     )
     log_print("RS_RAW=", weekly_dict.get("rs_raw", 0))
     db_dict.update(weekly_dict)
+    # Stalling Day 後付け検出 (issue #117 Part B)
+    high52 = db_dict.get("high52_weekly")
+    raw = db_dict.pop("_daily_price_list_raw", None)
+    if high52 and raw:
+        price.add_stalling_days(db_dict, raw, high52)
     return {key: db_dict}
 
 
@@ -943,7 +953,7 @@ def _html_market(market_db):
             db = market_db[db_name]
             # 指数向けに trend_template の RS 基準を補正してから表示文字列を作る (issue #148 Part 1)
             adjusted_db = _adjust_index_trend_template(db)
-            trend_expr = make_stock_db.get_trend_template_expr(adjusted_db)
+            trend_expr, trend_misses = make_stock_db.get_index_trend_template_expr(adjusted_db)
 
             # State Machine と整合した DD/FTD/状態表示 (Part B)
             state_meta = db.get("state_meta", {}) or {}
@@ -987,10 +997,12 @@ def _html_market(market_db):
             state_css = market_state.STATE_CSS_CLASS.get(state, "")
             state_class = ' class="%s"' % state_css if state_css else ""
 
-            # トレンドのCSSクラス
+            # トレンドのCSSクラス + 不通過項目を title 属性 (ホバー詳細)
             trend_class = ""
             if trend_expr.startswith("◯") or trend_expr.startswith("◎"):
                 trend_class = ' class="trend-good"'
+            trend_title = (' title="不通過: %s"' % html_mod.escape(trend_misses)
+                           if trend_misses else "")
 
             rs_raw = db.get("rs_raw", "")
             rs_class = _rs_class(rs_raw)
@@ -999,7 +1011,7 @@ def _html_market(market_db):
                 '<tr>\n'
                 '  <td><strong>%s</strong></td>\n'
                 '  <td%s>%s</td>\n'
-                '  <td%s>%s</td>\n'
+                '  <td%s%s>%s</td>\n'
                 '  <td%s%s>%s</td>\n'
                 '  <td>%s</td>\n'
                 '  <td%s>%s</td>\n'
@@ -1008,7 +1020,7 @@ def _html_market(market_db):
                 '</tr>' % (
                     html_mod.escape(market_name),
                     rs_class, rs_raw,
-                    trend_class, html_mod.escape(str(trend_expr)),
+                    trend_class, trend_title, html_mod.escape(str(trend_expr)),
                     dd_class, dd_title, html_mod.escape(dd_display),
                     html_mod.escape(ftd_rally_display),
                     state_class, html_mod.escape(state_display),

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -493,11 +493,15 @@ def _update_index_market_state(prev_index_db, new_index_db):
                 today_dict, prev_dict, rally_meta, daily_history,
             )
 
-    # 6. 状態遷移
+    # 6. 状態遷移 (DD/FTD + 週足10MA明確割れ補助ルール、issue #117 Part B)
+    below_10ma = market_state.is_below_10ma_clearly(
+        new_index_db.get("price_kairi_wma10")
+    )
     new_state, trigger = market_state.derive_state(
         prev_state=prev_state,
         valid_dd_count=len(valid_dd),
         ftd_today=ftd_today,
+        below_10ma=below_10ma,
     )
 
     # 7. state_history 更新

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -733,6 +733,9 @@ tr:hover { background: #f5f5f5; }
 .state-confirmed { background: #eafaf1; color: #27ae60; font-weight: bold; }
 .state-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
 .state-correction { background: #fdedec; color: #c0392b; font-weight: bold; }
+/* DD 進行度の警告色 (issue #117 Part B) */
+.dd-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
+.dd-correction { background: #fdedec; color: #c0392b; font-weight: bold; }
 
 /* 決算 */
 .kessan-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
@@ -922,9 +925,11 @@ def _html_market(market_db):
     Returns:
         str: 市場セクションのHTML文字列
     """
+    import market_state
+
     markets = [
         ("topix", "TOPIX"),
-        ("mothers", "マザーズ指数"),
+        ("mothers", "グロース250"),
         ("nikkei225", "日経225"),
         ("nasdaq", "NASDAQ"),
         ("sp500", "S&P 500"),
@@ -939,27 +944,48 @@ def _html_market(market_db):
             # 指数向けに trend_template の RS 基準を補正してから表示文字列を作る (issue #148 Part 1)
             adjusted_db = _adjust_index_trend_template(db)
             trend_expr = make_stock_db.get_trend_template_expr(adjusted_db)
-            distribution_days = ", ".join([s[3:] for s in db.get("distribution_days", [])])
-            followthrough_days = ", ".join([s[3:] for s in db.get("followthrough_days", [])])
-            signal = db.get("direction_signal", "")
-            diff = db.get("spr_buygagher", 0) - db.get("spr_20", 0)
-            spr_eval = step_func(diff, [-10, -5, 0, 5, 10], ["E", "D", "C", "B", "A"])
 
-            # シグナルのCSSクラス (issue #117 Part A: market_state ベース)
-            # signal の値は "<state>,YYMMDD" 形式 (例: "confirmed_uptrend,26/04/30")
-            signal_str = str(signal).lower()
-            signal_class = ""
-            if "market_in_correction" in signal_str:
-                signal_class = ' class="state-correction"'
-            elif "uptrend_under_pressure" in signal_str:
-                signal_class = ' class="state-pressure"'
-            elif "confirmed_uptrend" in signal_str:
-                signal_class = ' class="state-confirmed"'
-            # 後方互換: 旧 sell/buy にもフォールバック
-            elif "sell" in signal_str:
-                signal_class = ' class="signal-sell"'
-            elif "buy" in signal_str:
-                signal_class = ' class="signal-buy"'
+            # State Machine と整合した DD/FTD/状態表示 (Part B)
+            state_meta = db.get("state_meta", {}) or {}
+            state_history = db.get("state_history", []) or []
+            state = db.get("market_state", "")
+
+            # DD列: 有効DD数 / 危険水準 (例: "3 / 6"、6以上は "6+ / 6")
+            # 状態でセル色を切替: pressure=黄、correction=赤
+            dd_with_close = state_meta.get("distribution_days_with_close", []) or []
+            dd_count = len(dd_with_close)
+            dd_threshold = market_state.DD_THRESHOLD_TO_CORRECTION
+            if dd_count >= dd_threshold:
+                dd_display = "%d+ / %d" % (dd_threshold, dd_threshold)
+            else:
+                dd_display = "%d / %d" % (dd_count, dd_threshold)
+            dd_dates = ", ".join([d[0][3:] for d in dd_with_close if d and len(d) >= 1])
+            dd_title = ' title="%s"' % html_mod.escape(dd_dates) if dd_dates else ""
+            dd_class = ""
+            if dd_count >= market_state.DD_THRESHOLD_TO_CORRECTION:
+                dd_class = ' class="dd-correction"'
+            elif dd_count >= market_state.DD_THRESHOLD_TO_PRESSURE:
+                dd_class = ' class="dd-pressure"'
+
+            # FTD/ラリー列: correction中はラリー Day N、それ以外は直近FTD日
+            if state == market_state.MARKET_IN_CORRECTION:
+                rally_start = state_meta.get("rally_attempt_start_date")
+                daily_history = db.get("daily_history", []) or []
+                day_n = market_state.calc_rally_day(rally_start, daily_history)
+                ftd_rally_display = "ラリー Day %d" % day_n if day_n else "—"
+            else:
+                last_ftd = state_meta.get("last_ftd_date")
+                ftd_rally_display = last_ftd[3:] if last_ftd else "—"
+
+            # 市場状態: 日本語ラベル + 遷移日
+            state_label = market_state.format_state_label(state)
+            trans_date = market_state.find_state_transition_date(state_history, state)
+            if state_label and trans_date:
+                state_display = "%s (%s〜)" % (state_label, trans_date[3:])
+            else:
+                state_display = state_label
+            state_css = market_state.STATE_CSS_CLASS.get(state, "")
+            state_class = ' class="%s"' % state_css if state_css else ""
 
             # トレンドのCSSクラス
             trend_class = ""
@@ -974,19 +1000,19 @@ def _html_market(market_db):
                 '  <td><strong>%s</strong></td>\n'
                 '  <td%s>%s</td>\n'
                 '  <td%s>%s</td>\n'
-                '  <td>%s</td>\n'
+                '  <td%s%s>%s</td>\n'
                 '  <td>%s</td>\n'
                 '  <td%s>%s</td>\n'
-                '  <td>%d, %d, <strong>%s</strong></td>\n'
+                '  <td>%d, %d</td>\n'
                 '  <td>%.1f, %.1f</td>\n'
                 '</tr>' % (
                     html_mod.escape(market_name),
                     rs_class, rs_raw,
                     trend_class, html_mod.escape(str(trend_expr)),
-                    html_mod.escape(distribution_days),
-                    html_mod.escape(followthrough_days),
-                    signal_class, html_mod.escape(str(signal)),
-                    db.get("spr_20", 0), db.get("spr_5", 0), spr_eval,
+                    dd_class, dd_title, html_mod.escape(dd_display),
+                    html_mod.escape(ftd_rally_display),
+                    state_class, html_mod.escape(state_display),
+                    db.get("spr_20", 0), db.get("spr_5", 0),
                     db.get("rv_20", 0.0), db.get("rv_5", 0.0),
                 )
             )
@@ -1001,8 +1027,8 @@ def _html_market(market_db):
         '<table class="market-table">\n'
         '<thead><tr>\n'
         '  <th>市場名</th><th>RS</th><th>トレンド</th>\n'
-        '  <th>ディストリビューション</th><th>フォロースルー</th>\n'
-        '  <th>シグナル</th><th>売り圧力レシオ (20,5)</th><th>ボラティリティ (20,5)</th>\n'
+        '  <th>DD</th><th>FTD/ラリー</th>\n'
+        '  <th>市場状態</th><th>売り圧力レシオ (20,5)</th><th>ボラティリティ (20,5)</th>\n'
         '</tr></thead>\n'
         '<tbody>'
     )

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -312,7 +312,7 @@ def make_db_common(code_s):
     pricew_dict = price.get_weekly_price_data(code_s, upd=UPD_INTERVAL, prices=[pr, pr, pr])
     log_print("RS_RAW=", pricew_dict.get("rs_raw", 0))
     db.update(pricew_dict)
-    # Stalling Day 後付け検出 (issue #117 Part B): 週足の high52_weekly を使う
+    # Stalling Day は週足の high52_weekly を使うため、週足計算後に後付け検出
     high52 = db.get("high52_weekly")
     raw = db.pop("_daily_price_list_raw", None)
     if high52 and raw:
@@ -363,7 +363,6 @@ def _make_us_index_db(code_s, ticker_symbol, key):
     )
     log_print("RS_RAW=", weekly_dict.get("rs_raw", 0))
     db_dict.update(weekly_dict)
-    # Stalling Day 後付け検出 (issue #117 Part B)
     high52 = db_dict.get("high52_weekly")
     raw = db_dict.pop("_daily_price_list_raw", None)
     if high52 and raw:
@@ -411,8 +410,8 @@ def _save_market_db(market_db):
 def _update_index_market_state(prev_index_db, new_index_db):
     """指数 dict に market_state / state_meta / state_history / direction_signal を計算して書き込む。
 
-    issue #117 Part A: 前日 state_meta を引き継ぎ、当日の DD/FTD 候補から
-    market_state.py の純関数群で新state を導出する。
+    前日 state_meta を引き継ぎ、当日の DD/FTD 候補から market_state.py の純関数群で
+    新state を導出する。
 
     Args:
         prev_index_db: 前日の market_db[index_name] dict (なければ {})
@@ -493,7 +492,7 @@ def _update_index_market_state(prev_index_db, new_index_db):
                 today_dict, prev_dict, rally_meta, daily_history,
             )
 
-    # 6. 状態遷移 (DD/FTD + 週足10MA明確割れ補助ルール、issue #117 Part B)
+    # 6. 状態遷移 (DD/FTD + 週足10MA明確割れ補助ルール)
     below_10ma = market_state.is_below_10ma_clearly(
         new_index_db.get("price_kairi_wma10")
     )
@@ -558,7 +557,6 @@ def update_market_db():
         new_data = maker()  # {index_name: {...}}
         new_index_db = new_data.get(index_name, {})
         if new_index_db:
-            # 市場状態の計算 (issue #117 Part A)
             try:
                 _update_index_market_state(prev_index_db, new_index_db)
             except Exception as e:
@@ -743,11 +741,11 @@ tr:hover { background: #f5f5f5; }
 .trend-good { color: #27ae60; font-weight: bold; }
 .rs-strong { color: #27ae60; font-weight: bold; }
 .rs-weak { color: #c0392b; font-weight: bold; }
-/* market_state (issue #117 Part A) */
+/* market_state */
 .state-confirmed { background: #eafaf1; color: #27ae60; font-weight: bold; }
 .state-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
 .state-correction { background: #fdedec; color: #c0392b; font-weight: bold; }
-/* DD 進行度の警告色 (issue #117 Part B) */
+/* DD 進行度の警告色 */
 .dd-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
 .dd-correction { background: #fdedec; color: #c0392b; font-weight: bold; }
 
@@ -959,7 +957,7 @@ def _html_market(market_db):
             adjusted_db = _adjust_index_trend_template(db)
             trend_expr, trend_misses = make_stock_db.get_index_trend_template_expr(adjusted_db)
 
-            # State Machine と整合した DD/FTD/状態表示 (Part B)
+            # State Machine と整合した DD/FTD/状態表示
             state_meta = db.get("state_meta", {}) or {}
             state_history = db.get("state_history", []) or []
             state = db.get("market_state", "")

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -800,7 +800,7 @@ def get_trend_template_expr(stock):
 
 
 def get_index_trend_template_expr(stock):
-    """指数向けトレンドテンプレート簡略表記 (issue #117 Part B)
+    """指数向けトレンドテンプレート簡略表記。
 
     個別銘柄向け get_trend_template_expr と異なり、
     通過率を分数で示し詳細はホバー (title属性) に逃がす。

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -799,6 +799,31 @@ def get_trend_template_expr(stock):
     return ""
 
 
+def get_index_trend_template_expr(stock):
+    """指数向けトレンドテンプレート簡略表記 (issue #117 Part B)
+
+    個別銘柄向け get_trend_template_expr と異なり、
+    通過率を分数で示し詳細はホバー (title属性) に逃がす。
+
+    Returns:
+        tuple: (display_str, miss_str) — display は "◎ 7/7" 等、
+               miss_str は不通過項目をカンマ区切り (空なら "")
+    """
+    if "trend_template" not in stock:
+        return ("-", "")
+    misses = stock["trend_template"]
+    miss_count = len(misses)
+    pass_count = 7 - miss_count
+    miss_str = ",".join(misses) if misses else ""
+    if miss_count == 0:
+        return ("◎ %d/7" % pass_count, miss_str)
+    if miss_count <= 2:
+        return ("◯ %d/7" % pass_count, miss_str)
+    if miss_count <= 4:
+        return ("▲ %d/7" % pass_count, miss_str)
+    return ("△ %d/7" % pass_count, miss_str)
+
+
 def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
     """銘柄DBデータから、シグナル情報を作成する。
 

--- a/scripts/market_state.py
+++ b/scripts/market_state.py
@@ -37,6 +37,11 @@ DD_THRESHOLD_TO_CONFIRMED_FROM_PRESSURE = 4  # pressure → confirmed: DD < 4 �
 FTD_GAIN_THRESHOLD = 1.0  # %、ラリー Day 4 以降の最低上昇率
 FTD_MIN_DAYS_FROM_RALLY_START = 3  # Day 1 から3取引日後 = Day 4
 
+# 週足10MA 補助遷移 (issue #117 Part B)
+# 週足10MA = 日足50MA とほぼ同義 (10週 ≈ 50営業日)。指数価格の中期トレンド維持を補助判定する。
+# 単純な < 0 ではノイズに反応するため、明確に下回る水準として -1% を採用。
+WEEKLY_10MA_BREAK_THRESHOLD = -1.0  # %、price_kairi_wma10 がこれ以下なら明確割れ
+
 # state_history 保持件数
 STATE_HISTORY_MAX = 30
 
@@ -180,10 +185,27 @@ def check_follow_through_day(today, prev, rally_meta, daily_history):
 # ==================================================
 # 状態遷移
 # ==================================================
-def derive_state(prev_state, valid_dd_count, ftd_today):
-    """前日 state と当日の DD 数 / FTD成立から、新 state を計算する (純関数)。
+def is_below_10ma_clearly(kairi):
+    """price_kairi_wma10 から「10週MA明確割れ」を判定する純関数 (issue #117 Part B)。
 
-    遷移ルール:
+    Args:
+        kairi: price_kairi_wma10 (10週MAとの乖離率%)。None や数値以外の場合は False
+
+    Returns:
+        bool: kairi <= WEEKLY_10MA_BREAK_THRESHOLD (= -1.0%) なら True
+    """
+    if kairi is None:
+        return False
+    try:
+        return float(kairi) <= WEEKLY_10MA_BREAK_THRESHOLD
+    except (TypeError, ValueError):
+        return False
+
+
+def derive_state(prev_state, valid_dd_count, ftd_today, below_10ma=False):
+    """前日 state と当日の DD 数 / FTD成立 / 10MA割れから、新 state を計算する (純関数)。
+
+    遷移ルール (DD/FTD ベース):
     - market_in_correction → confirmed_uptrend: FTD成立
     - confirmed_uptrend → uptrend_under_pressure: 有効DD ≥ 4 (かつ < 6)
     - confirmed_uptrend → market_in_correction: 有効DD ≥ 6
@@ -191,16 +213,22 @@ def derive_state(prev_state, valid_dd_count, ftd_today):
     - uptrend_under_pressure → confirmed_uptrend: 有効DD < 4
     - それ以外: 状態維持
 
+    補助ルール (issue #117 Part B、週足10MA明確割れ = price_kairi_wma10 <= -1%):
+    - confirmed_uptrend → market_in_correction: DD ≥ 4 かつ 10MA明確割れ (correction優先)
+    - confirmed_uptrend → uptrend_under_pressure: DD < 4 でも 10MA明確割れ
+    - uptrend_under_pressure → confirmed_uptrend: DD < 4 かつ NOT 10MA明確割れ
+
     Args:
         prev_state: 前日の state (None の場合は初期判定)
         valid_dd_count: 有効DD数
         ftd_today: bool 当日 FTD 成立か
+        below_10ma: bool 週足10MA明確割れ (is_below_10ma_clearly の結果を渡す)
 
     Returns:
         tuple: (new_state, trigger_reason)
-            trigger_reason: 遷移理由文字列 ("ftd" / "dd>=4" / "dd>=6" / "dd<4_recover" / "init" / "stay")
     """
     # 初回 (prev_state なし) は遷移ルールと同じ閾値で判定
+    # 補助ルールは初回判定では使わない (履歴がないため安全側)
     if prev_state is None or prev_state not in ALL_STATES:
         if valid_dd_count >= DD_THRESHOLD_TO_CORRECTION:
             return MARKET_IN_CORRECTION, "init"
@@ -214,16 +242,21 @@ def derive_state(prev_state, valid_dd_count, ftd_today):
         return MARKET_IN_CORRECTION, "stay"
 
     if prev_state == CONFIRMED_UPTREND:
+        # correction を優先評価 (より厳しい状態を優先)
         if valid_dd_count >= DD_THRESHOLD_TO_CORRECTION:
             return MARKET_IN_CORRECTION, "dd>=6"
+        if valid_dd_count >= DD_THRESHOLD_TO_PRESSURE and below_10ma:
+            return MARKET_IN_CORRECTION, "dd>=4_and_below_10ma"
         if valid_dd_count >= DD_THRESHOLD_TO_PRESSURE:
             return UPTREND_UNDER_PRESSURE, "dd>=4"
+        if below_10ma:
+            return UPTREND_UNDER_PRESSURE, "below_10ma"
         return CONFIRMED_UPTREND, "stay"
 
     if prev_state == UPTREND_UNDER_PRESSURE:
         if valid_dd_count >= DD_THRESHOLD_TO_CORRECTION:
             return MARKET_IN_CORRECTION, "dd>=6"
-        if valid_dd_count < DD_THRESHOLD_TO_CONFIRMED_FROM_PRESSURE:
+        if valid_dd_count < DD_THRESHOLD_TO_CONFIRMED_FROM_PRESSURE and not below_10ma:
             return CONFIRMED_UPTREND, "dd<4_recover"
         return UPTREND_UNDER_PRESSURE, "stay"
 

--- a/scripts/market_state.py
+++ b/scripts/market_state.py
@@ -37,7 +37,6 @@ DD_THRESHOLD_TO_CONFIRMED_FROM_PRESSURE = 4  # pressure → confirmed: DD < 4 �
 FTD_GAIN_THRESHOLD = 1.0  # %、ラリー Day 4 以降の最低上昇率
 FTD_MIN_DAYS_FROM_RALLY_START = 3  # Day 1 から3取引日後 = Day 4
 
-# 週足10MA 補助遷移 (issue #117 Part B)
 # 週足10MA = 日足50MA とほぼ同義 (10週 ≈ 50営業日)。指数価格の中期トレンド維持を補助判定する。
 # 単純な < 0 ではノイズに反応するため、明確に下回る水準として -1% を採用。
 WEEKLY_10MA_BREAK_THRESHOLD = -1.0  # %、price_kairi_wma10 がこれ以下なら明確割れ
@@ -186,7 +185,7 @@ def check_follow_through_day(today, prev, rally_meta, daily_history):
 # 状態遷移
 # ==================================================
 def is_below_10ma_clearly(kairi):
-    """price_kairi_wma10 から「10週MA明確割れ」を判定する純関数 (issue #117 Part B)。
+    """price_kairi_wma10 から「10週MA明確割れ」を判定する純関数。
 
     Args:
         kairi: price_kairi_wma10 (10週MAとの乖離率%)。None や数値以外の場合は False
@@ -213,7 +212,7 @@ def derive_state(prev_state, valid_dd_count, ftd_today, below_10ma=False):
     - uptrend_under_pressure → confirmed_uptrend: 有効DD < 4
     - それ以外: 状態維持
 
-    補助ルール (issue #117 Part B、週足10MA明確割れ = price_kairi_wma10 <= -1%):
+    補助ルール (週足10MA明確割れ = price_kairi_wma10 <= -1%):
     - confirmed_uptrend → market_in_correction: DD ≥ 4 かつ 10MA明確割れ (correction優先)
     - confirmed_uptrend → uptrend_under_pressure: DD < 4 でも 10MA明確割れ
     - uptrend_under_pressure → confirmed_uptrend: DD < 4 かつ NOT 10MA明確割れ
@@ -226,6 +225,8 @@ def derive_state(prev_state, valid_dd_count, ftd_today, below_10ma=False):
 
     Returns:
         tuple: (new_state, trigger_reason)
+            trigger_reason は "ftd" / "dd>=4" / "dd>=6" / "dd>=4_and_below_10ma" /
+            "below_10ma" / "dd<4_recover" / "init" / "stay"
     """
     # 初回 (prev_state なし) は遷移ルールと同じ閾値で判定
     # 補助ルールは初回判定では使わない (履歴がないため安全側)
@@ -298,7 +299,7 @@ def to_direction_signal(state, today_date):
 
 
 # ==================================================
-# 表示用ヘルパー (issue #117 Part B)
+# 表示用ヘルパー
 # ==================================================
 STATE_LABEL = {
     CONFIRMED_UPTREND: "上昇トレンド",

--- a/scripts/market_state.py
+++ b/scripts/market_state.py
@@ -262,3 +262,99 @@ def to_direction_signal(state, today_date):
     既存形式 "<value>,YYMMDD" を継続、value のみ変更。
     """
     return "%s,%s" % (state, today_date)
+
+
+# ==================================================
+# 表示用ヘルパー (issue #117 Part B)
+# ==================================================
+STATE_LABEL = {
+    CONFIRMED_UPTREND: "上昇トレンド",
+    UPTREND_UNDER_PRESSURE: "圧力下",
+    MARKET_IN_CORRECTION: "調整相場",
+}
+
+STATE_CSS_CLASS = {
+    CONFIRMED_UPTREND: "state-confirmed",
+    UPTREND_UNDER_PRESSURE: "state-pressure",
+    MARKET_IN_CORRECTION: "state-correction",
+}
+
+
+def format_state_label(state):
+    """state 値を日本語ラベルに変換する。未知の値は元値を返す。"""
+    if state is None:
+        return ""
+    return STATE_LABEL.get(state, state)
+
+
+def find_state_transition_date(state_history, current_state):
+    """state_history (新しい順) から current_state が続いている最初の日付を返す。
+
+    遷移日 = 過去にさかのぼって current_state が連続する最も古い日。
+
+    Args:
+        state_history: [(date, state, trigger), ...] (新しい日が先頭)
+        current_state: 現在の state
+
+    Returns:
+        str | None: 遷移日。current_state エントリが無い・空履歴は None
+    """
+    if not state_history or current_state is None:
+        return None
+    transition_date = None
+    for entry in state_history:
+        if not entry or len(entry) < 2:
+            break
+        date_str, state = entry[0], entry[1]
+        if state == current_state:
+            transition_date = date_str
+        else:
+            break
+    return transition_date
+
+
+def extract_ftd_history(state_history, max_count=3):
+    """state_history から trigger=='ftd' のエントリ日付を新しい順に返す。
+
+    Args:
+        state_history: [(date, state, trigger), ...] (新しい日が先頭)
+        max_count: 最大件数
+
+    Returns:
+        list[str]: FTD成立日の日付リスト
+    """
+    if not state_history:
+        return []
+    result = []
+    for entry in state_history:
+        if not entry or len(entry) < 3:
+            continue
+        if entry[2] == "ftd":
+            result.append(entry[0])
+            if len(result) >= max_count:
+                break
+    return result
+
+
+def calc_rally_day(rally_start_date, daily_history):
+    """ラリーアテンプト開始日から当日までの取引日数 (Day N) を返す。
+
+    correction 状態でラリーアテンプトが追跡されているとき、
+    Day 1 = ラリー開始日、Day 4 以降が FTD 判定対象になる。
+
+    Args:
+        rally_start_date: state_meta.rally_attempt_start_date (str | None)
+        daily_history: [date_str, ...] 新しい日が先頭
+
+    Returns:
+        int | None: Day N (1始まり)。ラリー未開始または日付不一致なら None
+    """
+    if not rally_start_date or not daily_history:
+        return None
+    try:
+        start_idx = daily_history.index(rally_start_date)
+    except ValueError:
+        return None
+    # daily_history は新しい日が先頭、当日は index 0
+    # start_idx は当日から見て start_idx 日前 → Day = start_idx + 1
+    return start_idx + 1

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -260,7 +260,89 @@ def parse_price_d_html_kabutan(html):
     ):
         daily_price_list.append(m.groups())
 
-    return _calc_daily_indicators(daily_price_list)
+    dic = _calc_daily_indicators(daily_price_list)
+    # Stalling Day を後付け検出するため raw データを内部的に保持 (Part B)
+    if dic:
+        dic["_daily_price_list_raw"] = daily_price_list
+    return dic
+
+
+def _is_stalling_day(d, pd, high52_weekly):
+    """Stalling Day (停滞日) 判定 (O'Neil 原典準拠 / issue #117 Part B)
+
+    条件 (すべて満たす):
+    - 52週高値の97%以上 (高値圏)
+    - 前日比が 0% 超 ~ +0.4% 未満 (微増)
+    - 出来高が前日より増加
+    - 終値が日足の下半分 (高値から引けが離れた)
+
+    Args:
+        d: 当日 8要素タプル (日付, 始値, 高値, 安値, 終値, 前日比, 前日比%, 売買高)
+        pd: 前日 8要素タプル
+        high52_weekly: 52週高値 (週足から計算済)
+    Returns:
+        bool: Stalling Day なら True
+    """
+    if not high52_weekly or high52_weekly <= 0:
+        return False
+    try:
+        dh = float(d[2].replace(",", ""))
+        dl = float(d[3].replace(",", ""))
+        dp = float(d[4].replace(",", ""))
+        dv = int(d[7].replace(",", ""))
+        pdv = int(pd[7].replace(",", ""))
+        dr = float(d[6].replace(",", ""))
+    except (ValueError, IndexError):
+        return False
+    if dp < high52_weekly * 0.97:
+        return False
+    if not (0 < dr < 0.4):
+        return False
+    if dv <= pdv:
+        return False
+    if dh <= dl:
+        return False
+    return dp <= dl + (dh - dl) / 2
+
+
+def add_stalling_days(dic, daily_price_list, high52_weekly):
+    """既存の日次指標 dict に Stalling Day を追加検出する (issue #117 Part B)
+
+    `_calc_daily_indicators` で計算した distribution_days* の結果に、
+    Stalling Day を後付けで追加する。通常DDと重複しない日のみ追加。
+    日付順序は古い→新しい (元々の append 順) を保つ。
+
+    Args:
+        dic: _calc_daily_indicators の戻り値 dict
+        daily_price_list: 元の日次価格リスト (新しい日が先頭)
+        high52_weekly: 52週高値 (週足計算後に取得可能になる)
+    Returns:
+        dict: 同じ dict (in-place 更新)
+    """
+    if not high52_weekly or not daily_price_list or not dic:
+        return dic
+    count_day = 20
+    target_days = list(reversed(daily_price_list[: count_day + 1]))
+    if len(target_days) < 2:
+        return dic
+    existing_dd = set(dic.get("distribution_days", []))
+    new_dd_dates = list(dic.get("distribution_days", []))
+    new_dd_with_close = list(dic.get("distribution_days_with_close", []))
+    for d, pd in zip(target_days[1:], target_days[:-1]):
+        if d[0] in existing_dd:
+            continue  # 既に通常DDとして計上されている
+        if _is_stalling_day(d, pd, high52_weekly):
+            try:
+                dp = float(d[4].replace(",", ""))
+            except ValueError:
+                continue
+            new_dd_dates.append(d[0])
+            new_dd_with_close.append((d[0], dp))
+            existing_dd.add(d[0])
+            log_debug("Stalling Day:", d[0])
+    dic["distribution_days"] = new_dd_dates
+    dic["distribution_days_with_close"] = new_dd_with_close
+    return dic
 
 
 def _calc_daily_indicators(daily_price_list):
@@ -273,10 +355,11 @@ def _calc_daily_indicators(daily_price_list):
     - FTD候補: 前日比 +1.0% 以上 + 出来高が前日より増加
       (ラリーアテンプト Day 4 以降の判定は market_state.py 側で行うため、ここでは候補日のみ拾う)
 
+    Stalling Day は週足の high52_weekly が必要なため、本関数では検出せず
+    `add_stalling_days()` を呼び出し側で別途実行する (Part B)。
+
     direction_signal の最終値は make_market_db.py が market_state を計算してから上書きする。
     本関数では空文字をデフォルトとして入れておく (フィールド自体は後方互換で維持)。
-
-    Stalling Day はデータ拡張PRで対応 (52週高値が必要)。
 
     Args:
         daily_price_list: 8要素タプル(文字列)のリスト
@@ -502,6 +585,14 @@ def _calc_weekly_indicators(weekly_price_list, cur_prices=[]):
     rs_rank = calc_momentum_pt()
     if rs_rank > 0:  # 0はエラーのため更新しない
         price_dict["momentum_pt"] = rs_rank
+
+    # ---- 52週高値/安値 (Stalling Day 判定で日足側からも参照する)
+    try:
+        if highs and lows:
+            price_dict["high52_weekly"] = max(highs[0:52])
+            price_dict["low52_weekly"] = min(lows[0:52])
+    except (ValueError, IndexError):
+        pass
 
     # ---- トレンドテンプレート
     def calc_trend_template():
@@ -951,6 +1042,7 @@ def get_us_index_daily(code_s, ticker_symbol, upd=UPD_INTERVAL):
                     dic["access_date_price"] = datetime.fromtimestamp(
                         os.stat(cache_fname).st_mtime
                     )
+                    dic["_daily_price_list_raw"] = daily_price_list
                 return dic
 
     log_print("----> %sの日次価格情報をyfinance(%s)から取得します" % (code_s, ticker_symbol))
@@ -990,6 +1082,7 @@ def get_us_index_daily(code_s, ticker_symbol, upd=UPD_INTERVAL):
         latest_close = 0
     dic["price"] = latest_close
     dic["access_date_price"] = datetime.now()
+    dic["_daily_price_list_raw"] = daily_price_list
 
     # キャッシュに保存
     _save_yfinance_cache(cache_fname, latest_close, daily_price_list)

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -261,14 +261,14 @@ def parse_price_d_html_kabutan(html):
         daily_price_list.append(m.groups())
 
     dic = _calc_daily_indicators(daily_price_list)
-    # Stalling Day を後付け検出するため raw データを内部的に保持 (Part B)
+    # Stalling Day を後付け検出するため raw データを内部的に保持
     if dic:
         dic["_daily_price_list_raw"] = daily_price_list
     return dic
 
 
 def _is_stalling_day(d, pd, high52_weekly):
-    """Stalling Day (停滞日) 判定 (O'Neil 原典準拠 / issue #117 Part B)
+    """Stalling Day (停滞日) 判定 (O'Neil 原典準拠)
 
     条件 (すべて満たす):
     - 52週高値の97%以上 (高値圏)
@@ -306,7 +306,7 @@ def _is_stalling_day(d, pd, high52_weekly):
 
 
 def add_stalling_days(dic, daily_price_list, high52_weekly):
-    """既存の日次指標 dict に Stalling Day を追加検出する (issue #117 Part B)
+    """既存の日次指標 dict に Stalling Day を追加検出する。
 
     `_calc_daily_indicators` で計算した distribution_days* の結果に、
     Stalling Day を後付けで追加する。通常DDと重複しない日のみ追加。
@@ -350,13 +350,13 @@ def _calc_daily_indicators(daily_price_list):
     parse_price_d_html_kabutanから指標計算部分を分離。
     Kabutan HTML パスと yfinance パス共通で使用する。
 
-    DD/FTD 判定は O'Neil 原典準拠 (issue #117 Part A):
+    DD/FTD 判定は O'Neil 原典準拠:
     - 通常DD: 前日比 -0.2% 以下 + 出来高が前日より増加
     - FTD候補: 前日比 +1.0% 以上 + 出来高が前日より増加
       (ラリーアテンプト Day 4 以降の判定は market_state.py 側で行うため、ここでは候補日のみ拾う)
 
     Stalling Day は週足の high52_weekly が必要なため、本関数では検出せず
-    `add_stalling_days()` を呼び出し側で別途実行する (Part B)。
+    `add_stalling_days()` を呼び出し側で別途実行する。
 
     direction_signal の最終値は make_market_db.py が market_state を計算してから上書きする。
     本関数では空文字をデフォルトとして入れておく (フィールド自体は後方互換で維持)。

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -350,14 +350,27 @@ class TestHtmlMarket:
     """市場指標HTML生成テスト"""
 
     def _make_market_db(self):
-        """テスト用market_db"""
+        """テスト用market_db (Part B: state_meta / state_history を保持)"""
         return {
             "topix": {
                 "rs_raw": 1.18,
                 "trend_template": [],  # 空リスト=◎
+                "market_state": "uptrend_under_pressure",
+                "state_meta": {
+                    "distribution_days_with_close": [
+                        ("26/02/13", 2700.0),
+                        ("26/02/20", 2680.0),
+                    ],
+                    "last_ftd_date": None,
+                },
+                "state_history": [
+                    ("26/03/13", "uptrend_under_pressure", "dd>=4"),
+                    ("26/03/12", "confirmed_uptrend", "stay"),
+                ],
+                # 後方互換フィールド (price.py が今も埋める)
                 "distribution_days": ["260213", "260220"],
                 "followthrough_days": ["260305"],
-                "direction_signal": "sell 26/03/13",
+                "direction_signal": "uptrend_under_pressure,26/03/13",
                 "spr_buygagher": 49,
                 "spr_20": 47,
                 "spr_5": 45,
@@ -367,9 +380,18 @@ class TestHtmlMarket:
             "mothers": {
                 "rs_raw": 1.09,
                 "trend_template": ["ma30>ma40", "RS"],
+                "market_state": "confirmed_uptrend",
+                "state_meta": {
+                    "distribution_days_with_close": [],
+                    "last_ftd_date": "26/03/10",
+                },
+                "state_history": [
+                    ("26/03/10", "confirmed_uptrend", "ftd"),
+                    ("26/03/09", "market_in_correction", "stay"),
+                ],
                 "distribution_days": [],
                 "followthrough_days": [],
-                "direction_signal": "buy 26/03/10",
+                "direction_signal": "confirmed_uptrend,26/03/10",
                 "spr_buygagher": 55,
                 "spr_20": 52,
                 "spr_5": 50,
@@ -379,9 +401,17 @@ class TestHtmlMarket:
             "nasdaq": {
                 "rs_raw": 1.05,
                 "trend_template": [],
+                "market_state": "confirmed_uptrend",
+                "state_meta": {
+                    "distribution_days_with_close": [("26/03/01", 18000.0)],
+                    "last_ftd_date": None,
+                },
+                "state_history": [
+                    ("26/03/13", "confirmed_uptrend", "stay"),
+                ],
                 "distribution_days": ["260301"],
                 "followthrough_days": [],
-                "direction_signal": "neutral 26/03/13",
+                "direction_signal": "confirmed_uptrend,26/03/13",
                 "spr_buygagher": 50,
                 "spr_20": 48,
                 "spr_5": 47,
@@ -391,9 +421,18 @@ class TestHtmlMarket:
             "sp500": {
                 "rs_raw": 1.02,
                 "trend_template": [],
+                "market_state": "confirmed_uptrend",
+                "state_meta": {
+                    "distribution_days_with_close": [],
+                    "last_ftd_date": "26/03/08",
+                },
+                "state_history": [
+                    ("26/03/13", "confirmed_uptrend", "stay"),
+                    ("26/03/08", "confirmed_uptrend", "ftd"),
+                ],
                 "distribution_days": [],
                 "followthrough_days": ["260308"],
-                "direction_signal": "neutral 26/03/13",
+                "direction_signal": "confirmed_uptrend,26/03/13",
                 "spr_buygagher": 51,
                 "spr_20": 50,
                 "spr_5": 49,
@@ -402,34 +441,22 @@ class TestHtmlMarket:
             },
         }
 
-    def test_signal_sell_class(self):
-        """sellシグナルにsignal-sellクラスが付く (後方互換: 旧文字列でも動く)"""
-        result = make_market_db._html_market(self._make_market_db())
-        assert 'signal-sell' in result
-
-    def test_signal_buy_class(self):
-        """buyシグナルにsignal-buyクラスが付く (後方互換: 旧文字列でも動く)"""
-        result = make_market_db._html_market(self._make_market_db())
-        assert 'signal-buy' in result
-
     def test_state_correction_class(self):
-        """direction_signal が market_in_correction なら state-correction クラス (issue #117 Part A)"""
+        """market_state が market_in_correction なら state-correction クラス"""
         db = self._make_market_db()
-        db["topix"]["direction_signal"] = "market_in_correction,26/04/30"
+        db["topix"]["market_state"] = "market_in_correction"
         result = make_market_db._html_market(db)
         assert 'state-correction' in result
 
     def test_state_pressure_class(self):
-        """direction_signal が uptrend_under_pressure なら state-pressure クラス"""
-        db = self._make_market_db()
-        db["topix"]["direction_signal"] = "uptrend_under_pressure,26/04/30"
-        result = make_market_db._html_market(db)
+        """market_state が uptrend_under_pressure なら state-pressure クラス"""
+        result = make_market_db._html_market(self._make_market_db())
         assert 'state-pressure' in result
 
     def test_state_confirmed_class(self):
-        """direction_signal が confirmed_uptrend なら state-confirmed クラス"""
+        """market_state が confirmed_uptrend なら state-confirmed クラス"""
         db = self._make_market_db()
-        db["topix"]["direction_signal"] = "confirmed_uptrend,26/04/30"
+        db["topix"]["market_state"] = "confirmed_uptrend"
         result = make_market_db._html_market(db)
         assert 'state-confirmed' in result
 
@@ -439,10 +466,166 @@ class TestHtmlMarket:
         assert 'trend-good' in result
 
     def test_market_table_header(self):
-        """テーブルヘッダーが含まれる"""
+        """テーブルヘッダーが含まれる (Part B: DD/FTD 列名改修)"""
         result = make_market_db._html_market(self._make_market_db())
         assert 'market-table' in result
-        assert 'ディストリビューション' in result
+        assert '<th>DD</th>' in result
+        assert '<th>FTD/ラリー</th>' in result
+
+    # ===== Part B: 表示文言・列構成テスト =====
+    def test_market_state_header_label(self):
+        """列ヘッダが「市場状態」になっている"""
+        result = make_market_db._html_market(self._make_market_db())
+        assert '市場状態' in result
+        assert '<th>シグナル</th>' not in result
+
+    def test_state_label_japanese(self):
+        """state が日本語で表示される"""
+        result = make_market_db._html_market(self._make_market_db())
+        # topix=pressure, mothers=confirmed が含まれるテストデータ
+        assert '上昇トレンド' in result
+        assert '圧力下' in result
+
+    def test_state_with_transition_date(self):
+        """遷移日が (M/D〜) で併記される"""
+        result = make_market_db._html_market(self._make_market_db())
+        # topix の history で uptrend_under_pressure 遷移日は 26/03/13 → 表示は (03/13〜)
+        assert '(03/13〜)' in result
+
+    def test_buygagher_eval_removed(self):
+        """売り圧力レシオ列から A-E 評価が削除されている"""
+        result = make_market_db._html_market(self._make_market_db())
+        # 旧形式: <td>%d, %d, <strong>A</strong></td>
+        for grade in ['<strong>A</strong>', '<strong>B</strong>', '<strong>C</strong>',
+                      '<strong>D</strong>', '<strong>E</strong>']:
+            assert grade not in result
+
+    def test_dd_count_format(self):
+        """DD列が `数 / 6` 形式で表示される (案B)"""
+        result = make_market_db._html_market(self._make_market_db())
+        # TOPIX は dd_with_close が2件 → "2 / 6"
+        assert "2 / 6" in result
+        # mothers は dd_with_close が0件 → "0 / 6"
+        assert "0 / 6" in result
+
+    def test_dd_correction_format_when_at_threshold(self):
+        """DD ≥ 6 のとき "6+ / 6" 表示 + dd-correction クラス"""
+        db = {
+            "topix": {
+                "rs_raw": 1.0, "trend_template": [],
+                "market_state": "market_in_correction",
+                "state_meta": {
+                    "distribution_days_with_close": [
+                        ("26/04/%02d" % d, 100.0) for d in range(1, 8)  # 7件
+                    ],
+                    "last_ftd_date": None,
+                },
+                "state_history": [("26/04/30", "market_in_correction", "dd>=6")],
+                "spr_20": 50, "spr_5": 50, "rv_20": 1.0, "rv_5": 1.0,
+            }
+        }
+        result = make_market_db._html_market(db)
+        assert "6+ / 6" in result
+        assert "dd-correction" in result
+
+    def test_dd_pressure_class_when_4_to_5(self):
+        """4 ≤ DD < 6 のとき dd-pressure クラス"""
+        db = {
+            "topix": {
+                "rs_raw": 1.0, "trend_template": [],
+                "market_state": "uptrend_under_pressure",
+                "state_meta": {
+                    "distribution_days_with_close": [
+                        ("26/04/%02d" % d, 100.0) for d in range(1, 5)  # 4件
+                    ],
+                    "last_ftd_date": None,
+                },
+                "state_history": [("26/04/30", "uptrend_under_pressure", "dd>=4")],
+                "spr_20": 50, "spr_5": 50, "rv_20": 1.0, "rv_5": 1.0,
+            }
+        }
+        result = make_market_db._html_market(db)
+        assert "4 / 6" in result
+        assert "dd-pressure" in result
+
+    def test_dd_dates_in_title_attribute(self):
+        """DD詳細日付は title 属性 (ホバー) で確認できる"""
+        result = make_market_db._html_market(self._make_market_db())
+        # TOPIX の dd_with_close は 02/13, 02/20 → title="02/13, 02/20"
+        assert 'title="02/13, 02/20"' in result
+
+    def test_ftd_shows_last_ftd_date_when_not_correction(self):
+        """confirmed/pressure 状態では FTD列に last_ftd_date を表示"""
+        result = make_market_db._html_market(self._make_market_db())
+        # mothers: confirmed, last_ftd_date=26/03/10 → "03/10"
+        assert "03/10" in result
+        # sp500: confirmed, last_ftd_date=26/03/08 → "03/08"
+        assert "03/08" in result
+
+    def test_ftd_em_dash_when_no_ftd(self):
+        """FTD なしのときは "—" 表示"""
+        db = {
+            "topix": {
+                "rs_raw": 1.0, "trend_template": [],
+                "market_state": "confirmed_uptrend",
+                "state_meta": {
+                    "distribution_days_with_close": [],
+                    "last_ftd_date": None,
+                },
+                "state_history": [("26/04/30", "confirmed_uptrend", "stay")],
+                "spr_20": 50, "spr_5": 50, "rv_20": 1.0, "rv_5": 1.0,
+            }
+        }
+        result = make_market_db._html_market(db)
+        # FTD/ラリー 列に — が出ること
+        assert "—" in result
+
+    def test_rally_day_in_correction(self):
+        """correction 状態ではラリー Day N が表示される"""
+        db = {
+            "topix": {
+                "rs_raw": 1.0, "trend_template": [],
+                "market_state": "market_in_correction",
+                "state_meta": {
+                    "distribution_days_with_close": [],
+                    "last_ftd_date": None,
+                    "rally_attempt_start_date": "26/04/28",
+                    "rally_attempt_start_low": 100.0,
+                },
+                "state_history": [("26/04/30", "market_in_correction", "stay")],
+                "daily_history": ["26/04/30", "26/04/29", "26/04/28"],  # Day 3
+                "spr_20": 50, "spr_5": 50, "rv_20": 1.0, "rv_5": 1.0,
+            }
+        }
+        result = make_market_db._html_market(db)
+        assert "ラリー Day 3" in result
+
+    def test_rally_em_dash_when_no_attempt(self):
+        """correction でラリー未開始なら — 表示"""
+        db = {
+            "topix": {
+                "rs_raw": 1.0, "trend_template": [],
+                "market_state": "market_in_correction",
+                "state_meta": {
+                    "distribution_days_with_close": [],
+                    "last_ftd_date": None,
+                    "rally_attempt_start_date": None,
+                },
+                "state_history": [("26/04/30", "market_in_correction", "stay")],
+                "daily_history": ["26/04/30"],
+                "spr_20": 50, "spr_5": 50, "rv_20": 1.0, "rv_5": 1.0,
+            }
+        }
+        result = make_market_db._html_market(db)
+        # correction なので FTD 列ではなくラリー位置、ラリー未開始なら —
+        assert "—" in result
+        assert "ラリー Day" not in result
+
+    def test_growth250_label(self):
+        """マザーズ行が「グロース250」で表示される"""
+        result = make_market_db._html_market(self._make_market_db())
+        assert "グロース250" in result
+        assert "マザーズ" not in result
 
     def test_empty_market_db(self):
         """市場データがない場合は空文字列"""

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -99,6 +99,50 @@ class TestGetTrendTemplateExpr:
 
 
 # ==================================================
+# get_index_trend_template_expr (issue #117 Part B)
+# ==================================================
+class TestGetIndexTrendTemplateExpr:
+    """指数向けトレンドテンプレート簡略表記"""
+
+    def test_no_key(self):
+        assert make_stock_db.get_index_trend_template_expr({}) == ("-", "")
+
+    def test_perfect(self):
+        """全通過 → ◎ 7/7、ホバー文字列は空"""
+        assert make_stock_db.get_index_trend_template_expr({"trend_template": []}) == ("◎ 7/7", "")
+
+    def test_minor_miss(self):
+        """1-2 不通過 → ◯ N/7、ホバーに不通過項目"""
+        display, miss = make_stock_db.get_index_trend_template_expr(
+            {"trend_template": ["ma30>ma40", "RS"]}
+        )
+        assert display == "◯ 5/7"
+        assert miss == "ma30>ma40,RS"
+
+    def test_moderate_miss(self):
+        """3-4 不通過 → ▲ N/7"""
+        display, miss = make_stock_db.get_index_trend_template_expr(
+            {"trend_template": ["a", "b", "c", "d"]}
+        )
+        assert display == "▲ 3/7"
+        assert miss == "a,b,c,d"
+
+    def test_many_miss(self):
+        """5-7 不通過 → △ N/7"""
+        display, miss = make_stock_db.get_index_trend_template_expr(
+            {"trend_template": ["a", "b", "c", "d", "e"]}
+        )
+        assert display == "△ 2/7"
+        assert miss == "a,b,c,d,e"
+
+    def test_all_miss(self):
+        display, miss = make_stock_db.get_index_trend_template_expr(
+            {"trend_template": ["a", "b", "c", "d", "e", "f", "g"]}
+        )
+        assert display == "△ 0/7"
+
+
+# ==================================================
 # make_signal
 # ==================================================
 class TestMakeSignal:

--- a/tests/test_market_state.py
+++ b/tests/test_market_state.py
@@ -304,3 +304,136 @@ class TestToDirectionSignal:
     def test_format(self):
         s = ms.to_direction_signal(ms.CONFIRMED_UPTREND, "26/04/30")
         assert s == "confirmed_uptrend,26/04/30"
+
+
+# ==================================================
+# format_state_label (Part B)
+# ==================================================
+class TestFormatStateLabel:
+    """state を日本語ラベルに変換"""
+
+    def test_confirmed(self):
+        assert ms.format_state_label(ms.CONFIRMED_UPTREND) == "上昇トレンド"
+
+    def test_pressure(self):
+        assert ms.format_state_label(ms.UPTREND_UNDER_PRESSURE) == "圧力下"
+
+    def test_correction(self):
+        assert ms.format_state_label(ms.MARKET_IN_CORRECTION) == "調整相場"
+
+    def test_none(self):
+        assert ms.format_state_label(None) == ""
+
+    def test_unknown_returns_original(self):
+        assert ms.format_state_label("foo_bar") == "foo_bar"
+
+
+# ==================================================
+# find_state_transition_date (Part B)
+# ==================================================
+class TestFindStateTransitionDate:
+    """state_history から現在 state の遷移日を抽出"""
+
+    def test_basic(self):
+        history = [
+            ("26/05/01", ms.CONFIRMED_UPTREND, "stay"),
+            ("26/04/30", ms.CONFIRMED_UPTREND, "stay"),
+            ("26/04/15", ms.CONFIRMED_UPTREND, "ftd"),
+            ("26/04/14", ms.MARKET_IN_CORRECTION, "stay"),
+        ]
+        assert ms.find_state_transition_date(history, ms.CONFIRMED_UPTREND) == "26/04/15"
+
+    def test_single_match(self):
+        history = [("26/05/01", ms.CONFIRMED_UPTREND, "init")]
+        assert ms.find_state_transition_date(history, ms.CONFIRMED_UPTREND) == "26/05/01"
+
+    def test_single_mismatch(self):
+        history = [("26/05/01", ms.MARKET_IN_CORRECTION, "init")]
+        assert ms.find_state_transition_date(history, ms.CONFIRMED_UPTREND) is None
+
+    def test_empty(self):
+        assert ms.find_state_transition_date([], ms.CONFIRMED_UPTREND) is None
+
+    def test_no_match(self):
+        history = [
+            ("26/05/01", ms.MARKET_IN_CORRECTION, "stay"),
+            ("26/04/30", ms.UPTREND_UNDER_PRESSURE, "dd>=6"),
+        ]
+        assert ms.find_state_transition_date(history, ms.CONFIRMED_UPTREND) is None
+
+    def test_state_changed_today(self):
+        """今日 state が変わった場合 → 今日の日を返す"""
+        history = [
+            ("26/05/01", ms.CONFIRMED_UPTREND, "ftd"),
+            ("26/04/30", ms.MARKET_IN_CORRECTION, "stay"),
+        ]
+        assert ms.find_state_transition_date(history, ms.CONFIRMED_UPTREND) == "26/05/01"
+
+
+# ==================================================
+# extract_ftd_history (Part B)
+# ==================================================
+class TestExtractFtdHistory:
+    """state_history から FTD 成立日を抽出"""
+
+    def test_basic(self):
+        history = [
+            ("26/05/01", ms.CONFIRMED_UPTREND, "stay"),
+            ("26/04/15", ms.CONFIRMED_UPTREND, "ftd"),
+            ("26/04/14", ms.MARKET_IN_CORRECTION, "stay"),
+            ("26/03/01", ms.CONFIRMED_UPTREND, "ftd"),
+        ]
+        assert ms.extract_ftd_history(history) == ["26/04/15", "26/03/01"]
+
+    def test_max_count(self):
+        history = [
+            ("26/05/01", ms.CONFIRMED_UPTREND, "ftd"),
+            ("26/04/01", ms.CONFIRMED_UPTREND, "ftd"),
+            ("26/03/01", ms.CONFIRMED_UPTREND, "ftd"),
+            ("26/02/01", ms.CONFIRMED_UPTREND, "ftd"),
+        ]
+        result = ms.extract_ftd_history(history, max_count=2)
+        assert result == ["26/05/01", "26/04/01"]
+
+    def test_no_ftd(self):
+        history = [
+            ("26/05/01", ms.CONFIRMED_UPTREND, "stay"),
+            ("26/04/30", ms.UPTREND_UNDER_PRESSURE, "dd>=4"),
+        ]
+        assert ms.extract_ftd_history(history) == []
+
+    def test_empty(self):
+        assert ms.extract_ftd_history([]) == []
+
+
+# ==================================================
+# calc_rally_day (Part B)
+# ==================================================
+class TestCalcRallyDay:
+    """ラリーアテンプト Day N 計算"""
+
+    def test_day1_today(self):
+        """ラリー開始日 = 当日 → Day 1"""
+        history = ["26/04/30", "26/04/29", "26/04/28"]
+        assert ms.calc_rally_day("26/04/30", history) == 1
+
+    def test_day3(self):
+        """ラリー開始から2日経過 → Day 3"""
+        history = ["26/04/30", "26/04/29", "26/04/28", "26/04/27"]
+        assert ms.calc_rally_day("26/04/28", history) == 3
+
+    def test_day4(self):
+        """ラリー開始から3日経過 → Day 4 (FTD候補開始)"""
+        history = ["26/04/30", "26/04/29", "26/04/28", "26/04/27"]
+        assert ms.calc_rally_day("26/04/27", history) == 4
+
+    def test_no_rally_start(self):
+        assert ms.calc_rally_day(None, ["26/04/30"]) is None
+
+    def test_empty_history(self):
+        assert ms.calc_rally_day("26/04/30", []) is None
+
+    def test_start_not_in_history(self):
+        """ラリー開始日が daily_history に無い (窓外) → None"""
+        history = ["26/04/30", "26/04/29"]
+        assert ms.calc_rally_day("26/03/01", history) is None

--- a/tests/test_market_state.py
+++ b/tests/test_market_state.py
@@ -265,6 +265,117 @@ class TestDeriveState:
 
 
 # ==================================================
+# is_below_10ma_clearly (issue #117 Part B)
+# ==================================================
+class TestIsBelow10maClearly:
+    """週足10MA 明確割れ判定"""
+
+    def test_kairi_above_threshold(self):
+        """kairi = -0.5% (閾値より上) → False"""
+        assert ms.is_below_10ma_clearly(-0.5) is False
+
+    def test_kairi_at_threshold(self):
+        """kairi = -1.0% (境界) → True"""
+        assert ms.is_below_10ma_clearly(-1.0) is True
+
+    def test_kairi_below_threshold(self):
+        """kairi = -1.5% → True"""
+        assert ms.is_below_10ma_clearly(-1.5) is True
+
+    def test_kairi_positive(self):
+        """kairi = 1.0% (上) → False"""
+        assert ms.is_below_10ma_clearly(1.0) is False
+
+    def test_kairi_zero(self):
+        assert ms.is_below_10ma_clearly(0) is False
+
+    def test_kairi_none(self):
+        assert ms.is_below_10ma_clearly(None) is False
+
+    def test_kairi_invalid(self):
+        assert ms.is_below_10ma_clearly("foo") is False
+
+
+# ==================================================
+# derive_state with below_10ma (issue #117 Part B 補助遷移)
+# ==================================================
+class TestDeriveStateWith10maAux:
+    """週足10MA 補助遷移ルール"""
+
+    def test_confirmed_to_pressure_via_below_10ma(self):
+        """DD<4 でも 10MA明確割れで pressure 降格"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.CONFIRMED_UPTREND, valid_dd_count=2, ftd_today=False,
+            below_10ma=True,
+        )
+        assert state == ms.UPTREND_UNDER_PRESSURE
+        assert trigger == "below_10ma"
+
+    def test_confirmed_to_correction_via_dd4_and_below_10ma(self):
+        """DD=4 + 10MA明確割れ で correction 降格 (correction優先)"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.CONFIRMED_UPTREND, valid_dd_count=4, ftd_today=False,
+            below_10ma=True,
+        )
+        assert state == ms.MARKET_IN_CORRECTION
+        assert trigger == "dd>=4_and_below_10ma"
+
+    def test_confirmed_stays_pressure_when_dd4_above_10ma(self):
+        """DD=4 + 10MA上 → pressure 降格 (correction にはならない、現状挙動維持)"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.CONFIRMED_UPTREND, valid_dd_count=4, ftd_today=False,
+            below_10ma=False,
+        )
+        assert state == ms.UPTREND_UNDER_PRESSURE
+        assert trigger == "dd>=4"
+
+    def test_confirmed_to_correction_via_dd6_ignores_10ma(self):
+        """DD≥6 なら 10MA関係なく correction (DD>=6が最優先)"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.CONFIRMED_UPTREND, valid_dd_count=6, ftd_today=False,
+            below_10ma=False,
+        )
+        assert state == ms.MARKET_IN_CORRECTION
+        assert trigger == "dd>=6"
+
+    def test_pressure_stays_when_dd_low_below_10ma(self):
+        """DD<4 だが 10MA明確割れ → pressure 維持 (復帰しない)"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.UPTREND_UNDER_PRESSURE, valid_dd_count=2, ftd_today=False,
+            below_10ma=True,
+        )
+        assert state == ms.UPTREND_UNDER_PRESSURE
+        assert trigger == "stay"
+
+    def test_pressure_to_confirmed_when_dd_low_and_above_10ma(self):
+        """DD<4 + 10MA上 → confirmed 復帰"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.UPTREND_UNDER_PRESSURE, valid_dd_count=2, ftd_today=False,
+            below_10ma=False,
+        )
+        assert state == ms.CONFIRMED_UPTREND
+        assert trigger == "dd<4_recover"
+
+    def test_correction_to_confirmed_via_ftd_ignores_10ma(self):
+        """FTD出れば10MA関係なく confirmed"""
+        state, trigger = ms.derive_state(
+            prev_state=ms.MARKET_IN_CORRECTION, valid_dd_count=10, ftd_today=True,
+            below_10ma=True,
+        )
+        assert state == ms.CONFIRMED_UPTREND
+        assert trigger == "ftd"
+
+    def test_below_10ma_default_false_backward_compat(self):
+        """引数省略で既存挙動維持 (10MAルール不発動)"""
+        # confirmed + DD=2 + below_10ma 引数なし → confirmed 維持
+        state, trigger = ms.derive_state(
+            prev_state=ms.CONFIRMED_UPTREND, valid_dd_count=2, ftd_today=False,
+        )
+        assert state == ms.CONFIRMED_UPTREND
+        assert trigger == "stay"
+
+
+# ==================================================
 # append_state_history
 # ==================================================
 class TestAppendStateHistory:

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -903,3 +903,113 @@ class TestParsePriceTextFromList:
         result_dict, _ = price.parse_price_text_from_list(1050, price_list)
         # 入力が5件しかなければ price_log も最大5件
         assert len(result_dict["price_log"]) <= 5
+
+
+# ==================================================
+# Stalling Day 判定 (issue #117 Part B)
+# ==================================================
+class TestStallingDay:
+    """Stalling Day (停滞日) 判定"""
+
+    def _row(self, date, open_p, high, low, close, ratio_pct, volume):
+        """8要素タプルを作る"""
+        return (
+            date,
+            "{:,}".format(open_p),
+            "{:,}".format(high),
+            "{:,}".format(low),
+            "{:,}".format(close),
+            "0",
+            "{:.2f}".format(ratio_pct),
+            "{:,}".format(volume),
+        )
+
+    def test_is_stalling_day_basic(self):
+        """52週高値圏 + 微増 + 出来高増 + 下半分引け → True"""
+        # 52週高値=1000、当日 close=975 (97.5% > 97%)、ratio=+0.2%、出来高増、下半分
+        d = self._row("260501", 970, 985, 970, 975, 0.2, 12000)
+        # 下半分: dl=970, dh=985, half=977.5、close=975 ≤ 977.5
+        pd = self._row("260430", 968, 980, 965, 970, 0.0, 10000)
+        assert price._is_stalling_day(d, pd, high52_weekly=1000) is True
+
+    def test_is_stalling_day_skipped_below_high(self):
+        """52週高値の97%未満なら False"""
+        # close=900、52週高値=1000 → 90%
+        d = self._row("260501", 895, 905, 890, 900, 0.2, 12000)
+        pd = self._row("260430", 895, 905, 890, 898, 0.0, 10000)
+        assert price._is_stalling_day(d, pd, high52_weekly=1000) is False
+
+    def test_is_stalling_day_skipped_too_high_ratio(self):
+        """前日比 +0.4% 以上なら False (FTD候補に近い)"""
+        d = self._row("260501", 970, 985, 970, 985, 0.5, 12000)
+        pd = self._row("260430", 968, 980, 965, 980, 0.0, 10000)
+        assert price._is_stalling_day(d, pd, high52_weekly=1000) is False
+
+    def test_is_stalling_day_skipped_negative_ratio(self):
+        """前日比マイナスなら False (通常DDの領域)"""
+        d = self._row("260501", 970, 985, 970, 975, -0.1, 12000)
+        pd = self._row("260430", 968, 980, 965, 980, 0.0, 10000)
+        assert price._is_stalling_day(d, pd, high52_weekly=1000) is False
+
+    def test_is_stalling_day_skipped_no_volume_increase(self):
+        """出来高増していなければ False"""
+        d = self._row("260501", 970, 985, 970, 975, 0.2, 10000)
+        pd = self._row("260430", 968, 980, 965, 970, 0.0, 12000)
+        assert price._is_stalling_day(d, pd, high52_weekly=1000) is False
+
+    def test_is_stalling_day_skipped_upper_close(self):
+        """終値が日足の上半分なら False (下半分引けが条件)"""
+        # close=982、low=970, high=985、half=977.5 → 上半分
+        d = self._row("260501", 970, 985, 970, 982, 0.2, 12000)
+        pd = self._row("260430", 968, 980, 965, 980, 0.0, 10000)
+        assert price._is_stalling_day(d, pd, high52_weekly=1000) is False
+
+    def test_is_stalling_day_skipped_no_high52(self):
+        """high52_weekly が無ければ False"""
+        d = self._row("260501", 970, 985, 970, 975, 0.2, 12000)
+        pd = self._row("260430", 968, 980, 965, 970, 0.0, 10000)
+        assert price._is_stalling_day(d, pd, high52_weekly=None) is False
+        assert price._is_stalling_day(d, pd, high52_weekly=0) is False
+
+    def test_add_stalling_days_appends(self):
+        """add_stalling_days で既存DD に Stalling Day が追加される"""
+        # 既に通常DDが1つあり、別の日が Stalling Day 候補
+        daily_price_list = [
+            self._row("260501", 970, 985, 970, 975, 0.2, 12000),  # Stalling 候補
+            self._row("260430", 968, 980, 965, 970, 0.0, 10000),  # 前日
+            self._row("260429", 980, 990, 970, 970, -0.5, 11000),  # 通常DD
+            self._row("260428", 980, 990, 970, 975, 0.0, 9000),
+        ]
+        dic = {
+            "distribution_days": ["260429"],
+            "distribution_days_with_close": [("260429", 970.0)],
+        }
+        price.add_stalling_days(dic, daily_price_list, high52_weekly=1000)
+        assert "260501" in dic["distribution_days"]
+        assert ("260501", 975.0) in dic["distribution_days_with_close"]
+        # 既存の通常DDは保持
+        assert "260429" in dic["distribution_days"]
+
+    def test_add_stalling_days_no_duplicate(self):
+        """既に通常DDとして計上されている日は重複追加しない"""
+        daily_price_list = [
+            self._row("260501", 970, 985, 970, 975, 0.2, 12000),
+            self._row("260430", 968, 980, 965, 970, 0.0, 10000),
+        ]
+        dic = {
+            "distribution_days": ["260501"],
+            "distribution_days_with_close": [("260501", 975.0)],
+        }
+        price.add_stalling_days(dic, daily_price_list, high52_weekly=1000)
+        # 同じ日付が2回追加されていないこと
+        assert dic["distribution_days"].count("260501") == 1
+        assert len(dic["distribution_days_with_close"]) == 1
+
+    def test_add_stalling_days_skipped_no_high52(self):
+        """high52_weekly が無い場合は何もしない"""
+        daily_price_list = [
+            self._row("260501", 970, 985, 970, 975, 0.2, 12000),
+        ]
+        dic = {"distribution_days": [], "distribution_days_with_close": []}
+        price.add_stalling_days(dic, daily_price_list, high52_weekly=None)
+        assert dic["distribution_days"] == []


### PR DESCRIPTION
## Summary

issue #117 Part B として、market セクションの表示を State Machine (Part A) の判定結果と整合させた。
DD/FTD/市場状態の3列を、互いに関連した**統合表示**に再構成し、市場の健全度が一目で把握できるようにした。

ユーザーFBに基づき、当初案 (`[ブ?]` `[ブ!]` `[ポ?]` のタグ干渉) は破棄し、市場セクションの表示精度向上に振り直した。
さらに追加コミットで Stalling Day 検出と指数トレンドテンプレートの簡略表記を追加した。

## 主な変更

### 表示改善 (`_html_market`)
- **トレンド列**: 指数向け簡略表記 (案C) に変更
  - `◎ 7/7` / `◯ 5/7` / `▲ 3/7` / `△ 0/7` の通過率形式
  - 不通過項目は `title=` 属性 (ホバー) で確認: `不通過: ma30>ma40,RS`
  - 個別銘柄側 `get_trend_template_expr` は変更なし
- **DD列**: `04/22, 04/23, 04/30` → **`3 / 6`** (危険水準との比率表示)
  - 詳細日付はホバーで表示、4-5 で黄色 (pressure)、6+ で赤色 (correction)
- **FTD/ラリー列**: 単なる強い陽線リストではなく、状態に応じた表示
  - `confirmed`/`pressure` 時: `state_meta.last_ftd_date` (直近の真のFTD)
  - `correction` 時: `ラリー Day N` (回復試行中の経過日数)
  - なし: `—`
- **市場状態列**: `confirmed_uptrend,26/05/01` → `上昇トレンド (05/01〜)`
  - 日本語ラベル化 + 遷移日 `(M/D〜)` 併記
- **売り圧力レシオ**: 買い集め指数 A-E 評価を削除 (市場では機能していなかった)
- **マザーズ指数 → グロース250**: 2024年の指数再編に合わせて表示名更新 (DBキー `mothers` は維持)

### Stalling Day 検出 (O'Neil 原典準拠)
通常DD だけでは見落としていた**機関投資家の上値での売り抜け**を検出する。

- `price._is_stalling_day` / `price.add_stalling_days` を新設
- 判定条件: 52週高値の97%以上 + 微増 (0% < dr < 0.4%) + 出来高増 + 終値が日足の下半分
- 通常DDと重複する日は除外
- 週足計算で算出した `high52_weekly` を `_daily_price_list_raw` (一時) と組み合わせ、`make_db_common` / `_make_us_index_db` で**週足計算後に後付け検出**する

### State Machine ヘルパー追加 (`market_state.py`)
純関数として:
- `format_state_label(state)`: 日本語ラベル変換
- `find_state_transition_date(history, state)`: 遷移日抽出
- `extract_ftd_history(history, max_count)`: FTD成立日履歴抽出
- `calc_rally_day(rally_start, daily_history)`: ラリー Day N 計算
- 定数 `STATE_LABEL` / `STATE_CSS_CLASS`

### Dead code 削除
- 旧 `sell` / `buy` フォールバック CSS 分岐 (Part A 以降不要)

## 表示変更例

| 状態 | 旧表示 | 新表示 |
|---|---|---|
| confirmed | `02/13, 02/20` / `03/05` / `confirmed_uptrend,26/03/13` | `2 / 6` (ホバーで詳細) / `03/05` / `上昇トレンド (03/13〜)` |
| pressure | `02/13, 02/20, 03/01, 03/10` / `` / `uptrend_under_pressure,26/03/13` | **`4 / 6`** (黄) / `—` / `圧力下 (03/13〜)` |
| correction | `02/13, ...` (6個) / `` / `market_in_correction,26/03/13` | **`6+ / 6`** (赤) / `ラリー Day 5` / `調整相場 (03/13〜)` |

## Out of scope (後続)

- Part C: Minervini Breadth (トレンドテンプレート通過銘柄数)
- フェーズ列 (`trend_template × market_state` の統合判定列)
- データ拡張 (yfinance period 延長 + Kabutan ページング + 50日MA / 200日HV)

## Test plan

- [x] pytest tests/test_market_state.py tests/test_make_market_db.py tests/test_price.py tests/test_functional_market.py tests/test_make_stock_db.py — **313 passed**
- [x] `python -c "import make_market_db; make_market_db.update_market_db(); make_market_db.create_market_csv()"` で実DBで再計算、エラーなし
- [x] WebApp /market を Playwright で目視確認:
  - トレンド列「◎ 7/7」「◯ 5/7」 + ホバーで不通過項目
  - DD列「3 / 6」形式 + ホバーで詳細日付
  - FTD/ラリー列が状態に応じて切替
  - 市場状態が日本語 + (M/D〜)
  - 売り圧力レシオ列に A-E 評価がない
  - 「グロース250」表示
- [x] DB確認: `high52_weekly` が全指数で保存される

🤖 Generated with [Claude Code](https://claude.com/claude-code)