### PR TITLE
保有銘柄ダッシュボード: 管理ボタン化 + 準保有も除外可 + PER 整数表記 + ステージ Ctrl+クリック

### DIFF
--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -681,15 +681,18 @@ def delete_record(
     return True
 
 
+EXCLUDABLE_STATUSES = frozenset({"2準", "3監"})
+
+
 def exclude_from_universe(
     code_s: str,
     *,
     reason: str = "",
     db_path: Optional[str] = None,
 ) -> bool:
-    """3監レコードをユニバースから除外する (物理削除はしない)。
+    """2準/3監 レコードをユニバースから除外する (物理削除はしない)。
 
-    - 1保/2準 を除外しようとすると ValueError
+    - 1保 を除外しようとすると ValueError (保有中銘柄の誤除外を防ぐ)
     - レコードが存在しない場合は False を返す
     - 既に除外済みなら no-op で False を返す
     - 成功時はアクションログ「ユニバース除外」を 1 件記録
@@ -711,10 +714,10 @@ def exclude_from_universe(
             if record.get("excluded", False):
                 return False
             current_status = record.get("status")
-            if current_status != "3監":
+            if current_status not in EXCLUDABLE_STATUSES:
                 raise ValueError(
                     f"portfolio_shelve: {normalized} は status={current_status!r} のため "
-                    "ユニバース除外できません (3監 のみ除外可能、先に 3監 へ遷移してください)"
+                    "ユニバース除外できません (2準/3監 のみ除外可能)"
                 )
             record["excluded"] = True
             record["updated_at"] = now_iso()

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1491,6 +1491,20 @@ def _format_kessanbi_md(kessanbi: Any) -> str:
     return kessanbi
 
 
+def _format_per(per: Any) -> str:
+    """PER を表示用文字列に整形する。
+
+    - 二桁以上 (>= 10): 整数表記 (例: 25, 30)
+    - 一桁 (< 10): 小数1桁 (例: 5.3, 3.0)
+    - 数値でない: "—"
+    """
+    if not isinstance(per, (int, float)):
+        return "—"
+    if per >= 10:
+        return f"{per:.0f}"
+    return f"{per:.1f}"
+
+
 def _theoretical_diff_raw(stock: Dict[str, Any]) -> Optional[float]:
     """理論株価乖離率の生値 (整数化前) を返す。取れなければ None。"""
     if not stock or not stock.get("price") or not stock.get("rironkabuka"):
@@ -1615,7 +1629,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "rank": rank if isinstance(rank, int) else None,
         "kessanbi_md": _format_kessanbi_md(stock.get("kessanbi")),
         "kessanbi_raw": _parse_kessanbi(stock.get("kessanbi", "")),
-        "per": f"{per:.1f}" if isinstance(per, (int, float)) else "—",
+        "per": _format_per(per),
         "per_raw": per if isinstance(per, (int, float)) else None,
         # 表示はカテゴリ文字列 ("極小"〜"特大")。スプシの IFS 式に対応 (issue #177)
         "market_cap": _market_cap_category(market_cap_raw) or "—",

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -123,11 +123,11 @@ def _reject_when_fallback(redirect_query: str = "watch"):
 
 @portfolio_bp.route("/portfolio/bulk-exclude", methods=["POST"])
 def bulk_exclude():
-    """3監 銘柄を一括でユニバースから除外する (物理削除はしない)。
+    """2準/3監 銘柄を一括でユニバースから除外する (物理削除はしない)。
 
-    フォーム: codes=<code1>&codes=<code2>... / reason=<任意>
-    部分成功許容。1保/2準 が混入していたら該当のみ flash error で報告し、
-    3監 のみ除外を実行する。
+    フォーム: codes=<code1>&codes=<code2>... / reason=<任意> / return_to=<hold|semi|watch>
+    部分成功許容。1保 が混入していたら該当のみ flash error で報告し、2準/3監 のみ除外を実行する。
+    return_to はリダイレクト先タブ。不正値は watch にフォールバック。
     """
     rejected = _reject_when_fallback(redirect_query="watch")
     if rejected is not None:
@@ -135,10 +135,13 @@ def bulk_exclude():
 
     codes = [c.strip() for c in request.form.getlist("codes") if c and c.strip()]
     reason = (request.form.get("reason") or "").strip()
+    return_to = (request.form.get("return_to") or "watch").strip()
+    if return_to not in STATUS_QUERY_TO_VALUE:
+        return_to = "watch"
 
     if not codes:
         flash("除外対象が指定されていません", "error")
-        return redirect(url_for("portfolio.dashboard", status="watch"))
+        return redirect(url_for("portfolio.dashboard", status=return_to))
 
     success: list[str] = []
     failures: list[str] = []
@@ -164,7 +167,7 @@ def bulk_exclude():
         flash(f"{len(success)} 件をユニバースから除外しました ({', '.join(success)})", "info")
     if failures:
         flash("除外できなかったコードがあります: " + " / ".join(failures), "error")
-    return redirect(url_for("portfolio.dashboard", status="watch"))
+    return redirect(url_for("portfolio.dashboard", status=return_to))
 
 
 @portfolio_bp.route("/portfolio/<code_s>/transition", methods=["POST"])

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -21,7 +21,7 @@
   }
   /* 数値・短文列は明示的に狭くする */
   table.portfolio-list td.num { text-align: right; }
-  /* 削除モード時のみチェックボックス列を表示 (issue #186) */
+  /* 削除モード時のみチェックボックス列を表示 */
   .bulk-col { display: none; }
   body.delete-mode .bulk-col { display: table-cell; }
   /* 一括削除アクションバー */
@@ -33,14 +33,27 @@
   }
   .portfolio-add-form {
     display: flex; gap: 0.5em; align-items: center;
-    margin-bottom: 0.6em; font-size: 0.85em;
+    margin: 0; font-size: 0.85em;
   }
   .portfolio-add-form input[type="text"] { padding: 0.25em 0.4em; margin: 0; }
   .portfolio-add-form button { padding: 0.3em 0.8em; margin: 0; }
   .portfolio-add-form .hint { color: #999; font-size: 0.85em; }
-  #toggle-delete-mode { padding: 0.3em 0.8em; margin-bottom: 0.5em; font-size: 0.85em; }
+  /* 管理ボタン + 展開パネル */
+  .dashboard-header { display: flex; justify-content: space-between; align-items: baseline; gap: 1em; }
+  #toggle-manage-mode { padding: 0.3em 0.8em; font-size: 0.85em; margin: 0; }
+  #manage-panel {
+    padding: 0.6em 0.8em; margin: 0.4em 0 0.6em 0;
+    background: #f5f7fa; border: 1px solid #d8dee6; border-radius: 4px;
+    display: flex; flex-wrap: wrap; gap: 0.8em; align-items: center;
+  }
+  #toggle-delete-mode { padding: 0.3em 0.8em; font-size: 0.85em; margin: 0; }
 </style>
-<h2>保有銘柄ダッシュボード</h2>
+<div class="dashboard-header">
+  <h2 style="margin:0;">保有銘柄ダッシュボード</h2>
+  {% if not fallback_mode %}
+  <button type="button" id="toggle-manage-mode">管理</button>
+  {% endif %}
+</div>
 
 {% if fallback_mode %}
 <div style="padding:0.6em 1em;margin-bottom:1em;border-radius:4px;font-size:0.9em;background:#fff8e0;color:#a07000;border:1px solid #ecd07a;">
@@ -73,14 +86,17 @@
 
 <p style="font-size:0.85em;color:#666;">{{ rows|length }} 件</p>
 
-{% if active_query == "watch" and not fallback_mode %}
-<form action="/portfolio/add" method="POST" class="portfolio-add-form">
-  <label>コード <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
-  <button type="submit">追加</button>
-  <span class="hint">(除外済みコードを再入力すると復活します)</span>
-</form>
-<button type="button" id="toggle-delete-mode">削除モード</button>
-{% if rows %}
+{% if not fallback_mode %}
+<div id="manage-panel" style="display:none;">
+  <form action="/portfolio/add" method="POST" class="portfolio-add-form">
+    <label>コード <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
+    <button type="submit">追加</button>
+  </form>
+  {% if active_query in ("watch", "semi") and rows %}
+  <button type="button" id="toggle-delete-mode">削除モード</button>
+  {% endif %}
+</div>
+{% if active_query in ("watch", "semi") and rows %}
 <div id="bulk-delete-bar" style="display:none;">
   <span><strong id="selected-count">0</strong> 件選択中</span>
   <button type="button" id="bulk-delete-execute" class="contrast">削除 (ユニバース除外)</button>
@@ -94,7 +110,7 @@
 <table class="portfolio-list">
   <thead>
     <tr>
-      {% if active_query == "watch" and not fallback_mode %}<th class="bulk-col"></th>{% endif %}
+      {% if active_query in ("watch", "semi") and not fallback_mode %}<th class="bulk-col"></th>{% endif %}
       <th></th>
       <th>コード</th>
       <th>銘柄名</th>
@@ -122,7 +138,7 @@
   <tbody>
     {% for row in rows %}
     <tr data-code="{{ row.code_s }}">
-      {% if active_query == "watch" and not fallback_mode %}
+      {% if active_query in ("watch", "semi") and not fallback_mode %}
       <td class="bulk-col"><input type="checkbox" class="bulk-cb" value="{{ row.code_s }}"></td>
       {% endif %}
       <td>
@@ -158,7 +174,7 @@
           data-style-field="last_research_update"
           {% if not fallback_mode %}class="editable" data-code="{{ row.code_s }}" data-field="last_research_update" data-input-type="date"{% endif %}
           style="{{ row.styles.last_research_update or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.last_research_update or "—" }}</td>
-      <td title="クリックで編集 (ステージ変更時は更新日も自動で当日に)"
+      <td title="クリックで編集 (ステージ変更時は更新日も自動で当日に) / Ctrl+クリックで株探チャート"
           data-style-field="stage"
           {% if not fallback_mode %}class="editable" data-code="{{ row.code_s }}" data-field="stage" data-touch-update="1"{% endif %}
           style="{{ row.styles.stage or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.stage or "—" }}</td>
@@ -173,7 +189,7 @@
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      <td colspan="{% if active_query == 'watch' and not fallback_mode %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
+      <td colspan="{% if active_query in ('watch', 'semi') and not fallback_mode %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">
@@ -479,19 +495,52 @@ document.querySelectorAll('table details').forEach(function(d) {
     td.addEventListener('click', function(e) {
       // セル内のリンク (銘柄詳細など) クリックは編集モードに入らない
       if (e.target.tagName === 'A') return;
+      // ステージセルで Ctrl/Cmd+クリックなら株探チャートを別タブで開く (編集はしない)
+      if (td.dataset.field === 'stage' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        var code = td.dataset.code;
+        if (code) {
+          window.open('https://kabutan.jp/stock/chart?code=' + encodeURIComponent(code), '_blank', 'noopener');
+        }
+        return;
+      }
       startEdit(td);
     });
   });
 })();
 
-// ========== 削除モード = ユニバース除外一括 (issue #186) ==========
+// ========== 管理パネル開閉 ==========
+(function() {
+  var manageToggle = document.getElementById('toggle-manage-mode');
+  var panel = document.getElementById('manage-panel');
+  if (!manageToggle || !panel) return;
+  manageToggle.addEventListener('click', function() {
+    var open = panel.style.display !== 'none';
+    if (open) {
+      // 閉じる際は削除モードもクリア
+      panel.style.display = 'none';
+      document.body.classList.remove('delete-mode');
+      document.querySelectorAll('.bulk-cb').forEach(function(c) { c.checked = false; });
+      var bar = document.getElementById('bulk-delete-bar');
+      if (bar) bar.style.display = 'none';
+      var cnt = document.getElementById('selected-count');
+      if (cnt) cnt.textContent = '0';
+    } else {
+      panel.style.display = '';
+    }
+  });
+})();
+
+// ========== 削除モード = ユニバース除外一括 ==========
 (function() {
   var toggle = document.getElementById('toggle-delete-mode');
-  if (!toggle) return;  // 3監タブ以外では何もしない
+  if (!toggle) return;  // watch/semi タブ以外では何もしない
   var bar = document.getElementById('bulk-delete-bar');
   var countEl = document.getElementById('selected-count');
   var execBtn = document.getElementById('bulk-delete-execute');
   var cancelBtn = document.getElementById('bulk-delete-cancel');
+  // 現在のタブ (active_query) を Jinja で埋め込んで JS から参照
+  var returnTo = {{ active_query | tojson }};
 
   function refresh() {
     var checked = document.querySelectorAll('.bulk-cb:checked');
@@ -520,6 +569,7 @@ document.querySelectorAll('table details').forEach(function(d) {
     if (!confirm(codes.length + ' 件をユニバースから除外します。よろしいですか?')) return;
     var fd = new FormData();
     codes.forEach(function(c) { fd.append('codes', c); });
+    fd.append('return_to', returnTo);
     fetch('/portfolio/bulk-exclude', { method: 'POST', body: fd })
       .then(function(r) {
         if (r.redirected) location.href = r.url;

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -583,14 +583,21 @@ class TestExcludeFromUniverse:
     def test_exclude_1ho_rejected(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "1保", db_path=db_path)
-        with pytest.raises(ValueError, match="3監"):
+        with pytest.raises(ValueError, match="2準/3監"):
             ps.exclude_from_universe("4377", db_path=db_path)
 
-    def test_exclude_2jun_rejected(self, db_path):
+    def test_exclude_2jun_allowed(self, db_path):
+        """2準 銘柄もユニバース除外可能 (1保 は禁止のまま)"""
         ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "2準", db_path=db_path)
-        with pytest.raises(ValueError, match="3監"):
-            ps.exclude_from_universe("4377", db_path=db_path)
+        result = ps.exclude_from_universe("4377", reason="準保有から除外", db_path=db_path)
+        assert result is True
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec is not None
+        assert rec["excluded"] is True
+        assert rec["status"] == "2準"  # status は変えない、excluded フラグのみ
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert any(l["action_type"] == "ユニバース除外" for l in logs)
 
     def test_exclude_unregistered_returns_false(self, db_path):
         result = ps.exclude_from_universe("4377", db_path=db_path)

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1453,3 +1453,45 @@ class TestBuyCollectionScore:
     def test_with_spaces(self):
         # "A, B" のようなスペース付きでも動く
         assert helpers._buy_collection_score_sum("A, B") == 9
+
+
+class TestFormatPer:
+    """_format_per のユニットテスト (二桁以上は整数、一桁は小数1桁)"""
+
+    def test_two_digit_int(self):
+        assert helpers._format_per(25) == "25"
+
+    def test_two_digit_float(self):
+        assert helpers._format_per(30.0) == "30"
+
+    def test_two_digit_float_rounds(self):
+        # 二桁以上は整数化 (四捨五入)
+        assert helpers._format_per(25.4) == "25"
+        assert helpers._format_per(25.6) == "26"
+
+    def test_single_digit_float(self):
+        assert helpers._format_per(5.3) == "5.3"
+
+    def test_single_digit_int(self):
+        assert helpers._format_per(3) == "3.0"
+
+    def test_zero(self):
+        assert helpers._format_per(0) == "0.0"
+
+    def test_boundary_ten(self):
+        # ちょうど 10 は整数表記
+        assert helpers._format_per(10) == "10"
+        assert helpers._format_per(10.0) == "10"
+
+    def test_boundary_just_below_ten(self):
+        assert helpers._format_per(9.9) == "9.9"
+
+    def test_negative_under_ten(self):
+        # 負の PER (赤字) は一桁扱い
+        assert helpers._format_per(-3.5) == "-3.5"
+
+    def test_none(self):
+        assert helpers._format_per(None) == "—"
+
+    def test_string(self):
+        assert helpers._format_per("25") == "—"

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -135,8 +135,8 @@ class TestDashboardGet:
         """1保 タブで PER / モメンタム / 順位等の指標が表示される"""
         resp = client.get("/portfolio?status=hold")
         html = resp.data.decode()
-        # アズームの指標
-        assert "30.0" in html  # PER
+        # アズームの指標 (PER は二桁なので整数表記: 30)
+        assert ">30<" in html  # PER (二桁以上は整数)
         assert ">85<" in html  # モメンタム
         assert "50" in html    # rank
         # 売上成長%・利益成長% (アズーム fixture の gyoseki_current から計算: 50→100 は +100%)
@@ -297,6 +297,50 @@ class TestBulkExclude:
         rec_hold = ps.get_record("3496", db_path=portfolio_db_path)
         assert rec_hold["excluded"] is False
         assert rec_hold["status"] == "1保"
+
+    def test_bulk_exclude_2jun_allowed(self, client, portfolio_db_path):
+        """2準 銘柄もユニバース除外可能"""
+        resp = client.post(
+            "/portfolio/bulk-exclude",
+            data={"codes": "7203"},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("7203", db_path=portfolio_db_path)
+        assert rec is not None
+        assert rec["excluded"] is True
+        assert rec["status"] == "2準"  # status は 2準 のまま、excluded フラグのみ立つ
+        logs = ps.list_action_logs("7203", db_path=portfolio_db_path)
+        assert any(log.get("action_type") == "ユニバース除外" for log in logs)
+
+    def test_bulk_exclude_2jun_3kan_mixed(self, client, portfolio_db_path):
+        """2準 と 3監 を混ぜても両方除外される"""
+        resp = client.post(
+            "/portfolio/bulk-exclude",
+            data={"codes": ["6324", "7203"]},
+        )
+        assert resp.status_code == 302
+        for code in ("6324", "7203"):
+            rec = ps.get_record(code, db_path=portfolio_db_path)
+            assert rec is not None
+            assert rec["excluded"] is True
+
+    def test_bulk_exclude_redirects_to_return_to(self, client, portfolio_db_path):
+        """return_to=semi なら /portfolio?status=semi にリダイレクト"""
+        resp = client.post(
+            "/portfolio/bulk-exclude",
+            data={"codes": "7203", "return_to": "semi"},
+        )
+        assert resp.status_code == 302
+        assert "status=semi" in resp.headers["Location"]
+
+    def test_bulk_exclude_invalid_return_to_falls_back(self, client, portfolio_db_path):
+        """不正な return_to は watch にフォールバック"""
+        resp = client.post(
+            "/portfolio/bulk-exclude",
+            data={"codes": "6324", "return_to": "evil"},
+        )
+        assert resp.status_code == 302
+        assert "status=watch" in resp.headers["Location"]
 
     def test_bulk_exclude_empty_codes_flash_error(self, client, portfolio_db_path):
         resp = client.post("/portfolio/bulk-exclude", data={})


### PR DESCRIPTION
## Summary
- 右上に「管理」ボタンを集約 (押すと追加フォーム + 削除モード切替が展開、全タブ共通)
- 2準 (準保有) 銘柄もユニバース除外可能に (1保 は引き続き禁止)
- PER 表示を二桁以上は整数、一桁は小数1桁 (例: 25, 30, 5.3, 3.0)
- ステージセル Ctrl/Cmd+クリックで株探チャートを別タブで開く

## 変更詳細
- `portfolio_shelve.exclude_from_universe`: `EXCLUDABLE_STATUSES = {"2準", "3監"}` 導入、1保 のみ ValueError
- `webapp/routes/portfolio.bulk_exclude`: form `return_to` を受領 (whitelist 検証付き)、リダイレクト先を呼び出し元タブに
- `webapp/helpers._format_per`: PER 表示書式関数を新設、二桁以上は整数化
- `webapp/templates/portfolio_list.html`: 管理ボタン + `#manage-panel` 集約、bulk-col を watch/semi に拡張、ステージセル Ctrl/Cmd+クリックで株探チャート別タブ
- テスト追加 (272 件全 pass)
  - 2準 除外可 / 1保 除外不可
  - return_to=semi のリダイレクト、不正値の watch フォールバック
  - `_format_per` の境界値テスト (10, 9.9, 0, 負値, None, str)

## Test plan
- [x] `pytest tests/test_webapp_helpers.py tests/test_portfolio_shelve.py tests/test_webapp_portfolio_routes.py` (272 pass)
- [x] webapp 起動 → 保有/準保有/監視タブで管理ボタン展開挙動を Playwright で確認
- [x] 準保有タブで削除モード ON → チェックボックス表示確認
- [x] PER 表示: 二桁=整数, 一桁=小数1桁 を画面で確認
- [x] ステージセル Ctrl+クリック → 別タブで株探チャート (URL 確認済み)
- [ ] (要実機確認) 実際に準保有銘柄を 1 件除外して挙動確認
- [ ] (要実機確認) ステージ Ctrl+クリックで株探ページが正常に開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)