### PR TITLE
Phase 3a: portfolio_shelve 基盤 + my_watch_list.txt/スプシ移行

### DIFF
--- a/.claude/plans/issue-151-portfolio.md
+++ b/.claude/plans/issue-151-portfolio.md
@@ -1,0 +1,527 @@
+# issue151 実装計画: Phase 3 保有銘柄管理ダッシュボード
+
+> 要件仕様書: [doc/requirements/phase3_portfolio_requirements.md](../../doc/requirements/phase3_portfolio_requirements.md)
+> 親 issue: #151（Closes は使わず、トラッキング用に残す）
+
+---
+
+## 1. 全体方針
+
+### 1-1. issue 構造（インタビュー Q1: 3a/3b/3c 分割）
+
+`#151` を親 issue として残し、3 つの sub-issue に分割する。**親 issue には `Closes #151` を使わない**（Phase 1 だけマージで親が自動クローズしないように）。
+
+| Sub-issue | スコープ | PR 単位 |
+|---|---|---|
+| **Phase 3a** | portfolio_shelve 基盤 + スプシ移行 + my_watch_list.txt 取り込み + parse 置換 + shelve→txt 同期 | 1 PR |
+| **Phase 3b** | /portfolio ダッシュボード(3タブ) + ステータス変更/追加/売却/削除UI + アクションログ記録 | 1 PR |
+| **Phase 3c** | 振り返りビュー(アクションログ時系列) | 1 PR |
+| **(別 issue)** | my_watch_list.txt 廃止（Phase 3 マージ後、運用が安定したら別途検討） | — |
+
+### 1-2. スコープ外（インタビュー Q9-Q10）
+
+以下は要件仕様書に記載があるが、**Phase 3 では実装しない**:
+
+- §5-3 警告シグナル赤バッジ強調表示
+- §6-2 イベントログ自動記録（Shintakane 日次バッチへの組込み）
+- §6-1 アクションログ「見送り」「メモ」種別
+
+これらは Phase 4（別 issue）で扱う。Phase 3 のアクションログ種別は **`初回登録` / `ステータス変更` / `売却` / `削除`** の 4 種に限定する。
+
+### 1-3. テスト戦略（インタビュー Q5）
+
+- **ユニットテスト**: portfolio_shelve / 移行スクリプト / 状態遷移バリデーション / parse_my_portforio() 互換性
+- **Playwright E2E**: ダッシュボードの主要 3 シナリオ（追加 / ステータス変更 / 削除）の happy path
+
+---
+
+## 2. portfolio_shelve 設計（Phase 3a の中核）
+
+### 2-1. ファイル配置
+
+```
+data/stock_data/portfolio_shelve  ← 新規
+```
+
+`research_shelve` / `stocks_shelve` と同じ階層。`db_shelve.ShelveDB` をラップ。
+
+### 2-2. キー名前空間（インタビュー Q4: 単一 shelve 内で名前空間分離）
+
+| キー形式 | 内容 | レコード削除時の挙動 |
+|---|---|---|
+| `record:<code_s>` | 保有レコード本体（ステータス・手動メモ） | `削除` 操作時に `del` |
+| `action_log:<code_s>:<seq>` | アクションログ（手動判断） | **残す**（§5-5 / §6-1 要件） |
+
+`<seq>` は 6 桁ゼロパディングの単調増加整数。同一銘柄内で連番管理。`portfolio_shelve` 内に `_seq:<code_s>` キーで現在値を保持。
+
+### 2-3. レコードスキーマ
+
+`record:<code_s>` の値:
+
+```python
+{
+    "code_s": "6324",
+    "stock_name": "ハーモニック・ドライブ・システムズ",
+    "status": "1保",         # "1保" | "2準" | "3監"
+    "registered_at": "2026-05-03T09:00:00+09:00",
+    "updated_at": "2026-05-03T09:00:00+09:00",
+    # 手動メモ（§4 + §7-1）
+    "memo": {
+        "gyoutai_theme": "...",       # 業態・テーマ
+        "watch_in_reason": "...",     # ウォッチ・IN理由
+        "trade_idea": "...",          # 投資売買アイデア
+        "inago_origin": "...",        # イナゴ元・きっかけ
+        "takaichi_sensitivity": "..." # 高市感応度
+    }
+}
+```
+
+指標データ（PER・RS 等）は **保存しない**（§4 表示時に stocks_shelve から都度参照）。
+
+### 2-4. アクションログスキーマ
+
+`action_log:<code_s>:<seq>` の値:
+
+```python
+{
+    "code_s": "6324",
+    "seq": 1,
+    "timestamp": "2026-05-03T09:00:00+09:00",
+    "action_type": "初回登録",  # "初回登録" | "ステータス変更" | "売却" | "削除"
+    "status_from": None,        # "ステータス変更"/"売却" 時のみ。"初回登録"時は None
+    "status_to": "3監",
+    "reason": "..."             # 理由メモ。"初回登録"時は省略可
+}
+```
+
+### 2-5. ステータス遷移バリデーション
+
+`portfolio_shelve.py` で遷移を強制する。以下の遷移のみ許可:
+
+```
+（新規）→ 3監                 # 追加。1保/2準への直接登録は禁止
+3監 ⇄ 2準                    # 格上げ/格下げ
+2準 ⇄ 1保                    # 買い/売り
+3監 ⇄ 1保                    # 直接遷移（要件仕様書に明示禁止なし。一応許可）
+（任意）→ 3監 → （削除）       # 1保/2準 から直接削除は禁止
+```
+
+`1保 → 2準` の遷移は内部的に「売却」として action_type=`売却` で記録。それ以外のステータス変更は `ステータス変更`。
+
+### 2-6. 主要 API
+
+```python
+# portfolio_shelve.py
+
+def upsert_record(code_s: str, stock_name: str, memo: dict, *, db_path=None) -> None: ...
+def get_record(code_s: str, *, db_path=None) -> Optional[dict]: ...
+def list_records(status: Optional[str] = None, *, db_path=None) -> List[dict]: ...
+def delete_record(code_s: str, reason: str, *, db_path=None) -> None: ...
+
+def transition_status(code_s: str, new_status: str, reason: str, *, db_path=None) -> None: ...
+def add_to_watch(code_s: str, stock_name: str, *, db_path=None) -> None: ...
+
+def append_action_log(code_s: str, action_type: str, *, status_from=None, status_to=None, reason="", db_path=None) -> None: ...
+def list_action_logs(code_s: Optional[str] = None, *, db_path=None) -> List[dict]: ...
+```
+
+すべて `fcntl` フロックで保護（research_shelve と同パターン）。
+
+---
+
+## 3. Phase 3a 詳細
+
+### 3-1. 成果物
+
+| ファイル | 種別 | 内容 |
+|---|---|---|
+| `scripts/portfolio_shelve.py` | 新規 | §2 の DB モジュール |
+| `scripts/migrate_portfolio_from_csv.py` | 新規 | スプシ「保有銘柄シート」CSV → portfolio_shelve |
+| `scripts/migrate_my_watch_list_to_shelve.py` | 新規 | my_watch_list.txt → portfolio_shelve（初期取り込み + マージ） |
+| `scripts/portfolio.py` | 修正 | `parse_my_portforio()` の内部実装を portfolio_shelve 参照に置換（**シグネチャ無修正**）+ shelve → txt 一方向同期書き出しの追加 |
+| `tests/test_portfolio_shelve.py` | 新規 | DB 層ユニットテスト |
+| `tests/test_migrate_portfolio_from_csv.py` | 新規 | CSV 移行テスト |
+| `tests/test_migrate_my_watch_list_to_shelve.py` | 新規 | txt 取り込みテスト |
+| `tests/test_portfolio.py` | 修正/新規 | `parse_my_portforio()` の互換性テスト |
+
+### 3-2. スプシ移行手順（インタビュー Q2: 事前 CSV エクスポート）
+
+#### 3-2-1. 列マッピングの事前確定（**完了済み**）
+
+✅ ユーザーから受領した `銘柄調査 - 保有銘柄.csv` (36 列 × 139 銘柄) を分析し、§3-2-2 の列マッピングを確定済み。
+
+確定時の重要な発見:
+- スプシ「保有銘柄シート」の指標系列・順位・保有リスト列は **`code_rank.csv` からの参照値（VLOOKUP）**であり、スプシ上の手動入力ではない
+- よって移行対象は識別 2 列 + 真の手動メモ 5 列の **計 7 列のみ**
+- ステータス決定は **`my_watch_list.txt` のみ** を真実源とする（スプシのステータス列は無視）
+
+この発見により §3-3 のマージルールも大幅にシンプル化された。
+
+#### 3-2-2. 列マッピング（**確定済み**）
+
+CSV ファイル: `銘柄調査 - 保有銘柄.csv`（36 列、先頭 1 行は空行、2 行目がヘッダ、3 行目以降が 139 銘柄分のデータ）
+
+##### 重要な前提
+
+スプシ「保有銘柄シート」の **指標系列（順位・PER・配当・RS・トレンドテンプレート・シグナル・時価総額・決算日 等）と保有リスト列は、`code_rank.csv` からの参照値（VLOOKUP 等で表示しているだけ）**。スプシ上の手動入力は識別情報と「真の手動メモ」のみ。
+
+→ **移行対象は手動メモ系列の 5 列 + 識別 2 列の合計 7 列**。指標系列はすべて移行不要（要件仕様書 §4「指標データは portfolio_shelve に保存せず stocks_shelve から都度参照」と整合）。
+
+##### 移行対象の列マッピング（確定）
+
+| CSV col # | 列名 | 移行先 | 備考 |
+|---|---|---|---|
+| 0 | 銘柄コード | `code_s` | 文字列正規化（4 桁ゼロ埋め or 4 文字英数字） |
+| 1 | 銘柄名 | `stock_name` | そのまま |
+| 3 | 業態・テーマ | `memo.gyoutai_theme` | 改行を含むセルあり（複数行 OK） |
+| 31 | ウォッチ・IN理由 | `memo.watch_in_reason` | 改行を含むセルあり |
+| 33 | イナゴ元・きっかけ | `memo.inago_origin` | 改行を含むセルあり |
+| 34 | 投資売買アイデア | `memo.trade_idea` | 改行を含むセルあり |
+| 35 | 高市感応度 | `memo.takaichi_sensitivity` | 「A:〜」「B:〜」のような感応度ラベル付きの自由記述 |
+
+##### 取り込まない列（参考）
+
+| CSV col # | 列名 | 理由 |
+|---|---|---|
+| 2 | 保有リスト | `code_rank.csv` 由来の表示値。ステータスは **`my_watch_list.txt` のみ** を真実源とする |
+| 4–30, 32 | 指標・順位・チャート・需給チャート 等 | すべて `code_rank.csv` または stocks_shelve 由来の表示値。表示時に都度参照 |
+
+##### スプシの構造詳細
+
+- 1 行目: 全列空（区切り文字のみ）
+- 2 行目: ヘッダ（36 列）
+- 3 行目以降: データ 139 行
+- 文字エンコーディング: UTF-8
+- 改行を含むセルは Google Sheets の RFC 4180 仕様に従いダブルクォートで囲まれている（Python `csv` モジュールで標準パース可能）
+
+#### 3-2-3. 移行スクリプト実行手順
+
+1. ユーザーが CSV を `${KS_DATA_DIR}/migration/portfolio_sheet.csv` に配置
+2. `cd scripts && python migrate_portfolio_from_csv.py "${KS_DATA_DIR}/migration/portfolio_sheet.csv" --dry-run` で **dry-run** 実行し、件数とサンプル出力を目視確認
+3. 問題なければ `--dry-run` を外して本番実行
+4. 移行スクリプトは `migrate_research_from_csv.py` の 4 層構成パターンを踏襲:
+   - 読込層: `read_csv_rows()`
+   - パース層: `parse_status_column()` / `parse_memo_columns()`
+   - 統合層: `build_record_from_row()`
+   - 実行層: `migrate_csv_to_portfolio_shelve()`
+5. 移行時、各レコードに `初回登録` アクションログを 1 件記録
+6. 移行後、shelve のレコード数が CSV 行数とほぼ一致することを確認（ETF や空行は除外される可能性あり）
+
+#### 3-2-4. googledrive.py 経由の自動取り込みは Phase 3 では実装しない
+
+ユーザーが「移行後もスプシ↔shelve の同期を考えている可能性」と回答したが、Phase 3 のスコープでは **手動 CSV エクスポート** に限定する。理由:
+
+- `migrate_research_from_csv.py` も手動エクスポート方式で運用実績あり
+- `googledrive.py` には現状シート読み取り関数がなく、新規実装が必要 → スコープ膨張
+- 移行は 1 回限りの作業（移行後の真実源は portfolio_shelve）
+
+**ただし**、移行後もスプシで編集したい運用が想定される場合は、別 issue で「googledrive 経由の同期 / 再取り込みスクリプト」を後日検討する。Phase 3 の振り返り段階（PR 完了後）で運用感を確認し、必要なら新 issue を立てる。
+
+### 3-3. my_watch_list.txt 取り込み手順（インタビュー Q3, Q7、§3-2-2 の前提を反映）
+
+スプシのステータス列 (col2) は `code_rank.csv` 由来の表示値であり真実源ではない。よって **ステータスは `my_watch_list.txt` のみで決定**する（インタビュー Q7 の「txt 優先」原則をシンプル化）。
+
+#### マージルール（簡素化済み）
+
+| 状況 | ステータス | 手動メモ |
+|---|---|---|
+| txt のみ存在（H 接頭辞） | `1保` | 空 |
+| txt のみ存在（接頭辞なし） | `3監` | 空 |
+| スプシのみ存在 | **`3監`**（txt にない = ウォッチ扱いに倒す） | スプシ採用 |
+| 両方存在 | **txt のステータス**（H 付き→1保 / なし→3監） | スプシ採用 |
+
+#### 実装順序
+
+1. **スプシ CSV 移行**: 識別情報 + 手動メモ 5 列を取り込み、ステータスは仮で `3監` とする
+2. **txt 取り込み**: txt のステータスで上書き（H 付きは `1保`、なしは `3監`、txt にない銘柄は `3監` のまま）
+
+#### `2準` の扱い
+
+仕様書 §7-2 の通り、**txt には `2準` の概念がない**ため移行直後は `1保` / `3監` のみ。`2準` は WebApp（Phase 3b）からのステータス変更でのみ発生する。
+
+### 3-4. parse_my_portforio() 置換（要件 §7-2 ステップ 2）
+
+```python
+# 現行
+def parse_my_portforio() -> Tuple[List[str], List[str]]:
+    # my_watch_list.txt をパース
+    return (watch_codes, possess_codes)
+
+# 置換後（シグネチャ無修正）
+def parse_my_portforio() -> Tuple[List[str], List[str]]:
+    records = portfolio_shelve.list_records()
+    possess = [r["code_s"] for r in records if r["status"] == "1保"]
+    watch   = [r["code_s"] for r in records if r["status"] in ("2準", "3監")]
+    return (watch, possess)
+```
+
+呼び出し側（`make_stock_db.py` / `kessan.py` / `disclosure.py` / `webapp/helpers.py`）は無修正。
+
+#### 3-4-1. **返却の互換性（重要）**
+
+##### 下流処理の順序依存確認 ✅ 完了
+
+実装着手前に `make_stock_db.py` `kessan.py` `disclosure.py` `webapp/helpers.py` の全呼び出し（計 6 箇所）を grep で確認し、**すべて順序非依存** であることを確認:
+
+| 呼び出し元 | 使い方 | 順序依存 |
+|---|---|---|
+| make_stock_db.py:1089 | `(pf_stocks + possess_list)` を `set()` で集合化 | なし |
+| make_stock_db.py:1539 | `set(watch_codes) \| set(possess_codes)` | なし |
+| kessan.py:121 | `if k in code_list_s + possess_list_s` 所属チェック | なし |
+| disclosure.py:251 | for ループ後、最終出力は日付ソート | 実質なし |
+| webapp/helpers.py:680 | `set(possess_list)` 集合 | なし |
+| webapp/helpers.py:1066 | `set(watch_list) \| set(possess_list)` 集合 | なし |
+
+→ `migration_order` フィールドは **不要**。`parse_my_portforio()` は **`code_s` 昇順** など決定論的な順序で返せばよい。
+
+##### 集合の扱い: 「移行で増える分」を意識的に許容する
+
+スプシ移行で 139 件、my_watch_list.txt 取り込みで 327 件が portfolio_shelve に入る。**両者で重複しない銘柄が出るため、`parse_my_portforio()` が返す集合は移行前の txt より広くなりうる**。
+
+- 移行直後に集合が増えると、`make_stock_db.py` の更新対象銘柄が増える可能性がある
+- これは **設計上の意図された変化**（仕様書 §7-2 で portfolio_shelve を真実源にすると決めたため）
+- ただし「いきなり大量の銘柄が更新対象に追加されると挙動が読めない」リスクは残る
+
+##### 互換性検証の 2 段階アプローチ
+
+| 段階 | 比較対象 | 期待 | 目的 |
+|---|---|---|---|
+| **Step 1: データ移行前の純粋な置換テスト** | 現行 txt → 旧 parse vs txt のみを取り込んだ portfolio_shelve → 新 parse | **集合が完全一致**（順序不問） | 置換ロジック自体にバグがないことを保証 |
+| **Step 2: スプシ移行後の「妥当な変化」確認** | 旧 parse の結果 vs スプシ移行 + txt 取り込み後の新 parse | 集合は **新 parse ⊇ 旧 parse**（旧の銘柄はすべて含む）、増分はスプシ由来銘柄のみ | 意図した変化のみが起きたことを確認 |
+
+##### テストとパイロット
+
+1. `test_portfolio.py` に Step 1 テストを追加（fixture で txt のみの portfolio_shelve を作り、現行 parse と新 parse の **集合一致** を確認）
+2. Step 2 は実データでの **手動パイロット**（§3-7 の diff 比較で「増えた銘柄がスプシ由来か」を目視確認）
+
+### 3-5. shelve → txt 一方向同期（インタビュー Q6）
+
+※ インタビュー Q3 では当初「並行運用後に txt 完全削除」を選択していたが、後の判断で **txt 廃止は Phase 3 スコープ外（別 issue）** に変更した。よって本同期は Phase 3 完了後も動き続ける（§5-3 参照）。
+
+#### 同期トリガーの方針（実装中の調整）
+
+当初は「shelve への書き込み API 成功時に自動同期」を想定したが、テスト容易性 / 単一責務 / バルク書き込み時のパフォーマンスを考慮し、**「同期関数 `sync_to_my_watch_list_txt()` を提供し、明示的に呼ぶ」** 方式に変更:
+
+| Phase | 呼び出し元 |
+|---|---|
+| Phase 3a | 移行スクリプト末尾、parse_my_portforio() の置換テスト後 |
+| Phase 3b | WebApp の各書き込みハンドラ（追加・遷移・削除）の末尾 |
+
+DB 側で自動呼び出ししないことで、ユニットテストの DATA_DIR 設定不要で完結し、移行スクリプトのバルク処理も末尾の 1 回呼び出しで済む。
+
+`portfolio_shelve` への書き込み API（upsert / transition / delete）が成功するたびに、txt も書き出す（旧記述、参考）:
+
+```python
+def _sync_to_txt(records: List[dict]) -> None:
+    """portfolio_shelve の現在状態を my_watch_list.txt に書き出す。
+    H 接頭辞付き = 1保、接頭辞なし = 3監。2準 は 3監 として書き出す（txt は 2 値）。"""
+    lines = []
+    for r in sorted(records, key=lambda x: (x["status"], x["code_s"])):
+        prefix = "H" if r["status"] == "1保" else ""
+        lines.append(f"{prefix}{r['code_s']}{r['stock_name']}")
+    DATA_DIR.joinpath("my_watch_list.txt").write_text("\n".join(lines))
+```
+
+`2準` を txt 上で `1保` 扱いとするか `3監` 扱いとするかは、**「txt を見る既存コード」の挙動を変えない方針**が安全。`my_watch_list.txt` の H 接頭辞は「現在の保有」を意味するため、`2準`（直近売却 or もうすぐ買いたい）は `3監` 側に倒す。txt 廃止 issue（別 issue・将来）で txt が消えるまでの暫定処置。
+
+### 3-6. テスト
+
+- `test_portfolio_shelve.py`: upsert / get / list / delete / transition の各 API、ステータス遷移バリデーション、アクションログの不可削除性
+- `test_migrate_portfolio_from_csv.py`: CSV パース、列マッピング、`1保`/`2〇`/`3監` 正規化
+- `test_migrate_my_watch_list_to_shelve.py`: H 接頭辞パース、マージ規則（txt 優先/スプシメモ保持）
+- `test_portfolio.py`: `parse_my_portforio()` の互換性（§3-4-1 Step 1: txt のみ取り込み時に旧 parse と完全一致）、戻り値の型と要素順
+
+### 3-7. リスク・ロールバック
+
+- portfolio_shelve 破損時は my_watch_list.txt が並行運用で残るため、再構築可能
+- 万一 parse_my_portforio() の挙動が想定外に変わると make_stock_db.py / kessan.py 全体に波及。
+
+#### パイロット手順（2 段階）
+
+**Step A: 純粋な置換確認**（データ移行前、portfolio_shelve は空）
+
+1. `python make_stock_db.py list_all_db` を現行コードで実行し、出力 CSV を `_baseline_pre/` に保存
+2. portfolio.py を置換実装に切り替え、**txt のみを取り込んだ portfolio_shelve** を一時的に作成（テスト用 DB パスで）
+3. 同コマンドを再実行し、`_baseline_post_step_a/` に保存
+4. `diff -r _baseline_pre _baseline_post_step_a` → **完全一致** を期待。差分があれば置換ロジックにバグ
+
+**Step B: スプシ移行後の妥当な変化確認**
+
+5. スプシ CSV 移行を実行 → portfolio_shelve に 139 件 + 取り込み済み txt のマージ結果が入る
+6. 同コマンドを再実行し、`_baseline_post_step_b/` に保存
+7. `diff -r _baseline_post_step_a _baseline_post_step_b` → 差分は「スプシ由来銘柄が新規追加された分のみ」を期待
+8. 増えた銘柄を一覧化し、ユーザーが「これらは追加されて妥当」と確認
+
+#### 件数の目安
+
+- Step A 時点: 保有 24 件 + ウォッチ 303 件 = 計 327 件
+- Step B 時点: スプシ 139 件のうち txt にない銘柄が増分。最大 466 件、実際はスプシと txt の重複次第
+
+---
+
+## 4. Phase 3b 詳細
+
+### 4-1. 成果物
+
+| ファイル | 種別 | 内容 |
+|---|---|---|
+| `scripts/webapp/routes/portfolio.py` | 新規 | `/portfolio` ルート（GET / POST） |
+| `scripts/webapp/templates/portfolio_list.html` | 新規 | 3 タブ + 一覧表 |
+| `scripts/webapp/templates/portfolio_edit_dialog.html` | 新規 | ステータス変更/追加/売却/削除のダイアログ部品 |
+| `scripts/webapp/app.py` | 修正 | Blueprint 登録、ナビ追加 |
+| `scripts/webapp/templates/base.html` | 修正 | ナビに `保有銘柄` リンク追加 |
+| `scripts/webapp/templates/detail.html` | 修正 | 銘柄調査ページに「3監 に追加」ボタン追加 |
+| `tests/test_webapp_portfolio_routes.py` | 新規 | ルートのユニットテスト |
+| `tests/e2e/test_portfolio_dashboard.py` | 新規 | Playwright E2E |
+
+### 4-2. URL 設計（インタビュー Q8）
+
+| URL | メソッド | 機能 |
+|---|---|---|
+| `/portfolio?status=hold|semi|watch` | GET | ダッシュボード（タブ切替） |
+| `/portfolio/add` | POST | 銘柄を 3監 に追加 |
+| `/portfolio/<code_s>/transition` | POST | ステータス変更（売却含む） |
+| `/portfolio/<code_s>/delete` | POST | 削除（3監 からのみ） |
+
+`status=hold` ⇄ `1保`、`status=semi` ⇄ `2準`、`status=watch` ⇄ `3監`。
+
+### 4-3. ダッシュボード一覧表示
+
+要件 §5-2 の 6 カテゴリすべてを表示。情報密度が高いので、以下の階層で整理（実装時調整可）:
+
+- **常時表示（左から右へ）**:
+  - コード / 銘柄名 / ステータス
+  - PER / 時価総額 / 配当（最新指標）
+  - RS / ステージ / トレンドテンプレート（テクニカル）
+  - シグナル列（警/売/新高値 等のテキスト表示。**赤バッジ強調なし** = Phase 4 送り）
+  - 理論株価乖離率
+- **開閉式サブセクション（行クリックで展開）**:
+  - 業績の詳細（売上・利益成長率、進捗率）
+  - 手動メモ（IN理由、売買アイデア等）
+
+### 4-4. ステータス変更 UI
+
+ダイアログ:
+
+| シナリオ | UI 動作 | アクションログ種別 |
+|---|---|---|
+| `/stock/<code_s>` から 3監 追加 | 「3監 に追加」ボタン → 確認ダイアログ → POST /portfolio/add | `初回登録` |
+| ダッシュボード行 → 「ステータス変更」 | プルダウン（許可遷移のみ）+ 理由入力 → POST /portfolio/<code_s>/transition | `ステータス変更` または `売却`（1保→2準 の場合） |
+| ダッシュボード（3監 タブ）→ 「削除」 | 確認ダイアログ + 理由入力 → POST /portfolio/<code_s>/delete | `削除` |
+
+1保/2準 タブには「削除」ボタンを **表示しない**（誤操作防止）。
+
+### 4-5. テスト
+
+- `test_webapp_portfolio_routes.py`: 各ルートのリクエスト/レスポンス、不正遷移の拒否（例: 1保 → 削除）
+- Playwright E2E:
+  - シナリオ A: 銘柄詳細 → 「3監 に追加」 → /portfolio?status=watch で表示確認
+  - シナリオ B: 3監 → 2準 → 1保 → 2準 のステータス遷移、各時点でアクションログが増える
+  - シナリオ C: 1保 → 削除を試みてエラー、3監 に戻して削除成功
+
+---
+
+## 5. Phase 3c 詳細
+
+### 5-1. 成果物
+
+| ファイル | 種別 | 内容 |
+|---|---|---|
+| `scripts/webapp/routes/detail.py` | 修正 | 銘柄調査ページに「振り返り」セクション追加 |
+| `scripts/webapp/templates/detail.html` | 修正 | アクションログ時系列表示 |
+| `tests/test_webapp_detail_portfolio.py` | 新規 | 振り返り表示のユニットテスト |
+
+### 5-2. 振り返りビュー（要件 §6-3）
+
+`/stock/<code_s>` の既存ページに「振り返り」セクションを追加。アクションログを時系列降順で表示:
+
+```
+2026-05-03 09:00  ステータス変更 [3監 → 2準]  「決算良好。準保有に格上げ」
+2026-04-15 14:30  初回登録 [→ 3監]              （理由なし）
+```
+
+イベントログは Phase 3 スコープ外なので **アクションログのみ**。Phase 4 でイベントログ実装時に同じビューに統合する。
+
+### 5-3. my_watch_list.txt 廃止は別 issue に切り出し
+
+ユーザー判断により、**txt 廃止は Phase 3 のスコープ外**とする。理由:
+
+- Phase 3 完了直後に txt を消すと、shelve に問題が出た時のフォールバックがなくなる
+- 「運用が安定した」と判断できる期間を 1〜2 週間と決め打ちせず、実運用感覚で判断したい
+- 別 issue にすることで「いつ廃止するか」をユーザーが任意のタイミングで起票できる
+
+#### Phase 3 完了後の状態
+
+- `${KS_DATA_DIR}/my_watch_list.txt` は **存在し続ける**
+- `portfolio.py` の `_sync_to_txt()` (Phase 3a で実装) は **動き続ける**（shelve 更新時に txt も書き出される）
+- `parse_my_portforio()` は portfolio_shelve を真実源として返す
+- `my_watch_list.txt` は **shelve から自動生成されるバックアップ** として残る（手編集はしない方針）
+
+#### 別 issue で扱う作業（将来）
+
+- `_sync_to_txt()` の停止 → 削除
+- `${KS_DATA_DIR}/my_watch_list.txt` の物理削除（**repo 配下ではなく実運用 DATA_DIR 配下**。`KS_DATA_DIR=/Users/k_sohara/Ext/GoogleDrive/shintakane_data`）
+- `grep -r "my_watch_list"` で残存参照がないか確認
+
+これは Phase 3 の振り返り段階で別 issue を立てる。
+
+---
+
+## 6. 実装順序まとめ
+
+### Phase 3a（1 PR）
+
+0. **【ゲート】列マッピング確定** ✅ 完了済み（§3-2-2 参照）
+1. portfolio_shelve.py 作成 + ユニットテスト
+2. migrate_portfolio_from_csv.py 作成 + ユニットテスト
+3. migrate_my_watch_list_to_shelve.py 作成 + ユニットテスト
+4. portfolio.py の parse_my_portforio() を内部実装置換 + 互換性テスト（§3-4-1 Step 1）
+5. **パイロット Step A**: 現行コードでの `make_stock_db.py list_all_db` baseline 取得 → txt のみ取り込み portfolio_shelve で再実行 → 完全一致確認
+6. スプシ CSV 移行スクリプト本番実行（`--dry-run` で先に確認）
+7. **パイロット Step B**: スプシ移行後の `make_stock_db.py list_all_db` 再実行 → 増分がスプシ由来のみであることを確認
+8. shelve → txt 同期実装
+
+### Phase 3b（1 PR、3a マージ後）
+
+1. routes/portfolio.py + templates 作成
+2. base.html / detail.html 修正
+3. ユニットテスト + Playwright E2E
+
+### Phase 3c（1 PR、3b マージ後）
+
+1. 振り返りビュー実装
+
+※ my_watch_list.txt 廃止は **別 issue** に切り出し（運用安定後にユーザー判断で起票）
+
+---
+
+## 7. 開発コマンド
+
+```bash
+# Phase 3a テスト
+pytest tests/test_portfolio_shelve.py tests/test_migrate_portfolio_from_csv.py \
+       tests/test_migrate_my_watch_list_to_shelve.py tests/test_portfolio.py -v
+
+# Phase 3a 移行実行（ユーザー作業）
+cd scripts && python migrate_portfolio_from_csv.py "${KS_DATA_DIR}/migration/portfolio_sheet.csv"
+cd scripts && python migrate_my_watch_list_to_shelve.py
+
+# Phase 3a パイロット
+cd scripts && python make_stock_db.py list_all_db
+
+# Phase 3b テスト
+pytest tests/test_webapp_portfolio_routes.py -v
+pytest tests/e2e/test_portfolio_dashboard.py -v
+
+# Phase 3b 動作確認
+cd scripts && python -m webapp.app
+# → http://localhost:5001/portfolio
+```
+
+---
+
+## 8. オープンクエスチョン（実装時に決める）
+
+- ダッシュボード一覧の「常時表示」と「開閉式サブセクション」の境界（情報密度を見て調整）
+- アクションログ理由欄の必須/任意（種別ごとに変える: 初回登録は任意、削除は必須）
+- スプシ移行 CSV のエンコーディング・列名規約（実物 CSV を見て決定）

--- a/scripts/db_shelve.py
+++ b/scripts/db_shelve.py
@@ -311,6 +311,7 @@ MARKET_SHELVE = os.path.join(DATA_DIR, "market_data", "market_db_shelve")
 KESSAN_SHELVE = os.path.join(DATA_DIR, "todays_kessan_data", "pf_kessan_shelve")
 SECTOR_SHELVE = os.path.join(DATA_DIR, "stock_data", "sector", "sector_db_shelve")
 RESEARCH_SHELVE = os.path.join(DATA_DIR, "stock_data", "research_shelve")
+PORTFOLIO_SHELVE = os.path.join(DATA_DIR, "stock_data", "portfolio_shelve")
 
 
 # ===========================================

--- a/scripts/migrate_my_watch_list_to_shelve.py
+++ b/scripts/migrate_my_watch_list_to_shelve.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+my_watch_list.txt → portfolio_shelve 取り込みスクリプト (Phase 3a / issue #170)
+
+入力: ${KS_DATA_DIR}/my_watch_list.txt (H 接頭辞 = 1保、なし = 3監)
+出力: portfolio_shelve
+
+マージルール (計画書 §3-3):
+- txt のみ存在: ステータスを txt から決定 (H 付き→1保、なし→3監)、メモは空
+- スプシのみ存在: 既存の status="3監" のまま、メモはスプシ採用
+- 両方存在: ステータスは txt 優先で上書き、メモはスプシ採用 (上書きしない)
+
+ステータスは my_watch_list.txt のみを真実源とする (スプシのステータス列は無視)。
+スプシ移行 (migrate_portfolio_from_csv.py) を先に実行し、本スクリプトを後に実行する想定。
+"""
+
+import argparse
+import os
+import re
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+# scripts/ を sys.path に追加 (直接実行時)
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import DATA_DIR, log_print, log_warning, file_read
+except ImportError:
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+    def file_read(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+
+# my_watch_list.txt の行パターン: 先頭オプションの H + 銘柄コード + 銘柄名
+# 銘柄コードは "0001"〜"9999" または "215A" 形式
+LINE_PATTERN = re.compile(r"^(H?)(\d[0-9a-zA-Z]\d[0-9A-Z])(.*)$")
+
+
+def parse_my_watch_list(text: str) -> List[Tuple[str, str, str]]:
+    """テキスト内容をパースして [(code_s, stock_name, status), ...] を返す。
+
+    - H 接頭辞付き → status="1保"
+    - 接頭辞なし → status="3監"
+    - 重複は最初の出現を優先 (txt 内の重複を排除)
+    """
+    seen: Dict[str, Tuple[str, str, str]] = {}
+    for raw_line in text.split("\n"):
+        line = raw_line.strip()
+        if not line:
+            continue
+        m = LINE_PATTERN.match(line)
+        if not m:
+            continue
+        prefix, code_raw, rest = m.group(1), m.group(2), m.group(3)
+        try:
+            ps.validate_code_s(code_raw)
+        except (ValueError, TypeError):
+            continue
+        code_s = ps.normalize_code_s(code_raw)
+        stock_name = rest.strip()
+        status = "1保" if prefix == "H" else "3監"
+        if code_s not in seen:
+            seen[code_s] = (code_s, stock_name, status)
+    return list(seen.values())
+
+
+def merge_into_shelve(
+    entries: List[Tuple[str, str, str]],
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """txt 由来エントリを portfolio_shelve にマージする。
+
+    既存レコードがある場合 (スプシ移行済み):
+    - ステータスは txt 優先で上書き
+    - メモは既存の値を保持 (スプシ採用)
+    - stock_name は既存を保持 (スプシ優先) ※ txt の名前は揺れがあるため
+    既存レコードがない場合 (txt のみ):
+    - 新規レコード作成 (ステータス、銘柄名、メモは空)
+
+    Returns: {"total": int, "created": int, "updated": int, "unchanged": int}
+    """
+    created = 0
+    updated = 0
+    unchanged = 0
+    for code_s, stock_name, status in entries:
+        existing = ps.get_record(code_s, db_path=db_path)
+        if existing is None:
+            # 新規 (txt のみ存在パターン)
+            new_record = ps.create_record(
+                code_s, stock_name, status=status,
+            )
+            ps.upsert_record(new_record, db_path=db_path)
+            ps.append_action_log(
+                code_s,
+                "初回登録",
+                status_from=None,
+                status_to="3監",  # ライフサイクル上は新規=3監で記録
+                reason="txt 取り込み",
+                db_path=db_path,
+            )
+            # 実際の status が 1保 なら 3監→1保 の遷移ログも追加
+            if status != "3監":
+                ps.append_action_log(
+                    code_s,
+                    "ステータス変更",
+                    status_from="3監",
+                    status_to=status,
+                    reason="txt 取り込み (H 接頭辞)",
+                    db_path=db_path,
+                )
+            created += 1
+        else:
+            # 既存 (スプシ移行済み)
+            old_status = existing.get("status")
+            if old_status == status:
+                unchanged += 1
+                continue
+            # ステータスのみ更新、メモは保持
+            existing["status"] = status
+            existing["updated_at"] = ps.now_iso()
+            ps.upsert_record(existing, db_path=db_path)
+            ps.append_action_log(
+                code_s,
+                "ステータス変更",
+                status_from=old_status,
+                status_to=status,
+                reason="txt 取り込みでステータス上書き",
+                db_path=db_path,
+            )
+            updated += 1
+    log_print(
+        f"migrate_my_watch_list: 新規 {created} 件、更新 {updated} 件、"
+        f"変化なし {unchanged} 件"
+    )
+    return {
+        "total": len(entries),
+        "created": created,
+        "updated": updated,
+        "unchanged": unchanged,
+    }
+
+
+def import_my_watch_list(
+    txt_path: Optional[str] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """my_watch_list.txt を読み込んで portfolio_shelve に取り込む。
+
+    Args:
+        txt_path: 入力 txt パス。None なら ${DATA_DIR}/my_watch_list.txt
+
+    Returns: merge_into_shelve の戻り値 (totals)
+    """
+    if txt_path is None:
+        txt_path = os.path.join(DATA_DIR, "my_watch_list.txt")
+    if not os.path.isfile(txt_path):
+        raise FileNotFoundError(f"my_watch_list.txt が見つかりません: {txt_path}")
+    text = file_read(txt_path)
+    entries = parse_my_watch_list(text)
+    log_print(
+        f"migrate_my_watch_list: txt から {len(entries)} 件のエントリ抽出"
+    )
+    return merge_into_shelve(entries, db_path=db_path)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="my_watch_list.txt を portfolio_shelve に取り込む",
+    )
+    parser.add_argument(
+        "--txt-path",
+        type=str,
+        default=None,
+        help=f"入力 txt パス (デフォルト: {os.path.join(DATA_DIR, 'my_watch_list.txt')})",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=str,
+        default=None,
+        help="portfolio_shelve のパス上書き (テスト用)",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = import_my_watch_list(args.txt_path, db_path=args.db_path)
+    except FileNotFoundError as exc:
+        log_warning(str(exc))
+        return 2
+    print(
+        f"total={result['total']} created={result['created']} "
+        f"updated={result['updated']} unchanged={result['unchanged']}"
+    )
+    # 同期は呼ばない: txt 取り込み時は元の txt を上書きすべきでないため
+    # (取り込み入力 = txt 自体なので、上書きすると先頭順序などが壊れる)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_portfolio_from_csv.py
+++ b/scripts/migrate_portfolio_from_csv.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+保有銘柄シート CSV → portfolio_shelve 移行スクリプト (Phase 3a / issue #170)
+
+入力: Google スプレッドシートからエクスポートした CSV (36 列、139 銘柄想定)
+出力: portfolio_shelve
+
+4 層構成 (migrate_research_from_csv.py のパターン踏襲):
+    1. CSV 読込層 (read_csv_rows)
+    2. 列パース層 (parse_memo_columns)
+    3. 統合層 (build_record_from_row)
+    4. 実行層 (migrate_csv_to_portfolio_shelve + main)
+
+重要な前提:
+- スプシ 36 列のうち、指標系列 (順位・PER・配当・RS・トレンドテンプレート 等) と
+  保有リスト列は code_rank.csv からの VLOOKUP 表示値 → 移行対象外
+- ステータスは my_watch_list.txt のみで決定するため、本スクリプトでは設定しない
+  (仮で "3監" を埋めて、後段の migrate_my_watch_list_to_shelve.py で上書き)
+- 移行対象は計 7 列: 銘柄コード / 銘柄名 / 業態テーマ / IN理由 / 売買アイデア
+  / イナゴ元 / 高市感応度
+"""
+
+import argparse
+import csv
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+# scripts/ を sys.path に追加 (直接実行時)
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import log_print, log_warning
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+
+# ===========================================
+# 定数
+# ===========================================
+
+EXPECTED_COL_COUNT = 36
+
+# 列インデックス (確定済み、計画書 §3-2-2 参照)
+COL_CODE_S = 0           # 銘柄コード
+COL_STOCK_NAME = 1       # 銘柄名
+COL_GYOUTAI = 3          # 業態・テーマ
+COL_WATCH_REASON = 31    # ウォッチ・IN理由
+COL_INAGO = 33           # イナゴ元・きっかけ
+COL_TRADE_IDEA = 34      # 投資売買アイデア
+COL_TAKAICHI = 35        # 高市感応度
+
+
+# ===========================================
+# 1. CSV 読込層
+# ===========================================
+
+def read_csv_rows(csv_path: str) -> List[List[str]]:
+    """CSV を読み込み、ヘッダ・空行を除外した 36 列リストを返す。
+
+    入力 CSV の構造:
+    - 1 行目: 全列空 (区切り文字のみ)
+    - 2 行目: ヘッダ
+    - 3 行目以降: データ 139 行
+
+    - 全列空の行はスキップ
+    - 列数が 36 未満ならパディング、超えていれば警告して切り詰め
+    """
+    with open(csv_path, "r", encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        raw_rows = list(reader)
+
+    if not raw_rows:
+        return []
+
+    # 先頭の 2 行 (空行 + ヘッダ) をスキップ
+    # 2 行目がヘッダなのは確認済み (col[0]="銘柄コード")
+    data_start = 0
+    for i, row in enumerate(raw_rows):
+        if any((cell or "").strip() for cell in row):
+            # 最初の非空行がヘッダ
+            data_start = i + 1
+            break
+
+    data_rows = raw_rows[data_start:]
+
+    result: List[List[str]] = []
+    for row in data_rows:
+        if not any((cell or "").strip() for cell in row):
+            continue
+        if len(row) < EXPECTED_COL_COUNT:
+            row = row + [""] * (EXPECTED_COL_COUNT - len(row))
+        elif len(row) > EXPECTED_COL_COUNT:
+            log_warning(
+                f"migrate_portfolio: 列数が {EXPECTED_COL_COUNT} を超える行を切り詰めます: "
+                f"code={row[COL_CODE_S]!r}, cols={len(row)}"
+            )
+            row = row[:EXPECTED_COL_COUNT]
+        result.append(row)
+    return result
+
+
+# ===========================================
+# 2. 列パース層
+# ===========================================
+
+def parse_memo_columns(row: List[str]) -> Tuple[Dict[str, str], List[str]]:
+    """5 つのメモ列をパースして memo dict を返す。
+
+    Returns: (memo dict, warnings)
+    """
+    warnings: List[str] = []
+    if len(row) < EXPECTED_COL_COUNT:
+        warnings.append(
+            f"列数不足: {len(row)} < {EXPECTED_COL_COUNT}"
+        )
+        return ps.create_memo(), warnings
+
+    memo = ps.create_memo(
+        gyoutai_theme=(row[COL_GYOUTAI] or "").strip(),
+        watch_in_reason=(row[COL_WATCH_REASON] or "").strip(),
+        trade_idea=(row[COL_TRADE_IDEA] or "").strip(),
+        inago_origin=(row[COL_INAGO] or "").strip(),
+        takaichi_sensitivity=(row[COL_TAKAICHI] or "").strip(),
+    )
+    return memo, warnings
+
+
+# ===========================================
+# 3. 統合層
+# ===========================================
+
+def build_record_from_row(
+    row: List[str],
+) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    """1行から portfolio レコードを組み立てる。
+
+    Returns: (record dict, warnings)
+        - 銘柄コードが不正 / 空の場合は (None, warnings) を返す
+    """
+    warnings: List[str] = []
+    code_raw = (row[COL_CODE_S] or "").strip() if len(row) > COL_CODE_S else ""
+    if not code_raw:
+        warnings.append("空の銘柄コード行をスキップ")
+        return None, warnings
+
+    try:
+        ps.validate_code_s(code_raw)
+    except (ValueError, TypeError) as exc:
+        warnings.append(f"不正な銘柄コード: {code_raw!r} ({exc})")
+        return None, warnings
+
+    code_s = ps.normalize_code_s(code_raw)
+    stock_name = (row[COL_STOCK_NAME] or "").strip() if len(row) > COL_STOCK_NAME else ""
+    if not stock_name:
+        warnings.append(f"{code_s}: 銘柄名が空")
+
+    memo, memo_warnings = parse_memo_columns(row)
+    warnings.extend(memo_warnings)
+
+    # 仕様: ステータスは仮で 3監 (後段の txt 取り込みで上書きされる)
+    record = ps.create_record(
+        code_s,
+        stock_name,
+        status="3監",
+        memo=memo,
+    )
+    return record, warnings
+
+
+# ===========================================
+# 4. 実行層
+# ===========================================
+
+def migrate_csv_to_portfolio_shelve(
+    csv_path: str,
+    *,
+    dry_run: bool = False,
+    db_path: Optional[str] = None,
+    record_initial_log: bool = True,
+) -> Dict[str, Any]:
+    """CSV 全体を portfolio_shelve に移行する。
+
+    Args:
+        csv_path: 入力 CSV パス
+        dry_run: True なら読み込み・組立まで行うが書き込まない
+        db_path: portfolio_shelve のパス上書き (テスト用)
+        record_initial_log: True なら各レコードに 初回登録 ログを記録 (デフォルト)
+
+    Returns: {"total": int, "saved": int, "skipped": int, "warnings": List[str]}
+    """
+    rows = read_csv_rows(csv_path)
+    log_print(f"migrate_portfolio: {len(rows)} 行を読み込み")
+
+    saved = 0
+    skipped = 0
+    all_warnings: List[str] = []
+    sample_records: List[Dict[str, Any]] = []
+
+    for row in rows:
+        record, warnings = build_record_from_row(row)
+        if warnings:
+            all_warnings.extend(warnings)
+            for w in warnings:
+                log_warning(f"migrate_portfolio: {w}")
+        if record is None:
+            skipped += 1
+            continue
+        if dry_run:
+            if len(sample_records) < 3:
+                sample_records.append(record)
+            saved += 1
+            continue
+        # 既存があれば上書き、新規なら追加
+        existed = ps.get_record(record["code_s"], db_path=db_path) is not None
+        ps.upsert_record(record, db_path=db_path)
+        if record_initial_log and not existed:
+            ps.append_action_log(
+                record["code_s"],
+                "初回登録",
+                status_from=None,
+                status_to=record["status"],
+                reason="スプシ移行",
+                db_path=db_path,
+            )
+        saved += 1
+
+    log_print(
+        f"migrate_portfolio: 保存 {saved} 件、スキップ {skipped} 件、"
+        f"警告 {len(all_warnings)} 件"
+    )
+    if dry_run and sample_records:
+        log_print("migrate_portfolio: dry-run サンプル (先頭 3 件):")
+        for rec in sample_records:
+            log_print(
+                f"  - {rec['code_s']} {rec['stock_name']} status={rec['status']}"
+            )
+            for k, v in rec["memo"].items():
+                if v:
+                    snippet = v[:40].replace("\n", " ")
+                    log_print(f"      {k}: {snippet}{'...' if len(v) > 40 else ''}")
+    return {
+        "total": len(rows),
+        "saved": saved,
+        "skipped": skipped,
+        "warnings": all_warnings,
+    }
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="保有銘柄シート CSV を portfolio_shelve に移行する",
+    )
+    parser.add_argument(
+        "csv_path",
+        type=str,
+        help="入力 CSV パス (例: $KS_DATA_DIR/migration/portfolio_sheet.csv)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="DB に書き込まず、読み込み結果のサマリだけ表示する",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=str,
+        default=None,
+        help="portfolio_shelve のパス上書き (テスト用)",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    if not os.path.isfile(args.csv_path):
+        log_warning(f"migrate_portfolio: CSV が存在しません: {args.csv_path}")
+        return 2
+    result = migrate_csv_to_portfolio_shelve(
+        args.csv_path,
+        dry_run=args.dry_run,
+        db_path=args.db_path,
+    )
+    print(
+        f"total={result['total']} saved={result['saved']} "
+        f"skipped={result['skipped']} warnings={len(result['warnings'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -168,17 +168,15 @@ def parse_portfolio_txt():
     return stocks
 
 
-def parse_my_portforio():
-    """自分のウォッチリストの銘柄コードリストを返す
-    Returns:
-        (list<str>,list<str>): ウォッチリストの銘柄コードリスト、保有リスト
+def _parse_my_portforio_from_txt():
+    """my_watch_list.txt を直接パースして (watch, possess) を返す。
+
+    portfolio_shelve 移行前の旧実装。Phase 3a 移行完了後は
+    parse_my_portforio() のフォールバックとしてのみ使われる。
     """
-    # stocks = {}
     content = file_read(os.path.join(DATA_DIR, "my_watch_list.txt"))
     code_s_list = []
     possess_list = []
-    # 英数字コード対応
-    # for m in re.finditer(r'\d\d\d\d', content):
     for m in re.finditer(r"H?(\d[0-9a-zA-Z]\d[0-9A-Z])", content):
         if m.group(0).find("H") >= 0:
             if not m.group(1) in possess_list:
@@ -186,7 +184,39 @@ def parse_my_portforio():
         else:
             if not m.group(1) in code_s_list:
                 code_s_list.append(m.group(1))
-    # print code_list
+    return code_s_list, possess_list
+
+
+def parse_my_portforio():
+    """自分のウォッチリストの銘柄コードリストを返す。
+
+    Returns:
+        (list<str>,list<str>): (ウォッチ, 保有)
+            ウォッチ = ステータスが 2準 / 3監 の銘柄
+            保有     = ステータスが 1保 の銘柄
+            両リストとも code_s 昇順
+
+    portfolio_shelve を真実源として参照する (Phase 3a)。
+    portfolio_shelve が未作成・空の場合は my_watch_list.txt にフォールバック
+    する (移行前および shelve 障害時の保険)。
+    """
+    try:
+        import portfolio_shelve as ps
+        records = ps.list_records()
+    except Exception as e:
+        log_warning(f"parse_my_portforio: portfolio_shelve 参照失敗、txt にフォールバック: {e}")
+        return _parse_my_portforio_from_txt()
+
+    if not records:
+        # shelve は存在するが空 → txt フォールバック (移行前の挙動互換)
+        return _parse_my_portforio_from_txt()
+
+    possess_list = sorted(
+        r["code_s"] for r in records if r.get("status") == "1保"
+    )
+    code_s_list = sorted(
+        r["code_s"] for r in records if r.get("status") in ("2準", "3監")
+    )
     return code_s_list, possess_list
 
 

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""
+保有銘柄管理DB (portfolio_shelve) の基盤モジュール。
+
+保有銘柄のステータス・手動メモ・アクションログを永続化するための
+shelve ベースのラッパー。
+
+既存の stocks_shelve / research_shelve とは別DBとして分離運用する:
+- stocks_shelve: 揮発性キャッシュ (常に最新値で上書き)
+- research_shelve: 不可逆な蓄積資産 (時系列履歴 + 調査メモ)
+- portfolio_shelve: 保有状態 + 売買判断メモ + アクションログ
+
+依存は一方向: portfolio_shelve が他の2DBを参照する形。
+他のDBのコードは変更しない。
+
+キー名前空間:
+- record:<code_s>            -> 保有レコード本体
+- action_log:<code_s>:<seq>  -> アクションログ (削除後も残る)
+- _seq:<code_s>              -> アクションログの連番カウンタ
+
+ライフサイクル:
+- 追加: (新規) -> 3監 (1保/2準への直接登録は禁止)
+- ステータス変更: 3監 <-> 2準 <-> 1保 / 3監 <-> 1保
+- 売却: 1保 -> 2準 (アクションログ種別「売却」で記録)
+- 削除: 3監 のみ (1保/2準 から直接削除は禁止、レコードは物理削除)
+"""
+
+import fcntl
+import os
+import re
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional
+
+from db_shelve import PORTFOLIO_SHELVE, ShelveDB
+
+try:
+    from ks_util import DATA_DIR, log_print, log_warning
+except ImportError:
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+
+# ===========================================
+# スキーマ定数
+# ===========================================
+
+# 銘柄コードの正規表現 (CLAUDE.md 規約: "0001"〜"9999" または "215A" 形式)
+CODE_S_PATTERN = re.compile(r"^(?:\d{4}|\d{3}[A-Z])$")
+
+# ステータスの許容値
+VALID_STATUSES = frozenset({"1保", "2準", "3監"})
+
+# アクションログ種別
+VALID_ACTION_TYPES = frozenset({"初回登録", "ステータス変更", "売却", "削除"})
+
+# キー名前空間プレフィックス
+KEY_RECORD_PREFIX = "record:"
+KEY_ACTION_LOG_PREFIX = "action_log:"
+KEY_SEQ_PREFIX = "_seq:"
+
+# レコードの既知フィールド
+RECORD_FIELDS = frozenset(
+    {
+        "code_s",
+        "stock_name",
+        "status",
+        "registered_at",
+        "updated_at",
+        "memo",
+    }
+)
+
+MEMO_FIELDS = frozenset(
+    {
+        "gyoutai_theme",          # 業態・テーマ
+        "watch_in_reason",        # ウォッチ・IN理由
+        "trade_idea",             # 投資売買アイデア
+        "inago_origin",           # イナゴ元・きっかけ
+        "takaichi_sensitivity",   # 高市感応度
+    }
+)
+
+ACTION_LOG_FIELDS = frozenset(
+    {
+        "code_s",
+        "seq",
+        "timestamp",
+        "action_type",
+        "status_from",
+        "status_to",
+        "reason",
+    }
+)
+
+# 許可されるステータス遷移 (status_from, status_to)
+# (None, "3監") は新規追加。それ以外は (from, to) の組
+ALLOWED_TRANSITIONS = frozenset(
+    {
+        (None, "3監"),     # 新規追加 (1保/2準 への直接登録禁止)
+        ("3監", "2準"),
+        ("2準", "3監"),
+        ("2準", "1保"),
+        ("1保", "2準"),    # = 売却
+        ("3監", "1保"),
+        ("1保", "3監"),
+    }
+)
+
+
+# ===========================================
+# バリデーション・正規化
+# ===========================================
+
+# JST タイムゾーン (timestamp の付与に使う)
+JST = timezone(timedelta(hours=9))
+
+
+def normalize_code_s(code_s: Any) -> str:
+    """銘柄コード文字列を正規化する。
+
+    - 文字列型でない場合は TypeError
+    - 前後の空白を除去
+    - 英字部分を大文字化
+    """
+    if not isinstance(code_s, str):
+        raise TypeError(f"code_s must be str, got {type(code_s).__name__}")
+    return code_s.strip().upper()
+
+
+def validate_code_s(code_s: Any) -> None:
+    """銘柄コードを検証する。"""
+    normalized = normalize_code_s(code_s)
+    if not CODE_S_PATTERN.match(normalized):
+        raise ValueError(
+            f"invalid code_s: {code_s!r} (正規化後={normalized!r}、"
+            "期待形式は4文字の数字または3桁数字+大文字1文字)"
+        )
+
+
+def validate_status(status: Any) -> None:
+    """ステータスを検証する。"""
+    if status not in VALID_STATUSES:
+        raise ValueError(
+            f"invalid status: {status!r} (許容値: {sorted(VALID_STATUSES)})"
+        )
+
+
+def validate_action_type(action_type: Any) -> None:
+    """アクションログ種別を検証する。"""
+    if action_type not in VALID_ACTION_TYPES:
+        raise ValueError(
+            f"invalid action_type: {action_type!r} "
+            f"(許容値: {sorted(VALID_ACTION_TYPES)})"
+        )
+
+
+def validate_transition(status_from: Optional[str], status_to: str) -> None:
+    """ステータス遷移を検証する。
+
+    status_from=None は新規追加を表す。
+    """
+    if status_from is not None:
+        validate_status(status_from)
+    validate_status(status_to)
+    if (status_from, status_to) not in ALLOWED_TRANSITIONS:
+        raise ValueError(
+            f"invalid transition: {status_from!r} -> {status_to!r} "
+            f"(許可されていない遷移)"
+        )
+
+
+def now_iso() -> str:
+    """現在時刻を ISO 8601 文字列 (JST) で返す。"""
+    return datetime.now(JST).isoformat()
+
+
+# ===========================================
+# キー組立
+# ===========================================
+
+def _record_key(code_s: str) -> str:
+    return f"{KEY_RECORD_PREFIX}{code_s}"
+
+
+def _action_log_key(code_s: str, seq: int) -> str:
+    return f"{KEY_ACTION_LOG_PREFIX}{code_s}:{seq:06d}"
+
+
+def _seq_key(code_s: str) -> str:
+    return f"{KEY_SEQ_PREFIX}{code_s}"
+
+
+def _action_log_prefix_for(code_s: str) -> str:
+    return f"{KEY_ACTION_LOG_PREFIX}{code_s}:"
+
+
+# ===========================================
+# プロセス間排他制御
+# ===========================================
+
+_flock_holder = threading.local()
+
+
+def _lock_path_for(db_path: Optional[str] = None) -> str:
+    base = db_path if db_path is not None else PORTFOLIO_SHELVE
+    return base + ".lock"
+
+
+@contextmanager
+def _flock(db_path: Optional[str] = None):
+    """portfolio_shelve 書き込み用の排他ロック。
+
+    research_shelve と同じパターン。同一スレッドのリエントラントは深さで管理。
+    """
+    if getattr(_flock_holder, "depth", 0) > 0:
+        _flock_holder.depth += 1
+        try:
+            yield
+        finally:
+            _flock_holder.depth -= 1
+        return
+
+    lock_file = _lock_path_for(db_path)
+    lock_dir = os.path.dirname(lock_file)
+    if lock_dir and not os.path.exists(lock_dir):
+        os.makedirs(lock_dir, exist_ok=True)
+    fd = open(lock_file, "a")
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        _flock_holder.depth = 1
+        try:
+            yield
+        finally:
+            _flock_holder.depth = 0
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        fd.close()
+
+
+def _resolve_db_path(db_path: Optional[str]) -> str:
+    return db_path if db_path is not None else PORTFOLIO_SHELVE
+
+
+# ===========================================
+# ファクトリ
+# ===========================================
+
+def create_memo(
+    *,
+    gyoutai_theme: str = "",
+    watch_in_reason: str = "",
+    trade_idea: str = "",
+    inago_origin: str = "",
+    takaichi_sensitivity: str = "",
+) -> Dict[str, str]:
+    """手動メモ dict を生成する。"""
+    return {
+        "gyoutai_theme": gyoutai_theme,
+        "watch_in_reason": watch_in_reason,
+        "trade_idea": trade_idea,
+        "inago_origin": inago_origin,
+        "takaichi_sensitivity": takaichi_sensitivity,
+    }
+
+
+def create_record(
+    code_s: str,
+    stock_name: str,
+    *,
+    status: str = "3監",
+    memo: Optional[Dict[str, str]] = None,
+    registered_at: Optional[str] = None,
+    updated_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    """portfolio レコード dict を生成する。
+
+    - code_s は normalize_code_s で大文字化される
+    - status はデフォルト "3監" (新規追加用)
+    - memo が None なら空メモで埋める
+    - registered_at / updated_at が None なら現在時刻を埋める
+    """
+    validate_code_s(code_s)
+    normalized_code = normalize_code_s(code_s)
+    if not isinstance(stock_name, str):
+        raise TypeError(f"stock_name must be str, got {type(stock_name).__name__}")
+    validate_status(status)
+    if memo is None:
+        memo = create_memo()
+    elif not isinstance(memo, dict):
+        raise TypeError(f"memo must be dict, got {type(memo).__name__}")
+    timestamp = registered_at or now_iso()
+    return {
+        "code_s": normalized_code,
+        "stock_name": stock_name,
+        "status": status,
+        "registered_at": timestamp,
+        "updated_at": updated_at or timestamp,
+        "memo": dict(memo),
+    }
+
+
+# ===========================================
+# CRUD: レコード
+# ===========================================
+
+def get_record(
+    code_s: str,
+    *,
+    db_path: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """1銘柄の保有レコードを取得する。存在しなければ None。"""
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    path = _resolve_db_path(db_path)
+    with ShelveDB(path) as db:
+        return db.get(_record_key(normalized))
+
+
+def list_records(
+    status: Optional[str] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """保有レコードを一覧取得する。
+
+    - status: None で全件、"1保"/"2準"/"3監" 指定で絞り込み
+    - 結果は code_s 昇順
+    """
+    if status is not None:
+        validate_status(status)
+    path = _resolve_db_path(db_path)
+    results: List[Dict[str, Any]] = []
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_RECORD_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            if status is not None and value.get("status") != status:
+                continue
+            results.append(value)
+    results.sort(key=lambda r: r.get("code_s", ""))
+    return results
+
+
+def _next_seq(db: ShelveDB, code_s: str) -> int:
+    """指定銘柄の次のアクションログ seq を返し、カウンタを進める。
+
+    db は既にオープン済みの ShelveDB。呼び出し側で flock 保持を前提とする。
+    """
+    seq_k = _seq_key(code_s)
+    current = db.get(seq_k, 0)
+    nxt = int(current) + 1
+    db[seq_k] = nxt
+    return nxt
+
+
+def append_action_log(
+    code_s: str,
+    action_type: str,
+    *,
+    status_from: Optional[str] = None,
+    status_to: Optional[str] = None,
+    reason: str = "",
+    timestamp: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """アクションログを1件追加する。
+
+    内部利用および移行スクリプトからの直接利用を想定。
+    transition_status / add_to_watch / delete_record からも呼ばれる。
+    レコードを物理削除した後でもログ追記は可能 (ログだけ残す要件のため)。
+
+    Returns: 追記したログエントリ
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    validate_action_type(action_type)
+    if status_from is not None:
+        validate_status(status_from)
+    if status_to is not None:
+        validate_status(status_to)
+    if not isinstance(reason, str):
+        raise TypeError(f"reason must be str, got {type(reason).__name__}")
+    ts = timestamp or now_iso()
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            seq = _next_seq(db, normalized)
+            entry = {
+                "code_s": normalized,
+                "seq": seq,
+                "timestamp": ts,
+                "action_type": action_type,
+                "status_from": status_from,
+                "status_to": status_to,
+                "reason": reason,
+            }
+            db[_action_log_key(normalized, seq)] = entry
+    log_print(
+        "portfolio_shelve: action_log 追記",
+        normalized,
+        action_type,
+        f"seq={seq}",
+    )
+    return entry
+
+
+def list_action_logs(
+    code_s: Optional[str] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """アクションログを取得する。
+
+    - code_s 指定時はその銘柄のみ、None で全銘柄
+    - 結果は (code_s, seq) 昇順
+    """
+    if code_s is not None:
+        validate_code_s(code_s)
+        normalized = normalize_code_s(code_s)
+        prefix = _action_log_prefix_for(normalized)
+    else:
+        prefix = KEY_ACTION_LOG_PREFIX
+    path = _resolve_db_path(db_path)
+    results: List[Dict[str, Any]] = []
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(prefix):
+                continue
+            if not isinstance(value, dict):
+                continue
+            results.append(value)
+    results.sort(
+        key=lambda r: (r.get("code_s", ""), r.get("seq", 0)),
+    )
+    return results
+
+
+# ===========================================
+# 高レベル操作
+# ===========================================
+
+def add_to_watch(
+    code_s: str,
+    stock_name: str,
+    *,
+    memo: Optional[Dict[str, str]] = None,
+    reason: str = "",
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """銘柄を 3監 として新規追加する。
+
+    - 既存レコードが存在する場合は ValueError (重複登録防止)
+    - 同時に 初回登録 アクションログを 1 件記録
+
+    Returns: 追加したレコード
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    record = create_record(normalized, stock_name, status="3監", memo=memo)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            if _record_key(normalized) in db:
+                raise ValueError(
+                    f"portfolio_shelve: {normalized} は既に登録済みです"
+                )
+            db[_record_key(normalized)] = record
+        # ログ追加 (内部で flock 取得済みでもリエントラント対応)
+        append_action_log(
+            normalized,
+            "初回登録",
+            status_from=None,
+            status_to="3監",
+            reason=reason,
+            db_path=db_path,
+        )
+    log_print("portfolio_shelve: 3監 追加", normalized, stock_name)
+    return record
+
+
+def upsert_record(
+    record: Dict[str, Any],
+    *,
+    db_path: Optional[str] = None,
+) -> None:
+    """レコードを追加または上書きする (移行スクリプト用)。
+
+    add_to_watch / transition_status と異なりアクションログは追記しない。
+    呼び出し側で必要なら append_action_log を別途呼ぶこと。
+    """
+    if not isinstance(record, dict):
+        raise TypeError(f"record must be dict, got {type(record).__name__}")
+    if "code_s" not in record:
+        raise ValueError("record に code_s が必須です")
+    validate_code_s(record["code_s"])
+    if "status" in record:
+        validate_status(record["status"])
+    normalized = normalize_code_s(record["code_s"])
+    stored = dict(record)
+    stored["code_s"] = normalized
+
+    unknown = set(stored.keys()) - RECORD_FIELDS
+    if unknown:
+        log_warning(
+            "portfolio_shelve: 未知のレコードフィールドを保存します:",
+            sorted(unknown),
+        )
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            existed = _record_key(normalized) in db
+            db[_record_key(normalized)] = stored
+    if existed:
+        log_print("portfolio_shelve: レコード更新", normalized)
+    else:
+        log_print("portfolio_shelve: レコード追加", normalized)
+
+
+def transition_status(
+    code_s: str,
+    new_status: str,
+    *,
+    reason: str = "",
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """既存レコードのステータスを変更する。
+
+    - 1保 -> 2準 は内部的に「売却」として action_type=売却 で記録
+    - それ以外の遷移は action_type=ステータス変更
+    - 遷移バリデーション (ALLOWED_TRANSITIONS) を満たさなければ ValueError
+    - レコードが存在しない場合は KeyError
+
+    Returns: 更新後のレコード
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    validate_status(new_status)
+    if not isinstance(reason, str):
+        raise TypeError(f"reason must be str, got {type(reason).__name__}")
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _record_key(normalized)
+            if key not in db:
+                raise KeyError(
+                    f"portfolio_shelve: {normalized} はレコード未登録です"
+                )
+            record = db[key]
+            old_status = record.get("status")
+            if old_status == new_status:
+                # 同一ステータスへの遷移は no-op (バリデーション前に判定)
+                log_print(
+                    "portfolio_shelve: 同一ステータスのため遷移スキップ",
+                    normalized,
+                    new_status,
+                )
+                return record
+            validate_transition(old_status, new_status)
+            record["status"] = new_status
+            record["updated_at"] = now_iso()
+            db[key] = record
+        # アクションログ種別: 1保→2準 は売却、それ以外はステータス変更
+        action_type = "売却" if old_status == "1保" and new_status == "2準" else "ステータス変更"
+        append_action_log(
+            normalized,
+            action_type,
+            status_from=old_status,
+            status_to=new_status,
+            reason=reason,
+            db_path=db_path,
+        )
+    log_print(
+        "portfolio_shelve: ステータス変更",
+        normalized,
+        f"{old_status} -> {new_status}",
+    )
+    return record
+
+
+def delete_record(
+    code_s: str,
+    *,
+    reason: str = "",
+    db_path: Optional[str] = None,
+) -> bool:
+    """レコードを物理削除する (3監 のみ可能)。
+
+    - 1保/2準 を削除しようとすると ValueError
+    - レコードが存在しない場合は False を返す
+    - 削除に成功した場合は アクションログ「削除」を 1 件記録 (ログは残る)
+
+    Returns: 削除に成功すれば True、未存在なら False
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    if not isinstance(reason, str):
+        raise TypeError(f"reason must be str, got {type(reason).__name__}")
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _record_key(normalized)
+            if key not in db:
+                return False
+            record = db[key]
+            current_status = record.get("status")
+            if current_status != "3監":
+                raise ValueError(
+                    f"portfolio_shelve: {normalized} は status={current_status!r} のため "
+                    "削除できません (3監 のみ削除可能、先に 3監 へ遷移してください)"
+                )
+            del db[key]
+        append_action_log(
+            normalized,
+            "削除",
+            status_from="3監",
+            status_to=None,
+            reason=reason,
+            db_path=db_path,
+        )
+    log_print("portfolio_shelve: レコード削除", normalized)
+    return True
+
+
+# ===========================================
+# my_watch_list.txt 一方向同期
+# ===========================================
+
+def sync_to_my_watch_list_txt(
+    *,
+    txt_path: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> str:
+    """portfolio_shelve の現在状態を my_watch_list.txt に書き出す。
+
+    一方向同期 (shelve → txt)。txt 廃止 issue (将来) で sync 自体を停止する想定。
+    旧コードと既存運用との互換のため、Phase 3 完了後も同期は有効のまま残す。
+
+    フォーマット (現行 my_watch_list.txt 互換):
+    - 1保 → "H<code_s><stock_name>" (H 接頭辞)
+    - 2準 → "<code_s><stock_name>" (txt は 2 値しかないので 3監 扱い)
+    - 3監 → "<code_s><stock_name>"
+
+    出力順:
+    - 1保 を先頭にまとめる (H 付きが先頭にある現行 txt の見た目を維持)
+    - 各グループ内は code_s 昇順
+    - 1保 と 3監/2準 の間に空行を 1 行入れる (現行 txt の見た目互換)
+
+    Args:
+        txt_path: 出力 txt パス。None なら ${DATA_DIR}/my_watch_list.txt
+        db_path: portfolio_shelve のパス上書き (テスト用)
+
+    Returns: 書き出した txt のパス
+    """
+    if txt_path is None:
+        txt_path = os.path.join(DATA_DIR, "my_watch_list.txt")
+    records = list_records(db_path=db_path)
+
+    holds = sorted(
+        (r for r in records if r.get("status") == "1保"),
+        key=lambda r: r.get("code_s", ""),
+    )
+    others = sorted(
+        (r for r in records if r.get("status") in ("2準", "3監")),
+        key=lambda r: r.get("code_s", ""),
+    )
+
+    lines: List[str] = []
+    for r in holds:
+        lines.append(f"H{r.get('code_s', '')}{r.get('stock_name', '')}")
+    if holds and others:
+        lines.append("")
+    for r in others:
+        lines.append(f"{r.get('code_s', '')}{r.get('stock_name', '')}")
+
+    txt_dir = os.path.dirname(txt_path)
+    if txt_dir and not os.path.exists(txt_dir):
+        os.makedirs(txt_dir, exist_ok=True)
+    with open(txt_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+        if lines:
+            f.write("\n")
+
+    log_print(
+        f"portfolio_shelve: my_watch_list.txt 同期完了 holds={len(holds)} "
+        f"others={len(others)} path={txt_path}"
+    )
+    return txt_path

--- a/tests/test_migrate_my_watch_list_to_shelve.py
+++ b/tests/test_migrate_my_watch_list_to_shelve.py
@@ -1,0 +1,210 @@
+"""migrate_my_watch_list_to_shelve.py のテスト"""
+
+import pytest
+
+import migrate_my_watch_list_to_shelve as mw
+import portfolio_shelve as ps
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+@pytest.fixture
+def txt_path(tmp_path):
+    p = tmp_path / "my_watch_list.txt"
+    return str(p)
+
+
+def _write_txt(path, content):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+# ==================================================
+# parse_my_watch_list
+# ==================================================
+class TestParse:
+
+    def test_parse_h_prefix_as_hold(self):
+        text = "H7047ポート\nH4377ワンキャリア\n"
+        entries = mw.parse_my_watch_list(text)
+        assert len(entries) == 2
+        assert entries[0] == ("7047", "ポート", "1保")
+        assert entries[1] == ("4377", "ワンキャリア", "1保")
+
+    def test_parse_no_prefix_as_watch(self):
+        text = "5032AnyColor\n6232ACSL\n"
+        entries = mw.parse_my_watch_list(text)
+        assert entries[0] == ("5032", "AnyColor", "3監")
+        assert entries[1] == ("6232", "ACSL", "3監")
+
+    def test_parse_alpha_code(self):
+        text = "H402Aアクセルスペース\n"
+        entries = mw.parse_my_watch_list(text)
+        assert entries[0] == ("402A", "アクセルスペース", "1保")
+
+    def test_parse_skips_blank_and_invalid_lines(self):
+        text = "H7047ポート\n\nINVALID\n5032AnyColor\n"
+        entries = mw.parse_my_watch_list(text)
+        codes = [e[0] for e in entries]
+        assert codes == ["7047", "5032"]
+
+    def test_parse_dedupes_keeping_first(self):
+        text = "H7047ポート\n7047重複\n"
+        entries = mw.parse_my_watch_list(text)
+        assert len(entries) == 1
+        assert entries[0] == ("7047", "ポート", "1保")
+
+    def test_parse_real_format(self):
+        """実際の my_watch_list.txt と同じフォーマット"""
+        text = (
+            "H7047ポート\n"
+            "H2980SREHD\n"
+            "\n"
+            "7717ブイ・テクノロジー\n"
+            "5032AnyColor\n"
+        )
+        entries = mw.parse_my_watch_list(text)
+        codes = [(e[0], e[2]) for e in entries]
+        assert codes == [
+            ("7047", "1保"),
+            ("2980", "1保"),
+            ("7717", "3監"),
+            ("5032", "3監"),
+        ]
+
+
+# ==================================================
+# merge_into_shelve: txt のみ存在パターン
+# ==================================================
+class TestMergeTxtOnly:
+
+    def test_creates_new_records(self, db_path):
+        entries = [
+            ("7047", "ポート", "1保"),
+            ("5032", "AnyColor", "3監"),
+        ]
+        result = mw.merge_into_shelve(entries, db_path=db_path)
+        assert result["created"] == 2
+        assert result["updated"] == 0
+        records = ps.list_records(db_path=db_path)
+        assert len(records) == 2
+
+    def test_status_set_correctly_for_h_prefix(self, db_path):
+        mw.merge_into_shelve(
+            [("7047", "ポート", "1保")], db_path=db_path
+        )
+        rec = ps.get_record("7047", db_path=db_path)
+        assert rec["status"] == "1保"
+
+    def test_action_logs_for_new_hold(self, db_path):
+        """1保 で新規追加された場合、初回登録 + ステータス変更の 2 ログ"""
+        mw.merge_into_shelve(
+            [("7047", "ポート", "1保")], db_path=db_path
+        )
+        logs = ps.list_action_logs("7047", db_path=db_path)
+        assert len(logs) == 2
+        assert logs[0]["action_type"] == "初回登録"
+        assert logs[0]["status_to"] == "3監"  # ライフサイクル原則
+        assert logs[1]["action_type"] == "ステータス変更"
+        assert logs[1]["status_from"] == "3監"
+        assert logs[1]["status_to"] == "1保"
+
+    def test_action_log_for_new_watch(self, db_path):
+        """3監 で新規追加された場合、初回登録ログ 1 件のみ"""
+        mw.merge_into_shelve(
+            [("5032", "AnyColor", "3監")], db_path=db_path
+        )
+        logs = ps.list_action_logs("5032", db_path=db_path)
+        assert len(logs) == 1
+        assert logs[0]["action_type"] == "初回登録"
+        assert logs[0]["status_to"] == "3監"
+
+
+# ==================================================
+# merge_into_shelve: 既存レコード (スプシ移行済み) 上書き
+# ==================================================
+class TestMergeWithExisting:
+
+    def test_overwrites_status_keeps_memo(self, db_path):
+        """既存レコード (スプシ由来、メモあり) のステータスを txt で上書き"""
+        # 先にスプシ由来レコードを upsert (ステータスは仮で "3監")
+        memo = ps.create_memo(gyoutai_theme="人材", trade_idea="押し目")
+        existing = ps.create_record(
+            "7047", "ポート (スプシ名)", status="3監", memo=memo,
+        )
+        ps.upsert_record(existing, db_path=db_path)
+
+        # txt 取り込み (1保 として上書き)
+        mw.merge_into_shelve(
+            [("7047", "ポート (txt名)", "1保")], db_path=db_path
+        )
+
+        rec = ps.get_record("7047", db_path=db_path)
+        assert rec["status"] == "1保"  # txt のステータスで上書きされた
+        # メモは保持
+        assert rec["memo"]["gyoutai_theme"] == "人材"
+        assert rec["memo"]["trade_idea"] == "押し目"
+        # stock_name はスプシ由来を保持 (上書きしない)
+        assert rec["stock_name"] == "ポート (スプシ名)"
+
+    def test_no_change_when_status_matches(self, db_path):
+        existing = ps.create_record("5032", "AnyColor", status="3監")
+        ps.upsert_record(existing, db_path=db_path)
+
+        result = mw.merge_into_shelve(
+            [("5032", "AnyColor", "3監")], db_path=db_path
+        )
+        assert result["unchanged"] == 1
+        assert result["updated"] == 0
+        # アクションログは増えない
+        logs = ps.list_action_logs("5032", db_path=db_path)
+        assert logs == []
+
+    def test_records_status_change_log(self, db_path):
+        """既存ステータスからの変更ログが記録される"""
+        existing = ps.create_record("7047", "ポート", status="3監")
+        ps.upsert_record(existing, db_path=db_path)
+
+        mw.merge_into_shelve(
+            [("7047", "ポート", "1保")], db_path=db_path
+        )
+
+        logs = ps.list_action_logs("7047", db_path=db_path)
+        assert len(logs) == 1
+        assert logs[0]["action_type"] == "ステータス変更"
+        assert logs[0]["status_from"] == "3監"
+        assert logs[0]["status_to"] == "1保"
+
+
+# ==================================================
+# import_my_watch_list (実行層)
+# ==================================================
+class TestImport:
+
+    def test_import_from_file(self, txt_path, db_path):
+        _write_txt(txt_path, "H7047ポート\n5032AnyColor\n")
+        result = mw.import_my_watch_list(txt_path, db_path=db_path)
+        assert result["created"] == 2
+        records = ps.list_records(db_path=db_path)
+        codes = [r["code_s"] for r in records]
+        assert codes == ["5032", "7047"]
+        statuses = {r["code_s"]: r["status"] for r in records}
+        assert statuses == {"7047": "1保", "5032": "3監"}
+
+    def test_import_missing_file(self, tmp_path, db_path):
+        with pytest.raises(FileNotFoundError):
+            mw.import_my_watch_list(
+                str(tmp_path / "missing.txt"), db_path=db_path
+            )
+
+    def test_idempotent_rerun(self, txt_path, db_path):
+        """同じ txt を 2 回流しても二重登録にならない"""
+        _write_txt(txt_path, "H7047ポート\n5032AnyColor\n")
+        mw.import_my_watch_list(txt_path, db_path=db_path)
+        result = mw.import_my_watch_list(txt_path, db_path=db_path)
+        assert result["created"] == 0
+        assert result["updated"] == 0
+        assert result["unchanged"] == 2

--- a/tests/test_migrate_portfolio_from_csv.py
+++ b/tests/test_migrate_portfolio_from_csv.py
@@ -1,0 +1,258 @@
+"""migrate_portfolio_from_csv.py のテスト"""
+
+import csv
+
+import pytest
+
+import migrate_portfolio_from_csv as mp
+import portfolio_shelve as ps
+
+
+# ==================================================
+# fixtures
+# ==================================================
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+def _make_row(
+    *,
+    code_s: str = "",
+    stock_name: str = "",
+    gyoutai: str = "",
+    watch_reason: str = "",
+    inago: str = "",
+    trade_idea: str = "",
+    takaichi: str = "",
+) -> list:
+    """36 列の行を組み立てる。指標系列は空文字で埋める。"""
+    row = [""] * mp.EXPECTED_COL_COUNT
+    row[mp.COL_CODE_S] = code_s
+    row[mp.COL_STOCK_NAME] = stock_name
+    row[mp.COL_GYOUTAI] = gyoutai
+    row[mp.COL_WATCH_REASON] = watch_reason
+    row[mp.COL_INAGO] = inago
+    row[mp.COL_TRADE_IDEA] = trade_idea
+    row[mp.COL_TAKAICHI] = takaichi
+    return row
+
+
+@pytest.fixture
+def sample_csv(tmp_path):
+    """先頭空行 + ヘッダ + 3 行データの CSV を作成。"""
+    csv_path = tmp_path / "portfolio.csv"
+    rows = [
+        [""] * mp.EXPECTED_COL_COUNT,  # 1 行目: 空行
+        # 2 行目: ヘッダ
+        [
+            "銘柄コード", "銘柄名", "保有リスト", "業態・テーマ",
+            *([""] * 27),
+            "ウォッチ・IN理由",
+            "需給チャート",
+            "イナゴ元・きっかけ",
+            "投資売買アイデア",
+            "高市感応度",
+        ],
+        _make_row(
+            code_s="4377",
+            stock_name="ワンキャリア",
+            gyoutai="人材\n少子高齢",
+            watch_reason="新卒シェアトップ",
+            trade_idea="押し目買い",
+            inago="ケイ",
+            takaichi="C:給付付き税額控除",
+        ),
+        _make_row(
+            code_s="7089",
+            stock_name="フォースタートアップス",
+            gyoutai="人材",
+            takaichi="B:成長産業への積極投資",
+        ),
+        _make_row(
+            code_s="215A",
+            stock_name="アクセルスペース",
+        ),
+    ]
+    # ヘッダ行の長さ調整
+    if len(rows[1]) < mp.EXPECTED_COL_COUNT:
+        rows[1] += [""] * (mp.EXPECTED_COL_COUNT - len(rows[1]))
+    with open(csv_path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)
+    return str(csv_path)
+
+
+# ==================================================
+# 読込層
+# ==================================================
+class TestReadCsvRows:
+
+    def test_skips_empty_first_row_and_header(self, sample_csv):
+        rows = mp.read_csv_rows(sample_csv)
+        assert len(rows) == 3
+        assert rows[0][mp.COL_CODE_S] == "4377"
+        assert rows[1][mp.COL_CODE_S] == "7089"
+        assert rows[2][mp.COL_CODE_S] == "215A"
+
+    def test_pads_short_rows(self, tmp_path):
+        csv_path = tmp_path / "short.csv"
+        with open(csv_path, "w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            w.writerow([""] * mp.EXPECTED_COL_COUNT)  # 空行
+            w.writerow(["銘柄コード", "銘柄名"])     # ヘッダ
+            w.writerow(["4377", "ワンキャリア"])     # データ (2 列のみ)
+        rows = mp.read_csv_rows(str(csv_path))
+        assert len(rows) == 1
+        assert len(rows[0]) == mp.EXPECTED_COL_COUNT
+        assert rows[0][mp.COL_CODE_S] == "4377"
+
+
+# ==================================================
+# 列パース層
+# ==================================================
+class TestParseMemoColumns:
+
+    def test_extracts_5_memo_fields(self):
+        row = _make_row(
+            gyoutai="人材",
+            watch_reason="新卒",
+            trade_idea="押し目",
+            inago="ケイ",
+            takaichi="C",
+        )
+        memo, warnings = mp.parse_memo_columns(row)
+        assert memo["gyoutai_theme"] == "人材"
+        assert memo["watch_in_reason"] == "新卒"
+        assert memo["trade_idea"] == "押し目"
+        assert memo["inago_origin"] == "ケイ"
+        assert memo["takaichi_sensitivity"] == "C"
+        assert warnings == []
+
+    def test_strips_whitespace(self):
+        row = _make_row(gyoutai="  人材  ")
+        memo, _ = mp.parse_memo_columns(row)
+        assert memo["gyoutai_theme"] == "人材"
+
+    def test_handles_short_row(self):
+        memo, warnings = mp.parse_memo_columns(["4377", "x"])
+        assert memo == ps.create_memo()
+        assert warnings  # 列数不足の警告あり
+
+
+# ==================================================
+# 統合層
+# ==================================================
+class TestBuildRecordFromRow:
+
+    def test_minimal_row(self):
+        row = _make_row(code_s="4377", stock_name="ワンキャリア")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is not None
+        assert rec["code_s"] == "4377"
+        assert rec["stock_name"] == "ワンキャリア"
+        assert rec["status"] == "3監"  # 仮ステータス
+        assert warnings == []
+
+    def test_full_row(self):
+        row = _make_row(
+            code_s="4377",
+            stock_name="ワンキャリア",
+            gyoutai="人材",
+            takaichi="C",
+        )
+        rec, _ = mp.build_record_from_row(row)
+        assert rec["memo"]["gyoutai_theme"] == "人材"
+        assert rec["memo"]["takaichi_sensitivity"] == "C"
+
+    def test_empty_code_returns_none(self):
+        row = _make_row(stock_name="名前あり")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is None
+        assert any("空の銘柄コード" in w for w in warnings)
+
+    def test_invalid_code_returns_none(self):
+        row = _make_row(code_s="ABC1", stock_name="不正コード")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is None
+        assert any("不正な銘柄コード" in w for w in warnings)
+
+    def test_lowercase_code_normalized(self):
+        row = _make_row(code_s="215a", stock_name="テスト")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is not None
+        assert rec["code_s"] == "215A"
+
+    def test_empty_stock_name_warns_but_succeeds(self):
+        row = _make_row(code_s="4377")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is not None
+        assert rec["stock_name"] == ""
+        assert any("銘柄名が空" in w for w in warnings)
+
+
+# ==================================================
+# 実行層
+# ==================================================
+class TestMigrate:
+
+    def test_dry_run_does_not_write(self, sample_csv, db_path):
+        result = mp.migrate_csv_to_portfolio_shelve(
+            sample_csv, dry_run=True, db_path=db_path
+        )
+        assert result["total"] == 3
+        assert result["saved"] == 3
+        assert result["skipped"] == 0
+        # DB は空のまま
+        records = ps.list_records(db_path=db_path)
+        assert records == []
+
+    def test_writes_records(self, sample_csv, db_path):
+        result = mp.migrate_csv_to_portfolio_shelve(
+            sample_csv, dry_run=False, db_path=db_path
+        )
+        assert result["saved"] == 3
+        records = ps.list_records(db_path=db_path)
+        codes = sorted(r["code_s"] for r in records)
+        assert codes == ["215A", "4377", "7089"]
+
+    def test_records_initial_log(self, sample_csv, db_path):
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        for code in ["4377", "7089", "215A"]:
+            logs = ps.list_action_logs(code, db_path=db_path)
+            assert len(logs) == 1
+            assert logs[0]["action_type"] == "初回登録"
+            assert logs[0]["status_to"] == "3監"
+            assert logs[0]["reason"] == "スプシ移行"
+
+    def test_memo_preserves_multiline(self, sample_csv, db_path):
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        rec = ps.get_record("4377", db_path=db_path)
+        assert "\n" in rec["memo"]["gyoutai_theme"]
+        assert rec["memo"]["takaichi_sensitivity"] == "C:給付付き税額控除"
+
+    def test_skips_invalid_rows(self, tmp_path, db_path):
+        csv_path = tmp_path / "with_invalid.csv"
+        rows = [
+            [""] * mp.EXPECTED_COL_COUNT,
+            ["銘柄コード"] + [""] * (mp.EXPECTED_COL_COUNT - 1),
+            _make_row(code_s="4377", stock_name="OK"),
+            _make_row(code_s="ABC1", stock_name="不正コード"),
+            _make_row(stock_name="コード空"),
+            _make_row(code_s="7089", stock_name="OK2"),
+        ]
+        with open(csv_path, "w", encoding="utf-8", newline="") as f:
+            csv.writer(f).writerows(rows)
+        result = mp.migrate_csv_to_portfolio_shelve(
+            str(csv_path), db_path=db_path
+        )
+        assert result["saved"] == 2
+        assert result["skipped"] == 2
+
+    def test_rerun_does_not_duplicate_log(self, sample_csv, db_path):
+        """再実行しても 初回登録 ログは増えない (既存判定)"""
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 1

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,185 @@
+"""portfolio.py の parse_my_portforio() 互換性テスト。
+
+§3-4-1 Step 1: txt のみを取り込んだ portfolio_shelve に対し、
+新実装 (shelve 参照) と旧実装 (txt 直接パース) で **集合一致** を保証する。
+"""
+
+import os
+
+import pytest
+
+import portfolio
+import portfolio_shelve as ps
+import migrate_my_watch_list_to_shelve as mw
+
+
+# ==================================================
+# fixtures
+# ==================================================
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """portfolio.py が参照する DATA_DIR を一時ディレクトリに差し替える。
+
+    portfolio_shelve のパスも tmp_path 配下に変更し、テスト同士が干渉しないようにする。
+    """
+    monkeypatch.setattr(portfolio, "DATA_DIR", str(tmp_path))
+    # portfolio_shelve のグローバルパスを差し替えてテスト用 DB を使う
+    test_db_path = str(tmp_path / "portfolio_shelve")
+    monkeypatch.setattr(ps, "PORTFOLIO_SHELVE", test_db_path)
+    return tmp_path
+
+
+def _write_txt(tmp_path, content):
+    txt = tmp_path / "my_watch_list.txt"
+    with open(txt, "w", encoding="utf-8") as f:
+        f.write(content)
+    return str(txt)
+
+
+# ==================================================
+# フォールバック: shelve 空 / 障害時に txt 経由で動く
+# ==================================================
+class TestFallbackToTxt:
+
+    def test_falls_back_to_txt_when_shelve_empty(self, isolated_data_dir):
+        """portfolio_shelve が空なら旧実装 (txt) を使う"""
+        _write_txt(isolated_data_dir, "H7047ポート\n5032AnyColor\n")
+        watch, hold = portfolio.parse_my_portforio()
+        assert "7047" in hold
+        assert "5032" in watch
+
+    def test_uses_shelve_when_populated(self, isolated_data_dir):
+        """shelve に登録があれば shelve を使う (txt は無関係)"""
+        # shelve に書き込み
+        ps.add_to_watch("7047", "ポート")
+        ps.transition_status("7047", "1保")
+        # txt とは別の銘柄
+        _write_txt(isolated_data_dir, "H9999別銘柄\n")
+        watch, hold = portfolio.parse_my_portforio()
+        # shelve 由来のみ返る、txt の 9999 は無視
+        assert hold == ["7047"]
+        assert watch == []
+
+
+# ==================================================
+# Step 1 互換性: txt のみ取り込み → 集合一致
+# ==================================================
+class TestStep1CompatibilityWithTxtOnly:
+    """§3-4-1 Step 1: portfolio_shelve に txt のみを取り込んだ状態で、
+    旧実装 (txt 直接) と新実装 (shelve 参照) の戻り値の **集合が一致** することを確認。
+    """
+
+    def test_basic_compatibility(self, isolated_data_dir):
+        txt_content = (
+            "H7047ポート\n"
+            "H4377ワンキャリア\n"
+            "H402Aアクセルスペース\n"
+            "5032AnyColor\n"
+            "6232ACSL\n"
+            "5243note\n"
+        )
+        txt_path = _write_txt(isolated_data_dir, txt_content)
+
+        # 旧実装相当 (txt 直接 parse)
+        old_watch, old_hold = portfolio._parse_my_portforio_from_txt()
+
+        # txt を portfolio_shelve に取り込み
+        mw.import_my_watch_list(txt_path)
+
+        # 新実装 (shelve 参照)
+        new_watch, new_hold = portfolio.parse_my_portforio()
+
+        # 集合が完全一致
+        assert set(old_watch) == set(new_watch)
+        assert set(old_hold) == set(new_hold)
+
+    def test_empty_txt(self, isolated_data_dir):
+        _write_txt(isolated_data_dir, "")
+        old_watch, old_hold = portfolio._parse_my_portforio_from_txt()
+        new_watch, new_hold = portfolio.parse_my_portforio()
+        # 旧 (txt 空) と新 (shelve 空 → txt フォールバック → 空) で一致
+        assert old_watch == new_watch == []
+        assert old_hold == new_hold == []
+
+    def test_only_holds(self, isolated_data_dir):
+        txt_path = _write_txt(
+            isolated_data_dir, "H7047ポート\nH4377ワンキャリア\n"
+        )
+        mw.import_my_watch_list(txt_path)
+        watch, hold = portfolio.parse_my_portforio()
+        assert set(watch) == set()
+        assert set(hold) == {"7047", "4377"}
+
+    def test_only_watch(self, isolated_data_dir):
+        txt_path = _write_txt(
+            isolated_data_dir, "5032AnyColor\n6232ACSL\n"
+        )
+        mw.import_my_watch_list(txt_path)
+        watch, hold = portfolio.parse_my_portforio()
+        assert set(watch) == {"5032", "6232"}
+        assert set(hold) == set()
+
+
+# ==================================================
+# 戻り値の型・順序保証
+# ==================================================
+class TestReturnTypeAndOrder:
+
+    def test_returns_two_lists(self, isolated_data_dir):
+        ps.add_to_watch("7047", "ポート")
+        watch, hold = portfolio.parse_my_portforio()
+        assert isinstance(watch, list)
+        assert isinstance(hold, list)
+
+    def test_sorted_by_code_s(self, isolated_data_dir):
+        for code in ["7089", "4377", "215A"]:
+            ps.add_to_watch(code, code)
+        for code in ["7047", "2980", "402A"]:
+            ps.add_to_watch(code, code)
+            ps.transition_status(code, "1保")
+
+        watch, hold = portfolio.parse_my_portforio()
+        # code_s 昇順 (決定論的)
+        assert watch == sorted(watch)
+        assert hold == sorted(hold)
+
+    def test_2jun_treated_as_watch(self, isolated_data_dir):
+        """2準 はウォッチ側に含まれる (txt には 2準 がないが、shelve 経由では発生する)"""
+        ps.add_to_watch("7047", "ポート")
+        ps.transition_status("7047", "2準")
+        watch, hold = portfolio.parse_my_portforio()
+        assert "7047" in watch
+        assert "7047" not in hold
+
+
+# ==================================================
+# Step 2 互換性: 集合関係の確認
+# ==================================================
+class TestStep2SetRelation:
+    """§3-4-1 Step 2: スプシ移行後、新 parse は旧 parse の集合を **上回る** ことを確認。
+    増分はスプシ由来銘柄のみ。
+    """
+
+    def test_new_set_is_superset(self, isolated_data_dir):
+        """txt + スプシ追加銘柄を取り込んだ shelve は txt のみ集合を包含する"""
+        # txt 由来
+        txt_path = _write_txt(
+            isolated_data_dir, "H7047ポート\n5032AnyColor\n"
+        )
+        mw.import_my_watch_list(txt_path)
+        # txt のみ集合 (旧実装相当)
+        old_watch, old_hold = portfolio._parse_my_portforio_from_txt()
+        old_set = set(old_watch) | set(old_hold)
+
+        # スプシのみの銘柄を追加
+        ps.add_to_watch("4377", "スプシ追加銘柄")  # 3監
+
+        # 新 parse の集合
+        new_watch, new_hold = portfolio.parse_my_portforio()
+        new_set = set(new_watch) | set(new_hold)
+
+        # 旧 ⊆ 新
+        assert old_set <= new_set
+        # 増分はスプシ由来 (4377) のみ
+        assert new_set - old_set == {"4377"}

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1,0 +1,415 @@
+"""portfolio_shelve.py のテスト (tmp_path で一時DBを作成)"""
+
+import pytest
+
+import portfolio_shelve as ps
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """テスト用一時DBパスを返す"""
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+# ==================================================
+# スキーマ層: 正規化・バリデーション・ファクトリ
+# ==================================================
+class TestSchema:
+    """スキーマ層のユニットテスト"""
+
+    def test_normalize_code_s_strips_and_uppercases(self):
+        assert ps.normalize_code_s(" 6324 ") == "6324"
+        assert ps.normalize_code_s("215a") == "215A"
+
+    def test_normalize_code_s_rejects_non_str(self):
+        with pytest.raises(TypeError):
+            ps.normalize_code_s(6324)
+
+    def test_validate_code_s_accepts_valid(self):
+        ps.validate_code_s("6324")
+        ps.validate_code_s("215A")
+        ps.validate_code_s("0001")
+
+    def test_validate_code_s_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            ps.validate_code_s("63")
+        with pytest.raises(ValueError):
+            ps.validate_code_s("12345")
+
+    def test_validate_status_accepts_valid(self):
+        for s in ("1保", "2準", "3監"):
+            ps.validate_status(s)
+
+    def test_validate_status_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            ps.validate_status("4売")
+        with pytest.raises(ValueError):
+            ps.validate_status("hold")
+
+    def test_validate_action_type_accepts_valid(self):
+        for t in ("初回登録", "ステータス変更", "売却", "削除"):
+            ps.validate_action_type(t)
+
+    def test_validate_action_type_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            ps.validate_action_type("追加")
+
+    def test_validate_transition_allowed(self):
+        ps.validate_transition(None, "3監")          # 新規追加
+        ps.validate_transition("3監", "2準")          # 格上げ
+        ps.validate_transition("2準", "1保")          # 買い
+        ps.validate_transition("1保", "2準")          # 売却
+        ps.validate_transition("2準", "3監")          # 格下げ
+        ps.validate_transition("3監", "1保")          # 直接保有
+
+    def test_validate_transition_forbidden(self):
+        # 1保/2準 への直接登録は禁止
+        with pytest.raises(ValueError):
+            ps.validate_transition(None, "1保")
+        with pytest.raises(ValueError):
+            ps.validate_transition(None, "2準")
+
+    def test_create_memo_defaults(self):
+        memo = ps.create_memo()
+        assert set(memo.keys()) == ps.MEMO_FIELDS
+        assert all(v == "" for v in memo.values())
+
+    def test_create_memo_partial(self):
+        memo = ps.create_memo(gyoutai_theme="人材", trade_idea="押し目買い")
+        assert memo["gyoutai_theme"] == "人材"
+        assert memo["trade_idea"] == "押し目買い"
+        assert memo["watch_in_reason"] == ""
+
+    def test_create_record_minimal(self):
+        rec = ps.create_record("4377", "ワンキャリア")
+        assert rec["code_s"] == "4377"
+        assert rec["stock_name"] == "ワンキャリア"
+        assert rec["status"] == "3監"
+        assert rec["registered_at"]
+        assert rec["updated_at"] == rec["registered_at"]
+        assert set(rec["memo"].keys()) == ps.MEMO_FIELDS
+
+    def test_create_record_with_explicit_status(self):
+        rec = ps.create_record("4377", "ワンキャリア", status="1保")
+        assert rec["status"] == "1保"
+
+    def test_create_record_invalid_status(self):
+        with pytest.raises(ValueError):
+            ps.create_record("4377", "ワンキャリア", status="未定")
+
+
+# ==================================================
+# 高レベル操作: add_to_watch
+# ==================================================
+class TestAddToWatch:
+
+    def test_add_to_watch_creates_record(self, db_path):
+        rec = ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        assert rec["code_s"] == "4377"
+        assert rec["status"] == "3監"
+
+        loaded = ps.get_record("4377", db_path=db_path)
+        assert loaded is not None
+        assert loaded["stock_name"] == "ワンキャリア"
+
+    def test_add_to_watch_records_initial_log(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path, reason="新規登録")
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 1
+        assert logs[0]["action_type"] == "初回登録"
+        assert logs[0]["status_from"] is None
+        assert logs[0]["status_to"] == "3監"
+        assert logs[0]["reason"] == "新規登録"
+        assert logs[0]["seq"] == 1
+
+    def test_add_to_watch_duplicate_raises(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+
+    def test_add_to_watch_normalizes_code_s(self, db_path):
+        ps.add_to_watch("215a", "テスト銘柄", db_path=db_path)
+        loaded = ps.get_record("215A", db_path=db_path)
+        assert loaded is not None
+        assert loaded["code_s"] == "215A"
+
+
+# ==================================================
+# 高レベル操作: transition_status
+# ==================================================
+class TestTransitionStatus:
+
+    def test_transition_3kan_to_2jun(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        rec = ps.transition_status(
+            "4377", "2準", reason="そろそろ買う", db_path=db_path
+        )
+        assert rec["status"] == "2準"
+
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 2  # 初回登録 + ステータス変更
+        assert logs[1]["action_type"] == "ステータス変更"
+        assert logs[1]["status_from"] == "3監"
+        assert logs[1]["status_to"] == "2準"
+
+    def test_transition_1ho_to_2jun_records_uri_kyaku(self, db_path):
+        """1保 -> 2準 は売却として記録される"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        ps.transition_status("4377", "2準", reason="決算後売り", db_path=db_path)
+
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        # 初回登録 + 3監->1保 + 1保->2準 = 3件
+        assert len(logs) == 3
+        assert logs[2]["action_type"] == "売却"
+        assert logs[2]["status_from"] == "1保"
+        assert logs[2]["status_to"] == "2準"
+
+    def test_transition_to_1ho_directly_from_3kan(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        rec = ps.transition_status("4377", "1保", db_path=db_path)
+        assert rec["status"] == "1保"
+
+    def test_transition_invalid_path_rejected(self, db_path):
+        """禁止遷移は ValueError"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        # 3監 -> 3監 は同一遷移として ALLOWED に入っていないので禁止
+        # ただし transition_status は同一ステータスなら no-op としているため
+        # ここでは別の禁止パターンを試す。実装の ALLOWED_TRANSITIONS 上、
+        # すべての非同一遷移は許可されているので、不正遷移は同一以外発生しない。
+        # 同一遷移は no-op で通過するので、代わりに未登録銘柄のチェック。
+        with pytest.raises(KeyError):
+            ps.transition_status("9999", "2準", db_path=db_path)
+
+    def test_transition_same_status_is_noop(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "3監", db_path=db_path)  # no-op
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 1  # 初回登録だけ、ステータス変更ログは出ない
+
+
+# ==================================================
+# 高レベル操作: delete_record
+# ==================================================
+class TestDeleteRecord:
+
+    def test_delete_3kan_succeeds(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ok = ps.delete_record("4377", reason="興味なくなった", db_path=db_path)
+        assert ok is True
+        assert ps.get_record("4377", db_path=db_path) is None
+
+    def test_delete_records_log_after_record_gone(self, db_path):
+        """削除しても action_log は残る"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.delete_record("4377", reason="不要", db_path=db_path)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        # 初回登録 + 削除 = 2件
+        assert len(logs) == 2
+        assert logs[1]["action_type"] == "削除"
+        assert logs[1]["reason"] == "不要"
+
+    def test_delete_1ho_rejected(self, db_path):
+        """1保 から直接削除は禁止"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.delete_record("4377", db_path=db_path)
+        # レコードは残っている
+        assert ps.get_record("4377", db_path=db_path) is not None
+
+    def test_delete_2jun_rejected(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.delete_record("4377", db_path=db_path)
+
+    def test_delete_nonexistent_returns_false(self, db_path):
+        ok = ps.delete_record("4377", db_path=db_path)
+        assert ok is False
+
+
+# ==================================================
+# list_records / list_action_logs
+# ==================================================
+class TestListing:
+
+    def test_list_records_filters_by_status(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.transition_status("7089", "1保", db_path=db_path)
+
+        watch = ps.list_records(status="3監", db_path=db_path)
+        hold = ps.list_records(status="1保", db_path=db_path)
+        all_recs = ps.list_records(db_path=db_path)
+
+        assert [r["code_s"] for r in watch] == ["4377"]
+        assert [r["code_s"] for r in hold] == ["7089"]
+        assert [r["code_s"] for r in all_recs] == ["4377", "7089"]
+
+    def test_list_records_sorted_by_code_s(self, db_path):
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("215A", "アクセルスペース", db_path=db_path)
+
+        recs = ps.list_records(db_path=db_path)
+        assert [r["code_s"] for r in recs] == ["215A", "4377", "7089"]
+
+    def test_list_action_logs_per_code(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+
+        logs_4377 = ps.list_action_logs("4377", db_path=db_path)
+        logs_7089 = ps.list_action_logs("7089", db_path=db_path)
+        all_logs = ps.list_action_logs(db_path=db_path)
+
+        assert len(logs_4377) == 2
+        assert len(logs_7089) == 1
+        assert len(all_logs) == 3
+
+    def test_list_action_logs_sorted_by_seq(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        # seq が二桁・三桁で正しく順序が保たれることを確認するため複数遷移
+        for next_status in ["2準", "1保", "2準", "1保", "2準", "3監", "2準"]:
+            ps.transition_status("4377", next_status, db_path=db_path)
+
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        seqs = [log["seq"] for log in logs]
+        assert seqs == sorted(seqs)
+
+
+# ==================================================
+# upsert_record (移行スクリプト用)
+# ==================================================
+class TestUpsertRecord:
+
+    def test_upsert_record_creates_without_log(self, db_path):
+        rec = ps.create_record("4377", "ワンキャリア")
+        ps.upsert_record(rec, db_path=db_path)
+        loaded = ps.get_record("4377", db_path=db_path)
+        assert loaded is not None
+        # upsert は ログを残さない (移行用)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert logs == []
+
+    def test_upsert_record_overwrites(self, db_path):
+        rec1 = ps.create_record("4377", "ワンキャリア", status="3監")
+        ps.upsert_record(rec1, db_path=db_path)
+        rec2 = ps.create_record("4377", "ワンキャリア改名", status="1保")
+        ps.upsert_record(rec2, db_path=db_path)
+
+        loaded = ps.get_record("4377", db_path=db_path)
+        assert loaded["stock_name"] == "ワンキャリア改名"
+        assert loaded["status"] == "1保"
+
+    def test_upsert_record_requires_code_s(self, db_path):
+        with pytest.raises(ValueError):
+            ps.upsert_record({"stock_name": "x"}, db_path=db_path)
+
+
+# ==================================================
+# キー名前空間の独立性
+# ==================================================
+class TestKeyNamespaceIsolation:
+
+    def test_action_log_persists_after_delete(self, db_path):
+        """レコード削除後も action_log は残るかつ他キーに影響しない"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.delete_record("4377", db_path=db_path)
+
+        # 4377 のレコードはなくなる
+        assert ps.get_record("4377", db_path=db_path) is None
+        # 4377 のログは残る (初回登録 + 削除)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 2
+        # 7089 は無事
+        assert ps.get_record("7089", db_path=db_path) is not None
+
+    def test_seq_counter_isolated_per_code(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+        ps.transition_status("7089", "2準", db_path=db_path)
+
+        logs_4377 = ps.list_action_logs("4377", db_path=db_path)
+        logs_7089 = ps.list_action_logs("7089", db_path=db_path)
+        # seq は銘柄ごとに独立 (両方 1, 2 になる)
+        assert [log["seq"] for log in logs_4377] == [1, 2]
+        assert [log["seq"] for log in logs_7089] == [1, 2]
+
+
+# ==================================================
+# my_watch_list.txt 一方向同期
+# ==================================================
+class TestSyncToTxt:
+
+    def test_sync_writes_holds_with_h_prefix(self, db_path, tmp_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.transition_status("7089", "1保", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        # 1保 が H 接頭辞付きで code_s 昇順に並ぶ
+        assert "H4377ワンキャリア" in content
+        assert "H7089フォースタートアップス" in content
+        # 4377 が 7089 より先に来る
+        assert content.index("H4377") < content.index("H7089")
+
+    def test_sync_writes_watch_without_prefix(self, db_path, tmp_path):
+        ps.add_to_watch("5032", "AnyColor", db_path=db_path)
+        ps.add_to_watch("6232", "ACSL", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        assert "5032AnyColor" in content
+        assert "6232ACSL" in content
+        # H 接頭辞は付かない
+        assert "H5032" not in content
+
+    def test_sync_separates_holds_from_others(self, db_path, tmp_path):
+        ps.add_to_watch("4377", "保有銘柄", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        ps.add_to_watch("5032", "ウォッチ銘柄", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        # 1保 → 空行 → 3監 の順 (現行 my_watch_list.txt の見た目互換)
+        h_pos = content.index("H4377")
+        w_pos = content.index("5032ウォッチ銘柄")
+        assert h_pos < w_pos
+        # 間に空行あり
+        between = content[h_pos:w_pos]
+        assert "\n\n" in between
+
+    def test_sync_treats_2jun_as_watch(self, db_path, tmp_path):
+        """2準 は H 接頭辞なしで書き出される (txt は 2 値)"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        # H 接頭辞なし
+        assert "4377ワンキャリア" in content
+        assert "H4377" not in content
+
+    def test_sync_empty_db_writes_empty_file(self, db_path, tmp_path):
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+        with open(txt_path, encoding="utf-8") as f:
+            assert f.read() == ""


### PR DESCRIPTION
## Summary

Phase 3 保有銘柄管理ダッシュボードの**基盤層**を実装。 `portfolio_shelve` を新設し、スプシ「保有銘柄シート」と `my_watch_list.txt` を取り込み、`portfolio.parse_my_portforio()` の参照先を shelve に切り替える。

詳細仕様は実装計画書 [.claude/plans/issue-151-portfolio.md](https://github.com/nasumiso/KSKInvestSystem/blob/issue-170-portfolio-shelve/.claude/plans/issue-151-portfolio.md) を参照。

## 主な変更

### 新規モジュール
- `scripts/portfolio_shelve.py` — DB 層・状態遷移バリデーション・アクションログ・txt 同期
- `scripts/migrate_portfolio_from_csv.py` — スプシ CSV → portfolio_shelve（4 層構成、`--dry-run` 対応）
- `scripts/migrate_my_watch_list_to_shelve.py` — txt → portfolio_shelve（マージルール内蔵）

### 既存モジュール変更
- `scripts/db_shelve.py` — `PORTFOLIO_SHELVE` 定数追加
- `scripts/portfolio.py` — `parse_my_portforio()` の内部実装を shelve 参照に置換（シグネチャ無修正、空時 txt フォールバック）

### 重要な設計判断

- **スプシ 36 列のうち 7 列のみ移行**: 指標系列・順位・保有リスト列は `code_rank.csv` 由来の VLOOKUP 表示値で、スプシ上の手動入力は識別 2 列 + 真のメモ 5 列のみ
- **ステータスは `my_watch_list.txt` のみで決定**: スプシのステータス列は無視（実運用上の真実源は txt のため）
- **キー名前空間で分離**: `record:<code_s>` / `action_log:<code_s>:<seq>` で 1 shelve に同居。レコード削除後もアクションログは残る（要件 §5-5）
- **遷移バリデーション**: 1保 / 2準 への直接登録禁止、3監 のみ削除可、1保↔2準 の往復は「売却」として記録

## テスト

```bash
.venv/bin/python -m pytest tests/test_portfolio_shelve.py \
    tests/test_migrate_portfolio_from_csv.py \
    tests/test_migrate_my_watch_list_to_shelve.py \
    tests/test_portfolio.py -v
# → 86 passed
```

関連既存テスト 188 件も回帰なし確認済み。

## 動作確認済み

- 実 CSV (`銘柄調査 - 保有銘柄.csv`、139 行) で `--dry-run` 成功: 138 行読込 → 133 件保存、5 件スキップ（空行）
- 改行を含む日本語メモ列の正常パース確認

## Draft の理由（残作業）

このスコープ内で Phase 3a を完了させるためのパイロット検証と本番移行が未実行:

- [ ] **パイロット Step A**: 現行コード vs txt のみ取り込み版で `make_stock_db.py list_all_db` の baseline 一致確認
- [ ] **本番移行**: ユーザーがスプシ CSV を `\${KS_DATA_DIR}/migration/portfolio_sheet.csv` に配置 → 移行スクリプト実行
- [ ] **パイロット Step B**: スプシ移行後の差分確認（増分がスプシ由来のみ）
- [ ] パイロット 2 ステップ完了確認後、Draft → Ready for review に変更

## スコープ外（Phase 3 の他 sub-issue）

- ダッシュボード UI（→ #171 / Phase 3b）
- 振り返りビュー（→ #172 / Phase 3c）
- 警告シグナル赤バッジ強調・イベントログ自動記録（→ Phase 4）
- my_watch_list.txt 物理削除（→ 別 issue、運用安定後）

## Test plan

- [x] `pytest tests/test_portfolio_shelve.py` (43 件)
- [x] `pytest tests/test_migrate_portfolio_from_csv.py` (17 件)
- [x] `pytest tests/test_migrate_my_watch_list_to_shelve.py` (16 件)
- [x] `pytest tests/test_portfolio.py` (10 件)
- [x] 関連既存テスト回帰なし (188 件)
- [x] 実 CSV `--dry-run` 動作確認
- [ ] パイロット Step A 実行
- [ ] 本番 CSV 移行実行
- [ ] パイロット Step B 実行
- [ ] `make_stock_db.py list_all_db` 全件パイロット成功

Refs: #151, #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)