### PR TITLE
Phase 3a + 3b: portfolio_shelve 基盤 + 保有銘柄ダッシュボード

### DIFF
--- a/.claude/plans/issue-151-portfolio.md
+++ b/.claude/plans/issue-151-portfolio.md
@@ -1,0 +1,527 @@
+# issue151 実装計画: Phase 3 保有銘柄管理ダッシュボード
+
+> 要件仕様書: [doc/requirements/phase3_portfolio_requirements.md](../../doc/requirements/phase3_portfolio_requirements.md)
+> 親 issue: #151（Closes は使わず、トラッキング用に残す）
+
+---
+
+## 1. 全体方針
+
+### 1-1. issue 構造（インタビュー Q1: 3a/3b/3c 分割）
+
+`#151` を親 issue として残し、3 つの sub-issue に分割する。**親 issue には `Closes #151` を使わない**（Phase 1 だけマージで親が自動クローズしないように）。
+
+| Sub-issue | スコープ | PR 単位 |
+|---|---|---|
+| **Phase 3a** | portfolio_shelve 基盤 + スプシ移行 + my_watch_list.txt 取り込み + parse 置換 + shelve→txt 同期 | 1 PR |
+| **Phase 3b** | /portfolio ダッシュボード(3タブ) + ステータス変更/追加/売却/削除UI + アクションログ記録 | 1 PR |
+| **Phase 3c** | 振り返りビュー(アクションログ時系列) | 1 PR |
+| **(別 issue)** | my_watch_list.txt 廃止（Phase 3 マージ後、運用が安定したら別途検討） | — |
+
+### 1-2. スコープ外（インタビュー Q9-Q10）
+
+以下は要件仕様書に記載があるが、**Phase 3 では実装しない**:
+
+- §5-3 警告シグナル赤バッジ強調表示
+- §6-2 イベントログ自動記録（Shintakane 日次バッチへの組込み）
+- §6-1 アクションログ「見送り」「メモ」種別
+
+これらは Phase 4（別 issue）で扱う。Phase 3 のアクションログ種別は **`初回登録` / `ステータス変更` / `売却` / `削除`** の 4 種に限定する。
+
+### 1-3. テスト戦略（インタビュー Q5）
+
+- **ユニットテスト**: portfolio_shelve / 移行スクリプト / 状態遷移バリデーション / parse_my_portforio() 互換性
+- **Playwright E2E**: ダッシュボードの主要 3 シナリオ（追加 / ステータス変更 / 削除）の happy path
+
+---
+
+## 2. portfolio_shelve 設計（Phase 3a の中核）
+
+### 2-1. ファイル配置
+
+```
+data/stock_data/portfolio_shelve  ← 新規
+```
+
+`research_shelve` / `stocks_shelve` と同じ階層。`db_shelve.ShelveDB` をラップ。
+
+### 2-2. キー名前空間（インタビュー Q4: 単一 shelve 内で名前空間分離）
+
+| キー形式 | 内容 | レコード削除時の挙動 |
+|---|---|---|
+| `record:<code_s>` | 保有レコード本体（ステータス・手動メモ） | `削除` 操作時に `del` |
+| `action_log:<code_s>:<seq>` | アクションログ（手動判断） | **残す**（§5-5 / §6-1 要件） |
+
+`<seq>` は 6 桁ゼロパディングの単調増加整数。同一銘柄内で連番管理。`portfolio_shelve` 内に `_seq:<code_s>` キーで現在値を保持。
+
+### 2-3. レコードスキーマ
+
+`record:<code_s>` の値:
+
+```python
+{
+    "code_s": "6324",
+    "stock_name": "ハーモニック・ドライブ・システムズ",
+    "status": "1保",         # "1保" | "2準" | "3監"
+    "registered_at": "2026-05-03T09:00:00+09:00",
+    "updated_at": "2026-05-03T09:00:00+09:00",
+    # 手動メモ（§4 + §7-1）
+    "memo": {
+        "gyoutai_theme": "...",       # 業態・テーマ
+        "watch_in_reason": "...",     # ウォッチ・IN理由
+        "trade_idea": "...",          # 投資売買アイデア
+        "inago_origin": "...",        # イナゴ元・きっかけ
+        "takaichi_sensitivity": "..." # 高市感応度
+    }
+}
+```
+
+指標データ（PER・RS 等）は **保存しない**（§4 表示時に stocks_shelve から都度参照）。
+
+### 2-4. アクションログスキーマ
+
+`action_log:<code_s>:<seq>` の値:
+
+```python
+{
+    "code_s": "6324",
+    "seq": 1,
+    "timestamp": "2026-05-03T09:00:00+09:00",
+    "action_type": "初回登録",  # "初回登録" | "ステータス変更" | "売却" | "削除"
+    "status_from": None,        # "ステータス変更"/"売却" 時のみ。"初回登録"時は None
+    "status_to": "3監",
+    "reason": "..."             # 理由メモ。"初回登録"時は省略可
+}
+```
+
+### 2-5. ステータス遷移バリデーション
+
+`portfolio_shelve.py` で遷移を強制する。以下の遷移のみ許可:
+
+```
+（新規）→ 3監                 # 追加。1保/2準への直接登録は禁止
+3監 ⇄ 2準                    # 格上げ/格下げ
+2準 ⇄ 1保                    # 買い/売り
+3監 ⇄ 1保                    # 直接遷移（要件仕様書に明示禁止なし。一応許可）
+（任意）→ 3監 → （削除）       # 1保/2準 から直接削除は禁止
+```
+
+`1保 → 2準` の遷移は内部的に「売却」として action_type=`売却` で記録。それ以外のステータス変更は `ステータス変更`。
+
+### 2-6. 主要 API
+
+```python
+# portfolio_shelve.py
+
+def upsert_record(code_s: str, stock_name: str, memo: dict, *, db_path=None) -> None: ...
+def get_record(code_s: str, *, db_path=None) -> Optional[dict]: ...
+def list_records(status: Optional[str] = None, *, db_path=None) -> List[dict]: ...
+def delete_record(code_s: str, reason: str, *, db_path=None) -> None: ...
+
+def transition_status(code_s: str, new_status: str, reason: str, *, db_path=None) -> None: ...
+def add_to_watch(code_s: str, stock_name: str, *, db_path=None) -> None: ...
+
+def append_action_log(code_s: str, action_type: str, *, status_from=None, status_to=None, reason="", db_path=None) -> None: ...
+def list_action_logs(code_s: Optional[str] = None, *, db_path=None) -> List[dict]: ...
+```
+
+すべて `fcntl` フロックで保護（research_shelve と同パターン）。
+
+---
+
+## 3. Phase 3a 詳細
+
+### 3-1. 成果物
+
+| ファイル | 種別 | 内容 |
+|---|---|---|
+| `scripts/portfolio_shelve.py` | 新規 | §2 の DB モジュール |
+| `scripts/migrate_portfolio_from_csv.py` | 新規 | スプシ「保有銘柄シート」CSV → portfolio_shelve |
+| `scripts/migrate_my_watch_list_to_shelve.py` | 新規 | my_watch_list.txt → portfolio_shelve（初期取り込み + マージ） |
+| `scripts/portfolio.py` | 修正 | `parse_my_portforio()` の内部実装を portfolio_shelve 参照に置換（**シグネチャ無修正**）+ shelve → txt 一方向同期書き出しの追加 |
+| `tests/test_portfolio_shelve.py` | 新規 | DB 層ユニットテスト |
+| `tests/test_migrate_portfolio_from_csv.py` | 新規 | CSV 移行テスト |
+| `tests/test_migrate_my_watch_list_to_shelve.py` | 新規 | txt 取り込みテスト |
+| `tests/test_portfolio.py` | 修正/新規 | `parse_my_portforio()` の互換性テスト |
+
+### 3-2. スプシ移行手順（インタビュー Q2: 事前 CSV エクスポート）
+
+#### 3-2-1. 列マッピングの事前確定（**完了済み**）
+
+✅ ユーザーから受領した `銘柄調査 - 保有銘柄.csv` (36 列 × 139 銘柄) を分析し、§3-2-2 の列マッピングを確定済み。
+
+確定時の重要な発見:
+- スプシ「保有銘柄シート」の指標系列・順位・保有リスト列は **`code_rank.csv` からの参照値（VLOOKUP）**であり、スプシ上の手動入力ではない
+- よって移行対象は識別 2 列 + 真の手動メモ 5 列の **計 7 列のみ**
+- ステータス決定は **`my_watch_list.txt` のみ** を真実源とする（スプシのステータス列は無視）
+
+この発見により §3-3 のマージルールも大幅にシンプル化された。
+
+#### 3-2-2. 列マッピング（**確定済み**）
+
+CSV ファイル: `銘柄調査 - 保有銘柄.csv`（36 列、先頭 1 行は空行、2 行目がヘッダ、3 行目以降が 139 銘柄分のデータ）
+
+##### 重要な前提
+
+スプシ「保有銘柄シート」の **指標系列（順位・PER・配当・RS・トレンドテンプレート・シグナル・時価総額・決算日 等）と保有リスト列は、`code_rank.csv` からの参照値（VLOOKUP 等で表示しているだけ）**。スプシ上の手動入力は識別情報と「真の手動メモ」のみ。
+
+→ **移行対象は手動メモ系列の 5 列 + 識別 2 列の合計 7 列**。指標系列はすべて移行不要（要件仕様書 §4「指標データは portfolio_shelve に保存せず stocks_shelve から都度参照」と整合）。
+
+##### 移行対象の列マッピング（確定）
+
+| CSV col # | 列名 | 移行先 | 備考 |
+|---|---|---|---|
+| 0 | 銘柄コード | `code_s` | 文字列正規化（4 桁ゼロ埋め or 4 文字英数字） |
+| 1 | 銘柄名 | `stock_name` | そのまま |
+| 3 | 業態・テーマ | `memo.gyoutai_theme` | 改行を含むセルあり（複数行 OK） |
+| 31 | ウォッチ・IN理由 | `memo.watch_in_reason` | 改行を含むセルあり |
+| 33 | イナゴ元・きっかけ | `memo.inago_origin` | 改行を含むセルあり |
+| 34 | 投資売買アイデア | `memo.trade_idea` | 改行を含むセルあり |
+| 35 | 高市感応度 | `memo.takaichi_sensitivity` | 「A:〜」「B:〜」のような感応度ラベル付きの自由記述 |
+
+##### 取り込まない列（参考）
+
+| CSV col # | 列名 | 理由 |
+|---|---|---|
+| 2 | 保有リスト | `code_rank.csv` 由来の表示値。ステータスは **`my_watch_list.txt` のみ** を真実源とする |
+| 4–30, 32 | 指標・順位・チャート・需給チャート 等 | すべて `code_rank.csv` または stocks_shelve 由来の表示値。表示時に都度参照 |
+
+##### スプシの構造詳細
+
+- 1 行目: 全列空（区切り文字のみ）
+- 2 行目: ヘッダ（36 列）
+- 3 行目以降: データ 139 行
+- 文字エンコーディング: UTF-8
+- 改行を含むセルは Google Sheets の RFC 4180 仕様に従いダブルクォートで囲まれている（Python `csv` モジュールで標準パース可能）
+
+#### 3-2-3. 移行スクリプト実行手順
+
+1. ユーザーが CSV を `${KS_DATA_DIR}/migration/portfolio_sheet.csv` に配置
+2. `cd scripts && python migrate_portfolio_from_csv.py "${KS_DATA_DIR}/migration/portfolio_sheet.csv" --dry-run` で **dry-run** 実行し、件数とサンプル出力を目視確認
+3. 問題なければ `--dry-run` を外して本番実行
+4. 移行スクリプトは `migrate_research_from_csv.py` の 4 層構成パターンを踏襲:
+   - 読込層: `read_csv_rows()`
+   - パース層: `parse_status_column()` / `parse_memo_columns()`
+   - 統合層: `build_record_from_row()`
+   - 実行層: `migrate_csv_to_portfolio_shelve()`
+5. 移行時、各レコードに `初回登録` アクションログを 1 件記録
+6. 移行後、shelve のレコード数が CSV 行数とほぼ一致することを確認（ETF や空行は除外される可能性あり）
+
+#### 3-2-4. googledrive.py 経由の自動取り込みは Phase 3 では実装しない
+
+ユーザーが「移行後もスプシ↔shelve の同期を考えている可能性」と回答したが、Phase 3 のスコープでは **手動 CSV エクスポート** に限定する。理由:
+
+- `migrate_research_from_csv.py` も手動エクスポート方式で運用実績あり
+- `googledrive.py` には現状シート読み取り関数がなく、新規実装が必要 → スコープ膨張
+- 移行は 1 回限りの作業（移行後の真実源は portfolio_shelve）
+
+**ただし**、移行後もスプシで編集したい運用が想定される場合は、別 issue で「googledrive 経由の同期 / 再取り込みスクリプト」を後日検討する。Phase 3 の振り返り段階（PR 完了後）で運用感を確認し、必要なら新 issue を立てる。
+
+### 3-3. my_watch_list.txt 取り込み手順（インタビュー Q3, Q7、§3-2-2 の前提を反映）
+
+スプシのステータス列 (col2) は `code_rank.csv` 由来の表示値であり真実源ではない。よって **ステータスは `my_watch_list.txt` のみで決定**する（インタビュー Q7 の「txt 優先」原則をシンプル化）。
+
+#### マージルール（簡素化済み）
+
+| 状況 | ステータス | 手動メモ |
+|---|---|---|
+| txt のみ存在（H 接頭辞） | `1保` | 空 |
+| txt のみ存在（接頭辞なし） | `3監` | 空 |
+| スプシのみ存在 | **`3監`**（txt にない = ウォッチ扱いに倒す） | スプシ採用 |
+| 両方存在 | **txt のステータス**（H 付き→1保 / なし→3監） | スプシ採用 |
+
+#### 実装順序
+
+1. **スプシ CSV 移行**: 識別情報 + 手動メモ 5 列を取り込み、ステータスは仮で `3監` とする
+2. **txt 取り込み**: txt のステータスで上書き（H 付きは `1保`、なしは `3監`、txt にない銘柄は `3監` のまま）
+
+#### `2準` の扱い
+
+仕様書 §7-2 の通り、**txt には `2準` の概念がない**ため移行直後は `1保` / `3監` のみ。`2準` は WebApp（Phase 3b）からのステータス変更でのみ発生する。
+
+### 3-4. parse_my_portforio() 置換（要件 §7-2 ステップ 2）
+
+```python
+# 現行
+def parse_my_portforio() -> Tuple[List[str], List[str]]:
+    # my_watch_list.txt をパース
+    return (watch_codes, possess_codes)
+
+# 置換後（シグネチャ無修正）
+def parse_my_portforio() -> Tuple[List[str], List[str]]:
+    records = portfolio_shelve.list_records()
+    possess = [r["code_s"] for r in records if r["status"] == "1保"]
+    watch   = [r["code_s"] for r in records if r["status"] in ("2準", "3監")]
+    return (watch, possess)
+```
+
+呼び出し側（`make_stock_db.py` / `kessan.py` / `disclosure.py` / `webapp/helpers.py`）は無修正。
+
+#### 3-4-1. **返却の互換性（重要）**
+
+##### 下流処理の順序依存確認 ✅ 完了
+
+実装着手前に `make_stock_db.py` `kessan.py` `disclosure.py` `webapp/helpers.py` の全呼び出し（計 6 箇所）を grep で確認し、**すべて順序非依存** であることを確認:
+
+| 呼び出し元 | 使い方 | 順序依存 |
+|---|---|---|
+| make_stock_db.py:1089 | `(pf_stocks + possess_list)` を `set()` で集合化 | なし |
+| make_stock_db.py:1539 | `set(watch_codes) \| set(possess_codes)` | なし |
+| kessan.py:121 | `if k in code_list_s + possess_list_s` 所属チェック | なし |
+| disclosure.py:251 | for ループ後、最終出力は日付ソート | 実質なし |
+| webapp/helpers.py:680 | `set(possess_list)` 集合 | なし |
+| webapp/helpers.py:1066 | `set(watch_list) \| set(possess_list)` 集合 | なし |
+
+→ `migration_order` フィールドは **不要**。`parse_my_portforio()` は **`code_s` 昇順** など決定論的な順序で返せばよい。
+
+##### 集合の扱い: 「移行で増える分」を意識的に許容する
+
+スプシ移行で 139 件、my_watch_list.txt 取り込みで 327 件が portfolio_shelve に入る。**両者で重複しない銘柄が出るため、`parse_my_portforio()` が返す集合は移行前の txt より広くなりうる**。
+
+- 移行直後に集合が増えると、`make_stock_db.py` の更新対象銘柄が増える可能性がある
+- これは **設計上の意図された変化**（仕様書 §7-2 で portfolio_shelve を真実源にすると決めたため）
+- ただし「いきなり大量の銘柄が更新対象に追加されると挙動が読めない」リスクは残る
+
+##### 互換性検証の 2 段階アプローチ
+
+| 段階 | 比較対象 | 期待 | 目的 |
+|---|---|---|---|
+| **Step 1: データ移行前の純粋な置換テスト** | 現行 txt → 旧 parse vs txt のみを取り込んだ portfolio_shelve → 新 parse | **集合が完全一致**（順序不問） | 置換ロジック自体にバグがないことを保証 |
+| **Step 2: スプシ移行後の「妥当な変化」確認** | 旧 parse の結果 vs スプシ移行 + txt 取り込み後の新 parse | 集合は **新 parse ⊇ 旧 parse**（旧の銘柄はすべて含む）、増分はスプシ由来銘柄のみ | 意図した変化のみが起きたことを確認 |
+
+##### テストとパイロット
+
+1. `test_portfolio.py` に Step 1 テストを追加（fixture で txt のみの portfolio_shelve を作り、現行 parse と新 parse の **集合一致** を確認）
+2. Step 2 は実データでの **手動パイロット**（§3-7 の diff 比較で「増えた銘柄がスプシ由来か」を目視確認）
+
+### 3-5. shelve → txt 一方向同期（インタビュー Q6）
+
+※ インタビュー Q3 では当初「並行運用後に txt 完全削除」を選択していたが、後の判断で **txt 廃止は Phase 3 スコープ外（別 issue）** に変更した。よって本同期は Phase 3 完了後も動き続ける（§5-3 参照）。
+
+#### 同期トリガーの方針（実装中の調整）
+
+当初は「shelve への書き込み API 成功時に自動同期」を想定したが、テスト容易性 / 単一責務 / バルク書き込み時のパフォーマンスを考慮し、**「同期関数 `sync_to_my_watch_list_txt()` を提供し、明示的に呼ぶ」** 方式に変更:
+
+| Phase | 呼び出し元 |
+|---|---|
+| Phase 3a | 移行スクリプト末尾、parse_my_portforio() の置換テスト後 |
+| Phase 3b | WebApp の各書き込みハンドラ（追加・遷移・削除）の末尾 |
+
+DB 側で自動呼び出ししないことで、ユニットテストの DATA_DIR 設定不要で完結し、移行スクリプトのバルク処理も末尾の 1 回呼び出しで済む。
+
+`portfolio_shelve` への書き込み API（upsert / transition / delete）が成功するたびに、txt も書き出す（旧記述、参考）:
+
+```python
+def _sync_to_txt(records: List[dict]) -> None:
+    """portfolio_shelve の現在状態を my_watch_list.txt に書き出す。
+    H 接頭辞付き = 1保、接頭辞なし = 3監。2準 は 3監 として書き出す（txt は 2 値）。"""
+    lines = []
+    for r in sorted(records, key=lambda x: (x["status"], x["code_s"])):
+        prefix = "H" if r["status"] == "1保" else ""
+        lines.append(f"{prefix}{r['code_s']}{r['stock_name']}")
+    DATA_DIR.joinpath("my_watch_list.txt").write_text("\n".join(lines))
+```
+
+`2準` を txt 上で `1保` 扱いとするか `3監` 扱いとするかは、**「txt を見る既存コード」の挙動を変えない方針**が安全。`my_watch_list.txt` の H 接頭辞は「現在の保有」を意味するため、`2準`（直近売却 or もうすぐ買いたい）は `3監` 側に倒す。txt 廃止 issue（別 issue・将来）で txt が消えるまでの暫定処置。
+
+### 3-6. テスト
+
+- `test_portfolio_shelve.py`: upsert / get / list / delete / transition の各 API、ステータス遷移バリデーション、アクションログの不可削除性
+- `test_migrate_portfolio_from_csv.py`: CSV パース、列マッピング、`1保`/`2〇`/`3監` 正規化
+- `test_migrate_my_watch_list_to_shelve.py`: H 接頭辞パース、マージ規則（txt 優先/スプシメモ保持）
+- `test_portfolio.py`: `parse_my_portforio()` の互換性（§3-4-1 Step 1: txt のみ取り込み時に旧 parse と完全一致）、戻り値の型と要素順
+
+### 3-7. リスク・ロールバック
+
+- portfolio_shelve 破損時は my_watch_list.txt が並行運用で残るため、再構築可能
+- 万一 parse_my_portforio() の挙動が想定外に変わると make_stock_db.py / kessan.py 全体に波及。
+
+#### パイロット手順（2 段階）
+
+**Step A: 純粋な置換確認**（データ移行前、portfolio_shelve は空）
+
+1. `python make_stock_db.py list_all_db` を現行コードで実行し、出力 CSV を `_baseline_pre/` に保存
+2. portfolio.py を置換実装に切り替え、**txt のみを取り込んだ portfolio_shelve** を一時的に作成（テスト用 DB パスで）
+3. 同コマンドを再実行し、`_baseline_post_step_a/` に保存
+4. `diff -r _baseline_pre _baseline_post_step_a` → **完全一致** を期待。差分があれば置換ロジックにバグ
+
+**Step B: スプシ移行後の妥当な変化確認**
+
+5. スプシ CSV 移行を実行 → portfolio_shelve に 139 件 + 取り込み済み txt のマージ結果が入る
+6. 同コマンドを再実行し、`_baseline_post_step_b/` に保存
+7. `diff -r _baseline_post_step_a _baseline_post_step_b` → 差分は「スプシ由来銘柄が新規追加された分のみ」を期待
+8. 増えた銘柄を一覧化し、ユーザーが「これらは追加されて妥当」と確認
+
+#### 件数の目安
+
+- Step A 時点: 保有 24 件 + ウォッチ 303 件 = 計 327 件
+- Step B 時点: スプシ 139 件のうち txt にない銘柄が増分。最大 466 件、実際はスプシと txt の重複次第
+
+---
+
+## 4. Phase 3b 詳細
+
+### 4-1. 成果物
+
+| ファイル | 種別 | 内容 |
+|---|---|---|
+| `scripts/webapp/routes/portfolio.py` | 新規 | `/portfolio` ルート（GET / POST） |
+| `scripts/webapp/templates/portfolio_list.html` | 新規 | 3 タブ + 一覧表 |
+| `scripts/webapp/templates/portfolio_edit_dialog.html` | 新規 | ステータス変更/追加/売却/削除のダイアログ部品 |
+| `scripts/webapp/app.py` | 修正 | Blueprint 登録、ナビ追加 |
+| `scripts/webapp/templates/base.html` | 修正 | ナビに `保有銘柄` リンク追加 |
+| `scripts/webapp/templates/detail.html` | 修正 | 銘柄調査ページに「3監 に追加」ボタン追加 |
+| `tests/test_webapp_portfolio_routes.py` | 新規 | ルートのユニットテスト |
+| `tests/e2e/test_portfolio_dashboard.py` | 新規 | Playwright E2E |
+
+### 4-2. URL 設計（インタビュー Q8）
+
+| URL | メソッド | 機能 |
+|---|---|---|
+| `/portfolio?status=hold|semi|watch` | GET | ダッシュボード（タブ切替） |
+| `/portfolio/add` | POST | 銘柄を 3監 に追加 |
+| `/portfolio/<code_s>/transition` | POST | ステータス変更（売却含む） |
+| `/portfolio/<code_s>/delete` | POST | 削除（3監 からのみ） |
+
+`status=hold` ⇄ `1保`、`status=semi` ⇄ `2準`、`status=watch` ⇄ `3監`。
+
+### 4-3. ダッシュボード一覧表示
+
+要件 §5-2 の 6 カテゴリすべてを表示。情報密度が高いので、以下の階層で整理（実装時調整可）:
+
+- **常時表示（左から右へ）**:
+  - コード / 銘柄名 / ステータス
+  - PER / 時価総額 / 配当（最新指標）
+  - RS / ステージ / トレンドテンプレート（テクニカル）
+  - シグナル列（警/売/新高値 等のテキスト表示。**赤バッジ強調なし** = Phase 4 送り）
+  - 理論株価乖離率
+- **開閉式サブセクション（行クリックで展開）**:
+  - 業績の詳細（売上・利益成長率、進捗率）
+  - 手動メモ（IN理由、売買アイデア等）
+
+### 4-4. ステータス変更 UI
+
+ダイアログ:
+
+| シナリオ | UI 動作 | アクションログ種別 |
+|---|---|---|
+| `/stock/<code_s>` から 3監 追加 | 「3監 に追加」ボタン → 確認ダイアログ → POST /portfolio/add | `初回登録` |
+| ダッシュボード行 → 「ステータス変更」 | プルダウン（許可遷移のみ）+ 理由入力 → POST /portfolio/<code_s>/transition | `ステータス変更` または `売却`（1保→2準 の場合） |
+| ダッシュボード（3監 タブ）→ 「削除」 | 確認ダイアログ + 理由入力 → POST /portfolio/<code_s>/delete | `削除` |
+
+1保/2準 タブには「削除」ボタンを **表示しない**（誤操作防止）。
+
+### 4-5. テスト
+
+- `test_webapp_portfolio_routes.py`: 各ルートのリクエスト/レスポンス、不正遷移の拒否（例: 1保 → 削除）
+- Playwright E2E:
+  - シナリオ A: 銘柄詳細 → 「3監 に追加」 → /portfolio?status=watch で表示確認
+  - シナリオ B: 3監 → 2準 → 1保 → 2準 のステータス遷移、各時点でアクションログが増える
+  - シナリオ C: 1保 → 削除を試みてエラー、3監 に戻して削除成功
+
+---
+
+## 5. Phase 3c 詳細
+
+### 5-1. 成果物
+
+| ファイル | 種別 | 内容 |
+|---|---|---|
+| `scripts/webapp/routes/detail.py` | 修正 | 銘柄調査ページに「振り返り」セクション追加 |
+| `scripts/webapp/templates/detail.html` | 修正 | アクションログ時系列表示 |
+| `tests/test_webapp_detail_portfolio.py` | 新規 | 振り返り表示のユニットテスト |
+
+### 5-2. 振り返りビュー（要件 §6-3）
+
+`/stock/<code_s>` の既存ページに「振り返り」セクションを追加。アクションログを時系列降順で表示:
+
+```
+2026-05-03 09:00  ステータス変更 [3監 → 2準]  「決算良好。準保有に格上げ」
+2026-04-15 14:30  初回登録 [→ 3監]              （理由なし）
+```
+
+イベントログは Phase 3 スコープ外なので **アクションログのみ**。Phase 4 でイベントログ実装時に同じビューに統合する。
+
+### 5-3. my_watch_list.txt 廃止は別 issue に切り出し
+
+ユーザー判断により、**txt 廃止は Phase 3 のスコープ外**とする。理由:
+
+- Phase 3 完了直後に txt を消すと、shelve に問題が出た時のフォールバックがなくなる
+- 「運用が安定した」と判断できる期間を 1〜2 週間と決め打ちせず、実運用感覚で判断したい
+- 別 issue にすることで「いつ廃止するか」をユーザーが任意のタイミングで起票できる
+
+#### Phase 3 完了後の状態
+
+- `${KS_DATA_DIR}/my_watch_list.txt` は **存在し続ける**
+- `portfolio.py` の `_sync_to_txt()` (Phase 3a で実装) は **動き続ける**（shelve 更新時に txt も書き出される）
+- `parse_my_portforio()` は portfolio_shelve を真実源として返す
+- `my_watch_list.txt` は **shelve から自動生成されるバックアップ** として残る（手編集はしない方針）
+
+#### 別 issue で扱う作業（将来）
+
+- `_sync_to_txt()` の停止 → 削除
+- `${KS_DATA_DIR}/my_watch_list.txt` の物理削除（**repo 配下ではなく実運用 DATA_DIR 配下**。`KS_DATA_DIR=/Users/k_sohara/Ext/GoogleDrive/shintakane_data`）
+- `grep -r "my_watch_list"` で残存参照がないか確認
+
+これは Phase 3 の振り返り段階で別 issue を立てる。
+
+---
+
+## 6. 実装順序まとめ
+
+### Phase 3a（1 PR）
+
+0. **【ゲート】列マッピング確定** ✅ 完了済み（§3-2-2 参照）
+1. portfolio_shelve.py 作成 + ユニットテスト
+2. migrate_portfolio_from_csv.py 作成 + ユニットテスト
+3. migrate_my_watch_list_to_shelve.py 作成 + ユニットテスト
+4. portfolio.py の parse_my_portforio() を内部実装置換 + 互換性テスト（§3-4-1 Step 1）
+5. **パイロット Step A**: 現行コードでの `make_stock_db.py list_all_db` baseline 取得 → txt のみ取り込み portfolio_shelve で再実行 → 完全一致確認
+6. スプシ CSV 移行スクリプト本番実行（`--dry-run` で先に確認）
+7. **パイロット Step B**: スプシ移行後の `make_stock_db.py list_all_db` 再実行 → 増分がスプシ由来のみであることを確認
+8. shelve → txt 同期実装
+
+### Phase 3b（1 PR、3a マージ後）
+
+1. routes/portfolio.py + templates 作成
+2. base.html / detail.html 修正
+3. ユニットテスト + Playwright E2E
+
+### Phase 3c（1 PR、3b マージ後）
+
+1. 振り返りビュー実装
+
+※ my_watch_list.txt 廃止は **別 issue** に切り出し（運用安定後にユーザー判断で起票）
+
+---
+
+## 7. 開発コマンド
+
+```bash
+# Phase 3a テスト
+pytest tests/test_portfolio_shelve.py tests/test_migrate_portfolio_from_csv.py \
+       tests/test_migrate_my_watch_list_to_shelve.py tests/test_portfolio.py -v
+
+# Phase 3a 移行実行（ユーザー作業）
+cd scripts && python migrate_portfolio_from_csv.py "${KS_DATA_DIR}/migration/portfolio_sheet.csv"
+cd scripts && python migrate_my_watch_list_to_shelve.py
+
+# Phase 3a パイロット
+cd scripts && python make_stock_db.py list_all_db
+
+# Phase 3b テスト
+pytest tests/test_webapp_portfolio_routes.py -v
+pytest tests/e2e/test_portfolio_dashboard.py -v
+
+# Phase 3b 動作確認
+cd scripts && python -m webapp.app
+# → http://localhost:5001/portfolio
+```
+
+---
+
+## 8. オープンクエスチョン（実装時に決める）
+
+- ダッシュボード一覧の「常時表示」と「開閉式サブセクション」の境界（情報密度を見て調整）
+- アクションログ理由欄の必須/任意（種別ごとに変える: 初回登録は任意、削除は必須）
+- スプシ移行 CSV のエンコーディング・列名規約（実物 CSV を見て決定）

--- a/.claude/plans/issue-171-portfolio-dashboard.md
+++ b/.claude/plans/issue-171-portfolio-dashboard.md
@@ -1,0 +1,432 @@
+# issue #171 実装計画: Phase 3b 保有銘柄ダッシュボード UI
+
+> 親 issue: #151 (Phase 3 全体)
+> 依存: #170 (Phase 3a) のマージ後に main 取り込み。本 PR は `issue-170-portfolio-shelve` ブランチ起点でスタックする
+> 要件仕様書: [doc/requirements/phase3_portfolio_requirements.md](../../doc/requirements/phase3_portfolio_requirements.md) §5 / §6-1
+> 上位プラン: [.claude/plans/issue-151-portfolio.md](issue-151-portfolio.md) §4
+
+---
+
+## 1. スコープと前提
+
+### 1-1. 本 PR でやること
+
+- `/portfolio` ダッシュボード (3 タブ: 1保 / 2準 / 3監) の GET 実装
+- ステータス変更・追加・売却・削除の POST エンドポイント実装
+- 銘柄詳細ページに「3監に追加」ボタン追加
+- ナビに「保有銘柄」リンク追加
+- ユニットテスト + (必要なら) Playwright E2E
+
+### 1-2. スコープ外 (Phase 4 / 別 issue)
+
+- §5-3 警告シグナルの赤バッジ強調 (シグナルは **テキスト表示のみ**)
+- §6-2 イベントログ自動記録 (Shintakane 日次バッチ統合)
+- §6-3 振り返りビュー (→ Phase 3c / issue #172)
+- アクションログ「見送り」「メモ」種別 (Phase 4)
+
+### 1-3. ブランチ戦略
+
+- ブランチ名: `issue-171-portfolio-dashboard`
+- base: `issue-170-portfolio-shelve` (Phase 3a の PR #173 ブランチ)
+- PR base も同じ。Phase 3a が main にマージされたタイミングで GitHub が自動的に main 相対の差分に切り替える
+- 本番運用への影響: **Phase 3a がマージされるまでなし**。Phase 3b PR は main から見ると Phase 3a + 3b の累積差分になる
+
+---
+
+## 2. URL / Blueprint 設計
+
+### 2-1. ルート定義
+
+| URL | メソッド | ハンドラ | 機能 |
+|---|---|---|---|
+| `/portfolio` | GET | `portfolio.dashboard` | ダッシュボード (タブ切替: `?status=hold/semi/watch`、デフォルト `hold`) |
+| `/portfolio/add` | POST | `portfolio.add` | 銘柄を 3監 に追加 (理由任意) |
+| `/portfolio/<code_s>/transition` | POST | `portfolio.transition` | ステータス変更 (1保→2準 は内部で「売却」として記録) |
+| `/portfolio/<code_s>/delete` | POST | `portfolio.delete` | 削除 (3監 からのみ。理由必須) |
+
+`status` クエリパラメータ:
+- `hold` ⇄ `1保`、`semi` ⇄ `2準`、`watch` ⇄ `3監`
+- 内部で `1保` 等の正規化文字列に変換して `portfolio_shelve.list_records(status=...)` に渡す
+
+### 2-2. Blueprint 登録
+
+- `webapp/routes/portfolio.py` に `portfolio_bp = Blueprint("portfolio", __name__)`
+- `webapp/__init__.py` の `create_app()` に `from webapp.routes.portfolio import portfolio_bp` + `app.register_blueprint(portfolio_bp)` を追加
+- url_prefix なし (既存 Blueprint と統一)
+
+---
+
+## 3. ダッシュボード一覧表示 (`/portfolio`)
+
+### 3-1. 表示する情報
+
+要件 §5-2 の 6 カテゴリすべて。情報密度を抑えるため **常時表示** と **行クリック展開** に分割。
+
+#### 常時表示 (テーブル列、左→右)
+
+| 列 | データソース | フォーマット |
+|---|---|---|
+| コード | portfolio_shelve | `code_s` |
+| 銘柄名 | portfolio_shelve | `stock_name` (リンクで `/stock/<code_s>`) |
+| ステータス | portfolio_shelve | `1保` / `2準` / `3監` (タブ自体で絞り込みなので情報冗長だが揃え) |
+| 順位 | stocks_shelve | total_pt 順位 (なければ "—") |
+| PER | stocks_shelve | 整数 |
+| 時価総額 | stocks_shelve | 億円表示 |
+| 配当 | stocks_shelve | % |
+| RS | stocks_shelve | 整数 |
+| ステージ | stocks_shelve | "上昇" 等の短縮表記 |
+| トレンドテンプレート | stocks_shelve | 短縮表記 (既存の helper を流用) |
+| シグナル | stocks_shelve | テキスト列で「警」「売」「新高値」等を空白区切り。**赤バッジ強調なし** |
+| 理論株価乖離率 | stocks_shelve | % (上限/下限の近い方を表示、既存実装に倣う) |
+
+#### 行クリック展開 (アコーディオン or `<details>`)
+
+行クリックで下部に縦展開:
+- **業績の詳細**: 売上・利益成長率、進捗率 (stocks_shelve)
+- **手動メモ**: gyoutai_theme / watch_in_reason / trade_idea / inago_origin / takaichi_sensitivity (portfolio_shelve)
+- **アクションへのリンク**: 「ステータス変更」「(3監 タブのみ) 削除」「銘柄詳細を開く」
+
+実装は `<details><summary>` で JS 不要 (Pico.css の素朴な見栄えで十分)。後で UX 改善が必要になったら JS 化を検討する。
+
+### 3-2. タブナビ
+
+```
+[ 保有中 (1保) ] [ 準保有 (2準) ] [ 監視 (3監) ]
+```
+
+`<a href="/portfolio?status=hold">` 等の単純リンクで実装。アクティブタブはサーバー側で判定して CSS class を付与。タブ自体に件数を表示 (例: `保有中 (24)`)。
+
+### 3-3. ヘルパ関数の責務 (`webapp/helpers.py` への追加)
+
+```python
+def list_portfolio_with_indicators(status: str) -> list[dict]:
+    """portfolio_shelve のレコードに stocks_shelve から指標を補完。
+
+    Returns:
+        各 dict は { ...portfolio_record, "indicators": {per, market_cap, rs, ...},
+                     "rank": int|None, "signals": list[str], ... }
+    """
+```
+
+- `portfolio_shelve.list_records(status=...)` を呼ぶ
+- 各レコードに `stocks_shelve` から指標を補完 (なければ "—" 等のプレースホルダ)
+- ソート順: 既存総合 PT 順位昇順 (なければ末尾)
+
+### 3-4. テンプレート構造
+
+- `templates/portfolio_list.html` (新規):
+  - `{% extends "base.html" %}`
+  - 上部: タブナビ + 件数バッジ
+  - メイン: テーブル (`<table>` + Pico.css)
+  - 各行: `<details>` で展開セクション
+- `templates/portfolio_dialogs.html` (新規 / partial):
+  - 「ステータス変更」「削除」「3監に追加」のフォーム部品
+  - portfolio_list.html と detail.html の両方から `{% include %}` で再利用
+
+---
+
+## 4. ステータス変更 / 追加 / 売却 / 削除 の UI と内部動作
+
+### 4-1. 銘柄追加 (`/stock/<code_s>` から)
+
+#### UI
+- `templates/detail.html` の上部 `<div class="stock-header">` 右カラムに「3監に追加」ボタンを表示
+- ボタン押下で確認ダイアログ (HTML5 `confirm()` でも可) → POST `/portfolio/add` (form: `code_s`, `reason`)
+- `reason` は任意。Phase 3b では UI 上はシンプルに `code_s` のみ送信し、理由は空のまま `初回登録` ログを残す
+
+#### 内部
+- `portfolio_shelve.add_to_watch(code_s, stock_name, reason="WebApp 追加")` を呼ぶ
+  - **`upsert_record` は使わない** (重複時に既存メモを上書きするため危険)
+  - `add_to_watch` は内部で「重複なら ValueError」「初回登録ログ自動記録」「status=3監 固定」を提供する Phase 3a 実装済 API
+  - `reason` は **keyword-only 引数** なので `add_to_watch(code_s, stock_name, reason="...")` のように渡す
+- 既存銘柄の再追加 (= ValueError) は flash で「既に登録済みです」と警告のみ表示し no-op
+- 完了後 `redirect(url_for("portfolio.dashboard", status="watch"))` (3監 タブで確認できる)
+- `stock_name` は `stocks_shelve.get_stock_data(code_s)` から引く。ない場合は空文字 (移行と同じ振る舞い)
+
+#### バリデーション
+- `code_s` が `portfolio_shelve.validate_code_s` で OK か
+- 銘柄が `stocks_shelve` にあるか (なければ既存 `add_stock` を先に呼ぶ。research_shelve への登録ロジックは既存 `webapp.helpers.add_stock` を再利用)
+
+### 4-2. ステータス変更 (1保 ⇄ 2準 ⇄ 3監)
+
+#### UI
+- `/portfolio` の行クリック展開内に「ステータス変更」ボタン
+- 押下で簡易ダイアログ (`<dialog>` または HTML5 `prompt()`):
+  - **遷移先プルダウン** (許可遷移のみ表示): 例えば `1保` 行なら `2準 (売却)` / `3監` のみ。`portfolio_shelve.transition_status` 内部の許可表に整合
+  - **理由テキストエリア** (任意。1保→2準 売却時は推奨)
+- POST `/portfolio/<code_s>/transition` (form: `new_status`, `reason`)
+
+#### 内部
+- `portfolio_shelve.transition_status(code_s, new_status, reason=reason)` を呼ぶ (`reason` は **keyword-only**)
+- transition_status 内部の挙動 (Phase 3a 実装済):
+  - **同一ステータス遷移 (例: 1保→1保) は no-op、ValueError は投げない**
+  - 不正遷移 (許可表に含まれない) は ValueError
+  - レコード未登録は KeyError
+  - 1保→2準 は内部で `売却` 種別ログ、それ以外は `ステータス変更` ログ自動記録
+- 完了後 `redirect(url_for("portfolio.dashboard", status=<new_status_query>))`
+
+#### バリデーション
+- 遷移が `portfolio_shelve.ALLOWED_TRANSITIONS` (Phase 3a 定義) に含まれるか — transition_status 側で検証される
+- 不正遷移は ValueError、未登録は KeyError → flash + 元タブへリダイレクト (4xx は返さず UX 重視)
+- 同一遷移は no-op で正常 return → flash 出さずにダッシュボードに戻る (UI で disabled にしてここに来ないのが理想だが、二重発火対策で no-op を許容)
+
+### 4-3. 削除 (3監 からのみ)
+
+#### UI
+- `/portfolio?status=watch` の 3監 タブ行のみ「削除」ボタン表示
+- 1保 / 2準 タブには削除ボタン非表示 (誤操作防止 + ガード二重化)
+- 押下で確認ダイアログ + 理由必須テキストエリア
+- POST `/portfolio/<code_s>/delete` (form: `reason`)
+
+#### 内部
+- `portfolio_shelve.delete_record(code_s, reason=reason)` を呼ぶ (`reason` は **keyword-only**)
+- delete_record 内部の挙動 (Phase 3a 実装済):
+  - レコード未登録なら False を返す (例外なし)
+  - status が `3監` 以外なら ValueError (1保 / 2準 から直接削除はガード)
+  - 成功時は `削除` ログを 1 件記録、本体を物理削除
+- UI 側でも 3監 タブのみ削除ボタン表示 (二重ガード)
+- 完了後 `redirect(url_for("portfolio.dashboard", status="watch"))`
+
+#### バリデーション
+- `reason` が空文字なら flash で「削除理由は必須」と表示して reject
+- 1保 / 2準 銘柄に対する直接 POST は ValueError → 4xx 相当だが flash + redirect で対応
+
+### 4-4. shelve→txt 同期の発火タイミング
+
+Phase 3a で `portfolio_shelve.sync_to_my_watch_list_txt()` を実装済 (明示呼び出し方式)。Phase 3b の各 POST ハンドラの末尾で呼ぶ:
+
+```python
+# 例: portfolio.transition の末尾
+portfolio_shelve.transition_status(code_s, new_status, reason=reason)  # reason は keyword-only
+portfolio_shelve.sync_to_my_watch_list_txt()  # ← shelve 反映後に txt も書き出す
+return redirect(...)
+```
+
+ヘルパ関数 (例: `webapp/helpers.py:portfolio_after_write_hook()`) を作って 3 ハンドラから共通呼び出しする方が DRY だが、3 行程度なので各ハンドラに直接書く方がシンプル。**実装時に判断** (Karpathy 原則: シニアが overcomplicated と言うか自問)。
+
+---
+
+## 5. ナビゲーション統合
+
+### 5-1. `templates/base.html` のナビ修正
+
+既存の左 `<ul>` (L16-18) に 1 行追加:
+
+```html
+<li><a href="/portfolio">保有銘柄</a></li>
+```
+
+### 5-2. `templates/detail.html` の修正
+
+`<div class="stock-header">` 右カラムに条件分岐:
+
+```html
+{% if not in_portfolio %}
+  <form action="/portfolio/add" method="POST" style="display:inline">
+    <input type="hidden" name="code_s" value="{{ code_s }}">
+    <button type="submit" onclick="return confirm('3監に追加しますか?')">3監に追加</button>
+  </form>
+{% else %}
+  <span>portfolio: {{ portfolio_status }}</span>  {# 1保/2準/3監 #}
+  <a href="/portfolio?status={{ portfolio_status_query }}">→ ダッシュボードで開く</a>
+{% endif %}
+```
+
+`detail.py` の handler 側で `in_portfolio` / `portfolio_status` をテンプレに渡す。
+
+---
+
+## 6. ファイル構成
+
+### 6-1. 新規
+
+| ファイル | 内容 |
+|---|---|
+| `scripts/webapp/routes/portfolio.py` | Blueprint + 4 ハンドラ |
+| `scripts/webapp/templates/portfolio_list.html` | ダッシュボード本体 |
+| `scripts/webapp/templates/portfolio_dialogs.html` | 編集ダイアログ partial (`{% include %}`) |
+| `tests/test_webapp_portfolio_routes.py` | ルートのユニットテスト (test_webapp_routes.py パターン) |
+
+### 6-2. 修正
+
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/webapp/__init__.py` | `portfolio_bp` 登録 (2 行追加) |
+| `scripts/webapp/helpers.py` | `list_portfolio_with_indicators(status)` 追加 |
+| `scripts/webapp/templates/base.html` | ナビに「保有銘柄」リンク追加 |
+| `scripts/webapp/templates/detail.html` | 「3監に追加」ボタン追加 |
+| `scripts/webapp/routes/detail.py` | `in_portfolio` / `portfolio_status` を render_template に渡す |
+
+---
+
+## 7. テスト戦略
+
+### 7-1. ユニットテスト (`tests/test_webapp_portfolio_routes.py`)
+
+`tests/test_webapp_routes.py` の fixture パターンを踏襲:
+- `tmp_path` で一時 portfolio_shelve を作る
+- `monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", tmp_db_path)` で差し替え
+- `client.get("/portfolio?status=hold")` の status_code / レスポンス本文確認
+- 各 POST ハンドラ:
+  - 正常系: 302 リダイレクト + portfolio_shelve に反映
+  - 異常系: 不正遷移 / 削除理由空 / 銘柄コード不正
+
+#### 主要テストケース
+
+| ケース | 期待結果 |
+|---|---|
+| `GET /portfolio?status=hold` で 1保 タブ表示 | 200, 1保 銘柄が一覧に出る |
+| `POST /portfolio/add` (新規 code_s) | 302 → status=watch、shelve に追加、初回登録ログ記録 |
+| `POST /portfolio/add` (既存 code_s) | 302 → flash 警告、shelve は no-op |
+| `POST /portfolio/<c>/transition` (1保→3監) | 302 → ステータス変更ログ |
+| `POST /portfolio/<c>/transition` (1保→2準) | 302 → 売却ログ |
+| `POST /portfolio/<c>/transition` (1保→1保) | 302 → no-op (transition_status は同一遷移を許容、ログは追記されない) |
+| `POST /portfolio/<c>/transition` (許可外遷移) | flash エラー、shelve 変化なし |
+| `POST /portfolio/<c>/delete` (3監 + 理由あり) | 302 → 削除ログ、レコード削除 |
+| `POST /portfolio/<c>/delete` (1保) | flash エラー (ValueError)、レコード残る |
+| `POST /portfolio/<c>/delete` (理由空) | flash エラー (UI 層の必須バリデーション)、レコード残る |
+| `POST /portfolio/<c>/delete` (未登録 code_s) | 302 → flash 警告 (delete_record が False 返却)、shelve 変化なし |
+| txt 同期発火 | 各 POST 後に my_watch_list.txt が更新される (DATA_DIR は一時 fixture) |
+
+### 7-2. テンプレート rendering テスト
+
+`client.get("/portfolio?status=...")` のレスポンス本文に対して `assert "保有中" in resp.text` 等の表面的検証で十分。E2E は不要 (理由は §7-3)。
+
+### 7-3. Playwright E2E は **本 PR では見送り**
+
+理由:
+- 既存リポに `tests/e2e/` ディレクトリがなく、Playwright も導入されていない (調査結果)
+- 主要な動作 (ステータス変更・追加・削除) はサーバー側で完結し、Flask テストクライアントで十分カバーできる
+- タブ切り替えは単純なリンク遷移で JS 不要
+- `<details>` 展開は HTML 標準で JS 不要
+
+E2E 導入が必要になるのは:
+- 行クリック展開で AJAX 編集を導入する時
+- ダイアログを `<dialog>` / モーダルライブラリで実装し JS 動作検証が必要になる時
+
+これらが発生したら別 issue で導入する。Phase 3b の DoD には E2E を含めない。
+
+### 7-4. CSRF / セキュリティ観点
+
+既存 webapp は CSRF トークン未導入 (search.add_stock_route や memo 系も同様)。Phase 3b でも既存慣習に合わせ CSRF は未導入。本番運用前に webapp 全体で対応する別 issue を立てる方が筋。
+
+ただし削除エンドポイントは特に外部からの誤発火が事故になるため、**Referer ヘッダ確認** または **method 確認** 程度のガードは入れる:
+
+```python
+# 例: portfolio.delete の冒頭
+if request.referrer is None or "/portfolio" not in request.referrer:
+    flash("不正なリクエスト", "error")
+    return redirect(url_for("portfolio.dashboard"))
+```
+
+ただしこれは半端な対策なので、**実装時に「やる/やらない」を再判断** する。やらないなら本 PR の説明にリスクとして明記。
+
+---
+
+## 8. 実装順序
+
+1. **Blueprint + GET ハンドラ + テンプレ骨格**
+   - `routes/portfolio.py` 作成、`portfolio.dashboard` の最小実装 (タブ表示のみ、空テーブル)
+   - `templates/portfolio_list.html` 骨格
+   - `webapp/__init__.py` 登録、`base.html` ナビ追加
+   - `pytest tests/test_webapp_portfolio_routes.py::test_dashboard_shows_tabs` pass
+
+2. **`list_portfolio_with_indicators` ヘルパ**
+   - `webapp/helpers.py` に追加、stocks_shelve 補完
+   - 一覧テーブル本体 (常時表示列のみ) 実装
+   - ユニットテストでヘルパ単体 pass
+
+3. **行クリック展開 (`<details>`)**
+   - 業績詳細・手動メモ・操作ボタンを展開部に追加
+   - Pico.css の素朴な見栄えで OK
+
+4. **POST: 追加 (`/portfolio/add`)**
+   - `portfolio.add` ハンドラ実装
+   - `detail.html` に「3監に追加」ボタン追加
+   - `detail.py` で `in_portfolio` を渡す
+   - テスト 3 ケース pass (正常 / 既存 / 不正コード)
+
+5. **POST: ステータス変更 (`/portfolio/<c>/transition`)**
+   - `portfolio.transition` ハンドラ実装
+   - 一覧の展開部に変更ダイアログ追加
+   - txt 同期発火追加
+   - テスト 4 ケース pass
+
+6. **POST: 削除 (`/portfolio/<c>/delete`)**
+   - `portfolio.delete` ハンドラ実装
+   - 3監 タブのみに削除ボタン表示
+   - 理由必須バリデーション
+   - テスト 3 ケース pass
+
+7. **既存テスト回帰確認**
+   - `pytest tests/ -v -m "not local_db and not live_html"` 全 pass
+   - 既存 webapp ルートに影響がないことを確認
+
+8. **動作確認**
+   - `cd scripts && python -m webapp.app`
+   - `http://localhost:5001/portfolio` で各タブ確認
+   - 各操作を実 portfolio_shelve に対して実行 (パイロット用 DB を別途 KS_DATA_DIR 切り替えで用意)
+
+---
+
+## 9. リスク・オープンクエスチョン
+
+### 9-1. 一覧表の情報密度
+
+要件 §5-2 の 6 カテゴリすべてを表示すると 1 行が長くなる。横スクロールを許容する / 重要度の低い列を展開部に逃がす / Pico.css のレスポンシブ機構を使う、いずれの方針も合理的。**実装時に画面を見て判断**。
+
+### 9-2. 「ステータス変更ダイアログ」の実装方式
+
+3 候補:
+- (a) HTML5 `<dialog>` + 簡易 JS (推奨)
+- (b) サーバー側で別ページに遷移 (`/portfolio/<c>/edit`) → POST → リダイレクト
+- (c) HTML5 `prompt()` (理由 1 行のみ。複数行入力はできない)
+
+(a) は JS 必須だが UX 良。(b) は JS 不要だがクリック数増。Phase 3b は (b) で開始し、必要なら (a) に置き換える方針。
+
+### 9-3. txt 同期の失敗時の挙動
+
+`sync_to_my_watch_list_txt()` が IO エラーで失敗した場合、shelve 更新は成功している状態で txt との整合性が崩れる。**ハンドラ側で try/except + flash エラー** で対応。txt 廃止 issue で根本解決。
+
+### 9-4. 銘柄詳細ページから 3監 追加した際の `add_stock` 呼び出し
+
+要件: 銘柄詳細ページに到達した時点で `add_stock` (research_shelve への登録) は既に済んでいる前提。ただし新銘柄を URL 直叩きで `/stock/<未登録 code>` した場合、 `add_stock` が走るのが既存挙動 (search.add_stock_route)。Phase 3b の `/portfolio/add` でも同様に **未登録なら add_stock を先に呼ぶ** か、**登録済みのみ追加可** にするか。後者の方がガードとして堅いが、運用負荷を考えると前者が UX 良。**実装時に既存 `add_stock` の挙動を確認して判断**。
+
+### 9-5. 1保 銘柄の総合 PT 順位が低い場合の表示
+
+要件 §5-2 で「順位」は表示対象。stocks_shelve の `rank` フィールドは update_stock_rank で振られる。保有銘柄が常に上位とは限らないため、「順位 100 位以下です」的な気付きを促す表示にすべきか。本 PR では数値のみ表示し、強調は Phase 4 (赤バッジ強調と一緒に) に送る。
+
+---
+
+## 10. Definition of Done (issue #171)
+
+- [ ] `/portfolio` の GET でタブ切替が機能、各タブで銘柄一覧が正しく表示
+- [ ] 銘柄詳細ページから「3監 に追加」 → portfolio_shelve に `初回登録` ログが残る
+- [ ] ダッシュボードからステータス変更が動作。1保→2準 が `売却` ログとなる
+- [ ] 1保/2準 の銘柄に「削除」ボタンが表示されない、3監 からは削除可能
+- [ ] 不正遷移 (例: 1保 → 削除 を直接 POST) が flash エラーで弾かれる
+- [ ] `pytest tests/test_webapp_portfolio_routes.py -v` 全 pass
+- [ ] `pytest tests/ -v -m "not local_db and not live_html"` 全 pass (既存テスト回帰なし)
+- [ ] `python -m webapp.app` で起動し、ローカルブラウザで全シナリオを目視確認
+
+### スコープ外 (本 PR に含まない)
+
+- 警告シグナルの赤バッジ強調表示 → Phase 4
+- 振り返りビュー (アクションログ時系列) → Phase 3c (issue #172)
+- イベントログ自動記録 → Phase 4
+- Playwright E2E → 必要が顕在化したら別 issue
+- CSRF 対応 → webapp 全体の別 issue
+
+---
+
+## 11. 開発コマンド
+
+```bash
+# テスト
+pytest tests/test_webapp_portfolio_routes.py -v
+pytest tests/ -v -m "not local_db and not live_html"  # 全体回帰
+
+# ローカル起動 (動作確認)
+cd scripts && python -m webapp.app
+# → http://localhost:5001/portfolio
+```

--- a/.claude/plans/issue-175-portfolio-memo-edit.md
+++ b/.claude/plans/issue-175-portfolio-memo-edit.md
@@ -1,0 +1,375 @@
+# issue #175 実装計画: portfolio_shelve memo の WebApp 編集機能
+
+> 親 issue: #168 (Phase 3 全体)
+> 直前: #171 (Phase 3b 一覧ダッシュボード) - 同じブランチ `issue-171-portfolio-dashboard` 上で続けて実装
+> ベースブランチ: `issue-171-portfolio-dashboard` (PR #176 の HEAD `1973f33`)
+
+---
+
+## 1. スコープと前提
+
+### 1-1. 目的
+保有銘柄一覧画面 (`/portfolio`) の展開行に memo 編集 form を追加し、スプシ → CSV → migrate スクリプトの片道経路を廃止可能な状態にする。**売買アイデア・IN 理由を「保有一覧を見ながら同時に書き留めたい」性質**のため、銘柄詳細ページではなく一覧の展開行に form を配置する (issue 本文の案1)。
+
+### 1-2. 編集対象 (8 項目すべて = `MEMO_FIELDS` 全要素)
+- `gyoutai_theme` (業態・テーマ)
+- `watch_in_reason` (IN 理由)
+- `trade_idea` (売買アイデア)
+- `inago_origin` (イナゴ元)
+- `takaichi_sensitivity` (高市感応度)
+- `last_research_update` (調査更新日)
+- `stage` (ステージ)
+- `jukyu_chart` (需給チャート)
+
+### 1-3. スコープ外
+- スプシ運用廃止 / `migrate_portfolio_from_csv.py` のアーカイブ判断 (別 issue)
+- 銘柄詳細ページからの memo 編集 (案2、本 PR では実装しない)
+- フォールバックモード解消 (PR #176 の Codex 残課題、別対応)
+- memo 履歴の差分表示 (action_log には種別のみ記録、差分内容は記録しない)
+
+### 1-4. ブランチ戦略
+- 新ブランチ作成: `issue-175-portfolio-memo-edit`
+- base: `issue-171-portfolio-dashboard` (PR #176 の HEAD)
+- PR #176 は base=main で OPEN のままなので、**本 PR は #176 の上にスタック** (#176 がマージされたら GitHub が自動で base を main に切替)
+- 別ブランチに切り替える理由: PR #176 のレビュー指摘 2 件 (codex P1/P2) を保留中なので、それと混ぜたくない
+
+---
+
+## 2. バックエンド実装
+
+### 2-1. `scripts/portfolio_shelve.py` の追加
+
+#### 新 action_type 追加
+```python
+VALID_ACTION_TYPES = frozenset({"初回登録", "ステータス変更", "売却", "削除", "メモ更新"})  # ← "メモ更新" 追加
+```
+
+#### 新 API: `update_memo`
+```python
+def update_memo(
+    code_s: str,
+    fields: Dict[str, str],
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """既存レコードの memo フィールドを **部分更新** する。
+
+    - fields に含まれるキーのみ更新する (受け取らないキーは現行値を保持)
+    - fields のキーは MEMO_FIELDS のサブセットでなければ ValueError
+    - 値は str のみ受け付ける (None は空文字に正規化)
+    - 既存値と完全一致すれば no-op (action_log 追記なし、updated_at 据え置き)
+    - 1 つでも変更があれば action_log に "メモ更新" を 1 件追加 (差分内容は記録しない)
+    - レコード未登録なら KeyError
+    - _flock で排他 (transition_status と同じパターン)
+
+    部分更新セマンティクス (codex P1 指摘対応):
+    - クライアント不具合・将来 UI 変更・手動 POST でデータ欠損が起きないよう、
+      "未送信フィールド" と "明示的に空文字を送ったフィールド" を区別する
+    - 空文字 "" を **明示的に渡した** 場合は「メモ削除」として扱い空文字に上書きする
+    - キー自体が **fields に含まれない** 場合は現行値据え置き
+
+    Returns:
+        更新後のレコード dict (no-op 時も現行 record を返す)
+    """
+```
+
+実装ロジック:
+1. `validate_code_s(code_s)` → 正規化
+2. `fields` のキーが `MEMO_FIELDS` 以外を含むなら `ValueError`
+3. `fields` の値が str 以外なら `TypeError` (None は空文字に正規化)
+4. `_flock` ブロック内で:
+   - `record = db[record_key]` (なければ KeyError)
+   - `current_memo = record.get("memo", {})`
+   - 差分判定: `fields` の各 key について `current_memo.get(k, "") == fields[k]` がすべて成立すれば no-op で return
+   - 変更があれば `record["memo"] = {**current_memo, **fields}` で **部分マージ** (fields に含まれないキーは current_memo の値を保持)
+   - `record["updated_at"] = now_iso()`
+   - `db[record_key] = record`
+5. `_flock` ブロック内で `append_action_log(normalized, "メモ更新")` を呼ぶ
+   - reason は空文字、status_from / status_to なし
+
+#### 戻り値: 更新後 record dict
+no-op 時は変更前 record (= 現行 record) を返す。呼び出し側で「変更があったか」を知りたいなら `updated_at` の差分で判定可能 (本 PR では不要)。
+
+### 2-2. `scripts/webapp/routes/portfolio.py` の追加
+
+#### 新ハンドラ: `POST /portfolio/<code_s>/memo`
+```python
+@portfolio_bp.route("/portfolio/<code_s>/memo", methods=["POST"])
+def update_memo(code_s: str):
+    """memo 8 項目を一括保存する。"""
+    rejected = _reject_when_fallback()  # 既存3ハンドラと同じガード
+    if rejected is not None:
+        return rejected
+
+    try:
+        ps.validate_code_s(code_s)
+    except (ValueError, TypeError) as e:
+        flash(f"不正な銘柄コード: {e}", "error")
+        return redirect(url_for("portfolio.dashboard"))
+
+    fields = _extract_memo_fields_from_form(request.form)  # MEMO_FIELDS のみ抽出
+    try:
+        ps.update_memo(code_s, fields)
+    except KeyError:
+        flash(f"{code_s} は portfolio_shelve に未登録です", "error")
+        return redirect(url_for("portfolio.dashboard"))
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return _redirect_to_current_tab(code_s, fallback_query=DEFAULT_TAB)
+
+    flash(f"{code_s} のメモを保存しました", "info")
+    # txt 同期は memo 編集では不要 (txt は code/name/status のみで memo を持たない)
+    return _redirect_to_current_tab(code_s, fallback_query=DEFAULT_TAB)
+```
+
+#### ヘルパ: `_extract_memo_fields_from_form(form) -> Dict[str, str]`
+- **`form` に実際に存在するキーのみを抽出する** (codex P1 指摘対応)
+  - `for field in MEMO_FIELDS: if field in form: fields[field] = form[field]`
+  - `form.get(field, "")` でデフォルト値を埋めると「未送信フィールドを空文字で上書き」してしまうため不可
+- 抽出した値は前後 strip + 改行正規化 (`\r\n` → `\n`、`\r` → `\n`)
+- `MEMO_FIELDS` 外のキーは無視 (form に紛れ込んでも reject しない)
+- ブラウザの form は 8 項目すべての textarea を持つので通常は 8 キー全部含む。手動 POST で部分送信された場合は送られたキーだけが更新対象になる
+
+### 2-3. `scripts/webapp/helpers.py` の追加 (検討中)
+
+issue 本文には `save_portfolio_memo(code_s, form_data)` ヘルパを置く案があるが、**ハンドラ内で完結する 10 行程度の処理**なので、ヘルパ抽出は overcomplicated。`_extract_memo_fields_from_form` だけ `routes/portfolio.py` 内のモジュール private 関数で十分。
+
+→ **helpers.py には何も追加しない**。issue 本文との差異だが、Karpathy 原則 (Simplicity First) に基づく判断。
+
+---
+
+## 3. UI 実装
+
+### 3-1. `templates/portfolio_list.html` の手動メモセクション置換
+
+#### 現状 (L122-133)
+```html
+<div style="flex:0 1 auto;min-width:240px;max-width:50em;">
+  <strong style="font-size:0.85em;color:#666;">手動メモ</strong>
+  {% if row.memo.last_research_update %}
+  <span ...>調査更新日: {{ row.memo.last_research_update }}</span>
+  {% endif %}
+  <ul style="...">
+    <li><strong>IN 理由:</strong> {{ row.memo.watch_in_reason or "—" }}</li>
+    ...
+  </ul>
+</div>
+```
+
+#### 変更後
+```html
+<div style="flex:0 1 auto;min-width:300px;max-width:50em;">
+  <strong style="font-size:0.85em;color:#666;">手動メモ</strong>
+  {% if not fallback_mode %}
+  <form action="/portfolio/{{ row.code_s }}/memo" method="POST"
+        style="display:flex;flex-direction:column;gap:0.4em;margin:0.3em 0 0 0;font-size:0.85em;">
+    {% for field, label in [
+        ("gyoutai_theme", "業態・テーマ"),
+        ("watch_in_reason", "IN 理由"),
+        ("trade_idea", "売買アイデア"),
+        ("inago_origin", "イナゴ元"),
+        ("takaichi_sensitivity", "高市感応度"),
+        ("last_research_update", "調査更新日"),
+        ("stage", "ステージ"),
+        ("jukyu_chart", "需給チャート"),
+    ] %}
+    <label style="display:flex;flex-direction:column;gap:0.1em;margin:0;">
+      <span style="color:#666;">{{ label }}</span>
+      <textarea name="{{ field }}" rows="2"
+                style="font-size:0.85em;padding:0.3em;margin:0;font-family:inherit;"
+                >{{ row.memo[field] or "" }}</textarea>
+    </label>
+    {% endfor %}
+    <button type="submit"
+            style="padding:0.3em 0.6em;font-size:0.85em;margin:0.2em 0 0 0;align-self:flex-start;">
+      メモを保存
+    </button>
+  </form>
+  {% else %}
+  <!-- フォールバックモード時は読み取り専用表示を維持 -->
+  <ul style="font-size:0.85em;margin:0.3em 0 0 1em;padding:0;">
+    <li><strong>IN 理由:</strong> {{ row.memo.watch_in_reason or "—" }}</li>
+    <li><strong>売買アイデア:</strong> {{ row.memo.trade_idea or "—" }}</li>
+    <li><strong>イナゴ元:</strong> {{ row.memo.inago_origin or "—" }}</li>
+    <li><strong>高市感応度:</strong> {{ row.memo.takaichi_sensitivity or "—" }}</li>
+    <li><strong>需給チャート:</strong> {{ row.memo.jukyu_chart or "—" }}</li>
+  </ul>
+  {% endif %}
+</div>
+```
+
+#### ポイント
+- **8 項目すべて textarea (`rows="2"`) で統一** — `stage` `last_research_update` のような短文も textarea で揃える
+- **1 列縦並び** — 既存の操作セクションと並ぶレイアウトを保つ
+- **`row.memo[field]` で値を取得** — 現状 `row.memo.gyoutai_theme` のような attribute 形式でアクセスしているが、Jinja の dict は `[]` でも `.` でもアクセス可能なので問題なし
+- **フォールバックモード時は form を出さず、現行の読み取り専用 ul 表示を維持** — `_reject_when_fallback` で reject するので form を出してもエラーで戻されるが、UX 上「保存ボタンが押せるけど押すと失敗する」のは混乱を招くため
+- **L84-88 の常時表示列の業態・テーマ表示は変更不要** (textarea ではなく `<td>` での 2 行表示。既存ロジック維持)
+
+### 3-2. テンプレート Jinja 構造への注意
+
+`{% for field, label in [...] %}` のリストリテラルは Jinja2 で動作する (Jinja2 はタプル展開対応)。
+動作確認できなければ事前に `tuple` を辞書化 + ordered iteration で書き直す。
+
+---
+
+## 4. テスト
+
+### 4-1. `tests/test_portfolio_shelve.py` 追加 (`TestUpdateMemo` クラス)
+
+| ケース | 期待結果 |
+|---|---|
+| `update_memo("4377", {"trade_idea": "上値追い"})` (1 項目のみ送信) | trade_idea のみ更新、他の 7 項目は据え置き、action_log "メモ更新" 1 件、updated_at 更新 |
+| 既存値と完全一致で更新 (1 項目) | no-op、action_log 追記なし、updated_at 据え置き |
+| 8 項目を一括更新 | 全フィールド反映、action_log 1 件 |
+| **空 dict `{}` で呼び出し** | no-op、KeyError なし (差分なしと同等) |
+| **明示的に空文字 `{"trade_idea": ""}` を送信** (現行値が非空) | trade_idea が "" に上書きされる (= メモ削除扱い)、action_log 1 件 |
+| **未送信フィールドが据え置きされる** (`{"trade_idea": "X"}` だけ送って残り 7 項目に既存値あり) | trade_idea のみ更新、残り 7 項目の既存値は変化なし |
+| `MEMO_FIELDS` 外のキー (`{"unknown_field": "x"}`) | ValueError |
+| 値が str 以外 (`{"trade_idea": 123}`) | TypeError |
+| 値が None (`{"trade_idea": None}`) | "" に正規化されて保存される (空文字としての更新扱い) |
+| レコード未登録 (`update_memo("9999", {"trade_idea": "X"})`) | KeyError |
+| 不正な code_s (`update_memo("abc", {...})`) | ValueError |
+| 排他確認: 並行 update_memo を 2 スレッドで叩いて両方成功 | action_log seq が 2 件、最終値が一方の上書き勝ち (data race なし) |
+
+### 4-2. `tests/test_webapp_portfolio_routes.py` 追加 (`TestUpdateMemoRoute` クラス)
+
+| ケース | 期待結果 |
+|---|---|
+| `POST /portfolio/4377/memo` (form: 全 8 項目) | 302 リダイレクト → 銘柄の現在ステータスのタブ、shelve 反映、action_log 1 件 |
+| **`POST /portfolio/4377/memo` (form: 3 項目のみ)** | **送られた 3 項目のみ更新、残り 5 項目は据え置き** (codex P1 対応)、action_log 1 件 |
+| `POST /portfolio/4377/memo` (form: 全 8 項目すべて空文字) | 全項目が "" で上書きされる (= 全メモ削除)、現行値が非空なら action_log 1 件 |
+| `POST /portfolio/4377/memo` (差分なし: 全項目を現行値そのまま送る) | 302 → flash "保存しました" は出るが action_log 追記なし |
+| `POST /portfolio/9999/memo` (未登録) | flash "未登録"、リダイレクト |
+| `POST /portfolio/abc/memo` (不正コード) | flash エラー、リダイレクト |
+| フォールバックモード時の POST | flash "未移行モード" + redirect (既存 `_reject_when_fallback` の挙動と整合) |
+
+#### 「部分送信」と「空文字送信」の区別
+- **キー自体が form に含まれない** (= 手動 POST で省略された) → 該当フィールドは現行値据え置き
+- **キーは含まれるが値が ""** (= textarea を空にして送信) → 該当フィールドは "" に上書き (メモ削除の意図)
+
+ブラウザ form は常に 8 項目すべての textarea を持つので、通常運用では「キー自体が含まれない」ケースは発生しない。手動 POST や将来の AJAX 部分編集で安全に動くよう、サーバ側で区別する。
+
+### 4-3. 既存テストの回帰確認
+
+```bash
+.venv/bin/pytest tests/ -v -m "not local_db and not live_html"
+```
+
+現行 PR #176 で 188 件 + Phase 3b 分が追加された状態。本 PR で増えるのは `TestUpdateMemo` (約 10 件) + `TestUpdateMemoRoute` (約 6 件) = 16 件程度。
+
+---
+
+## 5. ファイル構成
+
+### 5-1. 修正
+| ファイル | 変更内容 | 推定行数 |
+|---|---|---|
+| `scripts/portfolio_shelve.py` | `VALID_ACTION_TYPES` に "メモ更新" 追加 (1 行) + `update_memo()` 新規 (約 50 行) | +51 |
+| `scripts/webapp/routes/portfolio.py` | `update_memo` ハンドラ + `_extract_memo_fields_from_form` ヘルパ (約 40 行) | +40 |
+| `scripts/webapp/templates/portfolio_list.html` | 手動メモ ul を form に置換 + フォールバック分岐維持 (約 30 行差し替え) | +25 |
+
+### 5-2. 新規
+なし (既存ファイルへの追記で完結)
+
+### 5-3. テスト
+| ファイル | 追加内容 |
+|---|---|
+| `tests/test_portfolio_shelve.py` | `TestUpdateMemo` クラス (約 10 ケース、約 120 行) |
+| `tests/test_webapp_portfolio_routes.py` | `TestUpdateMemoRoute` クラス (約 6 ケース、約 80 行) |
+
+---
+
+## 6. 実装順序
+
+1. **`portfolio_shelve.update_memo` 実装 + ユニットテスト**
+   - `VALID_ACTION_TYPES` 拡張
+   - `update_memo()` 実装
+   - `tests/test_portfolio_shelve.py::TestUpdateMemo` 全ケース pass
+
+2. **`webapp/routes/portfolio.py` ハンドラ追加 + ルートテスト**
+   - `update_memo` ハンドラ + ヘルパ
+   - `tests/test_webapp_portfolio_routes.py::TestUpdateMemoRoute` 全ケース pass
+
+3. **テンプレート差し替え**
+   - 手動メモ ul → form 置換
+   - フォールバック時の読み取り専用表示を維持
+   - ブラウザ動作確認 (port 5002)
+
+4. **既存テスト回帰確認**
+   - `.venv/bin/pytest tests/ -v -m "not local_db and not live_html"` 全 pass
+
+5. **動作確認**
+   - `cd scripts && python -m webapp.app`
+   - `/portfolio` の 3 タブで memo 編集 → 保存 → リロードで反映確認
+   - 同一値を保存して action_log に追記されないこと確認 (簡易な shelve 直読みで OK)
+
+---
+
+## 7. リスク・オープンクエスチョン
+
+### 7-1. textarea の改行ハンドリング
+
+- `request.form.get("trade_idea")` は textarea の改行 (`\r\n`) を保持する
+- 既存テンプレ L87 で `theme_line in row.memo.gyoutai_theme.split("\n")[:2]` のように `\n` で分割しているため、ブラウザが `\r\n` で送ってくると `\r` が混入する
+- 対策: `update_memo` 内で改行を `\n` に正規化 (`value.replace("\r\n", "\n").replace("\r", "\n")`) するか、ハンドラ側で正規化する
+
+→ **方針**: ハンドラ側 (`_extract_memo_fields_from_form`) で改行正規化 + 前後 strip。
+
+### 7-2. flash メッセージの粒度
+
+「変更がない場合 (no-op) でも保存メッセージを出す」のは UX 的に微妙。
+
+→ **方針**: 簡素化のため「保存しました」は no-op でも出す。差分検出して「変更ありませんでした」と出し分けるのは overcomplicated。
+
+### 7-3. 排他制御と action_log の整合性
+
+`update_memo` の内部で `_flock` を取り、その中で `db[key] = record` した後に `append_action_log` を呼ぶ。`append_action_log` も `_flock` を取るが、`_flock` は `_flock_holder.depth` で再入対応済み (L227)。
+
+→ 既存 `transition_status` と同じパターンなので問題なし。
+
+### 7-4. 「未送信」と「空文字送信」の区別 (codex P1 対応)
+
+部分更新方式を採用するため、サーバ側で 2 つの状態を区別する:
+
+| 入力 | 動作 |
+|---|---|
+| キー自体が `fields` dict (= form) に含まれない | 該当フィールドは現行値据え置き |
+| キーは含まれるが値が空文字 `""` | 該当フィールドは "" に上書き (メモ削除の意図) |
+| 値が None | "" に正規化 (空文字送信と同じ扱い) |
+
+ブラウザの form は常に 8 項目すべての textarea を含むので、通常運用では「未送信」は発生しない。手動 POST や将来の AJAX 部分編集で安全に動くよう、`_extract_memo_fields_from_form` は `form.get(field, "")` ではなく `form[field] if field in form else SKIP` のロジックで抽出する。
+
+### 7-5. CSRF トークン未導入
+
+既存 webapp ルートは CSRF 未対応 (`portfolio.transition` `portfolio.delete` も同様)。memo 編集だけ CSRF を入れるのは不整合。
+
+→ **方針**: 既存慣習に合わせ CSRF 未対応。webapp 全体での導入は別 issue。
+
+---
+
+## 8. Definition of Done (issue #175)
+
+- [ ] `MEMO_FIELDS` の 8 項目すべてが `/portfolio` 一覧画面の展開行から編集・保存できる
+- [ ] 保存後、shelve に反映され、action_log に "メモ更新" が記録される
+- [ ] 既存値と完全一致で保存した場合は action_log 追記なし
+- [ ] 一覧画面のレイアウトを大きく崩さない (常時表示列・操作セクションは変更なし)
+- [ ] フォールバックモード時は form を出さず、現行の読み取り専用表示を維持
+- [ ] **部分送信時に未送信フィールドが現行値据え置きになる** (codex P1 対応)
+- [ ] `pytest tests/test_portfolio_shelve.py tests/test_webapp_portfolio_routes.py -v` 全 pass
+- [ ] `pytest tests/ -v -m "not local_db and not live_html"` 全 pass (回帰なし)
+- [ ] ブラウザ目視確認: memo 編集 → 保存 → リロードで反映、改行入力が `\n` で保存される
+
+---
+
+## 9. 開発コマンド
+
+```bash
+# テスト
+.venv/bin/pytest tests/test_portfolio_shelve.py::TestUpdateMemo -v
+.venv/bin/pytest tests/test_webapp_portfolio_routes.py::TestUpdateMemoRoute -v
+.venv/bin/pytest tests/ -v -m "not local_db and not live_html"  # 回帰
+
+# ローカル起動 (動作確認)
+cd scripts && python -m webapp.app
+# → http://localhost:5001/portfolio
+```

--- a/scripts/db_shelve.py
+++ b/scripts/db_shelve.py
@@ -311,6 +311,7 @@ MARKET_SHELVE = os.path.join(DATA_DIR, "market_data", "market_db_shelve")
 KESSAN_SHELVE = os.path.join(DATA_DIR, "todays_kessan_data", "pf_kessan_shelve")
 SECTOR_SHELVE = os.path.join(DATA_DIR, "stock_data", "sector", "sector_db_shelve")
 RESEARCH_SHELVE = os.path.join(DATA_DIR, "stock_data", "research_shelve")
+PORTFOLIO_SHELVE = os.path.join(DATA_DIR, "stock_data", "portfolio_shelve")
 
 
 # ===========================================

--- a/scripts/migrate_my_watch_list_to_shelve.py
+++ b/scripts/migrate_my_watch_list_to_shelve.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+my_watch_list.txt → portfolio_shelve 取り込みスクリプト (Phase 3a / issue #170)
+
+入力: ${KS_DATA_DIR}/my_watch_list.txt (H 接頭辞 = 1保、なし = 3監)
+出力: portfolio_shelve
+
+マージルール (計画書 §3-3):
+- txt のみ存在: ステータスを txt から決定 (H 付き→1保、なし→3監)、メモは空
+- スプシのみ存在: 既存の status="3監" のまま、メモはスプシ採用
+- 両方存在: ステータスは txt 優先で上書き、メモはスプシ採用 (上書きしない)
+
+ステータスは my_watch_list.txt のみを真実源とする (スプシのステータス列は無視)。
+スプシ移行 (migrate_portfolio_from_csv.py) を先に実行し、本スクリプトを後に実行する想定。
+"""
+
+import argparse
+import os
+import re
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+# scripts/ を sys.path に追加 (直接実行時)
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import DATA_DIR, log_print, log_warning, file_read
+except ImportError:
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+    def file_read(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+
+# my_watch_list.txt の行パターン: 先頭オプションの H + 銘柄コード + 銘柄名
+# 銘柄コードは "0001"〜"9999" または "215A" 形式
+LINE_PATTERN = re.compile(r"^(H?)(\d[0-9a-zA-Z]\d[0-9A-Z])(.*)$")
+
+
+def parse_my_watch_list(text: str) -> List[Tuple[str, str, str]]:
+    """テキスト内容をパースして [(code_s, stock_name, status), ...] を返す。
+
+    - H 接頭辞付き → status="1保"
+    - 接頭辞なし → status="3監"
+    - 重複は最初の出現を優先 (txt 内の重複を排除)
+    """
+    seen: Dict[str, Tuple[str, str, str]] = {}
+    for raw_line in text.split("\n"):
+        line = raw_line.strip()
+        if not line:
+            continue
+        m = LINE_PATTERN.match(line)
+        if not m:
+            continue
+        prefix, code_raw, rest = m.group(1), m.group(2), m.group(3)
+        try:
+            ps.validate_code_s(code_raw)
+        except (ValueError, TypeError):
+            continue
+        code_s = ps.normalize_code_s(code_raw)
+        stock_name = rest.strip()
+        status = "1保" if prefix == "H" else "3監"
+        if code_s not in seen:
+            seen[code_s] = (code_s, stock_name, status)
+    return list(seen.values())
+
+
+def merge_into_shelve(
+    entries: List[Tuple[str, str, str]],
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """txt 由来エントリを portfolio_shelve にマージする。
+
+    既存レコードがある場合 (スプシ移行済み):
+    - ステータスは txt 優先で上書き
+    - メモは既存の値を保持 (スプシ採用)
+    - stock_name は既存を保持 (スプシ優先) ※ txt の名前は揺れがあるため
+    既存レコードがない場合 (txt のみ):
+    - 新規レコード作成 (ステータス、銘柄名、メモは空)
+
+    Returns: {"total": int, "created": int, "updated": int, "unchanged": int}
+    """
+    created = 0
+    updated = 0
+    unchanged = 0
+    for code_s, stock_name, status in entries:
+        existing = ps.get_record(code_s, db_path=db_path)
+        if existing is None:
+            # 新規 (txt のみ存在パターン)
+            new_record = ps.create_record(
+                code_s, stock_name, status=status,
+            )
+            ps.upsert_record(new_record, db_path=db_path)
+            ps.append_action_log(
+                code_s,
+                "初回登録",
+                status_from=None,
+                status_to="3監",  # ライフサイクル上は新規=3監で記録
+                reason="txt 取り込み",
+                db_path=db_path,
+            )
+            # 実際の status が 1保 なら 3監→1保 の遷移ログも追加
+            if status != "3監":
+                ps.append_action_log(
+                    code_s,
+                    "ステータス変更",
+                    status_from="3監",
+                    status_to=status,
+                    reason="txt 取り込み (H 接頭辞)",
+                    db_path=db_path,
+                )
+            created += 1
+        else:
+            # 既存 (スプシ移行済み)
+            old_status = existing.get("status")
+            if old_status == status:
+                unchanged += 1
+                continue
+            # ステータスのみ更新、メモは保持
+            existing["status"] = status
+            existing["updated_at"] = ps.now_iso()
+            ps.upsert_record(existing, db_path=db_path)
+            ps.append_action_log(
+                code_s,
+                "ステータス変更",
+                status_from=old_status,
+                status_to=status,
+                reason="txt 取り込みでステータス上書き",
+                db_path=db_path,
+            )
+            updated += 1
+    log_print(
+        f"migrate_my_watch_list: 新規 {created} 件、更新 {updated} 件、"
+        f"変化なし {unchanged} 件"
+    )
+    return {
+        "total": len(entries),
+        "created": created,
+        "updated": updated,
+        "unchanged": unchanged,
+    }
+
+
+def import_my_watch_list(
+    txt_path: Optional[str] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """my_watch_list.txt を読み込んで portfolio_shelve に取り込む。
+
+    Args:
+        txt_path: 入力 txt パス。None なら ${DATA_DIR}/my_watch_list.txt
+
+    Returns: merge_into_shelve の戻り値 (totals)
+    """
+    if txt_path is None:
+        txt_path = os.path.join(DATA_DIR, "my_watch_list.txt")
+    if not os.path.isfile(txt_path):
+        raise FileNotFoundError(f"my_watch_list.txt が見つかりません: {txt_path}")
+    text = file_read(txt_path)
+    entries = parse_my_watch_list(text)
+    log_print(
+        f"migrate_my_watch_list: txt から {len(entries)} 件のエントリ抽出"
+    )
+    return merge_into_shelve(entries, db_path=db_path)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="my_watch_list.txt を portfolio_shelve に取り込む",
+    )
+    parser.add_argument(
+        "--txt-path",
+        type=str,
+        default=None,
+        help=f"入力 txt パス (デフォルト: {os.path.join(DATA_DIR, 'my_watch_list.txt')})",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=str,
+        default=None,
+        help="portfolio_shelve のパス上書き (テスト用)",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = import_my_watch_list(args.txt_path, db_path=args.db_path)
+    except FileNotFoundError as exc:
+        log_warning(str(exc))
+        return 2
+    print(
+        f"total={result['total']} created={result['created']} "
+        f"updated={result['updated']} unchanged={result['unchanged']}"
+    )
+    # 同期は呼ばない: txt 取り込み時は元の txt を上書きすべきでないため
+    # (取り込み入力 = txt 自体なので、上書きすると先頭順序などが壊れる)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_my_watch_list_to_shelve.py
+++ b/scripts/migrate_my_watch_list_to_shelve.py
@@ -86,22 +86,22 @@ def merge_into_shelve(
     既存レコードがある場合 (スプシ移行済み):
     - ステータスは txt 優先で上書き
     - メモは既存の値を保持 (スプシ採用)
-    - stock_name は既存を保持 (スプシ優先) ※ txt の名前は揺れがあるため
     既存レコードがない場合 (txt のみ):
-    - 新規レコード作成 (ステータス、銘柄名、メモは空)
+    - 新規レコード作成 (ステータスは txt 由来、メモは空)
+
+    銘柄名は portfolio_shelve には保存しない (txt から読んでもレコードには埋めない)。
+    表示時は stocks_shelve / research_shelve から都度取得する。
 
     Returns: {"total": int, "created": int, "updated": int, "unchanged": int}
     """
     created = 0
     updated = 0
     unchanged = 0
-    for code_s, stock_name, status in entries:
+    for code_s, _stock_name, status in entries:
         existing = ps.get_record(code_s, db_path=db_path)
         if existing is None:
             # 新規 (txt のみ存在パターン)
-            new_record = ps.create_record(
-                code_s, stock_name, status=status,
-            )
+            new_record = ps.create_record(code_s, status=status)
             ps.upsert_record(new_record, db_path=db_path)
             ps.append_action_log(
                 code_s,

--- a/scripts/migrate_portfolio_drop_stock_name.py
+++ b/scripts/migrate_portfolio_drop_stock_name.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""portfolio_shelve の旧スキーマ (stock_name フィールド) を物理削除する 1 回限りマイグレーション。
+
+要件 §4 の延長で「銘柄名は portfolio_shelve に保存しない」方針となったため、
+既存レコードに残っている stock_name フィールドを削除する。
+
+usage:
+    python migrate_portfolio_drop_stock_name.py --dry-run  # 削除候補を表示
+    python migrate_portfolio_drop_stock_name.py            # 本番実行
+"""
+
+import argparse
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import log_print, log_warning
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+
+def drop_stock_name_field(
+    *,
+    dry_run: bool = False,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """全レコードを舐めて stock_name キーがあれば削除する。
+
+    Returns: {"total": int, "cleaned": int, "skipped": int}
+    """
+    records = ps.list_records(db_path=db_path)
+    total = len(records)
+    cleaned = 0
+    skipped = 0
+
+    for rec in records:
+        if "stock_name" not in rec:
+            skipped += 1
+            continue
+        if dry_run:
+            cleaned += 1
+            continue
+        new_rec = {k: v for k, v in rec.items() if k != "stock_name"}
+        ps.upsert_record(new_rec, db_path=db_path)
+        cleaned += 1
+
+    log_print(
+        f"migrate_drop_stock_name: 全 {total} 件、"
+        f"クリーン {cleaned} 件、スキップ {skipped} 件 (dry_run={dry_run})"
+    )
+    return {"total": total, "cleaned": cleaned, "skipped": skipped}
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="portfolio_shelve の旧 stock_name フィールドを物理削除",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="削除対象件数だけ表示し、shelve は変更しない",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=str,
+        default=None,
+        help="portfolio_shelve のパス上書き (テスト用)",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    result = drop_stock_name_field(dry_run=args.dry_run, db_path=args.db_path)
+    print(
+        f"total={result['total']} cleaned={result['cleaned']} "
+        f"skipped={result['skipped']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_portfolio_from_csv.py
+++ b/scripts/migrate_portfolio_from_csv.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+保有銘柄シート CSV → portfolio_shelve 移行スクリプト (Phase 3a / issue #170)
+
+入力: Google スプレッドシートからエクスポートした CSV (36 列、139 銘柄想定)
+出力: portfolio_shelve
+
+4 層構成 (migrate_research_from_csv.py のパターン踏襲):
+    1. CSV 読込層 (read_csv_rows)
+    2. 列パース層 (parse_memo_columns)
+    3. 統合層 (build_record_from_row)
+    4. 実行層 (migrate_csv_to_portfolio_shelve + main)
+
+重要な前提:
+- スプシ 36 列のうち、指標系列 (順位・PER・配当・RS・トレンドテンプレート 等) と
+  保有リスト列は code_rank.csv からの VLOOKUP 表示値 → 移行対象外
+- ステータスは my_watch_list.txt のみで決定するため、本スクリプトでは設定しない
+  (仮で "3監" を埋めて、後段の migrate_my_watch_list_to_shelve.py で上書き)
+- 移行対象は計 7 列: 銘柄コード / 銘柄名 / 業態テーマ / IN理由 / 売買アイデア
+  / イナゴ元 / 高市感応度
+"""
+
+import argparse
+import csv
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+# scripts/ を sys.path に追加 (直接実行時)
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import log_print, log_warning
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+
+# ===========================================
+# 定数
+# ===========================================
+
+EXPECTED_COL_COUNT = 36
+
+# 列インデックス (確定済み、計画書 §3-2-2 参照)
+COL_CODE_S = 0           # 銘柄コード
+COL_STOCK_NAME = 1       # 銘柄名
+COL_GYOUTAI = 3          # 業態・テーマ
+COL_WATCH_REASON = 31    # ウォッチ・IN理由
+COL_INAGO = 33           # イナゴ元・きっかけ
+COL_TRADE_IDEA = 34      # 投資売買アイデア
+COL_TAKAICHI = 35        # 高市感応度
+
+
+# ===========================================
+# 1. CSV 読込層
+# ===========================================
+
+def read_csv_rows(csv_path: str) -> List[List[str]]:
+    """CSV を読み込み、ヘッダ・空行を除外した 36 列リストを返す。
+
+    入力 CSV の構造:
+    - 1 行目: 全列空 (区切り文字のみ)
+    - 2 行目: ヘッダ
+    - 3 行目以降: データ 139 行
+
+    - 全列空の行はスキップ
+    - 列数が 36 未満ならパディング、超えていれば警告して切り詰め
+    """
+    with open(csv_path, "r", encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        raw_rows = list(reader)
+
+    if not raw_rows:
+        return []
+
+    # 先頭の 2 行 (空行 + ヘッダ) をスキップ
+    # 2 行目がヘッダなのは確認済み (col[0]="銘柄コード")
+    data_start = 0
+    for i, row in enumerate(raw_rows):
+        if any((cell or "").strip() for cell in row):
+            # 最初の非空行がヘッダ
+            data_start = i + 1
+            break
+
+    data_rows = raw_rows[data_start:]
+
+    result: List[List[str]] = []
+    for row in data_rows:
+        if not any((cell or "").strip() for cell in row):
+            continue
+        if len(row) < EXPECTED_COL_COUNT:
+            row = row + [""] * (EXPECTED_COL_COUNT - len(row))
+        elif len(row) > EXPECTED_COL_COUNT:
+            log_warning(
+                f"migrate_portfolio: 列数が {EXPECTED_COL_COUNT} を超える行を切り詰めます: "
+                f"code={row[COL_CODE_S]!r}, cols={len(row)}"
+            )
+            row = row[:EXPECTED_COL_COUNT]
+        result.append(row)
+    return result
+
+
+# ===========================================
+# 2. 列パース層
+# ===========================================
+
+def parse_memo_columns(row: List[str]) -> Tuple[Dict[str, str], List[str]]:
+    """5 つのメモ列をパースして memo dict を返す。
+
+    Returns: (memo dict, warnings)
+    """
+    warnings: List[str] = []
+    if len(row) < EXPECTED_COL_COUNT:
+        warnings.append(
+            f"列数不足: {len(row)} < {EXPECTED_COL_COUNT}"
+        )
+        return ps.create_memo(), warnings
+
+    memo = ps.create_memo(
+        gyoutai_theme=(row[COL_GYOUTAI] or "").strip(),
+        watch_in_reason=(row[COL_WATCH_REASON] or "").strip(),
+        trade_idea=(row[COL_TRADE_IDEA] or "").strip(),
+        inago_origin=(row[COL_INAGO] or "").strip(),
+        takaichi_sensitivity=(row[COL_TAKAICHI] or "").strip(),
+    )
+    return memo, warnings
+
+
+# ===========================================
+# 3. 統合層
+# ===========================================
+
+def build_record_from_row(
+    row: List[str],
+) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    """1行から portfolio レコードを組み立てる。
+
+    Returns: (record dict, warnings)
+        - 銘柄コードが不正 / 空の場合は (None, warnings) を返す
+    """
+    warnings: List[str] = []
+    code_raw = (row[COL_CODE_S] or "").strip() if len(row) > COL_CODE_S else ""
+    if not code_raw:
+        warnings.append("空の銘柄コード行をスキップ")
+        return None, warnings
+
+    try:
+        ps.validate_code_s(code_raw)
+    except (ValueError, TypeError) as exc:
+        warnings.append(f"不正な銘柄コード: {code_raw!r} ({exc})")
+        return None, warnings
+
+    code_s = ps.normalize_code_s(code_raw)
+    stock_name = (row[COL_STOCK_NAME] or "").strip() if len(row) > COL_STOCK_NAME else ""
+    if not stock_name:
+        warnings.append(f"{code_s}: 銘柄名が空")
+
+    memo, memo_warnings = parse_memo_columns(row)
+    warnings.extend(memo_warnings)
+
+    # 仕様: ステータスは仮で 3監 (後段の txt 取り込みで上書きされる)
+    record = ps.create_record(
+        code_s,
+        stock_name,
+        status="3監",
+        memo=memo,
+    )
+    return record, warnings
+
+
+# ===========================================
+# 4. 実行層
+# ===========================================
+
+def migrate_csv_to_portfolio_shelve(
+    csv_path: str,
+    *,
+    dry_run: bool = False,
+    db_path: Optional[str] = None,
+    record_initial_log: bool = True,
+) -> Dict[str, Any]:
+    """CSV 全体を portfolio_shelve に移行する。
+
+    Args:
+        csv_path: 入力 CSV パス
+        dry_run: True なら読み込み・組立まで行うが書き込まない
+        db_path: portfolio_shelve のパス上書き (テスト用)
+        record_initial_log: True なら各レコードに 初回登録 ログを記録 (デフォルト)
+
+    Returns: {"total": int, "saved": int, "skipped": int, "warnings": List[str]}
+    """
+    rows = read_csv_rows(csv_path)
+    log_print(f"migrate_portfolio: {len(rows)} 行を読み込み")
+
+    saved = 0
+    skipped = 0
+    all_warnings: List[str] = []
+    sample_records: List[Dict[str, Any]] = []
+
+    for row in rows:
+        record, warnings = build_record_from_row(row)
+        if warnings:
+            all_warnings.extend(warnings)
+            for w in warnings:
+                log_warning(f"migrate_portfolio: {w}")
+        if record is None:
+            skipped += 1
+            continue
+        if dry_run:
+            if len(sample_records) < 3:
+                sample_records.append(record)
+            saved += 1
+            continue
+        # 既存があれば上書き、新規なら追加
+        existed = ps.get_record(record["code_s"], db_path=db_path) is not None
+        ps.upsert_record(record, db_path=db_path)
+        if record_initial_log and not existed:
+            ps.append_action_log(
+                record["code_s"],
+                "初回登録",
+                status_from=None,
+                status_to=record["status"],
+                reason="スプシ移行",
+                db_path=db_path,
+            )
+        saved += 1
+
+    log_print(
+        f"migrate_portfolio: 保存 {saved} 件、スキップ {skipped} 件、"
+        f"警告 {len(all_warnings)} 件"
+    )
+    if dry_run and sample_records:
+        log_print("migrate_portfolio: dry-run サンプル (先頭 3 件):")
+        for rec in sample_records:
+            log_print(
+                f"  - {rec['code_s']} {rec['stock_name']} status={rec['status']}"
+            )
+            for k, v in rec["memo"].items():
+                if v:
+                    snippet = v[:40].replace("\n", " ")
+                    log_print(f"      {k}: {snippet}{'...' if len(v) > 40 else ''}")
+    return {
+        "total": len(rows),
+        "saved": saved,
+        "skipped": skipped,
+        "warnings": all_warnings,
+    }
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="保有銘柄シート CSV を portfolio_shelve に移行する",
+    )
+    parser.add_argument(
+        "csv_path",
+        type=str,
+        help="入力 CSV パス (例: $KS_DATA_DIR/migration/portfolio_sheet.csv)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="DB に書き込まず、読み込み結果のサマリだけ表示する",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=str,
+        default=None,
+        help="portfolio_shelve のパス上書き (テスト用)",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    if not os.path.isfile(args.csv_path):
+        log_warning(f"migrate_portfolio: CSV が存在しません: {args.csv_path}")
+        return 2
+    result = migrate_csv_to_portfolio_shelve(
+        args.csv_path,
+        dry_run=args.dry_run,
+        db_path=args.db_path,
+    )
+    print(
+        f"total={result['total']} saved={result['saved']} "
+        f"skipped={result['skipped']} warnings={len(result['warnings'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_portfolio_from_csv.py
+++ b/scripts/migrate_portfolio_from_csv.py
@@ -53,6 +53,7 @@ EXPECTED_COL_COUNT = 36
 COL_CODE_S = 0           # 銘柄コード
 COL_STOCK_NAME = 1       # 銘柄名
 COL_GYOUTAI = 3          # 業態・テーマ
+COL_LAST_UPDATE = 18     # 銘柄調査の更新日 (M/D 形式)
 COL_WATCH_REASON = 31    # ウォッチ・IN理由
 COL_INAGO = 33           # イナゴ元・きっかけ
 COL_TRADE_IDEA = 34      # 投資売買アイデア
@@ -113,7 +114,7 @@ def read_csv_rows(csv_path: str) -> List[List[str]]:
 # ===========================================
 
 def parse_memo_columns(row: List[str]) -> Tuple[Dict[str, str], List[str]]:
-    """5 つのメモ列をパースして memo dict を返す。
+    """6 つのメモ列をパースして memo dict を返す。
 
     Returns: (memo dict, warnings)
     """
@@ -130,6 +131,7 @@ def parse_memo_columns(row: List[str]) -> Tuple[Dict[str, str], List[str]]:
         trade_idea=(row[COL_TRADE_IDEA] or "").strip(),
         inago_origin=(row[COL_INAGO] or "").strip(),
         takaichi_sensitivity=(row[COL_TAKAICHI] or "").strip(),
+        last_research_update=(row[COL_LAST_UPDATE] or "").strip(),
     )
     return memo, warnings
 
@@ -186,6 +188,7 @@ def migrate_csv_to_portfolio_shelve(
     dry_run: bool = False,
     db_path: Optional[str] = None,
     record_initial_log: bool = True,
+    preserve_existing_status: bool = False,
 ) -> Dict[str, Any]:
     """CSV 全体を portfolio_shelve に移行する。
 
@@ -194,6 +197,8 @@ def migrate_csv_to_portfolio_shelve(
         dry_run: True なら読み込み・組立まで行うが書き込まない
         db_path: portfolio_shelve のパス上書き (テスト用)
         record_initial_log: True なら各レコードに 初回登録 ログを記録 (デフォルト)
+        preserve_existing_status: True なら既存レコードのステータスを保持し、memo のみ上書き
+            (運用後の再インポート用。初回移行では False で OK = 全部 3監 で書く)
 
     Returns: {"total": int, "saved": int, "skipped": int, "warnings": List[str]}
     """
@@ -220,7 +225,14 @@ def migrate_csv_to_portfolio_shelve(
             saved += 1
             continue
         # 既存があれば上書き、新規なら追加
-        existed = ps.get_record(record["code_s"], db_path=db_path) is not None
+        existing = ps.get_record(record["code_s"], db_path=db_path)
+        existed = existing is not None
+        if existed and preserve_existing_status:
+            # 既存レコードのステータス・registered_at を保持し、memo を CSV のもので上書き
+            record["status"] = existing.get("status", record["status"])
+            if existing.get("registered_at"):
+                record["registered_at"] = existing["registered_at"]
+            record["updated_at"] = ps.now_iso()
         ps.upsert_record(record, db_path=db_path)
         if record_initial_log and not existed:
             ps.append_action_log(
@@ -273,6 +285,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="portfolio_shelve のパス上書き (テスト用)",
     )
+    parser.add_argument(
+        "--preserve-status",
+        action="store_true",
+        help="既存レコードの status を保持し memo のみ上書きする (運用後の再インポート用)",
+    )
     return parser
 
 
@@ -286,6 +303,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         args.csv_path,
         dry_run=args.dry_run,
         db_path=args.db_path,
+        preserve_existing_status=args.preserve_status,
     )
     print(
         f"total={result['total']} saved={result['saved']} "

--- a/scripts/migrate_portfolio_from_csv.py
+++ b/scripts/migrate_portfolio_from_csv.py
@@ -159,9 +159,10 @@ def build_record_from_row(
         return None, warnings
 
     code_s = ps.normalize_code_s(code_raw)
-    stock_name = (row[COL_STOCK_NAME] or "").strip() if len(row) > COL_STOCK_NAME else ""
-    if not stock_name:
-        warnings.append(f"{code_s}: 銘柄名が空")
+    # 銘柄名は portfolio_shelve には保存しない (要件 §4: 表示時に他DBから取得)。
+    # CSV の銘柄名列は無視するが、空欄は CSV 側の不備として警告のみ出す。
+    if len(row) > COL_STOCK_NAME and not (row[COL_STOCK_NAME] or "").strip():
+        warnings.append(f"{code_s}: CSV の銘柄名列が空 (portfolio_shelve に保存しないため致命的ではない)")
 
     memo, memo_warnings = parse_memo_columns(row)
     warnings.extend(memo_warnings)
@@ -169,7 +170,6 @@ def build_record_from_row(
     # 仕様: ステータスは仮で 3監 (後段の txt 取り込みで上書きされる)
     record = ps.create_record(
         code_s,
-        stock_name,
         status="3監",
         memo=memo,
     )
@@ -240,9 +240,7 @@ def migrate_csv_to_portfolio_shelve(
     if dry_run and sample_records:
         log_print("migrate_portfolio: dry-run サンプル (先頭 3 件):")
         for rec in sample_records:
-            log_print(
-                f"  - {rec['code_s']} {rec['stock_name']} status={rec['status']}"
-            )
+            log_print(f"  - {rec['code_s']} status={rec['status']}")
             for k, v in rec["memo"].items():
                 if v:
                     snippet = v[:40].replace("\n", " ")

--- a/scripts/migrate_portfolio_from_csv.py
+++ b/scripts/migrate_portfolio_from_csv.py
@@ -54,7 +54,9 @@ COL_CODE_S = 0           # 銘柄コード
 COL_STOCK_NAME = 1       # 銘柄名
 COL_GYOUTAI = 3          # 業態・テーマ
 COL_LAST_UPDATE = 18     # 銘柄調査の更新日 (M/D 形式)
+COL_STAGE = 20           # ステージ (例: "1S", "2S(3T)", "3S")
 COL_WATCH_REASON = 31    # ウォッチ・IN理由
+COL_JUKYU_CHART = 32     # 需給チャートメモ (例: "月足低位ブレイク CWH")
 COL_INAGO = 33           # イナゴ元・きっかけ
 COL_TRADE_IDEA = 34      # 投資売買アイデア
 COL_TAKAICHI = 35        # 高市感応度
@@ -132,6 +134,8 @@ def parse_memo_columns(row: List[str]) -> Tuple[Dict[str, str], List[str]]:
         inago_origin=(row[COL_INAGO] or "").strip(),
         takaichi_sensitivity=(row[COL_TAKAICHI] or "").strip(),
         last_research_update=(row[COL_LAST_UPDATE] or "").strip(),
+        stage=(row[COL_STAGE] or "").strip(),
+        jukyu_chart=(row[COL_JUKYU_CHART] or "").strip(),
     )
     return memo, warnings
 

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -168,17 +168,15 @@ def parse_portfolio_txt():
     return stocks
 
 
-def parse_my_portforio():
-    """自分のウォッチリストの銘柄コードリストを返す
-    Returns:
-        (list<str>,list<str>): ウォッチリストの銘柄コードリスト、保有リスト
+def _parse_my_portforio_from_txt():
+    """my_watch_list.txt を直接パースして (watch, possess) を返す。
+
+    portfolio_shelve 移行前の旧実装。Phase 3a 移行完了後は
+    parse_my_portforio() のフォールバックとしてのみ使われる。
     """
-    # stocks = {}
     content = file_read(os.path.join(DATA_DIR, "my_watch_list.txt"))
     code_s_list = []
     possess_list = []
-    # 英数字コード対応
-    # for m in re.finditer(r'\d\d\d\d', content):
     for m in re.finditer(r"H?(\d[0-9a-zA-Z]\d[0-9A-Z])", content):
         if m.group(0).find("H") >= 0:
             if not m.group(1) in possess_list:
@@ -186,7 +184,39 @@ def parse_my_portforio():
         else:
             if not m.group(1) in code_s_list:
                 code_s_list.append(m.group(1))
-    # print code_list
+    return code_s_list, possess_list
+
+
+def parse_my_portforio():
+    """自分のウォッチリストの銘柄コードリストを返す。
+
+    Returns:
+        (list<str>,list<str>): (ウォッチ, 保有)
+            ウォッチ = ステータスが 2準 / 3監 の銘柄
+            保有     = ステータスが 1保 の銘柄
+            両リストとも code_s 昇順
+
+    portfolio_shelve を真実源として参照する (Phase 3a)。
+    portfolio_shelve が未作成・空の場合は my_watch_list.txt にフォールバック
+    する (移行前および shelve 障害時の保険)。
+    """
+    try:
+        import portfolio_shelve as ps
+        records = ps.list_records()
+    except Exception as e:
+        log_warning(f"parse_my_portforio: portfolio_shelve 参照失敗、txt にフォールバック: {e}")
+        return _parse_my_portforio_from_txt()
+
+    if not records:
+        # shelve は存在するが空 → txt フォールバック (移行前の挙動互換)
+        return _parse_my_portforio_from_txt()
+
+    possess_list = sorted(
+        r["code_s"] for r in records if r.get("status") == "1保"
+    )
+    code_s_list = sorted(
+        r["code_s"] for r in records if r.get("status") in ("2準", "3監")
+    )
     return code_s_list, possess_list
 
 

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""
+保有銘柄管理DB (portfolio_shelve) の基盤モジュール。
+
+保有銘柄のステータス・手動メモ・アクションログを永続化するための
+shelve ベースのラッパー。
+
+既存の stocks_shelve / research_shelve とは別DBとして分離運用する:
+- stocks_shelve: 揮発性キャッシュ (常に最新値で上書き)
+- research_shelve: 不可逆な蓄積資産 (時系列履歴 + 調査メモ)
+- portfolio_shelve: 保有状態 + 売買判断メモ + アクションログ
+
+依存は一方向: portfolio_shelve が他の2DBを参照する形。
+他のDBのコードは変更しない。
+
+キー名前空間:
+- record:<code_s>            -> 保有レコード本体
+- action_log:<code_s>:<seq>  -> アクションログ (削除後も残る)
+- _seq:<code_s>              -> アクションログの連番カウンタ
+
+ライフサイクル:
+- 追加: (新規) -> 3監 (1保/2準への直接登録は禁止)
+- ステータス変更: 3監 <-> 2準 <-> 1保 / 3監 <-> 1保
+- 売却: 1保 -> 2準 (アクションログ種別「売却」で記録)
+- 削除: 3監 のみ (1保/2準 から直接削除は禁止、レコードは物理削除)
+"""
+
+import fcntl
+import os
+import re
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional
+
+from db_shelve import PORTFOLIO_SHELVE, ShelveDB
+
+try:
+    from ks_util import DATA_DIR, log_print, log_warning
+except ImportError:
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+
+# ===========================================
+# スキーマ定数
+# ===========================================
+
+# 銘柄コードの正規表現 (CLAUDE.md 規約: "0001"〜"9999" または "215A" 形式)
+CODE_S_PATTERN = re.compile(r"^(?:\d{4}|\d{3}[A-Z])$")
+
+# ステータスの許容値
+VALID_STATUSES = frozenset({"1保", "2準", "3監"})
+
+# アクションログ種別
+VALID_ACTION_TYPES = frozenset({"初回登録", "ステータス変更", "売却", "削除"})
+
+# キー名前空間プレフィックス
+KEY_RECORD_PREFIX = "record:"
+KEY_ACTION_LOG_PREFIX = "action_log:"
+KEY_SEQ_PREFIX = "_seq:"
+
+# レコードの既知フィールド
+RECORD_FIELDS = frozenset(
+    {
+        "code_s",
+        "stock_name",
+        "status",
+        "registered_at",
+        "updated_at",
+        "memo",
+    }
+)
+
+MEMO_FIELDS = frozenset(
+    {
+        "gyoutai_theme",          # 業態・テーマ
+        "watch_in_reason",        # ウォッチ・IN理由
+        "trade_idea",             # 投資売買アイデア
+        "inago_origin",           # イナゴ元・きっかけ
+        "takaichi_sensitivity",   # 高市感応度
+    }
+)
+
+ACTION_LOG_FIELDS = frozenset(
+    {
+        "code_s",
+        "seq",
+        "timestamp",
+        "action_type",
+        "status_from",
+        "status_to",
+        "reason",
+    }
+)
+
+# 許可されるステータス遷移 (status_from, status_to)
+# (None, "3監") は新規追加。それ以外は (from, to) の組
+ALLOWED_TRANSITIONS = frozenset(
+    {
+        (None, "3監"),     # 新規追加 (1保/2準 への直接登録禁止)
+        ("3監", "2準"),
+        ("2準", "3監"),
+        ("2準", "1保"),
+        ("1保", "2準"),    # = 売却
+        ("3監", "1保"),
+        ("1保", "3監"),
+    }
+)
+
+
+# ===========================================
+# バリデーション・正規化
+# ===========================================
+
+# JST タイムゾーン (timestamp の付与に使う)
+JST = timezone(timedelta(hours=9))
+
+
+def normalize_code_s(code_s: Any) -> str:
+    """銘柄コード文字列を正規化する。
+
+    - 文字列型でない場合は TypeError
+    - 前後の空白を除去
+    - 英字部分を大文字化
+    """
+    if not isinstance(code_s, str):
+        raise TypeError(f"code_s must be str, got {type(code_s).__name__}")
+    return code_s.strip().upper()
+
+
+def validate_code_s(code_s: Any) -> None:
+    """銘柄コードを検証する。"""
+    normalized = normalize_code_s(code_s)
+    if not CODE_S_PATTERN.match(normalized):
+        raise ValueError(
+            f"invalid code_s: {code_s!r} (正規化後={normalized!r}、"
+            "期待形式は4文字の数字または3桁数字+大文字1文字)"
+        )
+
+
+def validate_status(status: Any) -> None:
+    """ステータスを検証する。"""
+    if status not in VALID_STATUSES:
+        raise ValueError(
+            f"invalid status: {status!r} (許容値: {sorted(VALID_STATUSES)})"
+        )
+
+
+def validate_action_type(action_type: Any) -> None:
+    """アクションログ種別を検証する。"""
+    if action_type not in VALID_ACTION_TYPES:
+        raise ValueError(
+            f"invalid action_type: {action_type!r} "
+            f"(許容値: {sorted(VALID_ACTION_TYPES)})"
+        )
+
+
+def validate_transition(status_from: Optional[str], status_to: str) -> None:
+    """ステータス遷移を検証する。
+
+    status_from=None は新規追加を表す。
+    """
+    if status_from is not None:
+        validate_status(status_from)
+    validate_status(status_to)
+    if (status_from, status_to) not in ALLOWED_TRANSITIONS:
+        raise ValueError(
+            f"invalid transition: {status_from!r} -> {status_to!r} "
+            f"(許可されていない遷移)"
+        )
+
+
+def now_iso() -> str:
+    """現在時刻を ISO 8601 文字列 (JST) で返す。"""
+    return datetime.now(JST).isoformat()
+
+
+# ===========================================
+# キー組立
+# ===========================================
+
+def _record_key(code_s: str) -> str:
+    return f"{KEY_RECORD_PREFIX}{code_s}"
+
+
+def _action_log_key(code_s: str, seq: int) -> str:
+    return f"{KEY_ACTION_LOG_PREFIX}{code_s}:{seq:06d}"
+
+
+def _seq_key(code_s: str) -> str:
+    return f"{KEY_SEQ_PREFIX}{code_s}"
+
+
+def _action_log_prefix_for(code_s: str) -> str:
+    return f"{KEY_ACTION_LOG_PREFIX}{code_s}:"
+
+
+# ===========================================
+# プロセス間排他制御
+# ===========================================
+
+_flock_holder = threading.local()
+
+
+def _lock_path_for(db_path: Optional[str] = None) -> str:
+    base = db_path if db_path is not None else PORTFOLIO_SHELVE
+    return base + ".lock"
+
+
+@contextmanager
+def _flock(db_path: Optional[str] = None):
+    """portfolio_shelve 書き込み用の排他ロック。
+
+    research_shelve と同じパターン。同一スレッドのリエントラントは深さで管理。
+    """
+    if getattr(_flock_holder, "depth", 0) > 0:
+        _flock_holder.depth += 1
+        try:
+            yield
+        finally:
+            _flock_holder.depth -= 1
+        return
+
+    lock_file = _lock_path_for(db_path)
+    lock_dir = os.path.dirname(lock_file)
+    if lock_dir and not os.path.exists(lock_dir):
+        os.makedirs(lock_dir, exist_ok=True)
+    fd = open(lock_file, "a")
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        _flock_holder.depth = 1
+        try:
+            yield
+        finally:
+            _flock_holder.depth = 0
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        fd.close()
+
+
+def _resolve_db_path(db_path: Optional[str]) -> str:
+    return db_path if db_path is not None else PORTFOLIO_SHELVE
+
+
+# ===========================================
+# ファクトリ
+# ===========================================
+
+def create_memo(
+    *,
+    gyoutai_theme: str = "",
+    watch_in_reason: str = "",
+    trade_idea: str = "",
+    inago_origin: str = "",
+    takaichi_sensitivity: str = "",
+) -> Dict[str, str]:
+    """手動メモ dict を生成する。"""
+    return {
+        "gyoutai_theme": gyoutai_theme,
+        "watch_in_reason": watch_in_reason,
+        "trade_idea": trade_idea,
+        "inago_origin": inago_origin,
+        "takaichi_sensitivity": takaichi_sensitivity,
+    }
+
+
+def create_record(
+    code_s: str,
+    stock_name: str,
+    *,
+    status: str = "3監",
+    memo: Optional[Dict[str, str]] = None,
+    registered_at: Optional[str] = None,
+    updated_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    """portfolio レコード dict を生成する。
+
+    - code_s は normalize_code_s で大文字化される
+    - status はデフォルト "3監" (新規追加用)
+    - memo が None なら空メモで埋める
+    - registered_at / updated_at が None なら現在時刻を埋める
+    """
+    validate_code_s(code_s)
+    normalized_code = normalize_code_s(code_s)
+    if not isinstance(stock_name, str):
+        raise TypeError(f"stock_name must be str, got {type(stock_name).__name__}")
+    validate_status(status)
+    if memo is None:
+        memo = create_memo()
+    elif not isinstance(memo, dict):
+        raise TypeError(f"memo must be dict, got {type(memo).__name__}")
+    timestamp = registered_at or now_iso()
+    return {
+        "code_s": normalized_code,
+        "stock_name": stock_name,
+        "status": status,
+        "registered_at": timestamp,
+        "updated_at": updated_at or timestamp,
+        "memo": dict(memo),
+    }
+
+
+# ===========================================
+# CRUD: レコード
+# ===========================================
+
+def get_record(
+    code_s: str,
+    *,
+    db_path: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """1銘柄の保有レコードを取得する。存在しなければ None。"""
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    path = _resolve_db_path(db_path)
+    with ShelveDB(path) as db:
+        return db.get(_record_key(normalized))
+
+
+def list_records(
+    status: Optional[str] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """保有レコードを一覧取得する。
+
+    - status: None で全件、"1保"/"2準"/"3監" 指定で絞り込み
+    - 結果は code_s 昇順
+    """
+    if status is not None:
+        validate_status(status)
+    path = _resolve_db_path(db_path)
+    results: List[Dict[str, Any]] = []
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_RECORD_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            if status is not None and value.get("status") != status:
+                continue
+            results.append(value)
+    results.sort(key=lambda r: r.get("code_s", ""))
+    return results
+
+
+def _next_seq(db: ShelveDB, code_s: str) -> int:
+    """指定銘柄の次のアクションログ seq を返し、カウンタを進める。
+
+    db は既にオープン済みの ShelveDB。呼び出し側で flock 保持を前提とする。
+    """
+    seq_k = _seq_key(code_s)
+    current = db.get(seq_k, 0)
+    nxt = int(current) + 1
+    db[seq_k] = nxt
+    return nxt
+
+
+def append_action_log(
+    code_s: str,
+    action_type: str,
+    *,
+    status_from: Optional[str] = None,
+    status_to: Optional[str] = None,
+    reason: str = "",
+    timestamp: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """アクションログを1件追加する。
+
+    内部利用および移行スクリプトからの直接利用を想定。
+    transition_status / add_to_watch / delete_record からも呼ばれる。
+    レコードを物理削除した後でもログ追記は可能 (ログだけ残す要件のため)。
+
+    Returns: 追記したログエントリ
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    validate_action_type(action_type)
+    if status_from is not None:
+        validate_status(status_from)
+    if status_to is not None:
+        validate_status(status_to)
+    if not isinstance(reason, str):
+        raise TypeError(f"reason must be str, got {type(reason).__name__}")
+    ts = timestamp or now_iso()
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            seq = _next_seq(db, normalized)
+            entry = {
+                "code_s": normalized,
+                "seq": seq,
+                "timestamp": ts,
+                "action_type": action_type,
+                "status_from": status_from,
+                "status_to": status_to,
+                "reason": reason,
+            }
+            db[_action_log_key(normalized, seq)] = entry
+    log_print(
+        "portfolio_shelve: action_log 追記",
+        normalized,
+        action_type,
+        f"seq={seq}",
+    )
+    return entry
+
+
+def list_action_logs(
+    code_s: Optional[str] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """アクションログを取得する。
+
+    - code_s 指定時はその銘柄のみ、None で全銘柄
+    - 結果は (code_s, seq) 昇順
+    """
+    if code_s is not None:
+        validate_code_s(code_s)
+        normalized = normalize_code_s(code_s)
+        prefix = _action_log_prefix_for(normalized)
+    else:
+        prefix = KEY_ACTION_LOG_PREFIX
+    path = _resolve_db_path(db_path)
+    results: List[Dict[str, Any]] = []
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(prefix):
+                continue
+            if not isinstance(value, dict):
+                continue
+            results.append(value)
+    results.sort(
+        key=lambda r: (r.get("code_s", ""), r.get("seq", 0)),
+    )
+    return results
+
+
+# ===========================================
+# 高レベル操作
+# ===========================================
+
+def add_to_watch(
+    code_s: str,
+    stock_name: str,
+    *,
+    memo: Optional[Dict[str, str]] = None,
+    reason: str = "",
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """銘柄を 3監 として新規追加する。
+
+    - 既存レコードが存在する場合は ValueError (重複登録防止)
+    - 同時に 初回登録 アクションログを 1 件記録
+
+    Returns: 追加したレコード
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    record = create_record(normalized, stock_name, status="3監", memo=memo)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            if _record_key(normalized) in db:
+                raise ValueError(
+                    f"portfolio_shelve: {normalized} は既に登録済みです"
+                )
+            db[_record_key(normalized)] = record
+        # ログ追加 (内部で flock 取得済みでもリエントラント対応)
+        append_action_log(
+            normalized,
+            "初回登録",
+            status_from=None,
+            status_to="3監",
+            reason=reason,
+            db_path=db_path,
+        )
+    log_print("portfolio_shelve: 3監 追加", normalized, stock_name)
+    return record
+
+
+def upsert_record(
+    record: Dict[str, Any],
+    *,
+    db_path: Optional[str] = None,
+) -> None:
+    """レコードを追加または上書きする (移行スクリプト用)。
+
+    add_to_watch / transition_status と異なりアクションログは追記しない。
+    呼び出し側で必要なら append_action_log を別途呼ぶこと。
+    """
+    if not isinstance(record, dict):
+        raise TypeError(f"record must be dict, got {type(record).__name__}")
+    if "code_s" not in record:
+        raise ValueError("record に code_s が必須です")
+    validate_code_s(record["code_s"])
+    if "status" in record:
+        validate_status(record["status"])
+    normalized = normalize_code_s(record["code_s"])
+    stored = dict(record)
+    stored["code_s"] = normalized
+
+    unknown = set(stored.keys()) - RECORD_FIELDS
+    if unknown:
+        log_warning(
+            "portfolio_shelve: 未知のレコードフィールドを保存します:",
+            sorted(unknown),
+        )
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            existed = _record_key(normalized) in db
+            db[_record_key(normalized)] = stored
+    if existed:
+        log_print("portfolio_shelve: レコード更新", normalized)
+    else:
+        log_print("portfolio_shelve: レコード追加", normalized)
+
+
+def transition_status(
+    code_s: str,
+    new_status: str,
+    *,
+    reason: str = "",
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """既存レコードのステータスを変更する。
+
+    - 1保 -> 2準 は内部的に「売却」として action_type=売却 で記録
+    - それ以外の遷移は action_type=ステータス変更
+    - 遷移バリデーション (ALLOWED_TRANSITIONS) を満たさなければ ValueError
+    - レコードが存在しない場合は KeyError
+
+    Returns: 更新後のレコード
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    validate_status(new_status)
+    if not isinstance(reason, str):
+        raise TypeError(f"reason must be str, got {type(reason).__name__}")
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _record_key(normalized)
+            if key not in db:
+                raise KeyError(
+                    f"portfolio_shelve: {normalized} はレコード未登録です"
+                )
+            record = db[key]
+            old_status = record.get("status")
+            if old_status == new_status:
+                # 同一ステータスへの遷移は no-op (バリデーション前に判定)
+                log_print(
+                    "portfolio_shelve: 同一ステータスのため遷移スキップ",
+                    normalized,
+                    new_status,
+                )
+                return record
+            validate_transition(old_status, new_status)
+            record["status"] = new_status
+            record["updated_at"] = now_iso()
+            db[key] = record
+        # アクションログ種別: 1保→2準 は売却、それ以外はステータス変更
+        action_type = "売却" if old_status == "1保" and new_status == "2準" else "ステータス変更"
+        append_action_log(
+            normalized,
+            action_type,
+            status_from=old_status,
+            status_to=new_status,
+            reason=reason,
+            db_path=db_path,
+        )
+    log_print(
+        "portfolio_shelve: ステータス変更",
+        normalized,
+        f"{old_status} -> {new_status}",
+    )
+    return record
+
+
+def delete_record(
+    code_s: str,
+    *,
+    reason: str = "",
+    db_path: Optional[str] = None,
+) -> bool:
+    """レコードを物理削除する (3監 のみ可能)。
+
+    - 1保/2準 を削除しようとすると ValueError
+    - レコードが存在しない場合は False を返す
+    - 削除に成功した場合は アクションログ「削除」を 1 件記録 (ログは残る)
+
+    Returns: 削除に成功すれば True、未存在なら False
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    if not isinstance(reason, str):
+        raise TypeError(f"reason must be str, got {type(reason).__name__}")
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _record_key(normalized)
+            if key not in db:
+                return False
+            record = db[key]
+            current_status = record.get("status")
+            if current_status != "3監":
+                raise ValueError(
+                    f"portfolio_shelve: {normalized} は status={current_status!r} のため "
+                    "削除できません (3監 のみ削除可能、先に 3監 へ遷移してください)"
+                )
+            del db[key]
+        append_action_log(
+            normalized,
+            "削除",
+            status_from="3監",
+            status_to=None,
+            reason=reason,
+            db_path=db_path,
+        )
+    log_print("portfolio_shelve: レコード削除", normalized)
+    return True
+
+
+# ===========================================
+# my_watch_list.txt 一方向同期
+# ===========================================
+
+def sync_to_my_watch_list_txt(
+    *,
+    txt_path: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> str:
+    """portfolio_shelve の現在状態を my_watch_list.txt に書き出す。
+
+    一方向同期 (shelve → txt)。txt 廃止 issue (将来) で sync 自体を停止する想定。
+    旧コードと既存運用との互換のため、Phase 3 完了後も同期は有効のまま残す。
+
+    フォーマット (現行 my_watch_list.txt 互換):
+    - 1保 → "H<code_s><stock_name>" (H 接頭辞)
+    - 2準 → "<code_s><stock_name>" (txt は 2 値しかないので 3監 扱い)
+    - 3監 → "<code_s><stock_name>"
+
+    出力順:
+    - 1保 を先頭にまとめる (H 付きが先頭にある現行 txt の見た目を維持)
+    - 各グループ内は code_s 昇順
+    - 1保 と 3監/2準 の間に空行を 1 行入れる (現行 txt の見た目互換)
+
+    Args:
+        txt_path: 出力 txt パス。None なら ${DATA_DIR}/my_watch_list.txt
+        db_path: portfolio_shelve のパス上書き (テスト用)
+
+    Returns: 書き出した txt のパス
+    """
+    if txt_path is None:
+        txt_path = os.path.join(DATA_DIR, "my_watch_list.txt")
+    records = list_records(db_path=db_path)
+
+    holds = sorted(
+        (r for r in records if r.get("status") == "1保"),
+        key=lambda r: r.get("code_s", ""),
+    )
+    others = sorted(
+        (r for r in records if r.get("status") in ("2準", "3監")),
+        key=lambda r: r.get("code_s", ""),
+    )
+
+    lines: List[str] = []
+    for r in holds:
+        lines.append(f"H{r.get('code_s', '')}{r.get('stock_name', '')}")
+    if holds and others:
+        lines.append("")
+    for r in others:
+        lines.append(f"{r.get('code_s', '')}{r.get('stock_name', '')}")
+
+    txt_dir = os.path.dirname(txt_path)
+    if txt_dir and not os.path.exists(txt_dir):
+        os.makedirs(txt_dir, exist_ok=True)
+    with open(txt_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+        if lines:
+            f.write("\n")
+
+    log_print(
+        f"portfolio_shelve: my_watch_list.txt 同期完了 holds={len(holds)} "
+        f"others={len(others)} path={txt_path}"
+    )
+    return txt_path

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -87,6 +87,8 @@ MEMO_FIELDS = frozenset(
         "inago_origin",           # イナゴ元・きっかけ
         "takaichi_sensitivity",   # 高市感応度
         "last_research_update",   # 銘柄調査スプシでの更新日 (M/D 形式、年なし)
+        "stage",                  # ステージ評価 (例: "1S", "2S(3T)", "3S")
+        "jukyu_chart",            # 需給チャートメモ (例: "月足低位ブレイク CWH")
     }
 )
 
@@ -263,6 +265,8 @@ def create_memo(
     inago_origin: str = "",
     takaichi_sensitivity: str = "",
     last_research_update: str = "",
+    stage: str = "",
+    jukyu_chart: str = "",
 ) -> Dict[str, str]:
     """手動メモ dict を生成する。"""
     return {
@@ -272,6 +276,8 @@ def create_memo(
         "inago_origin": inago_origin,
         "takaichi_sensitivity": takaichi_sensitivity,
         "last_research_update": last_research_update,
+        "stage": stage,
+        "jukyu_chart": jukyu_chart,
     }
 
 

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -86,6 +86,7 @@ MEMO_FIELDS = frozenset(
         "trade_idea",             # 投資売買アイデア
         "inago_origin",           # イナゴ元・きっかけ
         "takaichi_sensitivity",   # 高市感応度
+        "last_research_update",   # 銘柄調査スプシでの更新日 (M/D 形式、年なし)
     }
 )
 
@@ -261,6 +262,7 @@ def create_memo(
     trade_idea: str = "",
     inago_origin: str = "",
     takaichi_sensitivity: str = "",
+    last_research_update: str = "",
 ) -> Dict[str, str]:
     """手動メモ dict を生成する。"""
     return {
@@ -269,6 +271,7 @@ def create_memo(
         "trade_idea": trade_idea,
         "inago_origin": inago_origin,
         "takaichi_sensitivity": takaichi_sensitivity,
+        "last_research_update": last_research_update,
     }
 
 

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -58,7 +58,7 @@ CODE_S_PATTERN = re.compile(r"^(?:\d{4}|\d{3}[A-Z])$")
 VALID_STATUSES = frozenset({"1保", "2準", "3監"})
 
 # アクションログ種別
-VALID_ACTION_TYPES = frozenset({"初回登録", "ステータス変更", "売却", "削除"})
+VALID_ACTION_TYPES = frozenset({"初回登録", "ステータス変更", "売却", "削除", "メモ更新"})
 
 # キー名前空間プレフィックス
 KEY_RECORD_PREFIX = "record:"
@@ -643,6 +643,93 @@ def delete_record(
         )
     log_print("portfolio_shelve: レコード削除", normalized)
     return True
+
+
+def update_memo(
+    code_s: str,
+    fields: Dict[str, Any],
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """既存レコードの memo フィールドを部分更新する。
+
+    部分更新セマンティクス:
+    - fields に含まれるキーのみ更新する。fields に存在しないキーは現行値を保持
+    - 値 "" を明示的に渡した場合は「メモ削除」として "" に上書き
+    - 値 None は "" に正規化 (空文字送信と同じ扱い)
+
+    バリデーション:
+    - fields のキーは MEMO_FIELDS のサブセットでなければ ValueError
+    - 値は str (または None) のみ許容、それ以外は TypeError
+    - レコード未登録なら KeyError
+    - 排他制御は transition_status と同じ _flock パターン
+
+    差分判定:
+    - fields の各 key について現行値と完全一致すれば no-op
+      (action_log 追記なし、updated_at 据え置き)
+    - 1 つでも変更があれば action_log に "メモ更新" を 1 件追加
+      (差分内容は記録しない、reason は空文字)
+
+    Returns: 更新後のレコード dict (no-op 時も現行 record を返す)
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    if not isinstance(fields, dict):
+        raise TypeError(f"fields must be dict, got {type(fields).__name__}")
+
+    unknown_keys = set(fields.keys()) - MEMO_FIELDS
+    if unknown_keys:
+        raise ValueError(
+            f"portfolio_shelve: 未知の memo フィールド {sorted(unknown_keys)} "
+            f"(許容値: {sorted(MEMO_FIELDS)})"
+        )
+
+    normalized_fields: Dict[str, str] = {}
+    for k, v in fields.items():
+        if v is None:
+            normalized_fields[k] = ""
+        elif isinstance(v, str):
+            normalized_fields[k] = v
+        else:
+            raise TypeError(
+                f"portfolio_shelve: memo[{k!r}] must be str or None, "
+                f"got {type(v).__name__}"
+            )
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _record_key(normalized)
+            if key not in db:
+                raise KeyError(
+                    f"portfolio_shelve: {normalized} はレコード未登録です"
+                )
+            record = db[key]
+            current_memo = record.get("memo", {}) or {}
+            changed = any(
+                current_memo.get(k, "") != v
+                for k, v in normalized_fields.items()
+            )
+            if not changed:
+                log_print(
+                    "portfolio_shelve: メモ更新スキップ (差分なし)",
+                    normalized,
+                )
+                return record
+            record["memo"] = {**current_memo, **normalized_fields}
+            record["updated_at"] = now_iso()
+            db[key] = record
+        append_action_log(
+            normalized,
+            "メモ更新",
+            db_path=db_path,
+        )
+    log_print(
+        "portfolio_shelve: メモ更新",
+        normalized,
+        f"keys={sorted(normalized_fields.keys())}",
+    )
+    return record
 
 
 # ===========================================

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -65,17 +65,19 @@ KEY_RECORD_PREFIX = "record:"
 KEY_ACTION_LOG_PREFIX = "action_log:"
 KEY_SEQ_PREFIX = "_seq:"
 
-# レコードの既知フィールド
+# レコードの既知フィールド (銘柄名は持たない: 表示時に stocks_shelve / research_shelve から都度取得する)
 RECORD_FIELDS = frozenset(
     {
         "code_s",
-        "stock_name",
         "status",
         "registered_at",
         "updated_at",
         "memo",
     }
 )
+
+# 旧スキーマ由来で許容するが扱わないフィールド (新スキーマでは未使用、過去データ互換のため warning しない)
+LEGACY_RECORD_FIELDS = frozenset({"stock_name"})
 
 MEMO_FIELDS = frozenset(
     {
@@ -272,7 +274,6 @@ def create_memo(
 
 def create_record(
     code_s: str,
-    stock_name: str,
     *,
     status: str = "3監",
     memo: Optional[Dict[str, str]] = None,
@@ -281,6 +282,9 @@ def create_record(
 ) -> Dict[str, Any]:
     """portfolio レコード dict を生成する。
 
+    銘柄名はこのレコードには保存しない (要件 §4: 指標データは保存せず stocks_shelve から
+    都度参照する原則を銘柄名にも適用)。
+
     - code_s は normalize_code_s で大文字化される
     - status はデフォルト "3監" (新規追加用)
     - memo が None なら空メモで埋める
@@ -288,8 +292,6 @@ def create_record(
     """
     validate_code_s(code_s)
     normalized_code = normalize_code_s(code_s)
-    if not isinstance(stock_name, str):
-        raise TypeError(f"stock_name must be str, got {type(stock_name).__name__}")
     validate_status(status)
     if memo is None:
         memo = create_memo()
@@ -298,7 +300,6 @@ def create_record(
     timestamp = registered_at or now_iso()
     return {
         "code_s": normalized_code,
-        "stock_name": stock_name,
         "status": status,
         "registered_at": timestamp,
         "updated_at": updated_at or timestamp,
@@ -451,13 +452,14 @@ def list_action_logs(
 
 def add_to_watch(
     code_s: str,
-    stock_name: str,
     *,
     memo: Optional[Dict[str, str]] = None,
     reason: str = "",
     db_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """銘柄を 3監 として新規追加する。
+
+    銘柄名は持たない (表示時に stocks_shelve / research_shelve から都度取得)。
 
     - 既存レコードが存在する場合は ValueError (重複登録防止)
     - 同時に 初回登録 アクションログを 1 件記録
@@ -466,7 +468,7 @@ def add_to_watch(
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
-    record = create_record(normalized, stock_name, status="3監", memo=memo)
+    record = create_record(normalized, status="3監", memo=memo)
     path = _resolve_db_path(db_path)
     with _flock(db_path):
         with ShelveDB(path) as db:
@@ -484,7 +486,7 @@ def add_to_watch(
             reason=reason,
             db_path=db_path,
         )
-    log_print("portfolio_shelve: 3監 追加", normalized, stock_name)
+    log_print("portfolio_shelve: 3監 追加", normalized)
     return record
 
 
@@ -509,7 +511,7 @@ def upsert_record(
     stored = dict(record)
     stored["code_s"] = normalized
 
-    unknown = set(stored.keys()) - RECORD_FIELDS
+    unknown = set(stored.keys()) - RECORD_FIELDS - LEGACY_RECORD_FIELDS
     if unknown:
         log_warning(
             "portfolio_shelve: 未知のレコードフィールドを保存します:",
@@ -638,6 +640,42 @@ def delete_record(
 # my_watch_list.txt 一方向同期
 # ===========================================
 
+def _resolve_stock_names(code_list: List[str]) -> Dict[str, str]:
+    """code_s ごとの銘柄名を解決する (stocks_shelve → research_shelve → "" の優先順)。
+
+    portfolio_shelve は銘柄名を持たないため、表示や txt 同期で必要なら都度こちらを呼ぶ。
+    両 shelve とも未登録なら空文字。
+    """
+    from db_shelve import STOCKS_SHELVE, RESEARCH_SHELVE  # 遅延 import (循環回避)
+
+    result: Dict[str, str] = {c: "" for c in code_list}
+    if not code_list:
+        return result
+
+    try:
+        with ShelveDB(STOCKS_SHELVE) as db:
+            for c in code_list:
+                rec = db.get(c)
+                if rec and rec.get("stock_name"):
+                    result[c] = rec["stock_name"]
+    except Exception:
+        # stocks_shelve が無い等は無視 (research_shelve fallback に進む)
+        pass
+
+    missing = [c for c, n in result.items() if not n]
+    if missing:
+        try:
+            with ShelveDB(RESEARCH_SHELVE) as db:
+                for c in missing:
+                    rec = db.get(c)
+                    if rec and rec.get("stock_name"):
+                        result[c] = rec["stock_name"]
+        except Exception:
+            pass
+
+    return result
+
+
 def sync_to_my_watch_list_txt(
     *,
     txt_path: Optional[str] = None,
@@ -647,6 +685,9 @@ def sync_to_my_watch_list_txt(
 
     一方向同期 (shelve → txt)。txt 廃止 issue (将来) で sync 自体を停止する想定。
     旧コードと既存運用との互換のため、Phase 3 完了後も同期は有効のまま残す。
+
+    銘柄名は portfolio_shelve には保存されていないため stocks_shelve / research_shelve から
+    都度引く (どちらにも無ければ code のみ書き出す)。
 
     フォーマット (現行 my_watch_list.txt 互換):
     - 1保 → "H<code_s><stock_name>" (H 接頭辞)
@@ -677,13 +718,17 @@ def sync_to_my_watch_list_txt(
         key=lambda r: r.get("code_s", ""),
     )
 
+    name_map = _resolve_stock_names([r.get("code_s", "") for r in holds + others])
+
     lines: List[str] = []
     for r in holds:
-        lines.append(f"H{r.get('code_s', '')}{r.get('stock_name', '')}")
+        code = r.get("code_s", "")
+        lines.append(f"H{code}{name_map.get(code, '')}")
     if holds and others:
         lines.append("")
     for r in others:
-        lines.append(f"{r.get('code_s', '')}{r.get('stock_name', '')}")
+        code = r.get("code_s", "")
+        lines.append(f"{code}{name_map.get(code, '')}")
 
     txt_dir = os.path.dirname(txt_path)
     if txt_dir and not os.path.exists(txt_dir):

--- a/scripts/webapp/__init__.py
+++ b/scripts/webapp/__init__.py
@@ -25,11 +25,13 @@ def create_app() -> Flask:
     from webapp.routes.memo import memo_bp
     from webapp.routes.market import market_bp
     from webapp.routes.disclosure import disclosure_bp
+    from webapp.routes.portfolio import portfolio_bp
 
     app.register_blueprint(search_bp)
     app.register_blueprint(detail_bp)
     app.register_blueprint(memo_bp)
     app.register_blueprint(market_bp)
     app.register_blueprint(disclosure_bp)
+    app.register_blueprint(portfolio_bp)
 
     return app

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1424,6 +1424,29 @@ def _annual_growth(stock: Dict[str, Any]) -> tuple:
     return result[1], result[2]
 
 
+def _format_buy_collection(stock: Dict[str, Any]) -> str:
+    """買い集めの週/日アルファベット評価を "週,日" の形式で返す (例: "D,E")。
+
+    code_rank.csv SRR 列の "47,32,D,E,-6" のうち最後 (50DMA乖離率を除く)
+    アルファベット 2 文字に相当する。price.get_spr_expr のロジックを再利用。
+    """
+    if not stock:
+        return "—"
+    sprs = stock.get("sell_pressure_ratio") or []
+    sprs_w = stock.get("sell_pressure_ratio_w") or []
+    if not sprs:
+        return "—"
+    try:
+        from price import get_spr_expr  # 遅延 import (循環回避)
+        full = get_spr_expr(sprs, sprs_w)
+    except Exception:
+        return "—"
+    # full は "47,32,D,E" や "47,32,D" 等。アルファベット部分のみ抽出
+    parts = full.split(",")
+    letters = [p for p in parts if p and not p.lstrip("+-").isdigit()]
+    return ",".join(letters) if letters else "—"
+
+
 def _progress_quarter_and_diff(stock: Dict[str, Any]) -> tuple:
     """gyoseki.calc_progress_rate から (quarter_label, diff_str) を返す。
 
@@ -1483,7 +1506,9 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "quarter": "—",
             "progress_diff": "—",
             "trend_template": "—",
+            "trend_template_tooltip": "—",
             "tags": "—",
+            "buy_collection": "—",
             "theoretical_diff": "—",
             "gyoseki": {},
             "indicators_raw": {},
@@ -1524,6 +1549,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "trend_template": trend_expr,
         "trend_template_tooltip": trend_tooltip,
         "tags": _format_tags(stock),
+        "buy_collection": _format_buy_collection(stock),
         "theoretical_diff": _format_theoretical_diff(stock),
         "gyoseki": {
             "isKonki": stock.get("isKonki"),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1276,3 +1276,125 @@ def get_market_kessan_data() -> Dict[str, Any]:
         "recent_past_entries": recent_past_entries,
         "older_past_entries": older_past_entries,
     }
+
+
+def _bulk_get_stock_data(code_list: List[str]) -> Dict[str, Dict[str, Any]]:
+    """stocks_shelve を 1 度だけ open して複数銘柄をまとめて取得する。
+
+    `get_stock_data` を N 回呼ぶと N 回 open/close するため、一覧画面用のバルク版。
+    """
+    result: Dict[str, Dict[str, Any]] = {}
+    with ShelveDB(STOCKS_SHELVE) as db:
+        for code_s in code_list:
+            if not code_s:
+                continue
+            normalized = normalize_code_s(code_s)
+            result[code_s] = db.get(normalized) or {}
+    return result
+
+
+def list_portfolio_with_indicators(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """portfolio_shelve のレコード列に stocks_shelve から最新指標を補完する (Phase 3b)。
+
+    Args:
+        records: portfolio_shelve.list_records の戻り値 (既に status 等で絞り込み済み)
+
+    Returns:
+        各 dict: portfolio レコード + {rank, per, market_cap, dividend, rs,
+                                     trend_template, signals, theoretical_diff,
+                                     gyoseki, indicators_raw}
+        rank 昇順 (rank が None の銘柄は末尾)。
+    """
+    if not records:
+        return []
+
+    stock_map = _bulk_get_stock_data([r.get("code_s", "") for r in records])
+    rows: List[Dict[str, Any]] = []
+    for rec in records:
+        row = dict(rec)
+        row.update(_extract_indicators_for_portfolio(stock_map.get(rec.get("code_s", ""), {})))
+        rows.append(row)
+
+    rows.sort(key=lambda r: (r.get("rank") is None, r.get("rank") or 0, r.get("code_s", "")))
+    return rows
+
+
+def _format_signals(stock: Dict[str, Any]) -> str:
+    """stocks_shelve のシグナル系フィールドをテキストにまとめる。
+
+    Phase 3b は赤バッジ強調なし、テキスト列のみ。要件 §5-2 と §5-3 (Phase 4 送り)。
+    """
+    parts: List[str] = []
+    new_high = stock.get("new_high") or []
+    if new_high:
+        parts.append("[新]" + "".join(new_high))
+    breakout = stock.get("breakout") or []
+    if breakout:
+        parts.append("[ブ]" + ",".join(b.split(",")[0] for b in breakout if isinstance(b, str)))
+    pocket_pivot = stock.get("pocket_pivot") or []
+    if pocket_pivot:
+        parts.append("[ポ]" + ",".join(p.split(",")[0] for p in pocket_pivot if isinstance(p, str)))
+    return " ".join(parts) if parts else "—"
+
+
+def _format_theoretical_diff(stock: Dict[str, Any]) -> str:
+    """理論株価乖離率の表示。price と rironkabuka_up/down/rironkabuka から算出。"""
+    price = stock.get("price")
+    riron = stock.get("rironkabuka")
+    if not price or not riron:
+        return "—"
+    try:
+        diff_pct = (float(price) - float(riron)) / float(riron) * 100
+        return f"{diff_pct:+.1f}%"
+    except (TypeError, ValueError, ZeroDivisionError):
+        return "—"
+
+
+def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
+    """stocks_shelve の dict から portfolio 一覧表示用の指標を抽出する。
+
+    値は表示用の文字列 (なければ "—")。stocks_shelve の実フィールドに直結。
+    """
+    if not stock:
+        return {
+            "rank": None,
+            "per": "—",
+            "market_cap": "—",
+            "dividend": "—",
+            "rs": "—",
+            "trend_template": "—",
+            "signals": "—",
+            "theoretical_diff": "—",
+            "gyoseki": {},
+            "indicators_raw": {},
+        }
+
+    shihyo = stock.get("shihyo") or {}
+
+    # 順位は stock_rank_log の最新値 (= 直近更新時点での順位)
+    rank_log = stock.get("stock_rank_log") or []
+    rank = rank_log[0][1] if rank_log else None
+
+    per = shihyo.get("PER")
+    market_cap = stock.get("market_cap") or shihyo.get("jikasogaku")
+    dividend_yield = shihyo.get("dividend_yield")
+    rs_raw = stock.get("rs_raw")
+
+    from make_stock_db import get_trend_template_expr  # 遅延 import (循環回避)
+
+    return {
+        "rank": rank if isinstance(rank, int) else None,
+        "per": f"{per:.1f}" if isinstance(per, (int, float)) else "—",
+        "market_cap": f"{market_cap:.0f}億" if isinstance(market_cap, (int, float)) else "—",
+        "dividend": f"{dividend_yield:.2f}%" if isinstance(dividend_yield, (int, float)) else "—",
+        "rs": f"{rs_raw:.2f}" if isinstance(rs_raw, (int, float)) else "—",
+        "trend_template": get_trend_template_expr(stock),
+        "signals": _format_signals(stock),
+        "theoretical_diff": _format_theoretical_diff(stock),
+        "gyoseki": {
+            "score_gyoseki": stock.get("score_gyoseki"),
+            "kessanbi": stock.get("kessanbi"),
+            "isKonki": stock.get("isKonki"),
+        },
+        "indicators_raw": stock,
+    }

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1348,7 +1348,8 @@ def list_portfolio_with_indicators(records: List[Dict[str, Any]]) -> List[Dict[s
         records: portfolio_shelve.list_records の戻り値 (既に status 等で絞り込み済み)
 
     Returns:
-        各 dict: portfolio レコード + {stock_name, rank, per, market_cap, dividend, rs,
+        各 dict: portfolio レコード + {stock_name, rank, kessanbi_md, per, market_cap,
+                                     dividend, rs, sales_growth, profit_growth,
                                      trend_template, tags, theoretical_diff,
                                      gyoseki, indicators_raw}
         rank 昇順 (rank が None の銘柄は末尾)。
@@ -1405,6 +1406,34 @@ def _format_theoretical_diff(stock: Dict[str, Any]) -> str:
     return f"{int(kairi)}%"
 
 
+def _annual_growth(stock: Dict[str, Any]) -> tuple:
+    """gyoseki.calc_annual_growth を遅延 import で呼んで (sales%, profit%) を返す。
+
+    code_rank.csv の業績列 [A]X%,Y% の X, Y。取れなければ (None, None)。
+    """
+    if not stock:
+        return (None, None)
+    try:
+        from gyoseki import calc_annual_growth  # 遅延 import (循環回避)
+        result = calc_annual_growth(stock)
+    except Exception:
+        return (None, None)
+    if not result:
+        return (None, None)
+    # result = (年度, 売上%, 営利%)
+    return result[1], result[2]
+
+
+def _format_kessanbi_md(kessanbi: Any) -> str:
+    """kessanbi (YYYY/MM/DD) を MM/DD 形式に整形して返す。空なら "—"。"""
+    if not kessanbi or not isinstance(kessanbi, str):
+        return "—"
+    parts = kessanbi.split("/")
+    if len(parts) >= 3:
+        return f"{parts[1]}/{parts[2]}"
+    return kessanbi
+
+
 def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     """stocks_shelve の dict から portfolio 一覧表示用の指標を抽出する。
 
@@ -1413,10 +1442,13 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     if not stock:
         return {
             "rank": None,
+            "kessanbi_md": "—",
             "per": "—",
             "market_cap": "—",
             "dividend": "—",
             "rs": "—",
+            "sales_growth": "—",
+            "profit_growth": "—",
             "trend_template": "—",
             "tags": "—",
             "theoretical_diff": "—",
@@ -1433,22 +1465,31 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     per = shihyo.get("PER")
     market_cap = stock.get("market_cap") or shihyo.get("jikasogaku")
     dividend_yield = shihyo.get("dividend_yield")
-    rs_raw = stock.get("rs_raw")
+    # RS 列は code_rank.csv の「モメンタム(現在.20日比/5日比)」列の先頭値 (0〜100 の momentum_pt)
+    momentum_pt = stock.get("momentum_pt")
+    sales_growth, profit_growth = _annual_growth(stock)
 
     from make_stock_db import get_trend_template_expr  # 遅延 import (循環回避)
 
+    trend_expr = get_trend_template_expr(stock)
+    trend_misses = stock.get("trend_template") if isinstance(stock.get("trend_template"), list) else []
+    # tooltip 用: 不通過項目の全件 (テーブル列で見切れた時にホバーで参照)
+    trend_tooltip = ",".join(trend_misses) if trend_misses else trend_expr
+
     return {
         "rank": rank if isinstance(rank, int) else None,
+        "kessanbi_md": _format_kessanbi_md(stock.get("kessanbi")),
         "per": f"{per:.1f}" if isinstance(per, (int, float)) else "—",
         "market_cap": f"{market_cap:.0f}億" if isinstance(market_cap, (int, float)) else "—",
         "dividend": f"{dividend_yield:.2f}%" if isinstance(dividend_yield, (int, float)) else "—",
-        "rs": f"{rs_raw:.2f}" if isinstance(rs_raw, (int, float)) else "—",
-        "trend_template": get_trend_template_expr(stock),
+        "rs": f"{int(momentum_pt)}" if isinstance(momentum_pt, (int, float)) else "—",
+        "sales_growth": f"{int(sales_growth)}%" if isinstance(sales_growth, (int, float)) else "—",
+        "profit_growth": f"{int(profit_growth)}%" if isinstance(profit_growth, (int, float)) else "—",
+        "trend_template": trend_expr,
+        "trend_template_tooltip": trend_tooltip,
         "tags": _format_tags(stock),
         "theoretical_diff": _format_theoretical_diff(stock),
         "gyoseki": {
-            "score_gyoseki": stock.get("score_gyoseki"),
-            "kessanbi": stock.get("kessanbi"),
             "isKonki": stock.get("isKonki"),
         },
         "indicators_raw": stock,

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1293,61 +1293,116 @@ def _bulk_get_stock_data(code_list: List[str]) -> Dict[str, Dict[str, Any]]:
     return result
 
 
+def resolve_stock_name(code_s: str) -> str:
+    """銘柄名を stocks_shelve → research_shelve → "" の優先順で取得する。
+
+    portfolio_shelve は銘柄名を持たないため、表示時はこの関数経由で都度取得する。
+    """
+    from db_shelve import RESEARCH_SHELVE  # 遅延 import (循環回避)
+
+    if not code_s:
+        return ""
+    normalized = normalize_code_s(code_s)
+    with ShelveDB(STOCKS_SHELVE) as db:
+        rec = db.get(normalized)
+        if rec and rec.get("stock_name"):
+            return rec["stock_name"]
+    with ShelveDB(RESEARCH_SHELVE) as db:
+        rec = db.get(normalized)
+        if rec and rec.get("stock_name"):
+            return rec["stock_name"]
+    return ""
+
+
+def _bulk_resolve_stock_names(code_list: List[str]) -> Dict[str, str]:
+    """複数 code_s 分の銘柄名をバルク取得する (一覧画面用)。"""
+    from db_shelve import RESEARCH_SHELVE  # 遅延 import (循環回避)
+
+    result: Dict[str, str] = {c: "" for c in code_list if c}
+    if not result:
+        return result
+
+    with ShelveDB(STOCKS_SHELVE) as db:
+        for c in list(result.keys()):
+            rec = db.get(normalize_code_s(c))
+            if rec and rec.get("stock_name"):
+                result[c] = rec["stock_name"]
+
+    missing = [c for c, n in result.items() if not n]
+    if missing:
+        with ShelveDB(RESEARCH_SHELVE) as db:
+            for c in missing:
+                rec = db.get(normalize_code_s(c))
+                if rec and rec.get("stock_name"):
+                    result[c] = rec["stock_name"]
+    return result
+
+
 def list_portfolio_with_indicators(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """portfolio_shelve のレコード列に stocks_shelve から最新指標を補完する (Phase 3b)。
+
+    銘柄名は portfolio_shelve に保存されていないため stocks_shelve / research_shelve から
+    都度取得してマージする (要件 §4 の延長)。
 
     Args:
         records: portfolio_shelve.list_records の戻り値 (既に status 等で絞り込み済み)
 
     Returns:
-        各 dict: portfolio レコード + {rank, per, market_cap, dividend, rs,
-                                     trend_template, signals, theoretical_diff,
+        各 dict: portfolio レコード + {stock_name, rank, per, market_cap, dividend, rs,
+                                     trend_template, tags, theoretical_diff,
                                      gyoseki, indicators_raw}
         rank 昇順 (rank が None の銘柄は末尾)。
     """
     if not records:
         return []
 
-    stock_map = _bulk_get_stock_data([r.get("code_s", "") for r in records])
+    code_list = [r.get("code_s", "") for r in records]
+    stock_map = _bulk_get_stock_data(code_list)
+    name_map = _bulk_resolve_stock_names(code_list)
     rows: List[Dict[str, Any]] = []
     for rec in records:
+        code_s = rec.get("code_s", "")
         row = dict(rec)
-        row.update(_extract_indicators_for_portfolio(stock_map.get(rec.get("code_s", ""), {})))
+        row["stock_name"] = name_map.get(code_s, "") or rec.get("stock_name", "")  # 旧データ互換
+        row.update(_extract_indicators_for_portfolio(stock_map.get(code_s, {})))
         rows.append(row)
 
     rows.sort(key=lambda r: (r.get("rank") is None, r.get("rank") or 0, r.get("code_s", "")))
     return rows
 
 
-def _format_signals(stock: Dict[str, Any]) -> str:
-    """stocks_shelve のシグナル系フィールドをテキストにまとめる。
+def _format_tags(stock: Dict[str, Any]) -> str:
+    """code_rank.csv「タグ」列と同じ表記を返す。
 
-    Phase 3b は赤バッジ強調なし、テキスト列のみ。要件 §5-2 と §5-3 (Phase 4 送り)。
+    make_stock_db.make_signal() の tags リストを "/" join する。
+    market_db を渡さないので R高/強乖/弱乖 タグは出ない (Phase 4 送り)。
     """
-    parts: List[str] = []
-    new_high = stock.get("new_high") or []
-    if new_high:
-        parts.append("[新]" + "".join(new_high))
-    breakout = stock.get("breakout") or []
-    if breakout:
-        parts.append("[ブ]" + ",".join(b.split(",")[0] for b in breakout if isinstance(b, str)))
-    pocket_pivot = stock.get("pocket_pivot") or []
-    if pocket_pivot:
-        parts.append("[ポ]" + ",".join(p.split(",")[0] for p in pocket_pivot if isinstance(p, str)))
-    return " ".join(parts) if parts else "—"
+    if not stock:
+        return "—"
+    try:
+        from make_stock_db import make_signal  # 遅延 import
+        _signal, tags = make_signal(stock)
+    except Exception:
+        return "—"
+    return "/".join(tags) if tags else "—"
 
 
 def _format_theoretical_diff(stock: Dict[str, Any]) -> str:
-    """理論株価乖離率の表示。price と rironkabuka_up/down/rironkabuka から算出。"""
-    price = stock.get("price")
-    riron = stock.get("rironkabuka")
-    if not price or not riron:
+    """理論株価乖離率の表示 (code_rank.csv「理論株価(乖離率|上限,下限))」列の最初の値)。
+
+    rironkabuka.get_rironkabuka_kairi(stock) を再利用して同じ計算ロジックを使う。
+    返り値の tuple の先頭が乖離率 (= `(理論株価 - 株価) / 株価 * 100`)。
+    """
+    if not stock:
         return "—"
     try:
-        diff_pct = (float(price) - float(riron)) / float(riron) * 100
-        return f"{diff_pct:+.1f}%"
-    except (TypeError, ValueError, ZeroDivisionError):
+        from rironkabuka import get_rironkabuka_kairi  # 遅延 import
+        kairi, _up, _down, _preceding = get_rironkabuka_kairi(stock)
+    except Exception:
         return "—"
+    if not stock.get("price") or not stock.get("rironkabuka"):
+        return "—"
+    return f"{int(kairi)}%"
 
 
 def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
@@ -1363,7 +1418,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "dividend": "—",
             "rs": "—",
             "trend_template": "—",
-            "signals": "—",
+            "tags": "—",
             "theoretical_diff": "—",
             "gyoseki": {},
             "indicators_raw": {},
@@ -1389,7 +1444,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "dividend": f"{dividend_yield:.2f}%" if isinstance(dividend_yield, (int, float)) else "—",
         "rs": f"{rs_raw:.2f}" if isinstance(rs_raw, (int, float)) else "—",
         "trend_template": get_trend_template_expr(stock),
-        "signals": _format_signals(stock),
+        "tags": _format_tags(stock),
         "theoretical_diff": _format_theoretical_diff(stock),
         "gyoseki": {
             "score_gyoseki": stock.get("score_gyoseki"),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1350,8 +1350,8 @@ def list_portfolio_with_indicators(records: List[Dict[str, Any]]) -> List[Dict[s
     Returns:
         各 dict: portfolio レコード + {stock_name, rank, kessanbi_md, per, market_cap,
                                      dividend, rs, sales_growth, profit_growth,
-                                     trend_template, tags, theoretical_diff,
-                                     gyoseki, indicators_raw}
+                                     quarter, progress_diff, trend_template, tags,
+                                     theoretical_diff, gyoseki, indicators_raw}
         rank 昇順 (rank が None の銘柄は末尾)。
     """
     if not records:
@@ -1424,6 +1424,37 @@ def _annual_growth(stock: Dict[str, Any]) -> tuple:
     return result[1], result[2]
 
 
+def _progress_quarter_and_diff(stock: Dict[str, Any]) -> tuple:
+    """gyoseki.calc_progress_rate から (quarter_label, diff_str) を返す。
+
+    code_rank.csv 進捗率列 [P]3Q70%(72%),62%(44%) を分解:
+    - quarter_label: "3Q" などの文字列 (quarter=0 / 取れない時は "—")
+    - diff_str: "(sales-sales_pre)/(profit-profit_pre)" を整数化 (例: "-2/+18")
+                取れなければ "—"
+    """
+    if not stock:
+        return ("—", "—")
+    try:
+        from gyoseki import calc_progress_rate  # 遅延 import (循環回避)
+        progress = calc_progress_rate(stock)
+    except Exception:
+        return ("—", "—")
+    quarter = progress.get("quarter", 0) if isinstance(progress, dict) else 0
+    if not quarter or quarter <= 0:
+        return ("—", "—")
+    quarter_label = f"{quarter}Q"
+    sales = progress.get("sales")
+    sales_pre = progress.get("sales_pre")
+    profit = progress.get("profit")
+    profit_pre = progress.get("profit_pre")
+    if not all(isinstance(v, (int, float)) for v in (sales, sales_pre, profit, profit_pre)):
+        return (quarter_label, "—")
+    sales_diff = round(sales - sales_pre)
+    profit_diff = round(profit - profit_pre)
+    diff_str = f"{sales_diff:+d}/{profit_diff:+d}"
+    return (quarter_label, diff_str)
+
+
 def _format_kessanbi_md(kessanbi: Any) -> str:
     """kessanbi (YYYY/MM/DD) を MM/DD 形式に整形して返す。空なら "—"。"""
     if not kessanbi or not isinstance(kessanbi, str):
@@ -1449,6 +1480,8 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "rs": "—",
             "sales_growth": "—",
             "profit_growth": "—",
+            "quarter": "—",
+            "progress_diff": "—",
             "trend_template": "—",
             "tags": "—",
             "theoretical_diff": "—",
@@ -1468,6 +1501,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     # RS 列は code_rank.csv の「モメンタム(現在.20日比/5日比)」列の先頭値 (0〜100 の momentum_pt)
     momentum_pt = stock.get("momentum_pt")
     sales_growth, profit_growth = _annual_growth(stock)
+    quarter_label, progress_diff = _progress_quarter_and_diff(stock)
 
     from make_stock_db import get_trend_template_expr  # 遅延 import (循環回避)
 
@@ -1485,6 +1519,8 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "rs": f"{int(momentum_pt)}" if isinstance(momentum_pt, (int, float)) else "—",
         "sales_growth": f"{int(sales_growth)}%" if isinstance(sales_growth, (int, float)) else "—",
         "profit_growth": f"{int(profit_growth)}%" if isinstance(profit_growth, (int, float)) else "—",
+        "quarter": quarter_label,
+        "progress_diff": progress_diff,
         "trend_template": trend_expr,
         "trend_template_tooltip": trend_tooltip,
         "tags": _format_tags(stock),

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -39,9 +39,10 @@ def stock_detail(code_s: str):
 
     portfolio_record = ps.get_record(code_s)
     portfolio_status = portfolio_record.get("status") if portfolio_record else None
-    if portfolio_status is None:
-        # shelve 未移行環境のフォールバック: my_watch_list.txt 経由の所属を見る
-        # (portfolio.parse_my_portforio は shelve 空時に txt フォールバックする)
+    # shelve 未移行環境のフォールバック: shelve が空のとき my_watch_list.txt 経由の所属を見る
+    # (portfolio.parse_my_portforio は shelve 空時に txt フォールバックする)
+    portfolio_fallback_mode = not ps.list_records()
+    if portfolio_status is None and portfolio_fallback_mode:
         try:
             watch, possess = portfolio.parse_my_portforio()
         except Exception:  # noqa: BLE001
@@ -64,4 +65,5 @@ def stock_detail(code_s: str):
         portfolio_status=portfolio_status,
         portfolio_status_label=portfolio_status_label,
         portfolio_status_query=portfolio_status_query,
+        portfolio_fallback_mode=portfolio_fallback_mode,
     )

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -6,6 +6,7 @@ GET /stock/<code_s> : 銘柄の全セクション表示
 
 from flask import Blueprint, render_template, abort
 
+import portfolio
 import portfolio_shelve as ps
 from webapp.helpers import (
     get_research_detail,
@@ -38,6 +39,17 @@ def stock_detail(code_s: str):
 
     portfolio_record = ps.get_record(code_s)
     portfolio_status = portfolio_record.get("status") if portfolio_record else None
+    if portfolio_status is None:
+        # shelve 未移行環境のフォールバック: my_watch_list.txt 経由の所属を見る
+        # (portfolio.parse_my_portforio は shelve 空時に txt フォールバックする)
+        try:
+            watch, possess = portfolio.parse_my_portforio()
+        except Exception:  # noqa: BLE001
+            watch, possess = ([], [])
+        if code_s in possess:
+            portfolio_status = "1保"
+        elif code_s in watch:
+            portfolio_status = "3監"
     portfolio_status_label = STATUS_VALUE_TO_LABEL.get(portfolio_status) if portfolio_status else None
     portfolio_status_query = STATUS_VALUE_TO_QUERY.get(portfolio_status) if portfolio_status else None
 

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -6,12 +6,14 @@ GET /stock/<code_s> : 銘柄の全セクション表示
 
 from flask import Blueprint, render_template, abort
 
+import portfolio_shelve as ps
 from webapp.helpers import (
     get_research_detail,
     get_stock_data,
     get_disclosures,
     has_recent_disclosure,
 )
+from webapp.routes.portfolio import STATUS_VALUE_TO_LABEL, STATUS_VALUE_TO_QUERY
 from research_shelve import VALID_RATINGS
 
 detail_bp = Blueprint("detail", __name__)
@@ -34,6 +36,11 @@ def stock_detail(code_s: str):
         if s.get("quality_indicators") or s.get("rironkabuka_kairi")
     ]
 
+    portfolio_record = ps.get_record(code_s)
+    portfolio_status = portfolio_record.get("status") if portfolio_record else None
+    portfolio_status_label = STATUS_VALUE_TO_LABEL.get(portfolio_status) if portfolio_status else None
+    portfolio_status_query = STATUS_VALUE_TO_QUERY.get(portfolio_status) if portfolio_status else None
+
     return render_template(
         "detail.html",
         record=record,
@@ -42,4 +49,7 @@ def stock_detail(code_s: str):
         disclosures_has_recent=disclosures_has_recent,
         indicator_snaps=indicator_snaps,
         valid_ratings=sorted(VALID_RATINGS - {""}),
+        portfolio_status=portfolio_status,
+        portfolio_status_label=portfolio_status_label,
+        portfolio_status_query=portfolio_status_query,
     )

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -1,12 +1,14 @@
-"""保有銘柄ダッシュボードルート (Phase 3b / issue #171)。
+"""保有銘柄ダッシュボードルート (Phase 3b / issue #171, issue #175)。
 
 GET  /portfolio?status=hold|semi|watch  : 3 タブ式ダッシュボード
 POST /portfolio/add                     : 3監 への新規追加
 POST /portfolio/<code_s>/transition     : ステータス変更
 POST /portfolio/<code_s>/delete         : 削除 (3監 のみ)
+POST /portfolio/<code_s>/memo           : memo 部分更新 (issue #175)
 
 portfolio_shelve のレコードに stocks_shelve から指標を補完して表示する。
-書き込み API はすべて末尾で sync_to_my_watch_list_txt() を呼び、txt 同期を行う。
+書き込み API は txt 関連の状態を変えるもの (add/transition/delete) のみ
+末尾で sync_to_my_watch_list_txt() を呼ぶ。memo 更新は txt 内容に影響しないため同期不要。
 """
 
 from flask import Blueprint, flash, redirect, render_template, request, url_for
@@ -187,6 +189,59 @@ def transition(code_s: str):
 
     _sync_txt_safely()
     return redirect(url_for("portfolio.dashboard", status=STATUS_VALUE_TO_QUERY[new_status]))
+
+
+def _extract_memo_fields_from_form(form) -> dict:
+    """request.form から MEMO_FIELDS に該当するキーのみを抽出する。
+
+    部分更新セマンティクス (codex P1 対応):
+    - キー自体が form に含まれない → 該当フィールドは fields に入れない (現行値据え置き)
+    - キーは含まれるが値が "" → 該当フィールドは "" として扱う (メモ削除の意図)
+    したがって `form.get(field, "")` で埋めるのは不可。
+
+    抽出した値は textarea の改行 (\\r\\n / \\r) を \\n に正規化し、前後 strip する。
+    MEMO_FIELDS 外のキーは無視 (form に紛れ込んでも reject しない)。
+    """
+    fields = {}
+    for field in ps.MEMO_FIELDS:
+        if field not in form:
+            continue
+        raw = form[field] or ""
+        normalized = raw.replace("\r\n", "\n").replace("\r", "\n").strip()
+        fields[field] = normalized
+    return fields
+
+
+@portfolio_bp.route("/portfolio/<code_s>/memo", methods=["POST"])
+def update_memo(code_s: str):
+    """memo を部分更新する (issue #175)。
+
+    フォームから送られた MEMO_FIELDS のキーのみを対象に部分更新する。
+    送られなかったキーは現行値据え置き。空文字を明示送信した場合はメモ削除扱い。
+    """
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+
+    try:
+        ps.validate_code_s(code_s)
+    except (ValueError, TypeError) as e:
+        flash(f"不正な銘柄コード: {e}", "error")
+        return redirect(url_for("portfolio.dashboard"))
+
+    fields = _extract_memo_fields_from_form(request.form)
+
+    try:
+        ps.update_memo(code_s, fields)
+    except KeyError:
+        flash(f"{code_s} は portfolio_shelve に未登録です", "error")
+        return redirect(url_for("portfolio.dashboard"))
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return _redirect_to_current_tab(code_s, fallback_query=DEFAULT_TAB)
+
+    flash(f"{code_s} のメモを保存しました", "info")
+    return _redirect_to_current_tab(code_s, fallback_query=DEFAULT_TAB)
 
 
 @portfolio_bp.route("/portfolio/add", methods=["POST"])

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -92,6 +92,29 @@ def _redirect_to_current_tab(code_s: str, fallback_query: str = "watch"):
     return redirect(url_for("portfolio.dashboard", status=current_query))
 
 
+def _is_fallback_mode() -> bool:
+    """portfolio_shelve が空 = txt フォールバック中かを判定する。
+
+    フォールバック中に書き込み POST を許すと、shelve に 1 件レコードができた
+    時点で次回 dashboard が `list_records()` 非空 → フォールバック解除 →
+    残りの txt 銘柄が画面上から消える、という運用事故が起きる (codex 指摘)。
+    各 POST ハンドラ冒頭で本関数を見て reject する。
+    """
+    return not ps.list_records()
+
+
+def _reject_when_fallback(redirect_query: str = "watch"):
+    """フォールバック中なら flash + redirect を返す。そうでなければ None。"""
+    if _is_fallback_mode():
+        flash(
+            "portfolio_shelve 未移行モードのため、書き込み操作は無効です。"
+            "Phase 3a 移行スクリプト (migrate_my_watch_list_to_shelve.py) を実行してください。",
+            "error",
+        )
+        return redirect(url_for("portfolio.dashboard", status=redirect_query))
+    return None
+
+
 @portfolio_bp.route("/portfolio/<code_s>/delete", methods=["POST"])
 def delete(code_s: str):
     """3監 銘柄の物理削除。理由必須。
@@ -99,6 +122,10 @@ def delete(code_s: str):
     1保 / 2準 銘柄に対する直接 POST は portfolio_shelve.delete_record 内部で
     ValueError → flash で対応。UI 側でも 3監 タブのみ削除ボタンを表示する。
     """
+    rejected = _reject_when_fallback(redirect_query="watch")
+    if rejected is not None:
+        return rejected
+
     reason = (request.form.get("reason") or "").strip()
     if not reason:
         flash("削除理由は必須です", "error")
@@ -132,6 +159,10 @@ def transition(code_s: str):
     portfolio_shelve.transition_status のバリデーションに任せる。
     同一遷移は no-op (Phase 3a 仕様)、不正遷移は ValueError。
     """
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+
     new_status = (request.form.get("new_status") or "").strip()
     reason = (request.form.get("reason") or "").strip()
 
@@ -166,6 +197,10 @@ def add():
     銘柄名は portfolio_shelve には保存しない (表示時に他DBから引く)。
     flash メッセージ用にだけ stocks_shelve / research_shelve から取得する。
     """
+    rejected = _reject_when_fallback(redirect_query="watch")
+    if rejected is not None:
+        return rejected
+
     code_s = (request.form.get("code_s") or "").strip()
     if not code_s:
         flash("銘柄コードが空です", "error")

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -1,0 +1,218 @@
+"""保有銘柄ダッシュボードルート (Phase 3b / issue #171)。
+
+GET  /portfolio?status=hold|semi|watch  : 3 タブ式ダッシュボード
+POST /portfolio/add                     : 3監 への新規追加
+POST /portfolio/<code_s>/transition     : ステータス変更
+POST /portfolio/<code_s>/delete         : 削除 (3監 のみ)
+
+portfolio_shelve のレコードに stocks_shelve から指標を補完して表示する。
+書き込み API はすべて末尾で sync_to_my_watch_list_txt() を呼び、txt 同期を行う。
+"""
+
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+
+import portfolio_shelve as ps
+from webapp.helpers import get_stock_data, list_portfolio_with_indicators
+
+portfolio_bp = Blueprint("portfolio", __name__)
+
+
+STATUS_QUERY_TO_VALUE = {
+    "hold": "1保",
+    "semi": "2準",
+    "watch": "3監",
+}
+STATUS_VALUE_TO_QUERY = {v: k for k, v in STATUS_QUERY_TO_VALUE.items()}
+
+# 内部キー (1保/2準/3監) → ユーザー可視ラベル (保有/準保有/監視)。
+# DB 内部表記は数字付きのまま、UI 表示時はこのマップで日本語ラベルに置換する。
+STATUS_VALUE_TO_LABEL = {
+    "1保": "保有",
+    "2準": "準保有",
+    "3監": "監視",
+}
+
+# タブ表示順 (左から右): (query, status_value, label)
+TABS = [
+    ("hold", "1保", STATUS_VALUE_TO_LABEL["1保"]),
+    ("semi", "2準", STATUS_VALUE_TO_LABEL["2準"]),
+    ("watch", "3監", STATUS_VALUE_TO_LABEL["3監"]),
+]
+DEFAULT_TAB = TABS[0][0]
+
+
+def _resolve_status_query(query: str) -> tuple[str, str]:
+    """クエリ文字列を (正規化クエリ, status 値) に変換。不明値は DEFAULT_TAB。"""
+    q = (query or "").strip().lower()
+    if q not in STATUS_QUERY_TO_VALUE:
+        q = DEFAULT_TAB
+    return q, STATUS_QUERY_TO_VALUE[q]
+
+
+def _allowed_transitions_from(current: str) -> list[tuple[str, str]]:
+    """現在のステータスから許可される遷移先を (label, value) で返す。
+
+    label は UI 表示用 (例: 保有→準保有 は「準保有 (売却)」のように補注を入れる)。
+    """
+    pairs: list[tuple[str, str]] = []
+    for st_from, st_to in ps.ALLOWED_TRANSITIONS:
+        if st_from != current:
+            continue
+        label = STATUS_VALUE_TO_LABEL.get(st_to, st_to)
+        if current == "1保" and st_to == "2準":
+            label = f"{label} (売却)"
+        pairs.append((label, st_to))
+    pairs.sort(key=lambda x: x[1])
+    return pairs
+
+
+def _sync_txt_safely() -> None:
+    """shelve→txt 同期を try/except で囲んで失敗してもハンドラを止めない。
+
+    IO エラー時は flash で通知。shelve 更新は既に成功済みなので 200 系で返す。
+    """
+    try:
+        ps.sync_to_my_watch_list_txt()
+    except Exception as e:
+        flash(f"my_watch_list.txt 同期に失敗: {e}", "error")
+
+
+def _redirect_to_current_tab(code_s: str, fallback_query: str = "watch"):
+    """code_s の現在ステータスのタブにリダイレクトする。
+
+    エラー時に元タブに戻すための共通処理。レコードが取れない場合は fallback。
+    """
+    current = ps.get_record(code_s) or {}
+    current_query = STATUS_VALUE_TO_QUERY.get(current.get("status"), fallback_query)
+    return redirect(url_for("portfolio.dashboard", status=current_query))
+
+
+@portfolio_bp.route("/portfolio/<code_s>/delete", methods=["POST"])
+def delete(code_s: str):
+    """3監 銘柄の物理削除。理由必須。
+
+    1保 / 2準 銘柄に対する直接 POST は portfolio_shelve.delete_record 内部で
+    ValueError → flash で対応。UI 側でも 3監 タブのみ削除ボタンを表示する。
+    """
+    reason = (request.form.get("reason") or "").strip()
+    if not reason:
+        flash("削除理由は必須です", "error")
+        return redirect(url_for("portfolio.dashboard", status="watch"))
+
+    try:
+        ps.validate_code_s(code_s)
+    except (ValueError, TypeError) as e:
+        flash(f"不正な銘柄コード: {e}", "error")
+        return redirect(url_for("portfolio.dashboard", status="watch"))
+
+    try:
+        deleted = ps.delete_record(code_s, reason=reason)
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return _redirect_to_current_tab(code_s, fallback_query="watch")
+
+    if not deleted:
+        flash(f"{code_s} は portfolio_shelve に未登録です", "error")
+    else:
+        flash(f"{code_s} を削除しました", "info")
+
+    _sync_txt_safely()
+    return redirect(url_for("portfolio.dashboard", status="watch"))
+
+
+@portfolio_bp.route("/portfolio/<code_s>/transition", methods=["POST"])
+def transition(code_s: str):
+    """ステータス変更 (1保→2準 は内部で「売却」種別として記録)。
+
+    portfolio_shelve.transition_status のバリデーションに任せる。
+    同一遷移は no-op (Phase 3a 仕様)、不正遷移は ValueError。
+    """
+    new_status = (request.form.get("new_status") or "").strip()
+    reason = (request.form.get("reason") or "").strip()
+
+    try:
+        ps.validate_code_s(code_s)
+    except (ValueError, TypeError) as e:
+        flash(f"不正な銘柄コード: {e}", "error")
+        return redirect(url_for("portfolio.dashboard"))
+
+    if new_status not in ps.VALID_STATUSES:
+        flash(f"不正なステータス: {new_status!r}", "error")
+        return redirect(url_for("portfolio.dashboard"))
+
+    try:
+        ps.transition_status(code_s, new_status, reason=reason)
+    except KeyError as e:
+        flash(f"レコード未登録: {e}", "error")
+        return redirect(url_for("portfolio.dashboard"))
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return _redirect_to_current_tab(code_s, fallback_query=DEFAULT_TAB)
+
+    _sync_txt_safely()
+    return redirect(url_for("portfolio.dashboard", status=STATUS_VALUE_TO_QUERY[new_status]))
+
+
+@portfolio_bp.route("/portfolio/add", methods=["POST"])
+def add():
+    """銘柄を 3監 として新規追加する。
+
+    既存登録済みなら ValueError → flash 警告で no-op。
+    銘柄名は stocks_shelve から引く (なければフォーム値 → 空文字)。
+    """
+    code_s = (request.form.get("code_s") or "").strip()
+    if not code_s:
+        flash("銘柄コードが空です", "error")
+        return redirect(url_for("portfolio.dashboard"))
+
+    try:
+        ps.validate_code_s(code_s)
+    except (ValueError, TypeError) as e:
+        flash(f"不正な銘柄コード: {e}", "error")
+        return redirect(url_for("portfolio.dashboard"))
+
+    normalized = ps.normalize_code_s(code_s)
+    stock = get_stock_data(normalized)
+    stock_name = (
+        stock.get("stock_name")
+        or (request.form.get("stock_name") or "").strip()
+    )
+
+    try:
+        ps.add_to_watch(normalized, stock_name, reason="WebApp 追加")
+    except ValueError as e:
+        flash(str(e), "error")
+        return redirect(url_for("portfolio.dashboard", status="watch"))
+
+    _sync_txt_safely()
+    flash(f"{normalized} {stock_name} を監視に追加しました", "info")
+    return redirect(url_for("portfolio.dashboard", status="watch"))
+
+
+@portfolio_bp.route("/portfolio")
+def dashboard():
+    """3 タブ式ダッシュボード。"""
+    active_query, active_status = _resolve_status_query(request.args.get("status", DEFAULT_TAB))
+
+    # 全レコードを 1 度だけ取得し、件数 (全タブ) と表示行 (active タブ) を共に算出する
+    all_records = ps.list_records()
+    counts = {q: 0 for q, _, _ in TABS}
+    for r in all_records:
+        st = r.get("status")
+        if st in STATUS_VALUE_TO_QUERY:
+            counts[STATUS_VALUE_TO_QUERY[st]] += 1
+
+    active_records = [r for r in all_records if r.get("status") == active_status]
+    rows = list_portfolio_with_indicators(active_records)
+    transitions = _allowed_transitions_from(active_status)
+
+    return render_template(
+        "portfolio_list.html",
+        tabs=TABS,
+        active_query=active_query,
+        active_status=active_status,
+        counts=counts,
+        rows=rows,
+        transitions=transitions,
+        status_label=STATUS_VALUE_TO_LABEL,
+    )

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -12,7 +12,7 @@ portfolio_shelve のレコードに stocks_shelve から指標を補完して表
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 
 import portfolio_shelve as ps
-from webapp.helpers import get_stock_data, list_portfolio_with_indicators
+from webapp.helpers import list_portfolio_with_indicators, resolve_stock_name
 
 portfolio_bp = Blueprint("portfolio", __name__)
 
@@ -158,7 +158,8 @@ def add():
     """銘柄を 3監 として新規追加する。
 
     既存登録済みなら ValueError → flash 警告で no-op。
-    銘柄名は stocks_shelve から引く (なければフォーム値 → 空文字)。
+    銘柄名は portfolio_shelve には保存しない (表示時に他DBから引く)。
+    flash メッセージ用にだけ stocks_shelve / research_shelve から取得する。
     """
     code_s = (request.form.get("code_s") or "").strip()
     if not code_s:
@@ -172,20 +173,16 @@ def add():
         return redirect(url_for("portfolio.dashboard"))
 
     normalized = ps.normalize_code_s(code_s)
-    stock = get_stock_data(normalized)
-    stock_name = (
-        stock.get("stock_name")
-        or (request.form.get("stock_name") or "").strip()
-    )
 
     try:
-        ps.add_to_watch(normalized, stock_name, reason="WebApp 追加")
+        ps.add_to_watch(normalized, reason="WebApp 追加")
     except ValueError as e:
         flash(str(e), "error")
         return redirect(url_for("portfolio.dashboard", status="watch"))
 
     _sync_txt_safely()
-    flash(f"{normalized} {stock_name} を監視に追加しました", "info")
+    name_for_flash = resolve_stock_name(normalized)
+    flash(f"{normalized} {name_for_flash} を監視に追加しました".rstrip(), "info")
     return redirect(url_for("portfolio.dashboard", status="watch"))
 
 

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -11,8 +11,13 @@ portfolio_shelve のレコードに stocks_shelve から指標を補完して表
 
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 
+import portfolio
 import portfolio_shelve as ps
-from webapp.helpers import list_portfolio_with_indicators, resolve_stock_name
+from webapp.helpers import (
+    get_stock_data,
+    list_portfolio_with_indicators,
+    resolve_stock_name,
+)
 
 portfolio_bp = Blueprint("portfolio", __name__)
 
@@ -174,6 +179,15 @@ def add():
 
     normalized = ps.normalize_code_s(code_s)
 
+    # 未知コード防衛: stocks_shelve に存在しないコードは銘柄名解決もできず、
+    # txt 同期したときに識別不能な行が混ざるので reject する。
+    if not get_stock_data(normalized):
+        flash(
+            f"{normalized} は stocks_shelve に未登録のコードです。先に銘柄DBへの登録が必要です。",
+            "error",
+        )
+        return redirect(url_for("portfolio.dashboard", status="watch"))
+
     try:
         ps.add_to_watch(normalized, reason="WebApp 追加")
     except ValueError as e:
@@ -186,6 +200,27 @@ def add():
     return redirect(url_for("portfolio.dashboard", status="watch"))
 
 
+def _build_fallback_records() -> list[dict]:
+    """portfolio_shelve が空のとき、my_watch_list.txt から仮レコードを組み立てる。
+
+    Phase 3a で portfolio_shelve に移行したが、本ブランチを移行未実施環境で
+    動かすと shelve が空 → ダッシュボードも空になり既存運用が壊れる。
+    `portfolio.parse_my_portforio()` は同条件で txt にフォールバックする
+    挙動を持つので、UI も同じソースを共有する。
+    txt 由来レコードはメモを持たず、書き込み API も走らせない (= 表示専用)。
+    """
+    try:
+        watch, possess = portfolio.parse_my_portforio()
+    except Exception:  # noqa: BLE001 — txt 不在等は表示空でフェイルセーフ
+        return []
+    records: list[dict] = []
+    for code_s in possess:
+        records.append(ps.create_record(code_s, status="1保"))
+    for code_s in watch:
+        records.append(ps.create_record(code_s, status="3監"))
+    return records
+
+
 @portfolio_bp.route("/portfolio")
 def dashboard():
     """3 タブ式ダッシュボード。"""
@@ -193,6 +228,10 @@ def dashboard():
 
     # 全レコードを 1 度だけ取得し、件数 (全タブ) と表示行 (active タブ) を共に算出する
     all_records = ps.list_records()
+    fallback_mode = not all_records
+    if fallback_mode:
+        all_records = _build_fallback_records()
+
     counts = {q: 0 for q, _, _ in TABS}
     for r in all_records:
         st = r.get("status")
@@ -201,7 +240,9 @@ def dashboard():
 
     active_records = [r for r in all_records if r.get("status") == active_status]
     rows = list_portfolio_with_indicators(active_records)
-    transitions = _allowed_transitions_from(active_status)
+    # フォールバック中は書き込み UI (ステータス変更フォーム / 削除フォーム) を
+    # 出さない。shelve が空のため transition / delete を呼ぶと KeyError になる。
+    transitions = [] if fallback_mode else _allowed_transitions_from(active_status)
 
     return render_template(
         "portfolio_list.html",
@@ -212,4 +253,5 @@ def dashboard():
         rows=rows,
         transitions=transitions,
         status_label=STATUS_VALUE_TO_LABEL,
+        fallback_mode=fallback_mode,
     )

--- a/scripts/webapp/templates/base.html
+++ b/scripts/webapp/templates/base.html
@@ -14,6 +14,7 @@
   <ul>
     <li><a href="/" class="brand">Shintakane Research</a></li>
     <li><a href="/market" class="nav-link">市場データ</a></li>
+    <li><a href="/portfolio" class="nav-link">保有銘柄</a></li>
     <li><a href="/disclosure" class="nav-link">適宜開示</a></li>
   </ul>
   <ul>

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -21,6 +21,21 @@
         | <a href="https://kabutan.jp/stock/finance?code={{ record.code_s }}" target="_blank" rel="noopener noreferrer">業績</a>
         | <a href="https://finance.yahoo.co.jp/quote/{{ record.code_s }}.T/forum" target="_blank" rel="noopener noreferrer">掲示板</a>
       </div>
+      <div style="margin-top:0.4em;">
+        {% if portfolio_status %}
+        <span style="color:#666;font-size:0.85em;">保有銘柄: <strong>{{ portfolio_status_label }}</strong></span>
+        <a href="/portfolio?status={{ portfolio_status_query }}" style="font-size:0.85em;">→ ダッシュボードで開く</a>
+        {% else %}
+        <form action="/portfolio/add" method="POST" style="display:inline;margin:0;">
+          <input type="hidden" name="code_s" value="{{ record.code_s }}">
+          <input type="hidden" name="stock_name" value="{{ record.stock_name or '' }}">
+          <button type="submit" class="outline" style="padding:0.2em 0.6em;font-size:0.85em;margin:0;"
+                  onclick="return confirm('{{ record.code_s }} {{ record.stock_name or '' }} を監視に追加しますか?')">
+            + 監視に追加
+          </button>
+        </form>
+        {% endif %}
+      </div>
     </div>
   </div>
 </div>

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -25,6 +25,8 @@
         {% if portfolio_status %}
         <span style="color:#666;font-size:0.85em;">保有銘柄: <strong>{{ portfolio_status_label }}</strong></span>
         <a href="/portfolio?status={{ portfolio_status_query }}" style="font-size:0.85em;">→ ダッシュボードで開く</a>
+        {% elif portfolio_fallback_mode %}
+        <span style="color:#a07000;font-size:0.85em;">portfolio_shelve 未移行モード: 監視追加は移行後に有効化されます</span>
         {% else %}
         <form action="/portfolio/add" method="POST" style="display:inline;margin:0;">
           <input type="hidden" name="code_s" value="{{ record.code_s }}">

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -28,7 +28,6 @@
         {% else %}
         <form action="/portfolio/add" method="POST" style="display:inline;margin:0;">
           <input type="hidden" name="code_s" value="{{ record.code_s }}">
-          <input type="hidden" name="stock_name" value="{{ record.stock_name or '' }}">
           <button type="submit" class="outline" style="padding:0.2em 0.6em;font-size:0.85em;margin:0;"
                   onclick="return confirm('{{ record.code_s }} {{ record.stock_name or '' }} を監視に追加しますか?')">
             + 監視に追加

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -37,10 +37,13 @@
       <th>コード</th>
       <th>銘柄名</th>
       <th>順位</th>
+      <th>決算日</th>
       <th>PER</th>
       <th>時価総額</th>
       <th>配当</th>
-      <th>RS</th>
+      <th>売上成長</th>
+      <th>利益成長</th>
+      <th>モメンタム</th>
       <th>トレンド</th>
       <th>タグ</th>
       <th>理論株価乖離</th>
@@ -57,27 +60,31 @@
       <td><a href="/stock/{{ row.code_s }}">{{ row.code_s }}</a></td>
       <td>{{ row.stock_name }}</td>
       <td>{{ row.rank if row.rank is not none else "—" }}</td>
+      <td>{{ row.kessanbi_md }}</td>
       <td>{{ row.per }}</td>
       <td>{{ row.market_cap }}</td>
       <td>{{ row.dividend }}</td>
+      <td>{{ row.sales_growth }}</td>
+      <td>{{ row.profit_growth }}</td>
       <td>{{ row.rs }}</td>
-      <td>{{ row.trend_template }}</td>
+      <td title="{{ row.trend_template_tooltip }}"
+          style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ row.trend_template }}</td>
       <td>{{ row.tags }}</td>
       <td>{{ row.theoretical_diff }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      <td colspan="11" style="background:#f8f8f8;padding:0.8em 1em;">
+      <td colspan="14" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:1.5em;">
-          <div style="flex:1;min-width:240px;">
-            <strong style="font-size:0.85em;color:#666;">業績</strong>
-            <div style="font-size:0.85em;">
-              スコア: {{ row.gyoseki.score_gyoseki if row.gyoseki.score_gyoseki is not none else "—" }}
-              / 決算日: {{ row.gyoseki.kessanbi or "—" }}
-              {% if row.gyoseki.isKonki %} / 今期 {% endif %}
-            </div>
+          {% if row.gyoseki.isKonki %}
+          <div style="flex:0 0 auto;">
+            <strong style="font-size:0.85em;color:#666;">今期</strong>
           </div>
+          {% endif %}
           <div style="flex:1;min-width:240px;">
             <strong style="font-size:0.85em;color:#666;">手動メモ</strong>
+            {% if row.memo.last_research_update %}
+            <span style="font-size:0.85em;color:#999;margin-left:0.5em;">調査更新日: {{ row.memo.last_research_update }}</span>
+            {% endif %}
             <ul style="font-size:0.85em;margin:0.3em 0 0 1em;padding:0;">
               {% if row.memo.gyoutai_theme %}<li><strong>業態・テーマ:</strong> {{ row.memo.gyoutai_theme }}</li>{% endif %}
               {% if row.memo.watch_in_reason %}<li><strong>IN 理由:</strong> {{ row.memo.watch_in_reason }}</li>{% endif %}

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -42,7 +42,7 @@
       <th>配当</th>
       <th>RS</th>
       <th>トレンド</th>
-      <th>シグナル</th>
+      <th>タグ</th>
       <th>理論株価乖離</th>
     </tr>
   </thead>
@@ -62,7 +62,7 @@
       <td>{{ row.dividend }}</td>
       <td>{{ row.rs }}</td>
       <td>{{ row.trend_template }}</td>
-      <td>{{ row.signals }}</td>
+      <td>{{ row.tags }}</td>
       <td>{{ row.theoretical_diff }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -43,6 +43,8 @@
       <th>配当</th>
       <th>売上成長</th>
       <th>利益成長</th>
+      <th title="決算Q (進行中の四半期)">決算Q</th>
+      <th title="進捗率乖離: (売上進捗-前年同期) / (利益進捗-前年同期)">進捗率乖離</th>
       <th>モメンタム</th>
       <th>トレンド</th>
       <th>タグ</th>
@@ -66,6 +68,8 @@
       <td>{{ row.dividend }}</td>
       <td>{{ row.sales_growth }}</td>
       <td>{{ row.profit_growth }}</td>
+      <td>{{ row.quarter }}</td>
+      <td>{{ row.progress_diff }}</td>
       <td>{{ row.rs }}</td>
       <td title="{{ row.trend_template_tooltip }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ row.trend_template }}</td>
@@ -73,7 +77,7 @@
       <td>{{ row.theoretical_diff }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      <td colspan="14" style="background:#f8f8f8;padding:0.8em 1em;">
+      <td colspan="16" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:1.5em;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">
@@ -99,7 +103,6 @@
           <div style="flex:0 0 240px;">
             <strong style="font-size:0.85em;color:#666;">操作</strong>
             <div style="display:flex;flex-direction:column;gap:0.5em;margin-top:0.3em;font-size:0.85em;">
-              <a href="/stock/{{ row.code_s }}">→ 銘柄詳細</a>
               {% if transitions %}
               <form action="/portfolio/{{ row.code_s }}/transition" method="POST" style="display:flex;flex-direction:column;gap:0.3em;margin:0;">
                 <label style="font-size:0.85em;color:#666;">ステータス変更</label>

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -118,8 +118,35 @@
             <strong style="font-size:0.85em;color:#666;">今期</strong>
           </div>
           {% endif %}
-          <div style="flex:0 1 auto;min-width:240px;max-width:50em;">
+          <div style="flex:0 1 auto;min-width:300px;max-width:50em;">
             <strong style="font-size:0.85em;color:#666;">手動メモ</strong>
+            {% if not fallback_mode %}
+            <form action="/portfolio/{{ row.code_s }}/memo" method="POST"
+                  style="display:flex;flex-direction:column;gap:0.4em;margin:0.3em 0 0 0;font-size:0.85em;">
+              {% for field, label in [
+                  ("gyoutai_theme", "業態・テーマ"),
+                  ("watch_in_reason", "IN 理由"),
+                  ("trade_idea", "売買アイデア"),
+                  ("inago_origin", "イナゴ元"),
+                  ("takaichi_sensitivity", "高市感応度"),
+                  ("last_research_update", "調査更新日"),
+                  ("stage", "ステージ"),
+                  ("jukyu_chart", "需給チャート"),
+              ] %}
+              <label style="display:flex;flex-direction:column;gap:0.1em;margin:0;">
+                <span style="color:#666;">{{ label }}</span>
+                <textarea name="{{ field }}" rows="2"
+                          style="font-size:0.85em;padding:0.3em;margin:0;font-family:inherit;"
+                          >{{ row.memo[field] or "" }}</textarea>
+              </label>
+              {% endfor %}
+              <button type="submit"
+                      style="padding:0.3em 0.6em;font-size:0.85em;margin:0.2em 0 0 0;align-self:flex-start;">
+                メモを保存
+              </button>
+            </form>
+            {% else %}
+            {# フォールバックモード時は読み取り専用表示を維持 #}
             {% if row.memo.last_research_update %}
             <span style="font-size:0.85em;color:#999;margin-left:0.5em;">調査更新日: {{ row.memo.last_research_update }}</span>
             {% endif %}
@@ -130,6 +157,7 @@
               <li><strong>高市感応度:</strong> {{ row.memo.takaichi_sensitivity or "—" }}</li>
               <li><strong>需給チャート:</strong> {{ row.memo.jukyu_chart or "—" }}</li>
             </ul>
+            {% endif %}
           </div>
           <div style="flex:0 0 240px;">
             <strong style="font-size:0.85em;color:#666;">操作</strong>

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -2,6 +2,10 @@
 {% block title %}保有銘柄 | Shintakane Research{% endblock %}
 
 {% block content %}
+{# 一覧の列数を多く表示するため、main.container のデフォルト max-width を上書きして全幅化 #}
+<style>
+  main.container { max-width: 100% !important; padding-left: 0.8em !important; padding-right: 0.8em !important; }
+</style>
 <h2>保有銘柄ダッシュボード</h2>
 
 {% with messages = get_flashed_messages(with_categories=true) %}
@@ -36,19 +40,25 @@
       <th></th>
       <th>コード</th>
       <th>銘柄名</th>
+      <th>業態・テーマ</th>
       <th>順位</th>
-      <th>決算日</th>
-      <th>PER</th>
-      <th>時価総額</th>
-      <th>配当</th>
       <th>売上成長</th>
       <th>利益成長</th>
+      <th>PER</th>
+      <th>理論株価乖離</th>
+      <th>配当</th>
       <th title="決算Q (進行中の四半期)">決算Q</th>
       <th title="進捗率乖離: (売上進捗-前年同期) / (利益進捗-前年同期)">進捗率乖離</th>
-      <th>モメンタム</th>
+      <th>決算日</th>
+      <th>更新日</th>
+      <th>ステージ</th>
+      <th>RS</th>
+      <th>RSライン(20,5)</th>
       <th>トレンド</th>
       <th>タグ</th>
-      <th>理論株価乖離</th>
+      <th>株価向き(20,5)</th>
+      <th>買い集め</th>
+      <th>時価総額</th>
     </tr>
   </thead>
   <tbody>
@@ -59,45 +69,59 @@
           <summary style="cursor:pointer;list-style:none;">▸</summary>
         </details>
       </td>
-      <td><a href="/stock/{{ row.code_s }}">{{ row.code_s }}</a></td>
-      <td>{{ row.stock_name }}</td>
+      <td><a href="https://kabutan.jp/stock/chart?code={{ row.code_s }}" target="_blank" rel="noopener noreferrer">{{ row.code_s }}</a></td>
+      <td title="{{ row.stock_name }}"
+          style="max-width:10em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
+        <a href="/stock/{{ row.code_s }}">{{ row.stock_name }}</a>
+      </td>
+      <td title="{{ row.memo.gyoutai_theme }}"
+          style="max-width:11em;line-height:1.2;font-size:0.85em;overflow:hidden;">
+        {% if row.memo.gyoutai_theme %}
+          {% for theme_line in row.memo.gyoutai_theme.split("\n")[:2] %}
+          <div style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ theme_line }}</div>
+          {% endfor %}
+        {% else %}—{% endif %}
+      </td>
       <td>{{ row.rank if row.rank is not none else "—" }}</td>
-      <td>{{ row.kessanbi_md }}</td>
-      <td>{{ row.per }}</td>
-      <td>{{ row.market_cap }}</td>
-      <td>{{ row.dividend }}</td>
       <td>{{ row.sales_growth }}</td>
       <td>{{ row.profit_growth }}</td>
+      <td>{{ row.per }}</td>
+      <td>{{ row.theoretical_diff }}</td>
+      <td>{{ row.dividend }}</td>
       <td>{{ row.quarter }}</td>
       <td>{{ row.progress_diff }}</td>
+      <td>{{ row.kessanbi_md }}</td>
+      <td>{{ row.memo.last_research_update or "—" }}</td>
+      <td>{{ row.memo.stage or "—" }}</td>
       <td>{{ row.rs }}</td>
+      <td style="color:#bbb;">—</td>
       <td title="{{ row.trend_template_tooltip }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ row.trend_template }}</td>
-      <td>{{ row.tags }}</td>
-      <td>{{ row.theoretical_diff }}</td>
+      <td title="{{ row.tags }}"
+          style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ row.tags }}</td>
+      <td style="color:#bbb;">—</td>
+      <td>{{ row.buy_collection }}</td>
+      <td>{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      <td colspan="16" style="background:#f8f8f8;padding:0.8em 1em;">
-        <div style="display:flex;flex-wrap:wrap;gap:1.5em;">
+      <td colspan="22" style="background:#f8f8f8;padding:0.8em 1em;">
+        <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">
             <strong style="font-size:0.85em;color:#666;">今期</strong>
           </div>
           {% endif %}
-          <div style="flex:1;min-width:240px;">
+          <div style="flex:0 1 auto;min-width:240px;max-width:50em;">
             <strong style="font-size:0.85em;color:#666;">手動メモ</strong>
             {% if row.memo.last_research_update %}
             <span style="font-size:0.85em;color:#999;margin-left:0.5em;">調査更新日: {{ row.memo.last_research_update }}</span>
             {% endif %}
             <ul style="font-size:0.85em;margin:0.3em 0 0 1em;padding:0;">
-              {% if row.memo.gyoutai_theme %}<li><strong>業態・テーマ:</strong> {{ row.memo.gyoutai_theme }}</li>{% endif %}
-              {% if row.memo.watch_in_reason %}<li><strong>IN 理由:</strong> {{ row.memo.watch_in_reason }}</li>{% endif %}
-              {% if row.memo.trade_idea %}<li><strong>売買アイデア:</strong> {{ row.memo.trade_idea }}</li>{% endif %}
-              {% if row.memo.inago_origin %}<li><strong>イナゴ元:</strong> {{ row.memo.inago_origin }}</li>{% endif %}
-              {% if row.memo.takaichi_sensitivity %}<li><strong>高市感応度:</strong> {{ row.memo.takaichi_sensitivity }}</li>{% endif %}
-              {% if not (row.memo.gyoutai_theme or row.memo.watch_in_reason or row.memo.trade_idea or row.memo.inago_origin or row.memo.takaichi_sensitivity) %}
-              <li style="color:#aaa;">メモなし</li>
-              {% endif %}
+              <li><strong>IN 理由:</strong> {{ row.memo.watch_in_reason or "—" }}</li>
+              <li><strong>売買アイデア:</strong> {{ row.memo.trade_idea or "—" }}</li>
+              <li><strong>イナゴ元:</strong> {{ row.memo.inago_origin or "—" }}</li>
+              <li><strong>高市感応度:</strong> {{ row.memo.takaichi_sensitivity or "—" }}</li>
+              <li><strong>需給チャート:</strong> {{ row.memo.jukyu_chart or "—" }}</li>
             </ul>
           </div>
           <div style="flex:0 0 240px;">

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -8,6 +8,13 @@
 </style>
 <h2>保有銘柄ダッシュボード</h2>
 
+{% if fallback_mode %}
+<div style="padding:0.6em 1em;margin-bottom:1em;border-radius:4px;font-size:0.9em;background:#fff8e0;color:#a07000;border:1px solid #ecd07a;">
+  <strong>portfolio_shelve 未移行モード</strong>: 表示は <code>my_watch_list.txt</code> から復元しています。
+  ステータス変更・追加・削除などの書き込み操作は、Phase 3a 移行スクリプトを実行するまで無効です。
+</div>
+{% endif %}
+
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
   {% for category, message in messages %}
@@ -140,7 +147,7 @@
                         onclick="return confirm('{{ row.code_s }} のステータスを変更しますか?')">変更</button>
               </form>
               {% endif %}
-              {% if active_query == "watch" %}
+              {% if active_query == "watch" and not fallback_mode %}
               <form action="/portfolio/{{ row.code_s }}/delete" method="POST"
                     style="display:flex;flex-direction:column;gap:0.3em;margin:0;border-top:1px dashed #ccc;padding-top:0.5em;">
                 <label style="font-size:0.85em;color:#c00;">削除 (監視のみ)</label>

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -1,0 +1,147 @@
+{% extends "base.html" %}
+{% block title %}保有銘柄 | Shintakane Research{% endblock %}
+
+{% block content %}
+<h2>保有銘柄ダッシュボード</h2>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+  {% for category, message in messages %}
+  <div style="padding:0.5em 1em;margin-bottom:1em;border-radius:4px;font-size:0.9em;{% if category == 'error' %}background:#ffeaea;color:#c00;border:1px solid #fcc;{% else %}background:#eaffea;color:#060;border:1px solid #cfc;{% endif %}">{{ message }}</div>
+  {% endfor %}
+{% endif %}
+{% endwith %}
+
+<nav style="margin-bottom:1em;">
+  <ul style="display:flex;gap:0.5em;list-style:none;padding:0;margin:0;border-bottom:1px solid #ddd;">
+    {% for q, status_val, label in tabs %}
+    <li>
+      <a href="/portfolio?status={{ q }}"
+         style="display:inline-block;padding:0.5em 1em;text-decoration:none;
+                {% if q == active_query %}border-bottom:2px solid #06c;font-weight:bold;{% else %}color:#666;{% endif %}">
+        {{ label }} <span style="color:#999;font-size:0.85em;">{{ counts[q] }}</span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</nav>
+
+<p style="font-size:0.85em;color:#666;">{{ rows|length }} 件</p>
+
+{% if rows %}
+<div style="overflow-x:auto;">
+<table style="font-size:0.85em;">
+  <thead>
+    <tr>
+      <th></th>
+      <th>コード</th>
+      <th>銘柄名</th>
+      <th>順位</th>
+      <th>PER</th>
+      <th>時価総額</th>
+      <th>配当</th>
+      <th>RS</th>
+      <th>トレンド</th>
+      <th>シグナル</th>
+      <th>理論株価乖離</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      <td>
+        <details>
+          <summary style="cursor:pointer;list-style:none;">▸</summary>
+        </details>
+      </td>
+      <td><a href="/stock/{{ row.code_s }}">{{ row.code_s }}</a></td>
+      <td>{{ row.stock_name }}</td>
+      <td>{{ row.rank if row.rank is not none else "—" }}</td>
+      <td>{{ row.per }}</td>
+      <td>{{ row.market_cap }}</td>
+      <td>{{ row.dividend }}</td>
+      <td>{{ row.rs }}</td>
+      <td>{{ row.trend_template }}</td>
+      <td>{{ row.signals }}</td>
+      <td>{{ row.theoretical_diff }}</td>
+    </tr>
+    <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
+      <td colspan="11" style="background:#f8f8f8;padding:0.8em 1em;">
+        <div style="display:flex;flex-wrap:wrap;gap:1.5em;">
+          <div style="flex:1;min-width:240px;">
+            <strong style="font-size:0.85em;color:#666;">業績</strong>
+            <div style="font-size:0.85em;">
+              スコア: {{ row.gyoseki.score_gyoseki if row.gyoseki.score_gyoseki is not none else "—" }}
+              / 決算日: {{ row.gyoseki.kessanbi or "—" }}
+              {% if row.gyoseki.isKonki %} / 今期 {% endif %}
+            </div>
+          </div>
+          <div style="flex:1;min-width:240px;">
+            <strong style="font-size:0.85em;color:#666;">手動メモ</strong>
+            <ul style="font-size:0.85em;margin:0.3em 0 0 1em;padding:0;">
+              {% if row.memo.gyoutai_theme %}<li><strong>業態・テーマ:</strong> {{ row.memo.gyoutai_theme }}</li>{% endif %}
+              {% if row.memo.watch_in_reason %}<li><strong>IN 理由:</strong> {{ row.memo.watch_in_reason }}</li>{% endif %}
+              {% if row.memo.trade_idea %}<li><strong>売買アイデア:</strong> {{ row.memo.trade_idea }}</li>{% endif %}
+              {% if row.memo.inago_origin %}<li><strong>イナゴ元:</strong> {{ row.memo.inago_origin }}</li>{% endif %}
+              {% if row.memo.takaichi_sensitivity %}<li><strong>高市感応度:</strong> {{ row.memo.takaichi_sensitivity }}</li>{% endif %}
+              {% if not (row.memo.gyoutai_theme or row.memo.watch_in_reason or row.memo.trade_idea or row.memo.inago_origin or row.memo.takaichi_sensitivity) %}
+              <li style="color:#aaa;">メモなし</li>
+              {% endif %}
+            </ul>
+          </div>
+          <div style="flex:0 0 240px;">
+            <strong style="font-size:0.85em;color:#666;">操作</strong>
+            <div style="display:flex;flex-direction:column;gap:0.5em;margin-top:0.3em;font-size:0.85em;">
+              <a href="/stock/{{ row.code_s }}">→ 銘柄詳細</a>
+              {% if transitions %}
+              <form action="/portfolio/{{ row.code_s }}/transition" method="POST" style="display:flex;flex-direction:column;gap:0.3em;margin:0;">
+                <label style="font-size:0.85em;color:#666;">ステータス変更</label>
+                <select name="new_status" style="padding:0.3em;font-size:0.85em;margin:0;">
+                  {% for label, value in transitions %}
+                  <option value="{{ value }}">{{ label }}</option>
+                  {% endfor %}
+                </select>
+                <textarea name="reason" placeholder="理由 (任意)" rows="2" style="font-size:0.85em;padding:0.3em;margin:0;"></textarea>
+                <button type="submit" style="padding:0.3em 0.6em;font-size:0.85em;margin:0;"
+                        onclick="return confirm('{{ row.code_s }} のステータスを変更しますか?')">変更</button>
+              </form>
+              {% endif %}
+              {% if active_query == "watch" %}
+              <form action="/portfolio/{{ row.code_s }}/delete" method="POST"
+                    style="display:flex;flex-direction:column;gap:0.3em;margin:0;border-top:1px dashed #ccc;padding-top:0.5em;">
+                <label style="font-size:0.85em;color:#c00;">削除 (監視のみ)</label>
+                <textarea name="reason" placeholder="削除理由 (必須)" rows="2" required style="font-size:0.85em;padding:0.3em;margin:0;"></textarea>
+                <button type="submit" class="contrast" style="padding:0.3em 0.6em;font-size:0.85em;margin:0;"
+                        onclick="return confirm('{{ row.code_s }} を完全に削除しますか? (アクションログは残ります)')">削除</button>
+              </form>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</div>
+
+<script>
+// summary クリックで対応する .row-detail を展開
+document.querySelectorAll('table details').forEach(function(d) {
+  d.addEventListener('toggle', function() {
+    var row = d.closest('tr');
+    var nextRow = row.nextElementSibling;
+    if (nextRow && nextRow.classList.contains('row-detail')) {
+      nextRow.style.display = d.open ? '' : 'none';
+    }
+    var summary = d.querySelector('summary');
+    if (summary) summary.textContent = d.open ? '▾' : '▸';
+  });
+});
+</script>
+
+{% else %}
+<p style="color:#888;">該当銘柄なし</p>
+{% endif %}
+
+{% endblock %}

--- a/tests/test_migrate_my_watch_list_to_shelve.py
+++ b/tests/test_migrate_my_watch_list_to_shelve.py
@@ -132,9 +132,7 @@ class TestMergeWithExisting:
         """既存レコード (スプシ由来、メモあり) のステータスを txt で上書き"""
         # 先にスプシ由来レコードを upsert (ステータスは仮で "3監")
         memo = ps.create_memo(gyoutai_theme="人材", trade_idea="押し目")
-        existing = ps.create_record(
-            "7047", "ポート (スプシ名)", status="3監", memo=memo,
-        )
+        existing = ps.create_record("7047", status="3監", memo=memo)
         ps.upsert_record(existing, db_path=db_path)
 
         # txt 取り込み (1保 として上書き)
@@ -147,11 +145,11 @@ class TestMergeWithExisting:
         # メモは保持
         assert rec["memo"]["gyoutai_theme"] == "人材"
         assert rec["memo"]["trade_idea"] == "押し目"
-        # stock_name はスプシ由来を保持 (上書きしない)
-        assert rec["stock_name"] == "ポート (スプシ名)"
+        # 新スキーマでは stock_name は portfolio_shelve に保存されない
+        assert "stock_name" not in rec
 
     def test_no_change_when_status_matches(self, db_path):
-        existing = ps.create_record("5032", "AnyColor", status="3監")
+        existing = ps.create_record("5032", status="3監")
         ps.upsert_record(existing, db_path=db_path)
 
         result = mw.merge_into_shelve(
@@ -165,7 +163,7 @@ class TestMergeWithExisting:
 
     def test_records_status_change_log(self, db_path):
         """既存ステータスからの変更ログが記録される"""
-        existing = ps.create_record("7047", "ポート", status="3監")
+        existing = ps.create_record("7047", status="3監")
         ps.upsert_record(existing, db_path=db_path)
 
         mw.merge_into_shelve(

--- a/tests/test_migrate_my_watch_list_to_shelve.py
+++ b/tests/test_migrate_my_watch_list_to_shelve.py
@@ -1,0 +1,210 @@
+"""migrate_my_watch_list_to_shelve.py のテスト"""
+
+import pytest
+
+import migrate_my_watch_list_to_shelve as mw
+import portfolio_shelve as ps
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+@pytest.fixture
+def txt_path(tmp_path):
+    p = tmp_path / "my_watch_list.txt"
+    return str(p)
+
+
+def _write_txt(path, content):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+# ==================================================
+# parse_my_watch_list
+# ==================================================
+class TestParse:
+
+    def test_parse_h_prefix_as_hold(self):
+        text = "H7047ポート\nH4377ワンキャリア\n"
+        entries = mw.parse_my_watch_list(text)
+        assert len(entries) == 2
+        assert entries[0] == ("7047", "ポート", "1保")
+        assert entries[1] == ("4377", "ワンキャリア", "1保")
+
+    def test_parse_no_prefix_as_watch(self):
+        text = "5032AnyColor\n6232ACSL\n"
+        entries = mw.parse_my_watch_list(text)
+        assert entries[0] == ("5032", "AnyColor", "3監")
+        assert entries[1] == ("6232", "ACSL", "3監")
+
+    def test_parse_alpha_code(self):
+        text = "H402Aアクセルスペース\n"
+        entries = mw.parse_my_watch_list(text)
+        assert entries[0] == ("402A", "アクセルスペース", "1保")
+
+    def test_parse_skips_blank_and_invalid_lines(self):
+        text = "H7047ポート\n\nINVALID\n5032AnyColor\n"
+        entries = mw.parse_my_watch_list(text)
+        codes = [e[0] for e in entries]
+        assert codes == ["7047", "5032"]
+
+    def test_parse_dedupes_keeping_first(self):
+        text = "H7047ポート\n7047重複\n"
+        entries = mw.parse_my_watch_list(text)
+        assert len(entries) == 1
+        assert entries[0] == ("7047", "ポート", "1保")
+
+    def test_parse_real_format(self):
+        """実際の my_watch_list.txt と同じフォーマット"""
+        text = (
+            "H7047ポート\n"
+            "H2980SREHD\n"
+            "\n"
+            "7717ブイ・テクノロジー\n"
+            "5032AnyColor\n"
+        )
+        entries = mw.parse_my_watch_list(text)
+        codes = [(e[0], e[2]) for e in entries]
+        assert codes == [
+            ("7047", "1保"),
+            ("2980", "1保"),
+            ("7717", "3監"),
+            ("5032", "3監"),
+        ]
+
+
+# ==================================================
+# merge_into_shelve: txt のみ存在パターン
+# ==================================================
+class TestMergeTxtOnly:
+
+    def test_creates_new_records(self, db_path):
+        entries = [
+            ("7047", "ポート", "1保"),
+            ("5032", "AnyColor", "3監"),
+        ]
+        result = mw.merge_into_shelve(entries, db_path=db_path)
+        assert result["created"] == 2
+        assert result["updated"] == 0
+        records = ps.list_records(db_path=db_path)
+        assert len(records) == 2
+
+    def test_status_set_correctly_for_h_prefix(self, db_path):
+        mw.merge_into_shelve(
+            [("7047", "ポート", "1保")], db_path=db_path
+        )
+        rec = ps.get_record("7047", db_path=db_path)
+        assert rec["status"] == "1保"
+
+    def test_action_logs_for_new_hold(self, db_path):
+        """1保 で新規追加された場合、初回登録 + ステータス変更の 2 ログ"""
+        mw.merge_into_shelve(
+            [("7047", "ポート", "1保")], db_path=db_path
+        )
+        logs = ps.list_action_logs("7047", db_path=db_path)
+        assert len(logs) == 2
+        assert logs[0]["action_type"] == "初回登録"
+        assert logs[0]["status_to"] == "3監"  # ライフサイクル原則
+        assert logs[1]["action_type"] == "ステータス変更"
+        assert logs[1]["status_from"] == "3監"
+        assert logs[1]["status_to"] == "1保"
+
+    def test_action_log_for_new_watch(self, db_path):
+        """3監 で新規追加された場合、初回登録ログ 1 件のみ"""
+        mw.merge_into_shelve(
+            [("5032", "AnyColor", "3監")], db_path=db_path
+        )
+        logs = ps.list_action_logs("5032", db_path=db_path)
+        assert len(logs) == 1
+        assert logs[0]["action_type"] == "初回登録"
+        assert logs[0]["status_to"] == "3監"
+
+
+# ==================================================
+# merge_into_shelve: 既存レコード (スプシ移行済み) 上書き
+# ==================================================
+class TestMergeWithExisting:
+
+    def test_overwrites_status_keeps_memo(self, db_path):
+        """既存レコード (スプシ由来、メモあり) のステータスを txt で上書き"""
+        # 先にスプシ由来レコードを upsert (ステータスは仮で "3監")
+        memo = ps.create_memo(gyoutai_theme="人材", trade_idea="押し目")
+        existing = ps.create_record(
+            "7047", "ポート (スプシ名)", status="3監", memo=memo,
+        )
+        ps.upsert_record(existing, db_path=db_path)
+
+        # txt 取り込み (1保 として上書き)
+        mw.merge_into_shelve(
+            [("7047", "ポート (txt名)", "1保")], db_path=db_path
+        )
+
+        rec = ps.get_record("7047", db_path=db_path)
+        assert rec["status"] == "1保"  # txt のステータスで上書きされた
+        # メモは保持
+        assert rec["memo"]["gyoutai_theme"] == "人材"
+        assert rec["memo"]["trade_idea"] == "押し目"
+        # stock_name はスプシ由来を保持 (上書きしない)
+        assert rec["stock_name"] == "ポート (スプシ名)"
+
+    def test_no_change_when_status_matches(self, db_path):
+        existing = ps.create_record("5032", "AnyColor", status="3監")
+        ps.upsert_record(existing, db_path=db_path)
+
+        result = mw.merge_into_shelve(
+            [("5032", "AnyColor", "3監")], db_path=db_path
+        )
+        assert result["unchanged"] == 1
+        assert result["updated"] == 0
+        # アクションログは増えない
+        logs = ps.list_action_logs("5032", db_path=db_path)
+        assert logs == []
+
+    def test_records_status_change_log(self, db_path):
+        """既存ステータスからの変更ログが記録される"""
+        existing = ps.create_record("7047", "ポート", status="3監")
+        ps.upsert_record(existing, db_path=db_path)
+
+        mw.merge_into_shelve(
+            [("7047", "ポート", "1保")], db_path=db_path
+        )
+
+        logs = ps.list_action_logs("7047", db_path=db_path)
+        assert len(logs) == 1
+        assert logs[0]["action_type"] == "ステータス変更"
+        assert logs[0]["status_from"] == "3監"
+        assert logs[0]["status_to"] == "1保"
+
+
+# ==================================================
+# import_my_watch_list (実行層)
+# ==================================================
+class TestImport:
+
+    def test_import_from_file(self, txt_path, db_path):
+        _write_txt(txt_path, "H7047ポート\n5032AnyColor\n")
+        result = mw.import_my_watch_list(txt_path, db_path=db_path)
+        assert result["created"] == 2
+        records = ps.list_records(db_path=db_path)
+        codes = [r["code_s"] for r in records]
+        assert codes == ["5032", "7047"]
+        statuses = {r["code_s"]: r["status"] for r in records}
+        assert statuses == {"7047": "1保", "5032": "3監"}
+
+    def test_import_missing_file(self, tmp_path, db_path):
+        with pytest.raises(FileNotFoundError):
+            mw.import_my_watch_list(
+                str(tmp_path / "missing.txt"), db_path=db_path
+            )
+
+    def test_idempotent_rerun(self, txt_path, db_path):
+        """同じ txt を 2 回流しても二重登録にならない"""
+        _write_txt(txt_path, "H7047ポート\n5032AnyColor\n")
+        mw.import_my_watch_list(txt_path, db_path=db_path)
+        result = mw.import_my_watch_list(txt_path, db_path=db_path)
+        assert result["created"] == 0
+        assert result["updated"] == 0
+        assert result["unchanged"] == 2

--- a/tests/test_migrate_portfolio_drop_stock_name.py
+++ b/tests/test_migrate_portfolio_drop_stock_name.py
@@ -1,0 +1,73 @@
+"""migrate_portfolio_drop_stock_name.py のテスト"""
+
+import pytest
+
+import portfolio_shelve as ps
+import migrate_portfolio_drop_stock_name as m
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+@pytest.fixture
+def db_with_legacy_records(db_path):
+    """旧スキーマ (stock_name 付き) と新スキーマが混在した shelve を用意"""
+    # 新スキーマ (stock_name なし)
+    rec_new = ps.create_record("4377", status="3監")
+    ps.upsert_record(rec_new, db_path=db_path)
+
+    # 旧スキーマ風 (stock_name あり) を直接 upsert
+    rec_legacy = ps.create_record("7089", status="1保")
+    rec_legacy["stock_name"] = "フォースタートアップス"  # 旧データ模擬
+    ps.upsert_record(rec_legacy, db_path=db_path)
+
+    rec_legacy2 = ps.create_record("5032", status="3監")
+    rec_legacy2["stock_name"] = "AnyColor"
+    ps.upsert_record(rec_legacy2, db_path=db_path)
+
+    return db_path
+
+
+class TestDropStockName:
+
+    def test_dry_run_does_not_modify(self, db_with_legacy_records):
+        result = m.drop_stock_name_field(dry_run=True, db_path=db_with_legacy_records)
+        assert result["total"] == 3
+        assert result["cleaned"] == 2  # 7089, 5032
+        assert result["skipped"] == 1  # 4377
+
+        # shelve は変化なし
+        rec = ps.get_record("7089", db_path=db_with_legacy_records)
+        assert "stock_name" in rec  # 旧スキーマのまま
+
+    def test_real_run_drops_stock_name(self, db_with_legacy_records):
+        result = m.drop_stock_name_field(db_path=db_with_legacy_records)
+        assert result["total"] == 3
+        assert result["cleaned"] == 2
+        assert result["skipped"] == 1
+
+        for code in ("4377", "7089", "5032"):
+            rec = ps.get_record(code, db_path=db_with_legacy_records)
+            assert "stock_name" not in rec, f"{code} に stock_name が残っている"
+
+    def test_other_fields_preserved(self, db_with_legacy_records):
+        m.drop_stock_name_field(db_path=db_with_legacy_records)
+        rec = ps.get_record("7089", db_path=db_with_legacy_records)
+        assert rec["status"] == "1保"
+        assert rec["code_s"] == "7089"
+        assert "memo" in rec
+        assert rec["registered_at"]
+
+    def test_idempotent(self, db_with_legacy_records):
+        """2 回実行しても問題なし"""
+        m.drop_stock_name_field(db_path=db_with_legacy_records)
+        result = m.drop_stock_name_field(db_path=db_with_legacy_records)
+        assert result["cleaned"] == 0  # 2 回目はクリーン対象なし
+        assert result["skipped"] == 3
+
+    def test_empty_db(self, db_path):
+        """レコードが 0 件でもエラーにならない"""
+        result = m.drop_stock_name_field(db_path=db_path)
+        assert result == {"total": 0, "cleaned": 0, "skipped": 0}

--- a/tests/test_migrate_portfolio_from_csv.py
+++ b/tests/test_migrate_portfolio_from_csv.py
@@ -1,0 +1,258 @@
+"""migrate_portfolio_from_csv.py のテスト"""
+
+import csv
+
+import pytest
+
+import migrate_portfolio_from_csv as mp
+import portfolio_shelve as ps
+
+
+# ==================================================
+# fixtures
+# ==================================================
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+def _make_row(
+    *,
+    code_s: str = "",
+    stock_name: str = "",
+    gyoutai: str = "",
+    watch_reason: str = "",
+    inago: str = "",
+    trade_idea: str = "",
+    takaichi: str = "",
+) -> list:
+    """36 列の行を組み立てる。指標系列は空文字で埋める。"""
+    row = [""] * mp.EXPECTED_COL_COUNT
+    row[mp.COL_CODE_S] = code_s
+    row[mp.COL_STOCK_NAME] = stock_name
+    row[mp.COL_GYOUTAI] = gyoutai
+    row[mp.COL_WATCH_REASON] = watch_reason
+    row[mp.COL_INAGO] = inago
+    row[mp.COL_TRADE_IDEA] = trade_idea
+    row[mp.COL_TAKAICHI] = takaichi
+    return row
+
+
+@pytest.fixture
+def sample_csv(tmp_path):
+    """先頭空行 + ヘッダ + 3 行データの CSV を作成。"""
+    csv_path = tmp_path / "portfolio.csv"
+    rows = [
+        [""] * mp.EXPECTED_COL_COUNT,  # 1 行目: 空行
+        # 2 行目: ヘッダ
+        [
+            "銘柄コード", "銘柄名", "保有リスト", "業態・テーマ",
+            *([""] * 27),
+            "ウォッチ・IN理由",
+            "需給チャート",
+            "イナゴ元・きっかけ",
+            "投資売買アイデア",
+            "高市感応度",
+        ],
+        _make_row(
+            code_s="4377",
+            stock_name="ワンキャリア",
+            gyoutai="人材\n少子高齢",
+            watch_reason="新卒シェアトップ",
+            trade_idea="押し目買い",
+            inago="ケイ",
+            takaichi="C:給付付き税額控除",
+        ),
+        _make_row(
+            code_s="7089",
+            stock_name="フォースタートアップス",
+            gyoutai="人材",
+            takaichi="B:成長産業への積極投資",
+        ),
+        _make_row(
+            code_s="215A",
+            stock_name="アクセルスペース",
+        ),
+    ]
+    # ヘッダ行の長さ調整
+    if len(rows[1]) < mp.EXPECTED_COL_COUNT:
+        rows[1] += [""] * (mp.EXPECTED_COL_COUNT - len(rows[1]))
+    with open(csv_path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)
+    return str(csv_path)
+
+
+# ==================================================
+# 読込層
+# ==================================================
+class TestReadCsvRows:
+
+    def test_skips_empty_first_row_and_header(self, sample_csv):
+        rows = mp.read_csv_rows(sample_csv)
+        assert len(rows) == 3
+        assert rows[0][mp.COL_CODE_S] == "4377"
+        assert rows[1][mp.COL_CODE_S] == "7089"
+        assert rows[2][mp.COL_CODE_S] == "215A"
+
+    def test_pads_short_rows(self, tmp_path):
+        csv_path = tmp_path / "short.csv"
+        with open(csv_path, "w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            w.writerow([""] * mp.EXPECTED_COL_COUNT)  # 空行
+            w.writerow(["銘柄コード", "銘柄名"])     # ヘッダ
+            w.writerow(["4377", "ワンキャリア"])     # データ (2 列のみ)
+        rows = mp.read_csv_rows(str(csv_path))
+        assert len(rows) == 1
+        assert len(rows[0]) == mp.EXPECTED_COL_COUNT
+        assert rows[0][mp.COL_CODE_S] == "4377"
+
+
+# ==================================================
+# 列パース層
+# ==================================================
+class TestParseMemoColumns:
+
+    def test_extracts_5_memo_fields(self):
+        row = _make_row(
+            gyoutai="人材",
+            watch_reason="新卒",
+            trade_idea="押し目",
+            inago="ケイ",
+            takaichi="C",
+        )
+        memo, warnings = mp.parse_memo_columns(row)
+        assert memo["gyoutai_theme"] == "人材"
+        assert memo["watch_in_reason"] == "新卒"
+        assert memo["trade_idea"] == "押し目"
+        assert memo["inago_origin"] == "ケイ"
+        assert memo["takaichi_sensitivity"] == "C"
+        assert warnings == []
+
+    def test_strips_whitespace(self):
+        row = _make_row(gyoutai="  人材  ")
+        memo, _ = mp.parse_memo_columns(row)
+        assert memo["gyoutai_theme"] == "人材"
+
+    def test_handles_short_row(self):
+        memo, warnings = mp.parse_memo_columns(["4377", "x"])
+        assert memo == ps.create_memo()
+        assert warnings  # 列数不足の警告あり
+
+
+# ==================================================
+# 統合層
+# ==================================================
+class TestBuildRecordFromRow:
+
+    def test_minimal_row(self):
+        row = _make_row(code_s="4377", stock_name="ワンキャリア")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is not None
+        assert rec["code_s"] == "4377"
+        assert rec["stock_name"] == "ワンキャリア"
+        assert rec["status"] == "3監"  # 仮ステータス
+        assert warnings == []
+
+    def test_full_row(self):
+        row = _make_row(
+            code_s="4377",
+            stock_name="ワンキャリア",
+            gyoutai="人材",
+            takaichi="C",
+        )
+        rec, _ = mp.build_record_from_row(row)
+        assert rec["memo"]["gyoutai_theme"] == "人材"
+        assert rec["memo"]["takaichi_sensitivity"] == "C"
+
+    def test_empty_code_returns_none(self):
+        row = _make_row(stock_name="名前あり")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is None
+        assert any("空の銘柄コード" in w for w in warnings)
+
+    def test_invalid_code_returns_none(self):
+        row = _make_row(code_s="ABC1", stock_name="不正コード")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is None
+        assert any("不正な銘柄コード" in w for w in warnings)
+
+    def test_lowercase_code_normalized(self):
+        row = _make_row(code_s="215a", stock_name="テスト")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is not None
+        assert rec["code_s"] == "215A"
+
+    def test_empty_stock_name_warns_but_succeeds(self):
+        row = _make_row(code_s="4377")
+        rec, warnings = mp.build_record_from_row(row)
+        assert rec is not None
+        assert rec["stock_name"] == ""
+        assert any("銘柄名が空" in w for w in warnings)
+
+
+# ==================================================
+# 実行層
+# ==================================================
+class TestMigrate:
+
+    def test_dry_run_does_not_write(self, sample_csv, db_path):
+        result = mp.migrate_csv_to_portfolio_shelve(
+            sample_csv, dry_run=True, db_path=db_path
+        )
+        assert result["total"] == 3
+        assert result["saved"] == 3
+        assert result["skipped"] == 0
+        # DB は空のまま
+        records = ps.list_records(db_path=db_path)
+        assert records == []
+
+    def test_writes_records(self, sample_csv, db_path):
+        result = mp.migrate_csv_to_portfolio_shelve(
+            sample_csv, dry_run=False, db_path=db_path
+        )
+        assert result["saved"] == 3
+        records = ps.list_records(db_path=db_path)
+        codes = sorted(r["code_s"] for r in records)
+        assert codes == ["215A", "4377", "7089"]
+
+    def test_records_initial_log(self, sample_csv, db_path):
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        for code in ["4377", "7089", "215A"]:
+            logs = ps.list_action_logs(code, db_path=db_path)
+            assert len(logs) == 1
+            assert logs[0]["action_type"] == "初回登録"
+            assert logs[0]["status_to"] == "3監"
+            assert logs[0]["reason"] == "スプシ移行"
+
+    def test_memo_preserves_multiline(self, sample_csv, db_path):
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        rec = ps.get_record("4377", db_path=db_path)
+        assert "\n" in rec["memo"]["gyoutai_theme"]
+        assert rec["memo"]["takaichi_sensitivity"] == "C:給付付き税額控除"
+
+    def test_skips_invalid_rows(self, tmp_path, db_path):
+        csv_path = tmp_path / "with_invalid.csv"
+        rows = [
+            [""] * mp.EXPECTED_COL_COUNT,
+            ["銘柄コード"] + [""] * (mp.EXPECTED_COL_COUNT - 1),
+            _make_row(code_s="4377", stock_name="OK"),
+            _make_row(code_s="ABC1", stock_name="不正コード"),
+            _make_row(stock_name="コード空"),
+            _make_row(code_s="7089", stock_name="OK2"),
+        ]
+        with open(csv_path, "w", encoding="utf-8", newline="") as f:
+            csv.writer(f).writerows(rows)
+        result = mp.migrate_csv_to_portfolio_shelve(
+            str(csv_path), db_path=db_path
+        )
+        assert result["saved"] == 2
+        assert result["skipped"] == 2
+
+    def test_rerun_does_not_duplicate_log(self, sample_csv, db_path):
+        """再実行しても 初回登録 ログは増えない (既存判定)"""
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 1

--- a/tests/test_migrate_portfolio_from_csv.py
+++ b/tests/test_migrate_portfolio_from_csv.py
@@ -151,7 +151,7 @@ class TestBuildRecordFromRow:
         rec, warnings = mp.build_record_from_row(row)
         assert rec is not None
         assert rec["code_s"] == "4377"
-        assert rec["stock_name"] == "ワンキャリア"
+        assert "stock_name" not in rec  # 新スキーマでは保存しない
         assert rec["status"] == "3監"  # 仮ステータス
         assert warnings == []
 
@@ -188,8 +188,8 @@ class TestBuildRecordFromRow:
         row = _make_row(code_s="4377")
         rec, warnings = mp.build_record_from_row(row)
         assert rec is not None
-        assert rec["stock_name"] == ""
-        assert any("銘柄名が空" in w for w in warnings)
+        assert "stock_name" not in rec  # 新スキーマでは保存しない
+        assert any("銘柄名" in w for w in warnings)
 
 
 # ==================================================

--- a/tests/test_migrate_portfolio_from_csv.py
+++ b/tests/test_migrate_portfolio_from_csv.py
@@ -232,6 +232,32 @@ class TestMigrate:
         assert "\n" in rec["memo"]["gyoutai_theme"]
         assert rec["memo"]["takaichi_sensitivity"] == "C:給付付き税額控除"
 
+    def test_preserve_existing_status(self, sample_csv, db_path):
+        """既存レコードに 1保 / 2準 がある時、再インポートで status を保持する"""
+        # 1 回目: 通常移行 (全部 3監)
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        # 4377 を 1保 に変更
+        ps.transition_status("4377", "1保", db_path=db_path)
+
+        # 2 回目: preserve_existing_status=True で再インポート
+        mp.migrate_csv_to_portfolio_shelve(
+            sample_csv, db_path=db_path, preserve_existing_status=True,
+            record_initial_log=False,
+        )
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["status"] == "1保"  # 保持される
+
+    def test_preserve_existing_status_off_resets_status(self, sample_csv, db_path):
+        """preserve_existing_status=False (デフォルト) では既存 status が 3監 にリセットされる"""
+        mp.migrate_csv_to_portfolio_shelve(sample_csv, db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+
+        mp.migrate_csv_to_portfolio_shelve(
+            sample_csv, db_path=db_path, record_initial_log=False,
+        )
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["status"] == "3監"
+
     def test_skips_invalid_rows(self, tmp_path, db_path):
         csv_path = tmp_path / "with_invalid.csv"
         rows = [

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -52,7 +52,7 @@ class TestFallbackToTxt:
     def test_uses_shelve_when_populated(self, isolated_data_dir):
         """shelve に登録があれば shelve を使う (txt は無関係)"""
         # shelve に書き込み
-        ps.add_to_watch("7047", "ポート")
+        ps.add_to_watch("7047")
         ps.transition_status("7047", "1保")
         # txt とは別の銘柄
         _write_txt(isolated_data_dir, "H9999別銘柄\n")
@@ -127,16 +127,16 @@ class TestStep1CompatibilityWithTxtOnly:
 class TestReturnTypeAndOrder:
 
     def test_returns_two_lists(self, isolated_data_dir):
-        ps.add_to_watch("7047", "ポート")
+        ps.add_to_watch("7047")
         watch, hold = portfolio.parse_my_portforio()
         assert isinstance(watch, list)
         assert isinstance(hold, list)
 
     def test_sorted_by_code_s(self, isolated_data_dir):
         for code in ["7089", "4377", "215A"]:
-            ps.add_to_watch(code, code)
+            ps.add_to_watch(code)
         for code in ["7047", "2980", "402A"]:
-            ps.add_to_watch(code, code)
+            ps.add_to_watch(code)
             ps.transition_status(code, "1保")
 
         watch, hold = portfolio.parse_my_portforio()
@@ -146,7 +146,7 @@ class TestReturnTypeAndOrder:
 
     def test_2jun_treated_as_watch(self, isolated_data_dir):
         """2準 はウォッチ側に含まれる (txt には 2準 がないが、shelve 経由では発生する)"""
-        ps.add_to_watch("7047", "ポート")
+        ps.add_to_watch("7047")
         ps.transition_status("7047", "2準")
         watch, hold = portfolio.parse_my_portforio()
         assert "7047" in watch
@@ -173,7 +173,7 @@ class TestStep2SetRelation:
         old_set = set(old_watch) | set(old_hold)
 
         # スプシのみの銘柄を追加
-        ps.add_to_watch("4377", "スプシ追加銘柄")  # 3監
+        ps.add_to_watch("4377")  # 3監
 
         # 新 parse の集合
         new_watch, new_hold = portfolio.parse_my_portforio()

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,185 @@
+"""portfolio.py の parse_my_portforio() 互換性テスト。
+
+§3-4-1 Step 1: txt のみを取り込んだ portfolio_shelve に対し、
+新実装 (shelve 参照) と旧実装 (txt 直接パース) で **集合一致** を保証する。
+"""
+
+import os
+
+import pytest
+
+import portfolio
+import portfolio_shelve as ps
+import migrate_my_watch_list_to_shelve as mw
+
+
+# ==================================================
+# fixtures
+# ==================================================
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """portfolio.py が参照する DATA_DIR を一時ディレクトリに差し替える。
+
+    portfolio_shelve のパスも tmp_path 配下に変更し、テスト同士が干渉しないようにする。
+    """
+    monkeypatch.setattr(portfolio, "DATA_DIR", str(tmp_path))
+    # portfolio_shelve のグローバルパスを差し替えてテスト用 DB を使う
+    test_db_path = str(tmp_path / "portfolio_shelve")
+    monkeypatch.setattr(ps, "PORTFOLIO_SHELVE", test_db_path)
+    return tmp_path
+
+
+def _write_txt(tmp_path, content):
+    txt = tmp_path / "my_watch_list.txt"
+    with open(txt, "w", encoding="utf-8") as f:
+        f.write(content)
+    return str(txt)
+
+
+# ==================================================
+# フォールバック: shelve 空 / 障害時に txt 経由で動く
+# ==================================================
+class TestFallbackToTxt:
+
+    def test_falls_back_to_txt_when_shelve_empty(self, isolated_data_dir):
+        """portfolio_shelve が空なら旧実装 (txt) を使う"""
+        _write_txt(isolated_data_dir, "H7047ポート\n5032AnyColor\n")
+        watch, hold = portfolio.parse_my_portforio()
+        assert "7047" in hold
+        assert "5032" in watch
+
+    def test_uses_shelve_when_populated(self, isolated_data_dir):
+        """shelve に登録があれば shelve を使う (txt は無関係)"""
+        # shelve に書き込み
+        ps.add_to_watch("7047", "ポート")
+        ps.transition_status("7047", "1保")
+        # txt とは別の銘柄
+        _write_txt(isolated_data_dir, "H9999別銘柄\n")
+        watch, hold = portfolio.parse_my_portforio()
+        # shelve 由来のみ返る、txt の 9999 は無視
+        assert hold == ["7047"]
+        assert watch == []
+
+
+# ==================================================
+# Step 1 互換性: txt のみ取り込み → 集合一致
+# ==================================================
+class TestStep1CompatibilityWithTxtOnly:
+    """§3-4-1 Step 1: portfolio_shelve に txt のみを取り込んだ状態で、
+    旧実装 (txt 直接) と新実装 (shelve 参照) の戻り値の **集合が一致** することを確認。
+    """
+
+    def test_basic_compatibility(self, isolated_data_dir):
+        txt_content = (
+            "H7047ポート\n"
+            "H4377ワンキャリア\n"
+            "H402Aアクセルスペース\n"
+            "5032AnyColor\n"
+            "6232ACSL\n"
+            "5243note\n"
+        )
+        txt_path = _write_txt(isolated_data_dir, txt_content)
+
+        # 旧実装相当 (txt 直接 parse)
+        old_watch, old_hold = portfolio._parse_my_portforio_from_txt()
+
+        # txt を portfolio_shelve に取り込み
+        mw.import_my_watch_list(txt_path)
+
+        # 新実装 (shelve 参照)
+        new_watch, new_hold = portfolio.parse_my_portforio()
+
+        # 集合が完全一致
+        assert set(old_watch) == set(new_watch)
+        assert set(old_hold) == set(new_hold)
+
+    def test_empty_txt(self, isolated_data_dir):
+        _write_txt(isolated_data_dir, "")
+        old_watch, old_hold = portfolio._parse_my_portforio_from_txt()
+        new_watch, new_hold = portfolio.parse_my_portforio()
+        # 旧 (txt 空) と新 (shelve 空 → txt フォールバック → 空) で一致
+        assert old_watch == new_watch == []
+        assert old_hold == new_hold == []
+
+    def test_only_holds(self, isolated_data_dir):
+        txt_path = _write_txt(
+            isolated_data_dir, "H7047ポート\nH4377ワンキャリア\n"
+        )
+        mw.import_my_watch_list(txt_path)
+        watch, hold = portfolio.parse_my_portforio()
+        assert set(watch) == set()
+        assert set(hold) == {"7047", "4377"}
+
+    def test_only_watch(self, isolated_data_dir):
+        txt_path = _write_txt(
+            isolated_data_dir, "5032AnyColor\n6232ACSL\n"
+        )
+        mw.import_my_watch_list(txt_path)
+        watch, hold = portfolio.parse_my_portforio()
+        assert set(watch) == {"5032", "6232"}
+        assert set(hold) == set()
+
+
+# ==================================================
+# 戻り値の型・順序保証
+# ==================================================
+class TestReturnTypeAndOrder:
+
+    def test_returns_two_lists(self, isolated_data_dir):
+        ps.add_to_watch("7047", "ポート")
+        watch, hold = portfolio.parse_my_portforio()
+        assert isinstance(watch, list)
+        assert isinstance(hold, list)
+
+    def test_sorted_by_code_s(self, isolated_data_dir):
+        for code in ["7089", "4377", "215A"]:
+            ps.add_to_watch(code, code)
+        for code in ["7047", "2980", "402A"]:
+            ps.add_to_watch(code, code)
+            ps.transition_status(code, "1保")
+
+        watch, hold = portfolio.parse_my_portforio()
+        # code_s 昇順 (決定論的)
+        assert watch == sorted(watch)
+        assert hold == sorted(hold)
+
+    def test_2jun_treated_as_watch(self, isolated_data_dir):
+        """2準 はウォッチ側に含まれる (txt には 2準 がないが、shelve 経由では発生する)"""
+        ps.add_to_watch("7047", "ポート")
+        ps.transition_status("7047", "2準")
+        watch, hold = portfolio.parse_my_portforio()
+        assert "7047" in watch
+        assert "7047" not in hold
+
+
+# ==================================================
+# Step 2 互換性: 集合関係の確認
+# ==================================================
+class TestStep2SetRelation:
+    """§3-4-1 Step 2: スプシ移行後、新 parse は旧 parse の集合を **上回る** ことを確認。
+    増分はスプシ由来銘柄のみ。
+    """
+
+    def test_new_set_is_superset(self, isolated_data_dir):
+        """txt + スプシ追加銘柄を取り込んだ shelve は txt のみ集合を包含する"""
+        # txt 由来
+        txt_path = _write_txt(
+            isolated_data_dir, "H7047ポート\n5032AnyColor\n"
+        )
+        mw.import_my_watch_list(txt_path)
+        # txt のみ集合 (旧実装相当)
+        old_watch, old_hold = portfolio._parse_my_portforio_from_txt()
+        old_set = set(old_watch) | set(old_hold)
+
+        # スプシのみの銘柄を追加
+        ps.add_to_watch("4377", "スプシ追加銘柄")  # 3監
+
+        # 新 parse の集合
+        new_watch, new_hold = portfolio.parse_my_portforio()
+        new_set = set(new_watch) | set(new_hold)
+
+        # 旧 ⊆ 新
+        assert old_set <= new_set
+        # 増分はスプシ由来 (4377) のみ
+        assert new_set - old_set == {"4377"}

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1,0 +1,415 @@
+"""portfolio_shelve.py のテスト (tmp_path で一時DBを作成)"""
+
+import pytest
+
+import portfolio_shelve as ps
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """テスト用一時DBパスを返す"""
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+# ==================================================
+# スキーマ層: 正規化・バリデーション・ファクトリ
+# ==================================================
+class TestSchema:
+    """スキーマ層のユニットテスト"""
+
+    def test_normalize_code_s_strips_and_uppercases(self):
+        assert ps.normalize_code_s(" 6324 ") == "6324"
+        assert ps.normalize_code_s("215a") == "215A"
+
+    def test_normalize_code_s_rejects_non_str(self):
+        with pytest.raises(TypeError):
+            ps.normalize_code_s(6324)
+
+    def test_validate_code_s_accepts_valid(self):
+        ps.validate_code_s("6324")
+        ps.validate_code_s("215A")
+        ps.validate_code_s("0001")
+
+    def test_validate_code_s_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            ps.validate_code_s("63")
+        with pytest.raises(ValueError):
+            ps.validate_code_s("12345")
+
+    def test_validate_status_accepts_valid(self):
+        for s in ("1保", "2準", "3監"):
+            ps.validate_status(s)
+
+    def test_validate_status_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            ps.validate_status("4売")
+        with pytest.raises(ValueError):
+            ps.validate_status("hold")
+
+    def test_validate_action_type_accepts_valid(self):
+        for t in ("初回登録", "ステータス変更", "売却", "削除"):
+            ps.validate_action_type(t)
+
+    def test_validate_action_type_rejects_invalid(self):
+        with pytest.raises(ValueError):
+            ps.validate_action_type("追加")
+
+    def test_validate_transition_allowed(self):
+        ps.validate_transition(None, "3監")          # 新規追加
+        ps.validate_transition("3監", "2準")          # 格上げ
+        ps.validate_transition("2準", "1保")          # 買い
+        ps.validate_transition("1保", "2準")          # 売却
+        ps.validate_transition("2準", "3監")          # 格下げ
+        ps.validate_transition("3監", "1保")          # 直接保有
+
+    def test_validate_transition_forbidden(self):
+        # 1保/2準 への直接登録は禁止
+        with pytest.raises(ValueError):
+            ps.validate_transition(None, "1保")
+        with pytest.raises(ValueError):
+            ps.validate_transition(None, "2準")
+
+    def test_create_memo_defaults(self):
+        memo = ps.create_memo()
+        assert set(memo.keys()) == ps.MEMO_FIELDS
+        assert all(v == "" for v in memo.values())
+
+    def test_create_memo_partial(self):
+        memo = ps.create_memo(gyoutai_theme="人材", trade_idea="押し目買い")
+        assert memo["gyoutai_theme"] == "人材"
+        assert memo["trade_idea"] == "押し目買い"
+        assert memo["watch_in_reason"] == ""
+
+    def test_create_record_minimal(self):
+        rec = ps.create_record("4377", "ワンキャリア")
+        assert rec["code_s"] == "4377"
+        assert rec["stock_name"] == "ワンキャリア"
+        assert rec["status"] == "3監"
+        assert rec["registered_at"]
+        assert rec["updated_at"] == rec["registered_at"]
+        assert set(rec["memo"].keys()) == ps.MEMO_FIELDS
+
+    def test_create_record_with_explicit_status(self):
+        rec = ps.create_record("4377", "ワンキャリア", status="1保")
+        assert rec["status"] == "1保"
+
+    def test_create_record_invalid_status(self):
+        with pytest.raises(ValueError):
+            ps.create_record("4377", "ワンキャリア", status="未定")
+
+
+# ==================================================
+# 高レベル操作: add_to_watch
+# ==================================================
+class TestAddToWatch:
+
+    def test_add_to_watch_creates_record(self, db_path):
+        rec = ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        assert rec["code_s"] == "4377"
+        assert rec["status"] == "3監"
+
+        loaded = ps.get_record("4377", db_path=db_path)
+        assert loaded is not None
+        assert loaded["stock_name"] == "ワンキャリア"
+
+    def test_add_to_watch_records_initial_log(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path, reason="新規登録")
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 1
+        assert logs[0]["action_type"] == "初回登録"
+        assert logs[0]["status_from"] is None
+        assert logs[0]["status_to"] == "3監"
+        assert logs[0]["reason"] == "新規登録"
+        assert logs[0]["seq"] == 1
+
+    def test_add_to_watch_duplicate_raises(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+
+    def test_add_to_watch_normalizes_code_s(self, db_path):
+        ps.add_to_watch("215a", "テスト銘柄", db_path=db_path)
+        loaded = ps.get_record("215A", db_path=db_path)
+        assert loaded is not None
+        assert loaded["code_s"] == "215A"
+
+
+# ==================================================
+# 高レベル操作: transition_status
+# ==================================================
+class TestTransitionStatus:
+
+    def test_transition_3kan_to_2jun(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        rec = ps.transition_status(
+            "4377", "2準", reason="そろそろ買う", db_path=db_path
+        )
+        assert rec["status"] == "2準"
+
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 2  # 初回登録 + ステータス変更
+        assert logs[1]["action_type"] == "ステータス変更"
+        assert logs[1]["status_from"] == "3監"
+        assert logs[1]["status_to"] == "2準"
+
+    def test_transition_1ho_to_2jun_records_uri_kyaku(self, db_path):
+        """1保 -> 2準 は売却として記録される"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        ps.transition_status("4377", "2準", reason="決算後売り", db_path=db_path)
+
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        # 初回登録 + 3監->1保 + 1保->2準 = 3件
+        assert len(logs) == 3
+        assert logs[2]["action_type"] == "売却"
+        assert logs[2]["status_from"] == "1保"
+        assert logs[2]["status_to"] == "2準"
+
+    def test_transition_to_1ho_directly_from_3kan(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        rec = ps.transition_status("4377", "1保", db_path=db_path)
+        assert rec["status"] == "1保"
+
+    def test_transition_invalid_path_rejected(self, db_path):
+        """禁止遷移は ValueError"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        # 3監 -> 3監 は同一遷移として ALLOWED に入っていないので禁止
+        # ただし transition_status は同一ステータスなら no-op としているため
+        # ここでは別の禁止パターンを試す。実装の ALLOWED_TRANSITIONS 上、
+        # すべての非同一遷移は許可されているので、不正遷移は同一以外発生しない。
+        # 同一遷移は no-op で通過するので、代わりに未登録銘柄のチェック。
+        with pytest.raises(KeyError):
+            ps.transition_status("9999", "2準", db_path=db_path)
+
+    def test_transition_same_status_is_noop(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "3監", db_path=db_path)  # no-op
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 1  # 初回登録だけ、ステータス変更ログは出ない
+
+
+# ==================================================
+# 高レベル操作: delete_record
+# ==================================================
+class TestDeleteRecord:
+
+    def test_delete_3kan_succeeds(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ok = ps.delete_record("4377", reason="興味なくなった", db_path=db_path)
+        assert ok is True
+        assert ps.get_record("4377", db_path=db_path) is None
+
+    def test_delete_records_log_after_record_gone(self, db_path):
+        """削除しても action_log は残る"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.delete_record("4377", reason="不要", db_path=db_path)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        # 初回登録 + 削除 = 2件
+        assert len(logs) == 2
+        assert logs[1]["action_type"] == "削除"
+        assert logs[1]["reason"] == "不要"
+
+    def test_delete_1ho_rejected(self, db_path):
+        """1保 から直接削除は禁止"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.delete_record("4377", db_path=db_path)
+        # レコードは残っている
+        assert ps.get_record("4377", db_path=db_path) is not None
+
+    def test_delete_2jun_rejected(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.delete_record("4377", db_path=db_path)
+
+    def test_delete_nonexistent_returns_false(self, db_path):
+        ok = ps.delete_record("4377", db_path=db_path)
+        assert ok is False
+
+
+# ==================================================
+# list_records / list_action_logs
+# ==================================================
+class TestListing:
+
+    def test_list_records_filters_by_status(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.transition_status("7089", "1保", db_path=db_path)
+
+        watch = ps.list_records(status="3監", db_path=db_path)
+        hold = ps.list_records(status="1保", db_path=db_path)
+        all_recs = ps.list_records(db_path=db_path)
+
+        assert [r["code_s"] for r in watch] == ["4377"]
+        assert [r["code_s"] for r in hold] == ["7089"]
+        assert [r["code_s"] for r in all_recs] == ["4377", "7089"]
+
+    def test_list_records_sorted_by_code_s(self, db_path):
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("215A", "アクセルスペース", db_path=db_path)
+
+        recs = ps.list_records(db_path=db_path)
+        assert [r["code_s"] for r in recs] == ["215A", "4377", "7089"]
+
+    def test_list_action_logs_per_code(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+
+        logs_4377 = ps.list_action_logs("4377", db_path=db_path)
+        logs_7089 = ps.list_action_logs("7089", db_path=db_path)
+        all_logs = ps.list_action_logs(db_path=db_path)
+
+        assert len(logs_4377) == 2
+        assert len(logs_7089) == 1
+        assert len(all_logs) == 3
+
+    def test_list_action_logs_sorted_by_seq(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        # seq が二桁・三桁で正しく順序が保たれることを確認するため複数遷移
+        for next_status in ["2準", "1保", "2準", "1保", "2準", "3監", "2準"]:
+            ps.transition_status("4377", next_status, db_path=db_path)
+
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        seqs = [log["seq"] for log in logs]
+        assert seqs == sorted(seqs)
+
+
+# ==================================================
+# upsert_record (移行スクリプト用)
+# ==================================================
+class TestUpsertRecord:
+
+    def test_upsert_record_creates_without_log(self, db_path):
+        rec = ps.create_record("4377", "ワンキャリア")
+        ps.upsert_record(rec, db_path=db_path)
+        loaded = ps.get_record("4377", db_path=db_path)
+        assert loaded is not None
+        # upsert は ログを残さない (移行用)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert logs == []
+
+    def test_upsert_record_overwrites(self, db_path):
+        rec1 = ps.create_record("4377", "ワンキャリア", status="3監")
+        ps.upsert_record(rec1, db_path=db_path)
+        rec2 = ps.create_record("4377", "ワンキャリア改名", status="1保")
+        ps.upsert_record(rec2, db_path=db_path)
+
+        loaded = ps.get_record("4377", db_path=db_path)
+        assert loaded["stock_name"] == "ワンキャリア改名"
+        assert loaded["status"] == "1保"
+
+    def test_upsert_record_requires_code_s(self, db_path):
+        with pytest.raises(ValueError):
+            ps.upsert_record({"stock_name": "x"}, db_path=db_path)
+
+
+# ==================================================
+# キー名前空間の独立性
+# ==================================================
+class TestKeyNamespaceIsolation:
+
+    def test_action_log_persists_after_delete(self, db_path):
+        """レコード削除後も action_log は残るかつ他キーに影響しない"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.delete_record("4377", db_path=db_path)
+
+        # 4377 のレコードはなくなる
+        assert ps.get_record("4377", db_path=db_path) is None
+        # 4377 のログは残る (初回登録 + 削除)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 2
+        # 7089 は無事
+        assert ps.get_record("7089", db_path=db_path) is not None
+
+    def test_seq_counter_isolated_per_code(self, db_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+        ps.transition_status("7089", "2準", db_path=db_path)
+
+        logs_4377 = ps.list_action_logs("4377", db_path=db_path)
+        logs_7089 = ps.list_action_logs("7089", db_path=db_path)
+        # seq は銘柄ごとに独立 (両方 1, 2 になる)
+        assert [log["seq"] for log in logs_4377] == [1, 2]
+        assert [log["seq"] for log in logs_7089] == [1, 2]
+
+
+# ==================================================
+# my_watch_list.txt 一方向同期
+# ==================================================
+class TestSyncToTxt:
+
+    def test_sync_writes_holds_with_h_prefix(self, db_path, tmp_path):
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.transition_status("7089", "1保", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        # 1保 が H 接頭辞付きで code_s 昇順に並ぶ
+        assert "H4377ワンキャリア" in content
+        assert "H7089フォースタートアップス" in content
+        # 4377 が 7089 より先に来る
+        assert content.index("H4377") < content.index("H7089")
+
+    def test_sync_writes_watch_without_prefix(self, db_path, tmp_path):
+        ps.add_to_watch("5032", "AnyColor", db_path=db_path)
+        ps.add_to_watch("6232", "ACSL", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        assert "5032AnyColor" in content
+        assert "6232ACSL" in content
+        # H 接頭辞は付かない
+        assert "H5032" not in content
+
+    def test_sync_separates_holds_from_others(self, db_path, tmp_path):
+        ps.add_to_watch("4377", "保有銘柄", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        ps.add_to_watch("5032", "ウォッチ銘柄", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        # 1保 → 空行 → 3監 の順 (現行 my_watch_list.txt の見た目互換)
+        h_pos = content.index("H4377")
+        w_pos = content.index("5032ウォッチ銘柄")
+        assert h_pos < w_pos
+        # 間に空行あり
+        between = content[h_pos:w_pos]
+        assert "\n\n" in between
+
+    def test_sync_treats_2jun_as_watch(self, db_path, tmp_path):
+        """2準 は H 接頭辞なしで書き出される (txt は 2 値)"""
+        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        # H 接頭辞なし
+        assert "4377ワンキャリア" in content
+        assert "H4377" not in content
+
+    def test_sync_empty_db_writes_empty_file(self, db_path, tmp_path):
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+        with open(txt_path, encoding="utf-8") as f:
+            assert f.read() == ""

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -341,6 +341,105 @@ class TestKeyNamespaceIsolation:
 
 
 # ==================================================
+# 高レベル操作: update_memo (部分更新)
+# ==================================================
+class TestUpdateMemo:
+
+    def test_update_single_field(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        rec = ps.update_memo("4377", {"trade_idea": "上値追い"}, db_path=db_path)
+        assert rec["memo"]["trade_idea"] == "上値追い"
+        # action_log に "メモ更新" 1 件 (初回登録 1 件 + メモ更新 1 件 = 計 2 件)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 2
+        assert logs[1]["action_type"] == "メモ更新"
+        assert logs[1]["status_from"] is None
+        assert logs[1]["status_to"] is None
+
+    def test_update_partial_keeps_other_fields(self, db_path):
+        """部分更新: fields に含まれないキーは現行値据え置き (codex P1 対応)"""
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.update_memo(
+            "4377",
+            {"trade_idea": "A", "watch_in_reason": "B", "stage": "1S"},
+            db_path=db_path,
+        )
+        # 1 項目だけ送信、残りは据え置きされるべき
+        rec = ps.update_memo("4377", {"trade_idea": "X"}, db_path=db_path)
+        assert rec["memo"]["trade_idea"] == "X"
+        assert rec["memo"]["watch_in_reason"] == "B"  # 据え置き
+        assert rec["memo"]["stage"] == "1S"           # 据え置き
+
+    def test_update_with_empty_string_overwrites(self, db_path):
+        """空文字を明示的に渡したらメモ削除として "" に上書き"""
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "上値追い"}, db_path=db_path)
+        rec = ps.update_memo("4377", {"trade_idea": ""}, db_path=db_path)
+        assert rec["memo"]["trade_idea"] == ""
+        # action_log: 初回登録 + メモ更新×2 = 3 件
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 3
+
+    def test_update_with_none_normalizes_to_empty_string(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        rec = ps.update_memo("4377", {"trade_idea": None}, db_path=db_path)
+        assert rec["memo"]["trade_idea"] == ""
+
+    def test_update_all_eight_fields(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        all_fields = {f: f"val_{f}" for f in ps.MEMO_FIELDS}
+        rec = ps.update_memo("4377", all_fields, db_path=db_path)
+        for k, v in all_fields.items():
+            assert rec["memo"][k] == v
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len([log for log in logs if log["action_type"] == "メモ更新"]) == 1
+
+    def test_update_no_diff_is_noop(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "上値追い"}, db_path=db_path)
+        rec_before = ps.get_record("4377", db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "上値追い"}, db_path=db_path)
+        rec_after = ps.get_record("4377", db_path=db_path)
+        # updated_at が変わらない (no-op)
+        assert rec_before["updated_at"] == rec_after["updated_at"]
+        # action_log: 初回登録 + メモ更新×1 のみ (no-op で増えない)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len([log for log in logs if log["action_type"] == "メモ更新"]) == 1
+
+    def test_update_empty_dict_is_noop(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        rec = ps.update_memo("4377", {}, db_path=db_path)
+        # KeyError なし、no-op として現行 record を返す
+        assert rec["code_s"] == "4377"
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len([log for log in logs if log["action_type"] == "メモ更新"]) == 0
+
+    def test_update_unknown_field_raises(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.update_memo("4377", {"unknown_field": "x"}, db_path=db_path)
+
+    def test_update_non_str_value_raises(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        with pytest.raises(TypeError):
+            ps.update_memo("4377", {"trade_idea": 123}, db_path=db_path)
+
+    def test_update_unregistered_record_raises(self, db_path):
+        with pytest.raises(KeyError):
+            ps.update_memo("9999", {"trade_idea": "X"}, db_path=db_path)
+
+    def test_update_invalid_code_s_raises(self, db_path):
+        with pytest.raises(ValueError):
+            ps.update_memo("abc", {"trade_idea": "X"}, db_path=db_path)
+
+    def test_update_normalizes_code_s(self, db_path):
+        ps.add_to_watch("215A", db_path=db_path)
+        rec = ps.update_memo("215a", {"trade_idea": "X"}, db_path=db_path)
+        assert rec["code_s"] == "215A"
+        assert rec["memo"]["trade_idea"] == "X"
+
+
+# ==================================================
 # my_watch_list.txt 一方向同期
 # ==================================================
 @pytest.fixture

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -420,7 +420,7 @@ class TestSyncToTxt:
         between = content[h_pos:w_pos]
         assert "\n\n" in between
 
-    def test_sync_treats_2jun_as_watch(self, db_path, tmp_path):
+    def test_sync_treats_2jun_as_watch(self, db_path, tmp_path, stocks_db_for_sync):
         """2準 は H 接頭辞なしで書き出される (txt は 2 値)"""
         ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "2準", db_path=db_path)

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -81,21 +81,21 @@ class TestSchema:
         assert memo["watch_in_reason"] == ""
 
     def test_create_record_minimal(self):
-        rec = ps.create_record("4377", "ワンキャリア")
+        rec = ps.create_record("4377")
         assert rec["code_s"] == "4377"
-        assert rec["stock_name"] == "ワンキャリア"
+        assert "stock_name" not in rec  # 新スキーマでは銘柄名を持たない
         assert rec["status"] == "3監"
         assert rec["registered_at"]
         assert rec["updated_at"] == rec["registered_at"]
         assert set(rec["memo"].keys()) == ps.MEMO_FIELDS
 
     def test_create_record_with_explicit_status(self):
-        rec = ps.create_record("4377", "ワンキャリア", status="1保")
+        rec = ps.create_record("4377", status="1保")
         assert rec["status"] == "1保"
 
     def test_create_record_invalid_status(self):
         with pytest.raises(ValueError):
-            ps.create_record("4377", "ワンキャリア", status="未定")
+            ps.create_record("4377", status="未定")
 
 
 # ==================================================
@@ -104,16 +104,17 @@ class TestSchema:
 class TestAddToWatch:
 
     def test_add_to_watch_creates_record(self, db_path):
-        rec = ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        rec = ps.add_to_watch("4377", db_path=db_path)
         assert rec["code_s"] == "4377"
         assert rec["status"] == "3監"
+        assert "stock_name" not in rec  # 新スキーマでは銘柄名を持たない
 
         loaded = ps.get_record("4377", db_path=db_path)
         assert loaded is not None
-        assert loaded["stock_name"] == "ワンキャリア"
+        assert "stock_name" not in loaded
 
     def test_add_to_watch_records_initial_log(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path, reason="新規登録")
+        ps.add_to_watch("4377", db_path=db_path, reason="新規登録")
         logs = ps.list_action_logs("4377", db_path=db_path)
         assert len(logs) == 1
         assert logs[0]["action_type"] == "初回登録"
@@ -123,12 +124,12 @@ class TestAddToWatch:
         assert logs[0]["seq"] == 1
 
     def test_add_to_watch_duplicate_raises(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         with pytest.raises(ValueError):
-            ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+            ps.add_to_watch("4377", db_path=db_path)
 
     def test_add_to_watch_normalizes_code_s(self, db_path):
-        ps.add_to_watch("215a", "テスト銘柄", db_path=db_path)
+        ps.add_to_watch("215a", db_path=db_path)
         loaded = ps.get_record("215A", db_path=db_path)
         assert loaded is not None
         assert loaded["code_s"] == "215A"
@@ -140,7 +141,7 @@ class TestAddToWatch:
 class TestTransitionStatus:
 
     def test_transition_3kan_to_2jun(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         rec = ps.transition_status(
             "4377", "2準", reason="そろそろ買う", db_path=db_path
         )
@@ -154,7 +155,7 @@ class TestTransitionStatus:
 
     def test_transition_1ho_to_2jun_records_uri_kyaku(self, db_path):
         """1保 -> 2準 は売却として記録される"""
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "1保", db_path=db_path)
         ps.transition_status("4377", "2準", reason="決算後売り", db_path=db_path)
 
@@ -166,13 +167,13 @@ class TestTransitionStatus:
         assert logs[2]["status_to"] == "2準"
 
     def test_transition_to_1ho_directly_from_3kan(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         rec = ps.transition_status("4377", "1保", db_path=db_path)
         assert rec["status"] == "1保"
 
     def test_transition_invalid_path_rejected(self, db_path):
         """禁止遷移は ValueError"""
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         # 3監 -> 3監 は同一遷移として ALLOWED に入っていないので禁止
         # ただし transition_status は同一ステータスなら no-op としているため
         # ここでは別の禁止パターンを試す。実装の ALLOWED_TRANSITIONS 上、
@@ -182,7 +183,7 @@ class TestTransitionStatus:
             ps.transition_status("9999", "2準", db_path=db_path)
 
     def test_transition_same_status_is_noop(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "3監", db_path=db_path)  # no-op
         logs = ps.list_action_logs("4377", db_path=db_path)
         assert len(logs) == 1  # 初回登録だけ、ステータス変更ログは出ない
@@ -194,14 +195,14 @@ class TestTransitionStatus:
 class TestDeleteRecord:
 
     def test_delete_3kan_succeeds(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         ok = ps.delete_record("4377", reason="興味なくなった", db_path=db_path)
         assert ok is True
         assert ps.get_record("4377", db_path=db_path) is None
 
     def test_delete_records_log_after_record_gone(self, db_path):
         """削除しても action_log は残る"""
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         ps.delete_record("4377", reason="不要", db_path=db_path)
         logs = ps.list_action_logs("4377", db_path=db_path)
         # 初回登録 + 削除 = 2件
@@ -211,7 +212,7 @@ class TestDeleteRecord:
 
     def test_delete_1ho_rejected(self, db_path):
         """1保 から直接削除は禁止"""
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "1保", db_path=db_path)
         with pytest.raises(ValueError):
             ps.delete_record("4377", db_path=db_path)
@@ -219,7 +220,7 @@ class TestDeleteRecord:
         assert ps.get_record("4377", db_path=db_path) is not None
 
     def test_delete_2jun_rejected(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "2準", db_path=db_path)
         with pytest.raises(ValueError):
             ps.delete_record("4377", db_path=db_path)
@@ -235,8 +236,8 @@ class TestDeleteRecord:
 class TestListing:
 
     def test_list_records_filters_by_status(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
-        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.add_to_watch("7089", db_path=db_path)
         ps.transition_status("7089", "1保", db_path=db_path)
 
         watch = ps.list_records(status="3監", db_path=db_path)
@@ -248,16 +249,16 @@ class TestListing:
         assert [r["code_s"] for r in all_recs] == ["4377", "7089"]
 
     def test_list_records_sorted_by_code_s(self, db_path):
-        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
-        ps.add_to_watch("215A", "アクセルスペース", db_path=db_path)
+        ps.add_to_watch("7089", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.add_to_watch("215A", db_path=db_path)
 
         recs = ps.list_records(db_path=db_path)
         assert [r["code_s"] for r in recs] == ["215A", "4377", "7089"]
 
     def test_list_action_logs_per_code(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
-        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.add_to_watch("7089", db_path=db_path)
         ps.transition_status("4377", "2準", db_path=db_path)
 
         logs_4377 = ps.list_action_logs("4377", db_path=db_path)
@@ -269,7 +270,7 @@ class TestListing:
         assert len(all_logs) == 3
 
     def test_list_action_logs_sorted_by_seq(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         # seq が二桁・三桁で正しく順序が保たれることを確認するため複数遷移
         for next_status in ["2準", "1保", "2準", "1保", "2準", "3監", "2準"]:
             ps.transition_status("4377", next_status, db_path=db_path)
@@ -285,7 +286,7 @@ class TestListing:
 class TestUpsertRecord:
 
     def test_upsert_record_creates_without_log(self, db_path):
-        rec = ps.create_record("4377", "ワンキャリア")
+        rec = ps.create_record("4377")
         ps.upsert_record(rec, db_path=db_path)
         loaded = ps.get_record("4377", db_path=db_path)
         assert loaded is not None
@@ -294,18 +295,17 @@ class TestUpsertRecord:
         assert logs == []
 
     def test_upsert_record_overwrites(self, db_path):
-        rec1 = ps.create_record("4377", "ワンキャリア", status="3監")
+        rec1 = ps.create_record("4377", status="3監")
         ps.upsert_record(rec1, db_path=db_path)
-        rec2 = ps.create_record("4377", "ワンキャリア改名", status="1保")
+        rec2 = ps.create_record("4377", status="1保")
         ps.upsert_record(rec2, db_path=db_path)
 
         loaded = ps.get_record("4377", db_path=db_path)
-        assert loaded["stock_name"] == "ワンキャリア改名"
         assert loaded["status"] == "1保"
 
     def test_upsert_record_requires_code_s(self, db_path):
         with pytest.raises(ValueError):
-            ps.upsert_record({"stock_name": "x"}, db_path=db_path)
+            ps.upsert_record({"status": "3監"}, db_path=db_path)
 
 
 # ==================================================
@@ -315,8 +315,8 @@ class TestKeyNamespaceIsolation:
 
     def test_action_log_persists_after_delete(self, db_path):
         """レコード削除後も action_log は残るかつ他キーに影響しない"""
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
-        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.add_to_watch("7089", db_path=db_path)
         ps.delete_record("4377", db_path=db_path)
 
         # 4377 のレコードはなくなる
@@ -328,8 +328,8 @@ class TestKeyNamespaceIsolation:
         assert ps.get_record("7089", db_path=db_path) is not None
 
     def test_seq_counter_isolated_per_code(self, db_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
-        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.add_to_watch("7089", db_path=db_path)
         ps.transition_status("4377", "2準", db_path=db_path)
         ps.transition_status("7089", "2準", db_path=db_path)
 
@@ -343,12 +343,38 @@ class TestKeyNamespaceIsolation:
 # ==================================================
 # my_watch_list.txt 一方向同期
 # ==================================================
+@pytest.fixture
+def stocks_db_for_sync(tmp_path, monkeypatch):
+    """sync_to_my_watch_list_txt が銘柄名を引くための stocks_shelve を差し替え。
+
+    銘柄名は portfolio_shelve には保存されないため、sync は stocks_shelve / research_shelve
+    から都度取得する。テストでは tmp_path の stocks_shelve を用意して期待値を入れておく。
+    """
+    from db_shelve import ShelveDB
+
+    stocks_path = str(tmp_path / "test_stocks_shelve")
+    research_path = str(tmp_path / "test_research_shelve")
+    monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_path)
+    monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", research_path)
+
+    name_map = {
+        "4377": "ワンキャリア",
+        "7089": "フォースタートアップス",
+        "5032": "AnyColor",
+        "6232": "ACSL",
+    }
+    with ShelveDB(stocks_path) as db:
+        for code, name in name_map.items():
+            db[code] = {"code_s": code, "stock_name": name}
+    return stocks_path
+
+
 class TestSyncToTxt:
 
-    def test_sync_writes_holds_with_h_prefix(self, db_path, tmp_path):
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+    def test_sync_writes_holds_with_h_prefix(self, db_path, tmp_path, stocks_db_for_sync):
+        ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "1保", db_path=db_path)
-        ps.add_to_watch("7089", "フォースタートアップス", db_path=db_path)
+        ps.add_to_watch("7089", db_path=db_path)
         ps.transition_status("7089", "1保", db_path=db_path)
 
         txt_path = str(tmp_path / "my_watch_list.txt")
@@ -356,15 +382,15 @@ class TestSyncToTxt:
 
         with open(txt_path, encoding="utf-8") as f:
             content = f.read()
-        # 1保 が H 接頭辞付きで code_s 昇順に並ぶ
+        # 1保 が H 接頭辞付きで code_s 昇順に並ぶ。銘柄名は stocks_shelve から引かれる。
         assert "H4377ワンキャリア" in content
         assert "H7089フォースタートアップス" in content
         # 4377 が 7089 より先に来る
         assert content.index("H4377") < content.index("H7089")
 
-    def test_sync_writes_watch_without_prefix(self, db_path, tmp_path):
-        ps.add_to_watch("5032", "AnyColor", db_path=db_path)
-        ps.add_to_watch("6232", "ACSL", db_path=db_path)
+    def test_sync_writes_watch_without_prefix(self, db_path, tmp_path, stocks_db_for_sync):
+        ps.add_to_watch("5032", db_path=db_path)
+        ps.add_to_watch("6232", db_path=db_path)
 
         txt_path = str(tmp_path / "my_watch_list.txt")
         ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
@@ -376,10 +402,10 @@ class TestSyncToTxt:
         # H 接頭辞は付かない
         assert "H5032" not in content
 
-    def test_sync_separates_holds_from_others(self, db_path, tmp_path):
-        ps.add_to_watch("4377", "保有銘柄", db_path=db_path)
+    def test_sync_separates_holds_from_others(self, db_path, tmp_path, stocks_db_for_sync):
+        ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "1保", db_path=db_path)
-        ps.add_to_watch("5032", "ウォッチ銘柄", db_path=db_path)
+        ps.add_to_watch("5032", db_path=db_path)
 
         txt_path = str(tmp_path / "my_watch_list.txt")
         ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
@@ -388,7 +414,7 @@ class TestSyncToTxt:
             content = f.read()
         # 1保 → 空行 → 3監 の順 (現行 my_watch_list.txt の見た目互換)
         h_pos = content.index("H4377")
-        w_pos = content.index("5032ウォッチ銘柄")
+        w_pos = content.index("5032AnyColor")
         assert h_pos < w_pos
         # 間に空行あり
         between = content[h_pos:w_pos]
@@ -396,7 +422,7 @@ class TestSyncToTxt:
 
     def test_sync_treats_2jun_as_watch(self, db_path, tmp_path):
         """2準 は H 接頭辞なしで書き出される (txt は 2 値)"""
-        ps.add_to_watch("4377", "ワンキャリア", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "2準", db_path=db_path)
 
         txt_path = str(tmp_path / "my_watch_list.txt")

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -315,3 +315,93 @@ class TestDeletePost:
         assert resp.status_code == 302
         # 9999 はもとから未登録
         assert ps.get_record("9999", db_path=portfolio_db_path) is None
+
+
+# ==================================================
+# P2 (codex 指摘): 未知コードの監視追加 reject
+# ==================================================
+class TestAddUnknownCodeRejected:
+    """stocks_shelve に未登録のコードは reject されるべき (codex P2)"""
+
+    def test_add_unknown_code_does_not_persist(
+        self, client, portfolio_db_path, stocks_db_path
+    ):
+        before = len(ps.list_records(db_path=portfolio_db_path))
+        # 9999 は stocks_shelve に存在しない (fixture 未登録)
+        resp = client.post("/portfolio/add", data={"code_s": "9999"})
+        assert resp.status_code == 302
+        # shelve のレコードは変わらない
+        assert len(ps.list_records(db_path=portfolio_db_path)) == before
+        assert ps.get_record("9999", db_path=portfolio_db_path) is None
+
+
+# ==================================================
+# P1 (codex 指摘): portfolio_shelve 未移行時 txt フォールバック
+# ==================================================
+@pytest.fixture
+def fallback_app(tmp_path, monkeypatch):
+    """portfolio_shelve が空 + my_watch_list.txt にデータあり、の状態を再現する。"""
+    portfolio_db_path = str(tmp_path / "test_portfolio_shelve")
+    stocks_db_path = str(tmp_path / "test_stocks_shelve")
+    txt_path = tmp_path / "my_watch_list.txt"
+
+    monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db_path)
+    monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db_path)
+    monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db_path)
+    monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db_path)
+    monkeypatch.setattr("portfolio_shelve.DATA_DIR", str(tmp_path))
+    monkeypatch.setattr("portfolio.DATA_DIR", str(tmp_path))
+
+    # shelve は空のまま、txt に保有 (H...) と監視を書き込む
+    txt_path.write_text(
+        "# kabutan\n"
+        "H6324\n"   # 保有
+        "3496\n"    # 監視
+        "7203\n",   # 監視
+        encoding="utf-8",
+    )
+
+    # 表示時に銘柄名解決するため stocks_shelve にも入れる
+    with ShelveDB(stocks_db_path) as db:
+        db["6324"] = {"code_s": "6324", "stock_name": "ハーモニックドライブシステムズ",
+                      "shihyo": {"PER": 308.0}}
+        db["3496"] = {"code_s": "3496", "stock_name": "アズーム",
+                      "shihyo": {"PER": 30.0}}
+        db["7203"] = {"code_s": "7203", "stock_name": "トヨタ自動車",
+                      "shihyo": {"PER": 12.0}}
+
+    app = create_app()
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def fallback_client(fallback_app):
+    return fallback_app.test_client()
+
+
+class TestFallbackFromTxt:
+
+    def test_fallback_dashboard_shows_txt_records(self, fallback_client):
+        # 1保 タブ (デフォルト) にハーモニック (H プレフィクス) が出る
+        resp = fallback_client.get("/portfolio")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "ハーモニック" in html
+        # 監視タブには 3496/7203 が出る
+        resp = fallback_client.get("/portfolio?status=watch")
+        html = resp.data.decode()
+        assert "アズーム" in html
+        assert "トヨタ" in html
+
+    def test_fallback_shows_banner(self, fallback_client):
+        resp = fallback_client.get("/portfolio")
+        html = resp.data.decode()
+        assert "未移行モード" in html
+
+    def test_fallback_disables_transition_form(self, fallback_client):
+        # 書き込み UI (ステータス変更フォーム) は出ない
+        resp = fallback_client.get("/portfolio")
+        html = resp.data.decode()
+        assert "/transition" not in html
+        assert "/delete" not in html

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -405,3 +405,34 @@ class TestFallbackFromTxt:
         html = resp.data.decode()
         assert "/transition" not in html
         assert "/delete" not in html
+
+    def test_fallback_rejects_add_post(self, fallback_client, tmp_path):
+        """フォールバック中は /portfolio/add も reject (= shelve に書き込まれない)。
+
+        codex 指摘: バナーで「無効」と表示しても POST が通ると、shelve に 1 件
+        書かれた瞬間にフォールバック解除 → 残りの txt 銘柄が画面から消える。
+        """
+        portfolio_db_path = str(tmp_path / "test_portfolio_shelve")
+        before = ps.list_records(db_path=portfolio_db_path)
+        resp = fallback_client.post("/portfolio/add", data={"code_s": "8035"})
+        assert resp.status_code == 302
+        # shelve にレコードは増えていない
+        after = ps.list_records(db_path=portfolio_db_path)
+        assert len(after) == len(before)
+        assert ps.get_record("8035", db_path=portfolio_db_path) is None
+
+    def test_fallback_rejects_transition_post(self, fallback_client, tmp_path):
+        portfolio_db_path = str(tmp_path / "test_portfolio_shelve")
+        resp = fallback_client.post(
+            "/portfolio/3496/transition", data={"new_status": "1保"}
+        )
+        assert resp.status_code == 302
+        assert ps.list_records(db_path=portfolio_db_path) == []
+
+    def test_fallback_rejects_delete_post(self, fallback_client, tmp_path):
+        portfolio_db_path = str(tmp_path / "test_portfolio_shelve")
+        resp = fallback_client.post(
+            "/portfolio/3496/delete", data={"reason": "テスト"}
+        )
+        assert resp.status_code == 302
+        assert ps.list_records(db_path=portfolio_db_path) == []

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -54,21 +54,29 @@ def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
         db["6324"] = {
             "code_s": "6324", "stock_name": "ハーモニックドライブシステムズ",
             "shihyo": {"PER": 308.0, "dividend_yield": 0.39, "jikasogaku": 4960.0},
-            "market_cap": 4705.0, "rs_raw": 1.63, "trend_template": [],
+            "market_cap": 4705.0, "momentum_pt": 90, "trend_template": [],
             "stock_rank_log": [("2026-05-03", 612)],
             "price": 5150, "rironkabuka": 659,
         }
         db["3496"] = {
             "code_s": "3496", "stock_name": "アズーム",
             "shihyo": {"PER": 30.0, "dividend_yield": 1.5},
-            "market_cap": 100.0, "rs_raw": 2.5, "trend_template": [],
+            "market_cap": 100.0, "momentum_pt": 85, "trend_template": [],
             "stock_rank_log": [("2026-05-03", 50)],
             "new_high": ["新"],
+            # 年度成長率テスト用 (calc_annual_growth は tbl[-2], tbl[-3] を比較)
+            # gyoseki_current[i] = [年度, 売上, 営業益, 経常益, 純利益, EPS, BPS]
+            # -3=2023, -2=2024 (基準), -1=2025予 → 売上 50→100 (+100%), 営利 5→10 (+100%)
+            "gyoseki_current": [
+                ["2023.03", 50, 5, 5, 3, 0, 0],
+                ["2024.03", 100, 10, 11, 6, 0, 0],
+                ["2025.03", 138, 22, 22, 12, 0, 0],
+            ],
         }
         db["7203"] = {
             "code_s": "7203", "stock_name": "トヨタ自動車",
             "shihyo": {"PER": 12.0, "dividend_yield": 2.5},
-            "market_cap": 30000.0, "rs_raw": 0.95,
+            "market_cap": 30000.0, "momentum_pt": 40,
             "trend_template": ["不通過1", "不通過2", "不通過3"],
             "stock_rank_log": [("2026-05-03", 200)],
         }
@@ -124,13 +132,15 @@ class TestDashboardGet:
         assert "1 件" in html or "(1)" in html or ">1<" in html
 
     def test_dashboard_shows_indicators(self, client):
-        """1保 タブで PER / RS / 順位等の指標が表示される"""
+        """1保 タブで PER / モメンタム / 順位等の指標が表示される"""
         resp = client.get("/portfolio?status=hold")
         html = resp.data.decode()
         # アズームの指標
         assert "30.0" in html  # PER
-        assert "2.50" in html  # RS
+        assert ">85<" in html  # モメンタム
         assert "50" in html    # rank
+        # 売上成長%・利益成長% (アズーム fixture の gyoseki_current から計算: 50→100 は +100%)
+        assert ">100%<" in html
 
 
 class TestAddPost:

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -41,11 +41,12 @@ def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
     # my_watch_list.txt の出力先を tmp_path に
     monkeypatch.setattr("portfolio_shelve.DATA_DIR", os.path.dirname(txt_path))
 
-    # 銘柄を 3 件 portfolio_shelve に登録 (各タブに 1 件ずつ)
-    ps.add_to_watch("6324", "ハーモニックドライブシステムズ", reason="テスト 3監", db_path=portfolio_db_path)
-    ps.add_to_watch("3496", "アズーム", reason="テスト 1保 用", db_path=portfolio_db_path)
+    # 銘柄を 3 件 portfolio_shelve に登録 (各タブに 1 件ずつ)。
+    # 銘柄名は portfolio_shelve には保存されず、表示時に stocks_shelve から引かれる。
+    ps.add_to_watch("6324", reason="テスト 3監", db_path=portfolio_db_path)
+    ps.add_to_watch("3496", reason="テスト 1保 用", db_path=portfolio_db_path)
     ps.transition_status("3496", "1保", reason="テスト 1保 へ昇格 (3監→1保)", db_path=portfolio_db_path)
-    ps.add_to_watch("7203", "トヨタ自動車", reason="テスト 2準 用", db_path=portfolio_db_path)
+    ps.add_to_watch("7203", reason="テスト 2準 用", db_path=portfolio_db_path)
     ps.transition_status("7203", "2準", reason="テスト 2準 へ昇格 (3監→2準)", db_path=portfolio_db_path)
 
     # stocks_shelve にダミーデータ
@@ -136,17 +137,17 @@ class TestAddPost:
     """POST /portfolio/add"""
 
     def test_add_new_code_succeeds(self, client, portfolio_db_path, stocks_db_path):
-        # stocks_shelve に新銘柄登録
+        # stocks_shelve に新銘柄登録 (銘柄名は表示時に他DBから引かれる)
         with ShelveDB(stocks_db_path) as db:
             db["8035"] = {"code_s": "8035", "stock_name": "東京エレクトロン"}
 
         resp = client.post("/portfolio/add", data={"code_s": "8035"})
         assert resp.status_code == 302
-        # shelve に登録されている
+        # shelve に登録されている (banner 名は持たない)
         rec = ps.get_record("8035", db_path=portfolio_db_path)
         assert rec is not None
         assert rec["status"] == "3監"
-        assert rec["stock_name"] == "東京エレクトロン"
+        assert "stock_name" not in rec  # 新スキーマでは保存しない
         # 初回登録ログが記録されている
         logs = ps.list_action_logs(code_s="8035", db_path=portfolio_db_path)
         assert any(log.get("action_type") == "初回登録" for log in logs)

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -1,0 +1,306 @@
+"""webapp /portfolio ルートのユニットテスト (Phase 3b / issue #171)。
+
+portfolio_shelve / stocks_shelve / my_watch_list.txt を tmp_path に差し替えて
+Flask テストクライアントで各エンドポイントを叩く。
+"""
+
+import os
+
+import pytest
+
+import portfolio_shelve as ps
+from db_shelve import ShelveDB, STOCKS_SHELVE
+from webapp import create_app
+
+
+@pytest.fixture
+def portfolio_db_path(tmp_path):
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+@pytest.fixture
+def stocks_db_path(tmp_path):
+    return str(tmp_path / "test_stocks_shelve")
+
+
+@pytest.fixture
+def txt_path(tmp_path):
+    """sync_to_my_watch_list_txt の出力先を tmp_path に逃がす"""
+    return str(tmp_path / "my_watch_list.txt")
+
+
+@pytest.fixture
+def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
+    """テスト用 Flask アプリ。"""
+    # portfolio_shelve のパス差し替え
+    monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db_path)
+    monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db_path)
+    # stocks_shelve のパス差し替え
+    monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db_path)
+    monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db_path)
+    # my_watch_list.txt の出力先を tmp_path に
+    monkeypatch.setattr("portfolio_shelve.DATA_DIR", os.path.dirname(txt_path))
+
+    # 銘柄を 3 件 portfolio_shelve に登録 (各タブに 1 件ずつ)
+    ps.add_to_watch("6324", "ハーモニックドライブシステムズ", reason="テスト 3監", db_path=portfolio_db_path)
+    ps.add_to_watch("3496", "アズーム", reason="テスト 1保 用", db_path=portfolio_db_path)
+    ps.transition_status("3496", "1保", reason="テスト 1保 へ昇格 (3監→1保)", db_path=portfolio_db_path)
+    ps.add_to_watch("7203", "トヨタ自動車", reason="テスト 2準 用", db_path=portfolio_db_path)
+    ps.transition_status("7203", "2準", reason="テスト 2準 へ昇格 (3監→2準)", db_path=portfolio_db_path)
+
+    # stocks_shelve にダミーデータ
+    with ShelveDB(stocks_db_path) as db:
+        db["6324"] = {
+            "code_s": "6324", "stock_name": "ハーモニックドライブシステムズ",
+            "shihyo": {"PER": 308.0, "dividend_yield": 0.39, "jikasogaku": 4960.0},
+            "market_cap": 4705.0, "rs_raw": 1.63, "trend_template": [],
+            "stock_rank_log": [("2026-05-03", 612)],
+            "price": 5150, "rironkabuka": 659,
+        }
+        db["3496"] = {
+            "code_s": "3496", "stock_name": "アズーム",
+            "shihyo": {"PER": 30.0, "dividend_yield": 1.5},
+            "market_cap": 100.0, "rs_raw": 2.5, "trend_template": [],
+            "stock_rank_log": [("2026-05-03", 50)],
+            "new_high": ["新"],
+        }
+        db["7203"] = {
+            "code_s": "7203", "stock_name": "トヨタ自動車",
+            "shihyo": {"PER": 12.0, "dividend_yield": 2.5},
+            "market_cap": 30000.0, "rs_raw": 0.95,
+            "trend_template": ["不通過1", "不通過2", "不通過3"],
+            "stock_rank_log": [("2026-05-03", 200)],
+        }
+
+    app = create_app()
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestDashboardGet:
+    """GET /portfolio タブ表示"""
+
+    def test_dashboard_default_tab_is_hold(self, client):
+        resp = client.get("/portfolio")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        # 1保 (アズーム) が表示される
+        assert "アズーム" in html
+        # 2準 / 3監 の銘柄は表示されない (タブで絞り込み)
+        assert "ハーモニック" not in html
+        assert "トヨタ" not in html
+
+    def test_dashboard_watch_tab(self, client):
+        resp = client.get("/portfolio?status=watch")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "ハーモニック" in html
+        assert "アズーム" not in html
+
+    def test_dashboard_semi_tab(self, client):
+        resp = client.get("/portfolio?status=semi")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "トヨタ" in html
+        assert "アズーム" not in html
+
+    def test_dashboard_unknown_status_falls_back_to_hold(self, client):
+        resp = client.get("/portfolio?status=invalid")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "アズーム" in html
+
+    def test_dashboard_shows_tab_counts(self, client):
+        resp = client.get("/portfolio")
+        html = resp.data.decode()
+        # 各タブの件数が出ている (3 件登録: 1 / 1 / 1)
+        # タブ表示の数字を全て検証するのは見栄えに依存するので最低限件数行を確認
+        assert "1 件" in html or "(1)" in html or ">1<" in html
+
+    def test_dashboard_shows_indicators(self, client):
+        """1保 タブで PER / RS / 順位等の指標が表示される"""
+        resp = client.get("/portfolio?status=hold")
+        html = resp.data.decode()
+        # アズームの指標
+        assert "30.0" in html  # PER
+        assert "2.50" in html  # RS
+        assert "50" in html    # rank
+
+
+class TestAddPost:
+    """POST /portfolio/add"""
+
+    def test_add_new_code_succeeds(self, client, portfolio_db_path, stocks_db_path):
+        # stocks_shelve に新銘柄登録
+        with ShelveDB(stocks_db_path) as db:
+            db["8035"] = {"code_s": "8035", "stock_name": "東京エレクトロン"}
+
+        resp = client.post("/portfolio/add", data={"code_s": "8035"})
+        assert resp.status_code == 302
+        # shelve に登録されている
+        rec = ps.get_record("8035", db_path=portfolio_db_path)
+        assert rec is not None
+        assert rec["status"] == "3監"
+        assert rec["stock_name"] == "東京エレクトロン"
+        # 初回登録ログが記録されている
+        logs = ps.list_action_logs(code_s="8035", db_path=portfolio_db_path)
+        assert any(log.get("action_type") == "初回登録" for log in logs)
+
+    def test_add_existing_code_flash_warning(self, client, portfolio_db_path):
+        # 6324 は既に登録済み (fixture)
+        resp = client.post("/portfolio/add", data={"code_s": "6324"})
+        assert resp.status_code == 302
+        # shelve のレコードは変化なし
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec is not None
+        assert rec["status"] == "3監"  # 既存のまま
+
+    def test_add_invalid_code_flash_error(self, client, portfolio_db_path):
+        before = len(ps.list_records(db_path=portfolio_db_path))
+        resp = client.post("/portfolio/add", data={"code_s": "abc"})
+        assert resp.status_code == 302
+        # shelve のレコード数は変化なし
+        assert len(ps.list_records(db_path=portfolio_db_path)) == before
+
+    def test_add_empty_code_flash_error(self, client, portfolio_db_path):
+        resp = client.post("/portfolio/add", data={"code_s": ""})
+        assert resp.status_code == 302
+
+
+class TestTransitionPost:
+    """POST /portfolio/<code_s>/transition"""
+
+    def test_transition_1ho_to_3kan(self, client, portfolio_db_path):
+        # 3496 は 1保 (fixture)
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "3監", "reason": "格下げテスト"},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("3496", db_path=portfolio_db_path)
+        assert rec["status"] == "3監"
+        # ステータス変更 ログ
+        logs = ps.list_action_logs(code_s="3496", db_path=portfolio_db_path)
+        assert any(
+            log.get("action_type") == "ステータス変更"
+            and log.get("status_from") == "1保"
+            and log.get("status_to") == "3監"
+            for log in logs
+        )
+
+    def test_transition_1ho_to_2jun_records_uri_log(self, client, portfolio_db_path):
+        """1保 → 2準 は売却扱いで action_type=売却 のログが記録される"""
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "2準", "reason": "利確"},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("3496", db_path=portfolio_db_path)
+        assert rec["status"] == "2準"
+        logs = ps.list_action_logs(code_s="3496", db_path=portfolio_db_path)
+        assert any(
+            log.get("action_type") == "売却"
+            and log.get("status_from") == "1保"
+            and log.get("status_to") == "2準"
+            for log in logs
+        )
+
+    def test_transition_same_status_is_noop(self, client, portfolio_db_path):
+        """同一ステータス遷移は no-op (Phase 3a 仕様)、ログ追記なし"""
+        before_logs = ps.list_action_logs(code_s="3496", db_path=portfolio_db_path)
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "1保"},
+        )
+        assert resp.status_code == 302
+        after_logs = ps.list_action_logs(code_s="3496", db_path=portfolio_db_path)
+        # ログ件数は変化なし
+        assert len(after_logs) == len(before_logs)
+
+    def test_transition_disallowed_flash_error(self, client, portfolio_db_path):
+        """許可されない遷移先 (例: 1保 → 1保 は no-op だが、不正値はエラー)"""
+        # 不正な値を送る
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "INVALID"},
+        )
+        assert resp.status_code == 302
+        # shelve は変化なし
+        rec = ps.get_record("3496", db_path=portfolio_db_path)
+        assert rec["status"] == "1保"
+
+    def test_transition_unknown_code_flash_error(self, client, portfolio_db_path):
+        """portfolio_shelve に未登録の銘柄に対する遷移は KeyError → flash"""
+        resp = client.post(
+            "/portfolio/9999/transition",
+            data={"new_status": "1保"},
+        )
+        assert resp.status_code == 302
+        # 9999 は登録されていない
+        assert ps.get_record("9999", db_path=portfolio_db_path) is None
+
+
+class TestDeletePost:
+    """POST /portfolio/<code_s>/delete"""
+
+    def test_delete_3kan_with_reason_succeeds(self, client, portfolio_db_path):
+        # 6324 は 3監 (fixture)
+        resp = client.post(
+            "/portfolio/6324/delete",
+            data={"reason": "監視終了"},
+        )
+        assert resp.status_code == 302
+        # レコードは物理削除
+        assert ps.get_record("6324", db_path=portfolio_db_path) is None
+        # 削除アクションログは残る
+        logs = ps.list_action_logs(code_s="6324", db_path=portfolio_db_path)
+        assert any(log.get("action_type") == "削除" for log in logs)
+
+    def test_delete_1ho_flash_error(self, client, portfolio_db_path):
+        """1保 銘柄を削除しようとすると ValueError → flash で reject"""
+        resp = client.post(
+            "/portfolio/3496/delete",
+            data={"reason": "誤操作テスト"},
+        )
+        assert resp.status_code == 302
+        # レコードは残る
+        rec = ps.get_record("3496", db_path=portfolio_db_path)
+        assert rec is not None
+        assert rec["status"] == "1保"
+
+    def test_delete_2jun_flash_error(self, client, portfolio_db_path):
+        """2準 銘柄を削除しようとすると ValueError → flash で reject"""
+        resp = client.post(
+            "/portfolio/7203/delete",
+            data={"reason": "誤操作テスト"},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("7203", db_path=portfolio_db_path)
+        assert rec is not None
+        assert rec["status"] == "2準"
+
+    def test_delete_empty_reason_flash_error(self, client, portfolio_db_path):
+        """理由が空の削除は flash エラー"""
+        resp = client.post(
+            "/portfolio/6324/delete",
+            data={"reason": ""},
+        )
+        assert resp.status_code == 302
+        # レコードは残る
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec is not None
+
+    def test_delete_unknown_code_flash_error(self, client, portfolio_db_path):
+        """未登録銘柄に対する削除は False 返却 → flash"""
+        resp = client.post(
+            "/portfolio/9999/delete",
+            data={"reason": "テスト"},
+        )
+        assert resp.status_code == 302
+        # 9999 はもとから未登録
+        assert ps.get_record("9999", db_path=portfolio_db_path) is None

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -318,6 +318,114 @@ class TestDeletePost:
 
 
 # ==================================================
+# POST /portfolio/<code_s>/memo (issue #175 部分更新)
+# ==================================================
+class TestUpdateMemoPost:
+
+    def test_memo_full_eight_fields_persist(self, client, portfolio_db_path):
+        """ブラウザ form と同じく全 8 項目を送ったら全部反映される"""
+        form_data = {field: f"val_{field}" for field in ps.MEMO_FIELDS}
+        resp = client.post("/portfolio/6324/memo", data=form_data)
+        assert resp.status_code == 302
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        for field, expected in form_data.items():
+            assert rec["memo"][field] == expected
+        # action_log に "メモ更新" が 1 件追加 (初回登録 + メモ更新 = 2 件)
+        logs = ps.list_action_logs("6324", db_path=portfolio_db_path)
+        assert len([log for log in logs if log["action_type"] == "メモ更新"]) == 1
+
+    def test_memo_partial_three_fields_keeps_others(self, client, portfolio_db_path):
+        """部分送信: 送られたキーだけ更新、未送信フィールドは現行値据え置き (codex P1)"""
+        # 事前に 5 項目をセット
+        prefilled = {
+            "trade_idea": "X",
+            "watch_in_reason": "Y",
+            "stage": "1S",
+            "inago_origin": "twitter",
+            "jukyu_chart": "CWH",
+        }
+        ps.update_memo("6324", prefilled, db_path=portfolio_db_path)
+
+        # 3 項目だけ送信 (form に他のキーを含めない)
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"trade_idea": "X2", "watch_in_reason": "Y2", "stage": "2S"},
+        )
+        assert resp.status_code == 302
+
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        # 送られた 3 項目は更新
+        assert rec["memo"]["trade_idea"] == "X2"
+        assert rec["memo"]["watch_in_reason"] == "Y2"
+        assert rec["memo"]["stage"] == "2S"
+        # 送られなかった 2 項目は据え置き
+        assert rec["memo"]["inago_origin"] == "twitter"
+        assert rec["memo"]["jukyu_chart"] == "CWH"
+
+    def test_memo_empty_string_overwrites(self, client, portfolio_db_path):
+        """空文字を明示送信したら "" に上書き (メモ削除扱い)"""
+        ps.update_memo("6324", {"trade_idea": "X"}, db_path=portfolio_db_path)
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"trade_idea": ""},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["trade_idea"] == ""
+
+    def test_memo_no_diff_no_action_log(self, client, portfolio_db_path):
+        """全項目を現行値そのまま送ったら action_log は増えない"""
+        ps.update_memo("6324", {"trade_idea": "X"}, db_path=portfolio_db_path)
+        before_logs = ps.list_action_logs("6324", db_path=portfolio_db_path)
+
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"trade_idea": "X"},  # 現行値と同じ
+        )
+        assert resp.status_code == 302
+        after_logs = ps.list_action_logs("6324", db_path=portfolio_db_path)
+        assert len(after_logs) == len(before_logs)
+
+    def test_memo_unregistered_code_flash_error(self, client, portfolio_db_path):
+        resp = client.post(
+            "/portfolio/9999/memo",
+            data={"trade_idea": "X"},
+        )
+        assert resp.status_code == 302
+        assert ps.get_record("9999", db_path=portfolio_db_path) is None
+
+    def test_memo_invalid_code_flash_error(self, client):
+        resp = client.post(
+            "/portfolio/abc/memo",
+            data={"trade_idea": "X"},
+        )
+        assert resp.status_code == 302
+
+    def test_memo_normalizes_crlf_in_textarea(self, client, portfolio_db_path):
+        """textarea の改行 \\r\\n は \\n に正規化される"""
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"trade_idea": "上値追い\r\n決算待ち\r\n"},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        # 前後 strip + \r\n → \n 正規化
+        assert rec["memo"]["trade_idea"] == "上値追い\n決算待ち"
+
+    def test_memo_unknown_form_field_ignored(self, client, portfolio_db_path):
+        """MEMO_FIELDS 外のフォームキーは無視され、エラーにならない"""
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"trade_idea": "X", "csrf_token": "dummy", "garbage": "ignored"},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["trade_idea"] == "X"
+        assert "csrf_token" not in rec["memo"]
+        assert "garbage" not in rec["memo"]
+
+
+# ==================================================
 # P2 (codex 指摘): 未知コードの監視追加 reject
 # ==================================================
 class TestAddUnknownCodeRejected:
@@ -435,4 +543,14 @@ class TestFallbackFromTxt:
             "/portfolio/3496/delete", data={"reason": "テスト"}
         )
         assert resp.status_code == 302
+        assert ps.list_records(db_path=portfolio_db_path) == []
+
+    def test_fallback_rejects_memo_post(self, fallback_client, tmp_path):
+        """フォールバック中は /portfolio/<code>/memo も reject (issue #175)"""
+        portfolio_db_path = str(tmp_path / "test_portfolio_shelve")
+        resp = fallback_client.post(
+            "/portfolio/3496/memo", data={"trade_idea": "X"}
+        )
+        assert resp.status_code == 302
+        # shelve は空のまま (memo 更新で 1 件作られたら fallback 解除事故が起きる)
         assert ps.list_records(db_path=portfolio_db_path) == []


### PR DESCRIPTION
## Summary

Phase 3 保有銘柄管理機能の **基盤層 (3a) + UI 層 (3b) の統合 PR**。元は #173 (Phase 3a) と #176 (Phase 3b) の stacked PR 構成だったが、レビューを 1 か所に集約するため #176 を main 起点に切替えて統合。**#173 はクローズ**。

詳細仕様は実装計画書 [.claude/plans/issue-151-portfolio.md](https://github.com/nasumiso/KSKInvestSystem/blob/issue-171-portfolio-dashboard/.claude/plans/issue-151-portfolio.md) を参照。

---

## Phase 3a: portfolio_shelve 基盤 (issue #170)

### 新規モジュール
- `scripts/portfolio_shelve.py` — DB 層・状態遷移バリデーション・アクションログ・txt 同期
- `scripts/migrate_portfolio_from_csv.py` — スプシ CSV → portfolio_shelve (4 層構成、`--dry-run` / `--preserve-status` 対応)
- `scripts/migrate_my_watch_list_to_shelve.py` — txt → portfolio_shelve (マージルール内蔵)

### 既存モジュール変更
- `scripts/db_shelve.py` — `PORTFOLIO_SHELVE` 定数追加
- `scripts/portfolio.py` — `parse_my_portforio()` を shelve 参照に置換 (シグネチャ無修正、空時 txt フォールバック)

### 重要な設計判断
- **スプシ 36 列のうち 7 列のみ移行**: 指標系列は `code_rank.csv` 由来 VLOOKUP のため移行対象外
- **ステータスは `my_watch_list.txt` のみで決定**: スプシのステータス列は無視
- **キー名前空間で分離**: `record:<code_s>` / `action_log:<code_s>:<seq>` で 1 shelve に同居
- **遷移バリデーション**: 1保 / 2準 への直接登録禁止、3監 のみ削除可、1保↔2準 の往復は「売却」として記録

---

## Phase 3b: 保有銘柄ダッシュボード UI (issue #171)

### 新規
- `scripts/webapp/routes/portfolio.py` — Blueprint (4 ハンドラ: 一覧 / 追加 / ステータス変更 / 削除)
- `scripts/webapp/templates/portfolio_list.html` — 22 列ダッシュボード + 展開行 (手動メモ・操作)
- `scripts/webapp/helpers.py` — `list_portfolio_with_indicators()` ほか指標抽出ヘルパ群を末尾に追加
- `scripts/migrate_portfolio_drop_stock_name.py` — 1 回限り schema 縮小 migration

### 変更
- `scripts/webapp/routes/detail.py` — portfolio status を表示用に注入
- `scripts/webapp/__init__.py` / `scripts/webapp/templates/base.html` — Blueprint 登録 + ナビ追加
- `scripts/portfolio_shelve.py` — `stock_name` フィールドを排除 (`stocks_shelve` / `research_shelve` から表示時に取得)、`MEMO_FIELDS` に 5 項目追加

### 列構成 (22 列)

\`▸ / コード / 銘柄名 / 業態・テーマ / 順位 / 売上成長 / 利益成長 / PER / 理論株価乖離 / 配当 / 決算Q / 進捗率乖離 / 決算日 / 更新日 / ステージ / RS / RSライン(20,5) / トレンド / タグ / 株価向き(20,5) / 買い集め / 時価総額\`

- RSライン / 株価向きは現状プレースホルダ (—)
- 銘柄コード → 株探チャートへ外部リンク、銘柄名 → WebApp 詳細へ内部リンク

---

## 後続 (本 PR スコープ外)

- #175 — portfolio_shelve memo の WebApp 編集機能 (案1: 一覧展開行 form)
- スプシ運用廃止 + `migrate_portfolio_from_csv.py` のアーカイブ判断

## Test plan

- [x] Phase 3a: `pytest tests/test_portfolio_shelve.py tests/test_migrate_portfolio_from_csv.py tests/test_migrate_my_watch_list_to_shelve.py tests/test_portfolio.py -v` (86 passed)
- [x] Phase 3b: `pytest tests/test_webapp_portfolio_routes.py tests/test_portfolio_shelve.py tests/test_migrate_portfolio_from_csv.py tests/test_migrate_portfolio_drop_stock_name.py -v` (82 passed)
- [x] 既存テスト回帰なし: 188 件 pass
- [x] 実 CSV (139 行) でのパイロット移行確認 (138 読込 / 133 保存 / 5 空行スキップ)
- [x] webapp 手動確認 (port 5002): 全タブ表示 / ステータス変更 / 削除 / 業態 2 行表示 / ellipsis tooltip
- [x] 本番 portfolio_shelve への migration 適用済み (93 銘柄 3監→2準 / stock_name 物理削除 / sheet 再インポート preserve-status)

## Codex レビュー残課題

PR #173 で指摘されていた以下は本 PR で要対応:
- P1: 空 portfolio_shelve でも txt にフォールバックしない (`scripts/portfolio.py:212`) — フォールバック自体を消す方向で再検討予定
- P2: txt 内の重複コードは H 付き行を優先して統合する (`scripts/migrate_my_watch_list_to_shelve.py:75`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)