### PR TITLE
issue #186: 保有銘柄ダッシュボードに銘柄追加とユニバース除外UI

### DIFF
--- a/.claude/plans/issue-186-portfolio-add-exclude.md
+++ b/.claude/plans/issue-186-portfolio-add-exclude.md
@@ -1,0 +1,302 @@
+# issue: 保有銘柄ダッシュボードに「銘柄追加」「ユニバース除外 (=ダッシュボード非表示)」機能を追加
+
+## Context
+
+`/portfolio?status=watch` (3監タブ) は新高値銘柄の研究待機リストとして使われているが、
+- 新規候補をダッシュボードから追加する UI が無い (ハンドラ `POST /portfolio/add` だけ存在しフォーム未実装)
+- 不要になった銘柄をユニバースから外す手段が無い (`delete_record` は物理削除しか提供しておらず、メモ・履歴ごと消える)
+
+研究履歴とメモを残しつつ「もう追跡しない」状態にする運用が必要。
+追加 UI と「ユニバース除外」機能をセットで実装し、3監タブの管理を完結させる。
+
+## 確定要件
+
+- **削除 = 物理削除ではなくユニバース除外** (PortfolioRecord に `excluded:bool` フラグ追加、DB レコード・ログ・メモはすべて保持)
+- **対象タブ**: 3監のみ
+- **可視性**: 除外済みは `/portfolio` 全タブで完全非表示
+- **action_type**: `"ユニバース除外"` を新設 (`VALID_ACTION_TYPES`)
+- **復活 UI**: 既存追加フォームを再利用 (除外済みコードを再入力すると `excluded=False` に戻す)。除外専用ページは作らない
+- **削除 UI**: 「削除モード」トグル → 行頭チェックボックス → 一括「削除」ボタン (= ユニバース除外)。理由は任意
+- **追加 UI**: 3監タブ上部のインラインフォーム (コード入力 + 追加ボタン)
+
+## Critical Files
+
+- `scripts/portfolio_shelve.py` (主に修正)
+- `scripts/webapp/routes/portfolio.py`
+- `scripts/webapp/templates/portfolio_list.html`
+- `tests/test_portfolio_shelve.py`
+- `tests/test_webapp_portfolio_routes.py`
+
+## 実装内容
+
+### 1. `scripts/portfolio_shelve.py`
+
+#### 1-1. `VALID_ACTION_TYPES` に追加
+```python
+VALID_ACTION_TYPES = {"初回登録", "ステータス変更", "売却", "削除", "メモ更新", "ユニバース除外"}
+```
+
+#### 1-2. `PortfolioRecord` に `excluded` フィールド追加
+- 既存スキーマに `excluded: bool = False` を加える
+- `_load_record` 側で旧データ (excluded キーなし) は `False` フォールバック (後方互換)
+- save 時は新キー込みで書き出し
+
+#### 1-3. 新関数 `exclude_from_universe(code_s, *, reason="", db_path=None) -> bool`
+- 3監のレコードを `excluded=True` に更新
+- 既に `excluded=True` なら `False` 返す (no-op)
+- 1保/2準なら `ValueError("3監のみ除外可能")`
+- 未登録なら `False`
+- アクションログ `"ユニバース除外"` を追記
+- `_flock` 排他
+
+#### 1-4. `add_to_watch` を「除外解除」も兼ねるよう拡張
+- 既存レコードあり & `excluded=True` → `excluded=False` に戻す。アクションログは既存の `"ユニバース除外"` action_type を流用し `reason="復活"` を記録 (現行スキーマは `reason` フィールドのみで `note` は無いため)
+- 既存レコードあり & `excluded=False` → 従来通り `ValueError`
+- 既存レコードなし → 従来通り新規登録
+
+注: `add_to_watch` のシグネチャ・呼び出し側は変更しない。挙動変更だけ。docstring を更新。
+
+#### 1-5. `list_records` の挙動拡張 (除外フィルタ)
+**codex 指摘 #2 反映**: `list_records()` をそのまま使うと `sync_to_my_watch_list_txt()` が除外済みも txt に書き戻し、txt フォールバック経由で復活してしまう。
+- `list_records(*, include_excluded: bool = False, db_path=None)` の形で kwarg を追加 (デフォルト False)
+- 既存呼び出し箇所 (routes/portfolio.py の `ps.list_records()`、`sync_to_my_watch_list_txt()`、`portfolio.parse_my_portforio()` 等) は **すべてデフォルト=除外済を返さない** で動作。すなわち全タブから自動的に隠れる
+- 「除外済み一覧を見たい」用途 (今回スコープ外) のみ `include_excluded=True` を付けて取得
+- 影響範囲確認: `grep -rn "list_records(" scripts/` で呼出箇所をすべて見て、対応不要なら kwarg だけ追加するシンプル変更にとどめる
+
+### 2. `scripts/webapp/routes/portfolio.py`
+
+#### 2-1. dashboard() の取得方針変更 + 一覧表示で除外フィルタ
+**codex 指摘 #3, #5 反映**: 現行 `dashboard()` は `all_records = ps.list_records()` で 1 度だけ取得し、`fallback_mode = not all_records` 判定 + 件数カウント + 表示行抽出すべてに使い回している。`list_records()` のデフォルトを `include_excluded=False` にすると、全件除外時に fallback モード誤判定 → 追加 UI まで消えて復活不能のデッドロック。
+
+**対策** (dashboard() の取得を 2 段階化):
+```python
+# fallback 判定とタブ件数カウントは「除外含む全件」で行う
+all_records_inc = ps.list_records(include_excluded=True)
+fallback_mode = not all_records_inc
+
+# 表示用は除外フィルタ後
+visible_records = [r for r in all_records_inc if not r.get("excluded", False)]
+counts = ...  # visible_records ベース (除外済みは件数にも出さない)
+active_records = [r for r in visible_records if r.get("status") == active_status]
+```
+- カウント (タブのバッジ) は除外済みを含めない (= visible_records ベース)。除外済みはユーザから「いない」扱いなので件数 0 のタブは fallback ではなく単に空表示
+- fallback 判定だけは「DB 自体が空 (= 未移行)」を見るので除外含む全件で
+
+**同時に修正する場所**:
+- `_is_fallback_mode()` (もし別途存在するなら) も `include_excluded=True` 基準に統一
+- `_build_fallback_records()` 経路に変更不要 (fallback 時は txt から仮レコード組み立て、excluded 概念なし)
+
+#### 2-2. 既存 `POST /portfolio/<code_s>/delete` (line 121) は **撤去**
+**codex 指摘 #1 反映**: 物理削除エンドポイントを残すと「削除=ユニバース除外、メモ・履歴は保持」要件と矛盾し、誤 POST で履歴が消える事故リスクがある。
+- ルートハンドラと関連 import を削除 (UI からの導線も撤去するためルートが死ぬ)
+- 既存テスト `test_delete_*` は移行先 (TestBulkExclude) に置き換え or 削除
+- `portfolio_shelve.delete_record()` 関数自体は残してよい (内部 API、外部公開なし)。今回の plan では呼び出し元がいなくなるが、移行スクリプト等で将来必要になる可能性があるため触らない (Surgical Changes)
+
+#### 2-3. 新ルート `POST /portfolio/bulk-exclude`
+```python
+@portfolio_bp.route("/portfolio/bulk-exclude", methods=["POST"])
+def bulk_exclude():
+    """3監 銘柄をまとめてユニバースから除外する。"""
+    # フォールバックモード reject (_reject_when_fallback)
+    # codes = request.form.getlist("codes")
+    # reason = (request.form.get("reason") or "").strip()
+    # 各 code に対し:
+    #   validate_code_s → exclude_from_universe(code, reason=reason, db_path=...)
+    #   ValueError (1保/2準) → 失敗リスト
+    #   False (未登録 or 既除外) → スキップ
+    #   True → 成功
+    # _sync_txt_safely() を 1 回呼ぶ
+    # flash: "N件をユニバースから除外しました" / 失敗あれば error
+    # redirect → /portfolio?status=watch
+```
+
+#### 2-4. 既存 `POST /portfolio/add` (line 289) を「復活」も担うよう調整
+- `add_to_watch` 側で除外済みレコードを復活させる挙動になるので、`POST /portfolio/add` の例外処理だけ調整
+- 既存の `ValueError` (= 既登録 & 非除外) はそのまま flash error
+- 復活時は flash info `"ユニバースに復活しました: {code}"`
+- AJAX レスポンスは既存 add 同様 (今回 AJAX 化必須ではない)
+
+**stocks_shelve 未登録ガードの調整 (codex 指摘 #4 反映)**:
+現実装の `POST /portfolio/add` (line 314 付近) は `get_stock_data(normalized)` で stocks_shelve に登録があるか事前チェックしており、無ければ reject。これだと「除外済みレコードが portfolio_shelve にあるが stocks_shelve に無い」ケースで復活できない。
+対策:
+1. ルートの先に `ps.get_record(normalized)` で portfolio_shelve に既存レコードがあるか確認
+2. 既存 (excluded 問わず) なら **stocks_shelve チェックをスキップ** して `add_to_watch` を呼ぶ (復活パス)
+3. 既存無しなら従来通り stocks_shelve チェック → 無ければ reject (新規追加で未知コードは弾く)
+
+擬似コード:
+```python
+existing = ps.get_record(normalized)
+if existing is None:
+    if not get_stock_data(normalized):
+        flash("stocks_shelve に未登録のコードです", "error")
+        return redirect(...)
+# 既存 (除外済 含む) なら stocks_shelve チェックをスキップして add_to_watch
+ps.add_to_watch(normalized, ...)
+```
+
+### 3. `scripts/webapp/templates/portfolio_list.html`
+
+#### 3-1. 3監タブ上部 (active_query == "watch" かつ not fallback_mode のみレンダリング)
+
+```html
+<form action="/portfolio/add" method="POST" class="portfolio-add-form">
+  <label>コード <input name="code_s" required pattern="[0-9A-Za-z]+"></label>
+  <button type="submit">追加</button>
+  <span class="hint">(除外済みコードを入れると復活します)</span>
+</form>
+
+<button type="button" id="toggle-delete-mode">削除モード</button>
+
+<div id="bulk-delete-bar" hidden>
+  <span><strong id="selected-count">0</strong> 件選択中</span>
+  <button type="button" id="bulk-delete-execute">削除 (ユニバース除外)</button>
+  <button type="button" id="bulk-delete-cancel">キャンセル</button>
+</div>
+```
+
+#### 3-2. チェックボックス列
+- `<thead><tr>` 先頭に `<th class="bulk-col">` (CSS で初期 hidden)
+- `<tbody><tr>` 先頭に `<td class="bulk-col"><input type="checkbox" class="bulk-cb" value="{{ row.code_s }}"></td>`
+- CSS: `body.delete-mode .bulk-col { display: table-cell; }` / 既定 `.bulk-col { display: none; }`
+
+#### 3-3. 既存「行ごと削除フォーム」(line 200-208) を撤去
+削除モードに統合する。
+
+#### 3-4. JS 追加 (既存 IIFE の隣に新規 IIFE)
+```js
+(function() {
+  const toggle = document.getElementById('toggle-delete-mode');
+  if (!toggle) return;  // 3監タブ以外は何もしない
+  const bar = document.getElementById('bulk-delete-bar');
+  const countEl = document.getElementById('selected-count');
+  const execBtn = document.getElementById('bulk-delete-execute');
+  const cancelBtn = document.getElementById('bulk-delete-cancel');
+
+  function refresh() {
+    const checked = document.querySelectorAll('.bulk-cb:checked');
+    countEl.textContent = checked.length;
+    bar.hidden = !document.body.classList.contains('delete-mode');
+  }
+  toggle.addEventListener('click', () => {
+    document.body.classList.toggle('delete-mode');
+    if (!document.body.classList.contains('delete-mode')) {
+      document.querySelectorAll('.bulk-cb').forEach(c => c.checked = false);
+    }
+    refresh();
+  });
+  cancelBtn.addEventListener('click', () => {
+    document.body.classList.remove('delete-mode');
+    document.querySelectorAll('.bulk-cb').forEach(c => c.checked = false);
+    refresh();
+  });
+  document.addEventListener('change', e => {
+    if (e.target.classList.contains('bulk-cb')) refresh();
+  });
+  execBtn.addEventListener('click', () => {
+    const codes = [...document.querySelectorAll('.bulk-cb:checked')].map(c => c.value);
+    if (!codes.length) return;
+    if (!confirm(codes.length + ' 件をユニバースから除外します。よろしいですか?')) return;
+    const fd = new FormData();
+    codes.forEach(c => fd.append('codes', c));
+    fetch('/portfolio/bulk-exclude', { method: 'POST', body: fd })
+      .then(r => { if (r.redirected) location.href = r.url; else location.reload(); });
+  });
+})();
+```
+
+### 4. テスト追加
+
+#### 4-1. `tests/test_portfolio_shelve.py`
+- `TestExcludeFromUniverse`:
+  - 3監を除外 → record.excluded=True / ログ "ユニバース除外" / 戻り値 True
+  - 既に除外済 → False
+  - 1保 → ValueError
+  - 未登録 → False
+  - reason 空 OK
+- `TestAddToWatchRevive`:
+  - 除外済みコードを add_to_watch → excluded=False / ログ "ユニバース除外" reason="復活"
+  - 通常の既登録 (excluded=False) → ValueError (従来通り)
+- `TestPortfolioRecordBackwardCompat`:
+  - 旧形式 (excluded キーなし) を load → excluded=False で読める
+- `TestListRecordsFilterExcluded`:
+  - 3監 2 件のうち 1 件を除外 → `list_records()` は 1 件のみ返す
+  - `list_records(include_excluded=True)` は 2 件返す
+- `TestSyncTxtSkipsExcluded`:
+  - 除外済みは `sync_to_my_watch_list_txt` の出力に含まれない
+
+#### 4-2. `tests/test_webapp_portfolio_routes.py`
+- `TestBulkExclude`:
+  - 3監 2 件を bulk-exclude → 一覧から消える、shelve 上は excluded=True で残存
+  - 1保混入 → 1保はそのまま、3監のみ除外 + flash error
+  - 空 codes → flash error
+  - 未登録コード → スキップ + flash
+  - フォールバックモード → reject
+- `TestAddRevival`:
+  - 除外済みコードで `POST /portfolio/add` → 復活、一覧再表示、flash info
+  - 除外済みかつ stocks_shelve 未登録コードでも復活成功 (stocks_shelve チェックスキップ)
+- `TestExcludedHidden`:
+  - excluded=True レコードは `/portfolio?status=watch` に出ない
+- `TestFallbackJudgmentWithAllExcluded`:
+  - 全レコード excluded=True 状態でも fallback モードと誤判定されない (`_is_fallback_mode()` が False を返す)
+  - そのとき `/portfolio?status=watch` 画面で追加フォームが表示される (テンプレート上の `not fallback_mode` ガードを通過する)
+  - そのとき `POST /portfolio/add` で復活が許可される
+
+### 5. 検証手順 (Playwright E2E)
+
+1. `/portfolio?status=watch` 開く → 追加フォーム / 削除モード ボタンあり、1保/2準タブには無いこと
+2. 追加フォームに既存コードでないコードを入力 → 追加成功
+3. 「削除モード」 → チェックボックス列出現、画面下バー表示
+4. 2 件チェック → 「2 件選択中」
+5. 削除実行 → confirm OK → リロード後該当行が消える、shelve 上は残っている (DB 直読で excluded=True 確認)
+6. 同じコードを追加フォームで再投入 → 復活して再表示、ログに "ユニバース除外 (note=復活)" 残存
+7. shelve に研究メモが残っていることを確認 (excluded → 復活でも MEMO_FIELDS は保持)
+
+### 6. テスト実行コマンド (testing.md マッピング準拠)
+
+```bash
+pytest tests/test_portfolio_shelve.py tests/test_append_research_snapshots.py -v
+pytest tests/test_webapp_portfolio_routes.py -v
+```
+
+## 設計上の注意
+
+- **後方互換**: shelve スキーマに excluded を追加するため、`_load_record` で旧データを読めること必須
+- **研究メモ保護**: 除外しても MEMO_FIELDS とログは残す。物理削除との明確な差別化
+- **add_to_watch の挙動拡張**: 「既登録ならエラー」だった仕様が「除外済みなら復活」と分岐するため、関数 docstring を更新
+- **bulk_exclude の部分成功**: 1保混入時は 3監のみ処理し flash で報告 (PR で受け取り側に明示)
+
+## 実装後タスク (要件追加分)
+
+実装完了後、運用 DB と `my_watch_list.txt` の整合性を 1 度だけ手動同期する。
+これは UI 機能ではなく一回限りの保守作業。
+
+### 同期スクリプト (新設 or 既存 migrate スクリプトを再利用)
+
+**方針**:
+- 入力: `${KS_DATA_DIR}/my_watch_list.txt` (現行運用の真実源)
+- 出力: portfolio_shelve
+
+**処理**:
+1. txt をパース (1保 / 3監 を抽出、`migrate_my_watch_list_to_shelve.py` 既存ロジック再利用)
+2. portfolio_shelve から `list_records(include_excluded=True)` で全件取得
+3. 差分抽出:
+   - **txt にあるが DB に無い**: `add_to_watch(code, reason="my_watch_list 同期で追加")` (1保なら add してから transition で 1保 へ)
+   - **DB にあるが txt に無い**: `exclude_from_universe(code, reason="my_watch_list 同期で除外")` (3監のみ対象。1保が txt 不在になっているケースは異常として ERROR ログ + skip)
+4. dry-run モード必須 (差分プレビュー → ユーザ確認 → 実行)
+5. ログに追加/除外件数を出力
+
+**配置**: `scripts/sync_portfolio_with_txt.py` (新設) もしくは `migrate_my_watch_list_to_shelve.py` に `--sync-mode` オプション追加。既存スクリプトを汚さないため新設推奨。
+
+**テスト**: 別タスク扱い。本 plan の主要実装が終わってから着手。
+
+## 未確定事項
+
+なし。要件確定済み。
+
+## Plan Review
+
+実装着手前に `codex` でレビュー必須 (`.claude/rules/codex-plan-review.md`)。
+コマンド:
+```
+codex exec -m gpt-5.3-codex "Review this plan. Don't nitpick trivial things. Only point out critical issues: /Users/k_sohara/.claude/plans/enumerated-puzzling-patterson.md (ref: /Users/k_sohara/Library/CloudStorage/Dropbox/document/shintakane/CLAUDE.md)"
+```

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -22,7 +22,9 @@ shelve ベースのラッパー。
 - 追加: (新規) -> 3監 (1保/2準への直接登録は禁止)
 - ステータス変更: 3監 <-> 2準 <-> 1保 / 3監 <-> 1保
 - 売却: 1保 -> 2準 (アクションログ種別「売却」で記録)
-- 削除: 3監 のみ (1保/2準 から直接削除は禁止、レコードは物理削除)
+- 削除: 3監 のみ (1保/2準 から直接削除は禁止、レコードは物理削除) ※現在 UI 経路なし
+- ユニバース除外: 3監 のみ。`excluded=True` フラグで論理削除し、メモ・ログを保持。
+  add_to_watch で同コード再投入すると excluded=False に戻して復活する
 """
 
 import fcntl
@@ -58,7 +60,9 @@ CODE_S_PATTERN = re.compile(r"^(?:\d{4}|\d{3}[A-Z])$")
 VALID_STATUSES = frozenset({"1保", "2準", "3監"})
 
 # アクションログ種別
-VALID_ACTION_TYPES = frozenset({"初回登録", "ステータス変更", "売却", "削除", "メモ更新"})
+VALID_ACTION_TYPES = frozenset(
+    {"初回登録", "ステータス変更", "売却", "削除", "メモ更新", "ユニバース除外"}
+)
 
 # キー名前空間プレフィックス
 KEY_RECORD_PREFIX = "record:"
@@ -73,6 +77,7 @@ RECORD_FIELDS = frozenset(
         "registered_at",
         "updated_at",
         "memo",
+        "excluded",
     }
 )
 
@@ -313,6 +318,7 @@ def create_record(
         "registered_at": timestamp,
         "updated_at": updated_at or timestamp,
         "memo": dict(memo),
+        "excluded": False,
     }
 
 
@@ -336,11 +342,14 @@ def get_record(
 def list_records(
     status: Optional[str] = None,
     *,
+    include_excluded: bool = False,
     db_path: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """保有レコードを一覧取得する。
 
     - status: None で全件、"1保"/"2準"/"3監" 指定で絞り込み
+    - include_excluded: False (既定) なら excluded=True のレコードを除外。
+      True なら除外フラグ無視で全件返す (DB 整合性チェックや fallback 判定用)
     - 結果は code_s 昇順
     """
     if status is not None:
@@ -354,6 +363,8 @@ def list_records(
             if not isinstance(value, dict):
                 continue
             if status is not None and value.get("status") != status:
+                continue
+            if not include_excluded and value.get("excluded", False):
                 continue
             results.append(value)
     results.sort(key=lambda r: r.get("code_s", ""))
@@ -466,37 +477,62 @@ def add_to_watch(
     reason: str = "",
     db_path: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """銘柄を 3監 として新規追加する。
+    """銘柄を 3監 として登録、または除外済みレコードをユニバース復活させる。
 
     銘柄名は持たない (表示時に stocks_shelve / research_shelve から都度取得)。
 
-    - 既存レコードが存在する場合は ValueError (重複登録防止)
-    - 同時に 初回登録 アクションログを 1 件記録
+    挙動:
+    - 既存レコードなし → 新規追加 (3監)。「初回登録」ログを reason 引数で記録
+    - 既存レコードあり & excluded=True → 復活 (excluded=False に戻す)。
+      memo / status は既存値を保持。「ユニバース除外」ログを reason="復活" で記録
+      (復活時は reason 引数は無視される)
+    - 既存レコードあり & excluded=False → ValueError (重複登録防止)
 
-    Returns: 追加したレコード
+    Returns: 追加または復活したレコード
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
-    record = create_record(normalized, status="3監", memo=memo)
     path = _resolve_db_path(db_path)
     with _flock(db_path):
         with ShelveDB(path) as db:
-            if _record_key(normalized) in db:
-                raise ValueError(
-                    f"portfolio_shelve: {normalized} は既に登録済みです"
-                )
-            db[_record_key(normalized)] = record
-        # ログ追加 (内部で flock 取得済みでもリエントラント対応)
-        append_action_log(
-            normalized,
-            "初回登録",
-            status_from=None,
-            status_to="3監",
-            reason=reason,
-            db_path=db_path,
-        )
-    log_print("portfolio_shelve: 3監 追加", normalized)
-    return record
+            key = _record_key(normalized)
+            existing = db.get(key)
+            if existing is not None and isinstance(existing, dict):
+                if existing.get("excluded", False):
+                    existing["excluded"] = False
+                    existing["updated_at"] = now_iso()
+                    db[key] = existing
+                    revived_record = existing
+                    revived = True
+                else:
+                    raise ValueError(
+                        f"portfolio_shelve: {normalized} は既に登録済みです"
+                    )
+            else:
+                record = create_record(normalized, status="3監", memo=memo)
+                db[key] = record
+                revived_record = record
+                revived = False
+        if revived:
+            # 復活時は明示的に reason="復活" を記録 (除外ログとの判別用、reason 引数は無視)
+            append_action_log(
+                normalized,
+                "ユニバース除外",
+                reason="復活",
+                db_path=db_path,
+            )
+            log_print("portfolio_shelve: ユニバース復活", normalized)
+        else:
+            append_action_log(
+                normalized,
+                "初回登録",
+                status_from=None,
+                status_to="3監",
+                reason=reason,
+                db_path=db_path,
+            )
+            log_print("portfolio_shelve: 3監 追加", normalized)
+    return revived_record
 
 
 def upsert_record(
@@ -645,6 +681,54 @@ def delete_record(
     return True
 
 
+def exclude_from_universe(
+    code_s: str,
+    *,
+    reason: str = "",
+    db_path: Optional[str] = None,
+) -> bool:
+    """3監レコードをユニバースから除外する (物理削除はしない)。
+
+    - 1保/2準 を除外しようとすると ValueError
+    - レコードが存在しない場合は False を返す
+    - 既に除外済みなら no-op で False を返す
+    - 成功時はアクションログ「ユニバース除外」を 1 件記録
+
+    Returns: 除外を新規に行った場合 True、未存在/既除外なら False
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    if not isinstance(reason, str):
+        raise TypeError(f"reason must be str, got {type(reason).__name__}")
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _record_key(normalized)
+            if key not in db:
+                return False
+            record = db[key]
+            if record.get("excluded", False):
+                return False
+            current_status = record.get("status")
+            if current_status != "3監":
+                raise ValueError(
+                    f"portfolio_shelve: {normalized} は status={current_status!r} のため "
+                    "ユニバース除外できません (3監 のみ除外可能、先に 3監 へ遷移してください)"
+                )
+            record["excluded"] = True
+            record["updated_at"] = now_iso()
+            db[key] = record
+        append_action_log(
+            normalized,
+            "ユニバース除外",
+            reason=reason,
+            db_path=db_path,
+        )
+    log_print("portfolio_shelve: ユニバース除外", normalized)
+    return True
+
+
 def update_memo(
     code_s: str,
     fields: Dict[str, Any],
@@ -781,6 +865,8 @@ def sync_to_my_watch_list_txt(
 
     一方向同期 (shelve → txt)。txt 廃止 issue (将来) で sync 自体を停止する想定。
     旧コードと既存運用との互換のため、Phase 3 完了後も同期は有効のまま残す。
+
+    excluded=True のレコードは出力しない (`list_records` のデフォルトで除外される)。
 
     銘柄名は portfolio_shelve には保存されていないため stocks_shelve / research_shelve から
     都度引く (どちらにも無ければ code のみ書き出す)。

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -1,13 +1,13 @@
-"""保有銘柄ダッシュボードルート (Phase 3b / issue #171, issue #175)。
+"""保有銘柄ダッシュボードルート (Phase 3b / issue #171, issue #175, issue #186)。
 
 GET  /portfolio?status=hold|semi|watch  : 3 タブ式ダッシュボード
-POST /portfolio/add                     : 3監 への新規追加
+POST /portfolio/add                     : 3監 への新規追加 / 除外済みの復活
 POST /portfolio/<code_s>/transition     : ステータス変更
-POST /portfolio/<code_s>/delete         : 削除 (3監 のみ)
+POST /portfolio/bulk-exclude            : 3監 銘柄をユニバースから除外 (一括)
 POST /portfolio/<code_s>/memo           : memo 部分更新 (issue #175)
 
 portfolio_shelve のレコードに stocks_shelve から指標を補完して表示する。
-書き込み API は txt 関連の状態を変えるもの (add/transition/delete) のみ
+書き込み API は txt 関連の状態を変えるもの (add/transition/bulk-exclude) のみ
 末尾で sync_to_my_watch_list_txt() を呼ぶ。memo 更新は txt 内容に影響しないため同期不要。
 """
 
@@ -102,8 +102,11 @@ def _is_fallback_mode() -> bool:
     時点で次回 dashboard が `list_records()` 非空 → フォールバック解除 →
     残りの txt 銘柄が画面上から消える、という運用事故が起きる (codex 指摘)。
     各 POST ハンドラ冒頭で本関数を見て reject する。
+
+    issue #186: 全レコードが excluded=True の状態を fallback と誤判定しない
+    ため、include_excluded=True で取得して空判定する。
     """
-    return not ps.list_records()
+    return not ps.list_records(include_excluded=True)
 
 
 def _reject_when_fallback(redirect_query: str = "watch"):
@@ -118,40 +121,49 @@ def _reject_when_fallback(redirect_query: str = "watch"):
     return None
 
 
-@portfolio_bp.route("/portfolio/<code_s>/delete", methods=["POST"])
-def delete(code_s: str):
-    """3監 銘柄の物理削除。理由必須。
+@portfolio_bp.route("/portfolio/bulk-exclude", methods=["POST"])
+def bulk_exclude():
+    """3監 銘柄を一括でユニバースから除外する (物理削除はしない)。
 
-    1保 / 2準 銘柄に対する直接 POST は portfolio_shelve.delete_record 内部で
-    ValueError → flash で対応。UI 側でも 3監 タブのみ削除ボタンを表示する。
+    フォーム: codes=<code1>&codes=<code2>... / reason=<任意>
+    部分成功許容。1保/2準 が混入していたら該当のみ flash error で報告し、
+    3監 のみ除外を実行する。
     """
     rejected = _reject_when_fallback(redirect_query="watch")
     if rejected is not None:
         return rejected
 
+    codes = [c.strip() for c in request.form.getlist("codes") if c and c.strip()]
     reason = (request.form.get("reason") or "").strip()
-    if not reason:
-        flash("削除理由は必須です", "error")
+
+    if not codes:
+        flash("除外対象が指定されていません", "error")
         return redirect(url_for("portfolio.dashboard", status="watch"))
 
-    try:
-        ps.validate_code_s(code_s)
-    except (ValueError, TypeError) as e:
-        flash(f"不正な銘柄コード: {e}", "error")
-        return redirect(url_for("portfolio.dashboard", status="watch"))
+    success: list[str] = []
+    failures: list[str] = []
+    for raw in codes:
+        try:
+            ps.validate_code_s(raw)
+            normalized = ps.normalize_code_s(raw)
+        except (ValueError, TypeError) as e:
+            failures.append(f"{raw}: 不正なコード ({e})")
+            continue
+        try:
+            ok = ps.exclude_from_universe(normalized, reason=reason)
+        except (ValueError, TypeError) as e:
+            failures.append(f"{normalized}: {e}")
+            continue
+        if ok:
+            success.append(normalized)
+        else:
+            failures.append(f"{normalized}: 未登録または既に除外済み")
 
-    try:
-        deleted = ps.delete_record(code_s, reason=reason)
-    except (ValueError, TypeError) as e:
-        flash(str(e), "error")
-        return _redirect_to_current_tab(code_s, fallback_query="watch")
-
-    if not deleted:
-        flash(f"{code_s} は portfolio_shelve に未登録です", "error")
-    else:
-        flash(f"{code_s} を削除しました", "info")
-
-    _sync_txt_safely()
+    if success:
+        _sync_txt_safely()
+        flash(f"{len(success)} 件をユニバースから除外しました ({', '.join(success)})", "info")
+    if failures:
+        flash("除外できなかったコードがあります: " + " / ".join(failures), "error")
     return redirect(url_for("portfolio.dashboard", status="watch"))
 
 
@@ -288,11 +300,12 @@ def update_memo(code_s: str):
 
 @portfolio_bp.route("/portfolio/add", methods=["POST"])
 def add():
-    """銘柄を 3監 として新規追加する。
+    """銘柄を 3監 として新規追加する。除外済みコードを再投入したら復活する。
 
-    既存登録済みなら ValueError → flash 警告で no-op。
-    銘柄名は portfolio_shelve には保存しない (表示時に他DBから引く)。
-    flash メッセージ用にだけ stocks_shelve / research_shelve から取得する。
+    挙動:
+    - portfolio_shelve に未登録 → stocks_shelve 存在チェック → 新規追加
+    - portfolio_shelve に excluded=True で存在 → 復活 (stocks_shelve チェック skip)
+    - portfolio_shelve に excluded=False で存在 → 既登録扱い、ValueError flash
     """
     rejected = _reject_when_fallback(redirect_query="watch")
     if rejected is not None:
@@ -311,14 +324,17 @@ def add():
 
     normalized = ps.normalize_code_s(code_s)
 
-    # 未知コード防衛: stocks_shelve に存在しないコードは銘柄名解決もできず、
-    # txt 同期したときに識別不能な行が混ざるので reject する。
-    if not get_stock_data(normalized):
-        flash(
-            f"{normalized} は stocks_shelve に未登録のコードです。先に銘柄DBへの登録が必要です。",
-            "error",
-        )
-        return redirect(url_for("portfolio.dashboard", status="watch"))
+    # 既存レコード (除外済 含む) があれば stocks_shelve チェックを skip して復活パスへ。
+    # 未登録コードのときのみ未知コード防衛を適用する。
+    existing = ps.get_record(normalized)
+    is_revival = bool(existing and existing.get("excluded", False))
+    if existing is None:
+        if not get_stock_data(normalized):
+            flash(
+                f"{normalized} は stocks_shelve に未登録のコードです。先に銘柄DBへの登録が必要です。",
+                "error",
+            )
+            return redirect(url_for("portfolio.dashboard", status="watch"))
 
     try:
         ps.add_to_watch(normalized, reason="WebApp 追加")
@@ -328,7 +344,10 @@ def add():
 
     _sync_txt_safely()
     name_for_flash = resolve_stock_name(normalized)
-    flash(f"{normalized} {name_for_flash} を監視に追加しました".rstrip(), "info")
+    if is_revival:
+        flash(f"{normalized} {name_for_flash} をユニバースに復活しました".rstrip(), "info")
+    else:
+        flash(f"{normalized} {name_for_flash} を監視に追加しました".rstrip(), "info")
     return redirect(url_for("portfolio.dashboard", status="watch"))
 
 
@@ -358,22 +377,25 @@ def dashboard():
     """3 タブ式ダッシュボード。"""
     active_query, active_status = _resolve_status_query(request.args.get("status", DEFAULT_TAB))
 
-    # 全レコードを 1 度だけ取得し、件数 (全タブ) と表示行 (active タブ) を共に算出する
-    all_records = ps.list_records()
-    fallback_mode = not all_records
+    # issue #186: fallback 判定は除外含む全件で行う (全件除外時の誤判定を避ける)。
+    # 表示・件数カウントは除外を弾いた visible_records を使う。
+    all_records_inc = ps.list_records(include_excluded=True)
+    fallback_mode = not all_records_inc
     if fallback_mode:
-        all_records = _build_fallback_records()
+        visible_records = _build_fallback_records()
+    else:
+        visible_records = [r for r in all_records_inc if not r.get("excluded", False)]
 
     counts = {q: 0 for q, _, _ in TABS}
-    for r in all_records:
+    for r in visible_records:
         st = r.get("status")
         if st in STATUS_VALUE_TO_QUERY:
             counts[STATUS_VALUE_TO_QUERY[st]] += 1
 
-    active_records = [r for r in all_records if r.get("status") == active_status]
+    active_records = [r for r in visible_records if r.get("status") == active_status]
     rows = list_portfolio_with_indicators(active_records)
-    # フォールバック中は書き込み UI (ステータス変更フォーム / 削除フォーム) を
-    # 出さない。shelve が空のため transition / delete を呼ぶと KeyError になる。
+    # フォールバック中は書き込み UI (ステータス変更フォーム / 削除モード) を
+    # 出さない。shelve が空のため transition / exclude を呼ぶと KeyError になる。
     transitions = [] if fallback_mode else _allowed_transitions_from(active_status)
 
     return render_template(

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -21,6 +21,24 @@
   }
   /* 数値・短文列は明示的に狭くする */
   table.portfolio-list td.num { text-align: right; }
+  /* 削除モード時のみチェックボックス列を表示 (issue #186) */
+  .bulk-col { display: none; }
+  body.delete-mode .bulk-col { display: table-cell; }
+  /* 一括削除アクションバー */
+  #bulk-delete-bar {
+    position: sticky; bottom: 0; z-index: 10;
+    background: #fff; border-top: 2px solid #c00;
+    padding: 0.5em 1em; margin-top: 0.5em;
+    display: flex; gap: 0.8em; align-items: center;
+  }
+  .portfolio-add-form {
+    display: flex; gap: 0.5em; align-items: center;
+    margin-bottom: 0.6em; font-size: 0.85em;
+  }
+  .portfolio-add-form input[type="text"] { padding: 0.25em 0.4em; margin: 0; }
+  .portfolio-add-form button { padding: 0.3em 0.8em; margin: 0; }
+  .portfolio-add-form .hint { color: #999; font-size: 0.85em; }
+  #toggle-delete-mode { padding: 0.3em 0.8em; margin-bottom: 0.5em; font-size: 0.85em; }
 </style>
 <h2>保有銘柄ダッシュボード</h2>
 
@@ -55,11 +73,28 @@
 
 <p style="font-size:0.85em;color:#666;">{{ rows|length }} 件</p>
 
+{% if active_query == "watch" and not fallback_mode %}
+<form action="/portfolio/add" method="POST" class="portfolio-add-form">
+  <label>コード <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
+  <button type="submit">追加</button>
+  <span class="hint">(除外済みコードを再入力すると復活します)</span>
+</form>
+<button type="button" id="toggle-delete-mode">削除モード</button>
+{% if rows %}
+<div id="bulk-delete-bar" style="display:none;">
+  <span><strong id="selected-count">0</strong> 件選択中</span>
+  <button type="button" id="bulk-delete-execute" class="contrast">削除 (ユニバース除外)</button>
+  <button type="button" id="bulk-delete-cancel">キャンセル</button>
+</div>
+{% endif %}
+{% endif %}
+
 {% if rows %}
 <div style="overflow-x:auto;">
 <table class="portfolio-list">
   <thead>
     <tr>
+      {% if active_query == "watch" and not fallback_mode %}<th class="bulk-col"></th>{% endif %}
       <th></th>
       <th>コード</th>
       <th>銘柄名</th>
@@ -86,7 +121,10 @@
   </thead>
   <tbody>
     {% for row in rows %}
-    <tr>
+    <tr data-code="{{ row.code_s }}">
+      {% if active_query == "watch" and not fallback_mode %}
+      <td class="bulk-col"><input type="checkbox" class="bulk-cb" value="{{ row.code_s }}"></td>
+      {% endif %}
       <td>
         <details>
           <summary style="cursor:pointer;list-style:none;">▸</summary>
@@ -135,7 +173,7 @@
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      <td colspan="22" style="background:#f8f8f8;padding:0.8em 1em;">
+      <td colspan="{% if active_query == 'watch' and not fallback_mode %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">
@@ -197,15 +235,7 @@
                         onclick="return confirm('{{ row.code_s }} のステータスを変更しますか?')">変更</button>
               </form>
               {% endif %}
-              {% if active_query == "watch" and not fallback_mode %}
-              <form action="/portfolio/{{ row.code_s }}/delete" method="POST"
-                    style="display:flex;flex-direction:column;gap:0.3em;margin:0;border-top:1px dashed #ccc;padding-top:0.5em;">
-                <label style="font-size:0.85em;color:#c00;">削除 (監視のみ)</label>
-                <textarea name="reason" placeholder="削除理由 (必須)" rows="2" required style="font-size:0.85em;padding:0.3em;margin:0;"></textarea>
-                <button type="submit" class="contrast" style="padding:0.3em 0.6em;font-size:0.85em;margin:0;"
-                        onclick="return confirm('{{ row.code_s }} を完全に削除しますか? (アクションログは残ります)')">削除</button>
-              </form>
-              {% endif %}
+              {# 削除はテーブル上部の「削除モード」 (issue #186) で一括処理する #}
             </div>
           </div>
         </div>
@@ -452,6 +482,52 @@ document.querySelectorAll('table details').forEach(function(d) {
       startEdit(td);
     });
   });
+})();
+
+// ========== 削除モード = ユニバース除外一括 (issue #186) ==========
+(function() {
+  var toggle = document.getElementById('toggle-delete-mode');
+  if (!toggle) return;  // 3監タブ以外では何もしない
+  var bar = document.getElementById('bulk-delete-bar');
+  var countEl = document.getElementById('selected-count');
+  var execBtn = document.getElementById('bulk-delete-execute');
+  var cancelBtn = document.getElementById('bulk-delete-cancel');
+
+  function refresh() {
+    var checked = document.querySelectorAll('.bulk-cb:checked');
+    if (countEl) countEl.textContent = checked.length;
+    if (bar) bar.style.display = document.body.classList.contains('delete-mode') ? '' : 'none';
+  }
+  function clearChecks() {
+    document.querySelectorAll('.bulk-cb').forEach(function(c) { c.checked = false; });
+  }
+  toggle.addEventListener('click', function() {
+    document.body.classList.toggle('delete-mode');
+    if (!document.body.classList.contains('delete-mode')) clearChecks();
+    refresh();
+  });
+  if (cancelBtn) cancelBtn.addEventListener('click', function() {
+    document.body.classList.remove('delete-mode');
+    clearChecks();
+    refresh();
+  });
+  document.addEventListener('change', function(e) {
+    if (e.target && e.target.classList && e.target.classList.contains('bulk-cb')) refresh();
+  });
+  if (execBtn) execBtn.addEventListener('click', function() {
+    var codes = Array.prototype.slice.call(document.querySelectorAll('.bulk-cb:checked')).map(function(c) { return c.value; });
+    if (!codes.length) return;
+    if (!confirm(codes.length + ' 件をユニバースから除外します。よろしいですか?')) return;
+    var fd = new FormData();
+    codes.forEach(function(c) { fd.append('codes', c); });
+    fetch('/portfolio/bulk-exclude', { method: 'POST', body: fd })
+      .then(function(r) {
+        if (r.redirected) location.href = r.url;
+        else location.reload();
+      })
+      .catch(function(err) { alert('除外失敗: ' + err); });
+  });
+  refresh();
 })();
 </script>
 

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -538,3 +538,133 @@ class TestSyncToTxt:
         ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
         with open(txt_path, encoding="utf-8") as f:
             assert f.read() == ""
+
+    def test_sync_skips_excluded(self, db_path, tmp_path, stocks_db_for_sync):
+        """excluded=True のレコードは txt 出力に含まれない"""
+        ps.add_to_watch("5032", db_path=db_path)
+        ps.add_to_watch("6232", db_path=db_path)
+        ps.exclude_from_universe("6232", db_path=db_path)
+
+        txt_path = str(tmp_path / "my_watch_list.txt")
+        ps.sync_to_my_watch_list_txt(txt_path=txt_path, db_path=db_path)
+
+        with open(txt_path, encoding="utf-8") as f:
+            content = f.read()
+        assert "5032AnyColor" in content
+        assert "6232" not in content
+
+
+# ==================================================
+# ユニバース除外 (issue #186)
+# ==================================================
+class TestExcludeFromUniverse:
+
+    def test_exclude_3kan_record(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        result = ps.exclude_from_universe("4377", reason="不要", db_path=db_path)
+        assert result is True
+        record = ps.get_record("4377", db_path=db_path)
+        assert record["excluded"] is True
+
+    def test_exclude_logs_action(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.exclude_from_universe("4377", reason="ノイズ", db_path=db_path)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        # [初回登録, ユニバース除外]
+        assert logs[-1]["action_type"] == "ユニバース除外"
+        assert logs[-1]["reason"] == "ノイズ"
+
+    def test_exclude_already_excluded_returns_false(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.exclude_from_universe("4377", db_path=db_path)
+        result = ps.exclude_from_universe("4377", db_path=db_path)
+        assert result is False
+
+    def test_exclude_1ho_rejected(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        with pytest.raises(ValueError, match="3監"):
+            ps.exclude_from_universe("4377", db_path=db_path)
+
+    def test_exclude_2jun_rejected(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.transition_status("4377", "2準", db_path=db_path)
+        with pytest.raises(ValueError, match="3監"):
+            ps.exclude_from_universe("4377", db_path=db_path)
+
+    def test_exclude_unregistered_returns_false(self, db_path):
+        result = ps.exclude_from_universe("4377", db_path=db_path)
+        assert result is False
+
+    def test_exclude_empty_reason_ok(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        result = ps.exclude_from_universe("4377", db_path=db_path)
+        assert result is True
+
+
+class TestAddToWatchRevive:
+
+    def test_revive_excluded_record(self, db_path):
+        ps.add_to_watch("4377", memo=ps.create_memo(stage="3S"), db_path=db_path)
+        ps.exclude_from_universe("4377", db_path=db_path)
+        record = ps.add_to_watch("4377", db_path=db_path)
+        assert record["excluded"] is False
+        # メモは保持される
+        assert record["memo"]["stage"] == "3S"
+
+    def test_revive_logs_universe_exclusion_with_revive_reason(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.exclude_from_universe("4377", reason="ノイズ", db_path=db_path)
+        ps.add_to_watch("4377", db_path=db_path)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        # 末尾は復活ログ (action_type=ユニバース除外, reason=復活)
+        assert logs[-1]["action_type"] == "ユニバース除外"
+        assert logs[-1]["reason"] == "復活"
+
+    def test_add_to_watch_active_record_still_raises(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        with pytest.raises(ValueError, match="既に登録済み"):
+            ps.add_to_watch("4377", db_path=db_path)
+
+
+class TestPortfolioRecordBackwardCompat:
+
+    def test_legacy_record_without_excluded_loads_as_false(self, db_path):
+        """旧スキーマのレコード (excluded キーなし) を直接書き込み、list_records で読める"""
+        from db_shelve import ShelveDB
+
+        legacy_record = {
+            "code_s": "4377",
+            "status": "3監",
+            "registered_at": "2024-01-01T00:00:00+09:00",
+            "updated_at": "2024-01-01T00:00:00+09:00",
+            "memo": ps.create_memo(),
+        }
+        with ShelveDB(db_path) as db:
+            db["record:4377"] = legacy_record
+
+        records = ps.list_records(db_path=db_path)
+        assert len(records) == 1
+        # excluded キーが無くても表示される (デフォルト False 扱い)
+        assert records[0]["code_s"] == "4377"
+
+
+class TestListRecordsFilterExcluded:
+
+    def test_default_filters_excluded(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.add_to_watch("5032", db_path=db_path)
+        ps.exclude_from_universe("4377", db_path=db_path)
+
+        records = ps.list_records(db_path=db_path)
+        codes = [r["code_s"] for r in records]
+        assert codes == ["5032"]
+
+    def test_include_excluded_returns_all(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.add_to_watch("5032", db_path=db_path)
+        ps.exclude_from_universe("4377", db_path=db_path)
+
+        records = ps.list_records(include_excluded=True, db_path=db_path)
+        codes = [r["code_s"] for r in records]
+        assert codes == ["4377", "5032"]

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -257,65 +257,153 @@ class TestTransitionPost:
         assert ps.get_record("9999", db_path=portfolio_db_path) is None
 
 
-class TestDeletePost:
-    """POST /portfolio/<code_s>/delete"""
+class TestBulkExclude:
+    """POST /portfolio/bulk-exclude (issue #186)"""
 
-    def test_delete_3kan_with_reason_succeeds(self, client, portfolio_db_path):
-        # 6324 は 3監 (fixture)
-        resp = client.post(
-            "/portfolio/6324/delete",
-            data={"reason": "監視終了"},
-        )
+    def test_bulk_exclude_single_3kan(self, client, portfolio_db_path):
+        resp = client.post("/portfolio/bulk-exclude", data={"codes": "6324"})
         assert resp.status_code == 302
-        # レコードは物理削除
-        assert ps.get_record("6324", db_path=portfolio_db_path) is None
-        # 削除アクションログは残る
-        logs = ps.list_action_logs(code_s="6324", db_path=portfolio_db_path)
-        assert any(log.get("action_type") == "削除" for log in logs)
-
-    def test_delete_1ho_flash_error(self, client, portfolio_db_path):
-        """1保 銘柄を削除しようとすると ValueError → flash で reject"""
-        resp = client.post(
-            "/portfolio/3496/delete",
-            data={"reason": "誤操作テスト"},
-        )
-        assert resp.status_code == 302
-        # レコードは残る
-        rec = ps.get_record("3496", db_path=portfolio_db_path)
-        assert rec is not None
-        assert rec["status"] == "1保"
-
-    def test_delete_2jun_flash_error(self, client, portfolio_db_path):
-        """2準 銘柄を削除しようとすると ValueError → flash で reject"""
-        resp = client.post(
-            "/portfolio/7203/delete",
-            data={"reason": "誤操作テスト"},
-        )
-        assert resp.status_code == 302
-        rec = ps.get_record("7203", db_path=portfolio_db_path)
-        assert rec is not None
-        assert rec["status"] == "2準"
-
-    def test_delete_empty_reason_flash_error(self, client, portfolio_db_path):
-        """理由が空の削除は flash エラー"""
-        resp = client.post(
-            "/portfolio/6324/delete",
-            data={"reason": ""},
-        )
-        assert resp.status_code == 302
-        # レコードは残る
         rec = ps.get_record("6324", db_path=portfolio_db_path)
         assert rec is not None
+        assert rec["excluded"] is True
+        # アクションログに「ユニバース除外」
+        logs = ps.list_action_logs("6324", db_path=portfolio_db_path)
+        assert any(log.get("action_type") == "ユニバース除外" for log in logs)
 
-    def test_delete_unknown_code_flash_error(self, client, portfolio_db_path):
-        """未登録銘柄に対する削除は False 返却 → flash"""
+    def test_bulk_exclude_multiple(self, client, portfolio_db_path):
+        # 追加で 3監 をもう 1 件登録
+        ps.add_to_watch("4377", reason="テスト追加", db_path=portfolio_db_path)
         resp = client.post(
-            "/portfolio/9999/delete",
-            data={"reason": "テスト"},
+            "/portfolio/bulk-exclude",
+            data={"codes": ["6324", "4377"]},
         )
         assert resp.status_code == 302
-        # 9999 はもとから未登録
+        for code in ("6324", "4377"):
+            rec = ps.get_record(code, db_path=portfolio_db_path)
+            assert rec is not None
+            assert rec["excluded"] is True
+
+    def test_bulk_exclude_1ho_mixed_partial_success(self, client, portfolio_db_path):
+        """3監 + 1保 混入時、3監 のみ除外され 1保 はそのまま残る"""
+        resp = client.post(
+            "/portfolio/bulk-exclude",
+            data={"codes": ["6324", "3496"]},
+        )
+        assert resp.status_code == 302
+        # 3監 6324 は除外
+        rec_watch = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec_watch["excluded"] is True
+        # 1保 3496 は除外されない
+        rec_hold = ps.get_record("3496", db_path=portfolio_db_path)
+        assert rec_hold["excluded"] is False
+        assert rec_hold["status"] == "1保"
+
+    def test_bulk_exclude_empty_codes_flash_error(self, client, portfolio_db_path):
+        resp = client.post("/portfolio/bulk-exclude", data={})
+        assert resp.status_code == 302
+        # 6324 は除外されない
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["excluded"] is False
+
+    def test_bulk_exclude_unknown_code_no_change(self, client, portfolio_db_path):
+        """未登録コードのみ送信された場合、何も変更されない"""
+        resp = client.post("/portfolio/bulk-exclude", data={"codes": "9999"})
+        assert resp.status_code == 302
         assert ps.get_record("9999", db_path=portfolio_db_path) is None
+        # 既存の 6324 は影響なし
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["excluded"] is False
+
+    def test_bulk_exclude_invalid_code_in_list(self, client, portfolio_db_path):
+        """不正なコードが混じっても他のコードは正常に処理される"""
+        resp = client.post(
+            "/portfolio/bulk-exclude",
+            data={"codes": ["INVALID!", "6324"]},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["excluded"] is True
+
+
+class TestExcludedHidden:
+    """除外済みレコードはダッシュボードから消える (issue #186)"""
+
+    def test_excluded_record_not_in_watch_tab(self, client, portfolio_db_path):
+        ps.exclude_from_universe("6324", db_path=portfolio_db_path)
+        resp = client.get("/portfolio?status=watch")
+        assert resp.status_code == 200
+        # データテーブル行に 6324 が出ない (data-code 属性で判定)
+        assert b'data-code="6324"' not in resp.data
+
+    def test_excluded_record_not_in_any_tab(self, client, portfolio_db_path):
+        # 1保 を除外できないので一旦 3監 へ戻して除外
+        ps.transition_status("3496", "2準", db_path=portfolio_db_path)
+        ps.transition_status("3496", "3監", db_path=portfolio_db_path)
+        ps.exclude_from_universe("3496", db_path=portfolio_db_path)
+        for q in ("hold", "semi", "watch"):
+            resp = client.get(f"/portfolio?status={q}")
+            assert b'data-code="3496"' not in resp.data, f"3496 はタブ {q} で非表示のはず"
+
+
+class TestAddRevival:
+    """除外済みコードを再投入すると復活する (issue #186)"""
+
+    def test_revive_via_add_post(self, client, portfolio_db_path):
+        ps.exclude_from_universe("6324", db_path=portfolio_db_path)
+        resp = client.post("/portfolio/add", data={"code_s": "6324"})
+        assert resp.status_code == 302
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["excluded"] is False
+        # 「ユニバース除外」action_type の reason="復活" ログが追記される
+        logs = ps.list_action_logs("6324", db_path=portfolio_db_path)
+        revive_logs = [
+            log for log in logs
+            if log.get("action_type") == "ユニバース除外" and log.get("reason") == "復活"
+        ]
+        assert len(revive_logs) == 1
+
+    def test_revive_does_not_require_stocks_shelve(
+        self, client, portfolio_db_path, stocks_db_path, monkeypatch
+    ):
+        """除外済みレコードは stocks_shelve に登録が無くても復活できる"""
+        ps.exclude_from_universe("6324", db_path=portfolio_db_path)
+        # stocks_shelve 上の 6324 を削除して未登録状態にする
+        with ShelveDB(stocks_db_path) as db:
+            del db["6324"]
+        resp = client.post("/portfolio/add", data={"code_s": "6324"})
+        assert resp.status_code == 302
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["excluded"] is False
+
+
+class TestFallbackJudgmentWithAllExcluded:
+    """全レコードが excluded=True でも fallback モードと誤判定されない (issue #186)"""
+
+    def test_dashboard_not_in_fallback_when_all_excluded(self, client, portfolio_db_path):
+        # 全レコードを除外可能な状態 (3監) にしてから除外
+        ps.transition_status("3496", "2準", db_path=portfolio_db_path)
+        ps.transition_status("3496", "3監", db_path=portfolio_db_path)
+        ps.transition_status("7203", "3監", db_path=portfolio_db_path)
+        for code in ("6324", "3496", "7203"):
+            ps.exclude_from_universe(code, db_path=portfolio_db_path)
+        # この状態で /portfolio を開いても fallback バナーが出ないこと
+        resp = client.get("/portfolio?status=watch")
+        assert resp.status_code == 200
+        # fallback バナー文言の一部 ("portfolio_shelve 未移行" 等) が出ていない
+        assert "portfolio_shelve 未移行".encode("utf-8") not in resp.data
+
+    def test_revive_works_when_all_excluded(self, client, portfolio_db_path):
+        # 全レコードを除外
+        ps.transition_status("3496", "2準", db_path=portfolio_db_path)
+        ps.transition_status("3496", "3監", db_path=portfolio_db_path)
+        ps.transition_status("7203", "3監", db_path=portfolio_db_path)
+        for code in ("6324", "3496", "7203"):
+            ps.exclude_from_universe(code, db_path=portfolio_db_path)
+        # この状態で復活が許可されること
+        resp = client.post("/portfolio/add", data={"code_s": "6324"})
+        assert resp.status_code == 302
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["excluded"] is False
 
 
 # ==================================================
@@ -610,13 +698,14 @@ class TestFallbackFromTxt:
         assert resp.status_code == 302
         assert ps.list_records(db_path=portfolio_db_path) == []
 
-    def test_fallback_rejects_delete_post(self, fallback_client, tmp_path):
+    def test_fallback_rejects_bulk_exclude_post(self, fallback_client, tmp_path):
+        """フォールバック中は /portfolio/bulk-exclude も reject (issue #186)"""
         portfolio_db_path = str(tmp_path / "test_portfolio_shelve")
         resp = fallback_client.post(
-            "/portfolio/3496/delete", data={"reason": "テスト"}
+            "/portfolio/bulk-exclude", data={"codes": "3496"}
         )
         assert resp.status_code == 302
-        assert ps.list_records(db_path=portfolio_db_path) == []
+        assert ps.list_records(include_excluded=True, db_path=portfolio_db_path) == []
 
     def test_fallback_rejects_memo_post(self, fallback_client, tmp_path):
         """フォールバック中は /portfolio/<code>/memo も reject (issue #175)"""


### PR DESCRIPTION
## Summary

- 3監タブ上部に銘柄追加フォーム (除外済みコード再投入で復活も同じフォーム)
- 「削除モード」トグル → 行頭チェックボックス → 一括「ユニバース除外」
- 削除は物理削除ではなく `excluded:bool` フラグで論理除外。メモ・ログは保持
- 既存の `POST /portfolio/<code>/delete` (物理削除) と展開行内の削除フォームは撤去

## 主な変更

### portfolio_shelve.py
- `PortfolioRecord.excluded` 追加 (旧データは False で読める後方互換)
- `exclude_from_universe(code_s, *, reason)` を新設 (3監のみ、既除外は False、1保/2準は ValueError)
- `add_to_watch` を「除外済みなら復活」も担うよう拡張。復活時は `reason="復活"` のログを記録
- `list_records(*, include_excluded=False)` 追加。fallback 判定箇所のみ True で呼ぶ
- `sync_to_my_watch_list_txt` は `list_records()` の除外フィルタを活かし txt にも書き戻さない

### routes/portfolio.py
- `/portfolio/<code>/delete` ルートを撤去 (要件と矛盾する物理削除を遮断)
- `/portfolio/bulk-exclude` を新設 (`codes=[...] & reason=任意`、部分成功許容)
- `/portfolio/add` で既存レコードあれば stocks_shelve チェックをスキップ → 除外解除パスに進める
- `dashboard()` を 2 段階取得に変更:
  - fallback 判定は `list_records(include_excluded=True)` で全件
  - 表示・件数は除外フィルタ後

### templates/portfolio_list.html
- 3監タブ限定で追加フォーム + 「削除モード」ボタン + bulk-delete-bar
- 各行先頭に `bulk-col` セル (CSS で `body.delete-mode` 時のみ表示)
- 既存の展開行内「削除フォーム」を撤去
- JS IIFE で削除モード切替 + チェックボックス集計 + bulk-exclude POST

## テスト

- portfolio_shelve.py: 14 ケース追加 (TestExcludeFromUniverse / TestAddToWatchRevive / TestPortfolioRecordBackwardCompat / TestListRecordsFilterExcluded / sync_skips_excluded)
- routes: 12 ケース追加 (TestBulkExclude / TestExcludedHidden / TestAddRevival / TestFallbackJudgmentWithAllExcluded)、既存 TestDeletePost 撤去
- 結果: `pytest tests/test_portfolio_shelve.py tests/test_webapp_portfolio_routes.py tests/test_webapp_helpers.py` で 257 件パス

## codex レビュー

実装プラン (`.claude/plans/issue-186-portfolio-add-exclude.md`) は codex で 4 ラウンドレビュー、以下を反映:
- 物理削除エンドポイント残置と要件矛盾 → ルート撤去
- `sync_to_my_watch_list_txt` で除外済みも txt 反映 → list_records デフォルトで除外
- `_is_fallback_mode` / `dashboard()` 全件除外時の誤判定 → include_excluded=True で取得
- stocks_shelve 未登録ガードが復活を阻む → 既存レコードあれば skip
- 復活ログの note フィールドが現行スキーマに存在しない → reason="復活" を使用

## 動作確認 (Playwright E2E)

- [x] 3監タブで追加フォーム + 削除モードボタン表示
- [x] 削除モード ON でチェックボックス + アクションバー表示
- [x] 1 件選択 → 「1 件選択中」表示
- [x] 一括除外 → 該当行が消える、shelve は `excluded=True` で残る、ログに「ユニバース除外」追加
- [x] 同コードを追加フォームに再投入 → 復活、ログに `reason="復活"` 追記、メモ保持
- [x] 1保/2準タブには追加フォーム/削除モード非表示

## 実装後タスク (別 PR で対応)

`my_watch_list.txt` と portfolio_shelve の差分同期スクリプト (`scripts/sync_portfolio_with_txt.py`) を新設し、txt ↔ DB の整合性を 1 度だけ手動同期する保守作業を予定。

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)