### PR TITLE
決算Q列: quarter=0 を '0Q' として表示

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1454,7 +1454,9 @@ def _progress_quarter_and_diff(stock: Dict[str, Any]) -> tuple:
     """gyoseki.calc_progress_rate から (quarter_label, diff_str) を返す。
 
     code_rank.csv 進捗率列 [P]3Q70%(72%),62%(44%) を分解:
-    - quarter_label: "3Q" などの文字列 (quarter=0 / 取れない時は "—")
+    - quarter_label: "3Q" などの文字列。
+        - quarter=0 (1Q 未発表 / 新年度開始直後) は "0Q" として明示
+        - calc_progress_rate が値を返さない (データ不足) ときは "—"
     - diff_str: "(sales-sales_pre)/(profit-profit_pre)" を整数化 (例: "-2/+18")
                 取れなければ "—"
     """
@@ -1465,8 +1467,10 @@ def _progress_quarter_and_diff(stock: Dict[str, Any]) -> tuple:
         progress = calc_progress_rate(stock)
     except Exception:
         return ("—", "—")
-    quarter = progress.get("quarter", 0) if isinstance(progress, dict) else 0
-    if not quarter or quarter <= 0:
+    if not isinstance(progress, dict) or "quarter" not in progress:
+        return ("—", "—")
+    quarter = progress.get("quarter", 0)
+    if not isinstance(quarter, int) or quarter < 0:
         return ("—", "—")
     quarter_label = f"{quarter}Q"
     sales = progress.get("sales")

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1495,3 +1495,54 @@ class TestFormatPer:
 
     def test_string(self):
         assert helpers._format_per("25") == "—"
+
+
+class TestProgressQuarterAndDiff:
+    """_progress_quarter_and_diff の quarter_label 表示テスト"""
+
+    def test_quarter_zero_returns_0q(self, monkeypatch):
+        """1Q 未発表 (quarter=0) は '0Q' を表示する (旧仕様の '—' から変更)"""
+        # calc_progress_rate が {"quarter": 0} だけ返すケース (1Q 未発表 / 新年度初期)
+        import gyoseki
+        monkeypatch.setattr(gyoseki, "calc_progress_rate", lambda stock: {"quarter": 0})
+        label, diff = helpers._progress_quarter_and_diff({"code_s": "0001"})
+        assert label == "0Q"
+        assert diff == "—"  # sales/profit が無いので diff は "—"
+
+    def test_quarter_3_with_full_data(self, monkeypatch):
+        """3Q + 全数値あり -> '3Q' + diff 文字列"""
+        import gyoseki
+        monkeypatch.setattr(
+            gyoseki, "calc_progress_rate",
+            lambda stock: {
+                "quarter": 3,
+                "sales": 70.0, "sales_pre": 72.0,
+                "profit": 62.0, "profit_pre": 44.0,
+            },
+        )
+        label, diff = helpers._progress_quarter_and_diff({"code_s": "0001"})
+        assert label == "3Q"
+        assert diff == "-2/+18"
+
+    def test_no_progress_dict_returns_dash(self, monkeypatch):
+        """calc_progress_rate がデータ不足で {} を返すときは '—'"""
+        import gyoseki
+        monkeypatch.setattr(gyoseki, "calc_progress_rate", lambda stock: {})
+        label, diff = helpers._progress_quarter_and_diff({"code_s": "0001"})
+        assert label == "—"
+        assert diff == "—"
+
+    def test_empty_stock_returns_dash(self):
+        label, diff = helpers._progress_quarter_and_diff({})
+        assert label == "—"
+        assert diff == "—"
+
+    def test_calc_raises_returns_dash(self, monkeypatch):
+        """calc_progress_rate が例外を投げても '—' で安全にフォールバック"""
+        import gyoseki
+        def boom(stock):
+            raise RuntimeError("boom")
+        monkeypatch.setattr(gyoseki, "calc_progress_rate", boom)
+        label, diff = helpers._progress_quarter_and_diff({"code_s": "0001"})
+        assert label == "—"
+        assert diff == "—"


### PR DESCRIPTION
## Summary
- `_progress_quarter_and_diff` で quarter=0 (1Q 未発表 / 新年度開始直後) を '—' でなく '0Q' と表示
- データ不足 (`calc_progress_rate` が `{}` を返す) ときのみ '—' フォールバック
- 例外時も '—' に安全フォールバック

## Test plan
- [x] `pytest tests/test_webapp_helpers.py tests/test_webapp_portfolio_routes.py` (208 pass)
- [x] `TestProgressQuarterAndDiff` 5 ケース新規 (0Q, 3Q+full, 空dict, 空stock, 例外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)