### PR TITLE
issue #187 portfolio: 業態・テーマを構造化 (最大2スロット・datalist)

### DIFF
--- a/scripts/migrate_gyoutai_theme_to_list.py
+++ b/scripts/migrate_gyoutai_theme_to_list.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""portfolio_shelve.memo の旧 gyoutai_theme (str/改行区切り) を新 gyoutai_themes (list) に移行する 1 回限りマイグレーション (issue #187)。
+
+要件:
+- 旧 `gyoutai_theme` の改行区切り文字列を split → strip → 空除去 → 先頭 N 件
+- 新 `gyoutai_themes` に保存
+- 旧 `gyoutai_theme` は空文字に更新 (フィールド自体は残す)
+- excluded 銘柄も対象 (移行漏れさせない)
+- デフォルト dry-run、`--apply` で実書き込み
+
+usage:
+    python migrate_gyoutai_theme_to_list.py            # dry-run (デフォルト)
+    python migrate_gyoutai_theme_to_list.py --apply    # 本番実行
+"""
+
+import argparse
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import log_print
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+
+def migrate_gyoutai_theme_to_list(
+    *,
+    apply: bool = False,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """旧 gyoutai_theme (str) を新 gyoutai_themes (list) に移行する。
+
+    Returns: {"total": int, "converted": int, "skipped": int}
+    """
+    # excluded 銘柄も対象 (issue #187 codex P3 対応)
+    records = ps.list_records(include_excluded=True, db_path=db_path)
+    total = len(records)
+    converted = 0
+    skipped = 0
+
+    for rec in records:
+        code_s = rec.get("code_s", "")
+        memo = rec.get("memo") or {}
+        old = memo.get("gyoutai_theme", "") or ""
+        existing_new = memo.get("gyoutai_themes") or []
+
+        # 既に新フィールドに値が入っている / 旧フィールドが空 → スキップ
+        if existing_new or not old.strip():
+            skipped += 1
+            continue
+
+        themes = [t.strip() for t in old.split("\n") if t.strip()][
+            : ps.GYOUTAI_THEMES_MAX_SLOTS
+        ]
+        log_print(
+            f"migrate_gyoutai_theme: {code_s}: {old!r} -> {themes}"
+        )
+        if apply:
+            ps.update_memo(
+                code_s,
+                {
+                    "gyoutai_themes": themes,
+                    "gyoutai_theme": "",  # 空に更新 (フィールドは残す)
+                },
+                db_path=db_path,
+            )
+        converted += 1
+
+    log_print(
+        f"migrate_gyoutai_theme_to_list: 全 {total} 件、"
+        f"変換 {converted} 件、スキップ {skipped} 件 (apply={apply})"
+    )
+    return {"total": total, "converted": converted, "skipped": skipped}
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="portfolio_shelve.memo の gyoutai_theme (str) を gyoutai_themes (list) に移行",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="実際に書き込む。指定しない場合は dry-run (デフォルト)",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=str,
+        default=None,
+        help="portfolio_shelve のパス上書き (テスト用)",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    result = migrate_gyoutai_theme_to_list(apply=args.apply, db_path=args.db_path)
+    print(
+        f"total={result['total']} converted={result['converted']} "
+        f"skipped={result['skipped']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -86,7 +86,8 @@ LEGACY_RECORD_FIELDS = frozenset({"stock_name"})
 
 MEMO_FIELDS = frozenset(
     {
-        "gyoutai_theme",          # 業態・テーマ
+        "gyoutai_theme",          # 旧: 業態・テーマ (str/改行区切り、移行期間中のみ残す。issue #187)
+        "gyoutai_themes",         # 新: 業態・テーマ (list[str]、UI では最大2件)
         "watch_in_reason",        # ウォッチ・IN理由
         "trade_idea",             # 投資売買アイデア
         "inago_origin",           # イナゴ元・きっかけ
@@ -96,6 +97,12 @@ MEMO_FIELDS = frozenset(
         "jukyu_chart",            # 需給チャートメモ (例: "月足低位ブレイク CWH")
     }
 )
+
+# list[str] として扱う memo フィールド (str 系とバリデーションを分ける)
+MEMO_LIST_FIELDS = frozenset({"gyoutai_themes"})
+
+# gyoutai_themes の UI スロット上限 (issue #187)
+GYOUTAI_THEMES_MAX_SLOTS = 2
 
 ACTION_LOG_FIELDS = frozenset(
     {
@@ -265,6 +272,7 @@ def _resolve_db_path(db_path: Optional[str]) -> str:
 def create_memo(
     *,
     gyoutai_theme: str = "",
+    gyoutai_themes: Optional[List[str]] = None,
     watch_in_reason: str = "",
     trade_idea: str = "",
     inago_origin: str = "",
@@ -272,10 +280,11 @@ def create_memo(
     last_research_update: str = "",
     stage: str = "",
     jukyu_chart: str = "",
-) -> Dict[str, str]:
+) -> Dict[str, Any]:
     """手動メモ dict を生成する。"""
     return {
         "gyoutai_theme": gyoutai_theme,
+        "gyoutai_themes": list(gyoutai_themes) if gyoutai_themes else [],
         "watch_in_reason": watch_in_reason,
         "trade_idea": trade_idea,
         "inago_origin": inago_origin,
@@ -284,6 +293,31 @@ def create_memo(
         "stage": stage,
         "jukyu_chart": jukyu_chart,
     }
+
+
+def _normalize_loaded_memo(memo: Any) -> Dict[str, Any]:
+    """shelve から読み込んだ memo に新フィールドのデフォルトを補完する。
+
+    旧データに `gyoutai_themes` がない場合 `[]` を埋めて、UI/集計ヘルパーが
+    KeyError を踏まないようにする (issue #187 後方互換)。
+    """
+    if not isinstance(memo, dict):
+        return memo
+    result = dict(memo)
+    if "gyoutai_themes" not in result:
+        result["gyoutai_themes"] = []
+    return result
+
+
+def _normalize_loaded_record(record: Any) -> Any:
+    """shelve から読み込んだ record の memo を正規化する (issue #187)。"""
+    if not isinstance(record, dict):
+        return record
+    if "memo" in record:
+        result = dict(record)
+        result["memo"] = _normalize_loaded_memo(result.get("memo"))
+        return result
+    return record
 
 
 def create_record(
@@ -336,7 +370,8 @@ def get_record(
     normalized = normalize_code_s(code_s)
     path = _resolve_db_path(db_path)
     with ShelveDB(path) as db:
-        return db.get(_record_key(normalized))
+        record = db.get(_record_key(normalized))
+    return _normalize_loaded_record(record) if record is not None else None
 
 
 def list_records(
@@ -366,7 +401,7 @@ def list_records(
                 continue
             if not include_excluded and value.get("excluded", False):
                 continue
-            results.append(value)
+            results.append(_normalize_loaded_record(value))
     results.sort(key=lambda r: r.get("code_s", ""))
     return results
 
@@ -771,9 +806,21 @@ def update_memo(
             f"(許容値: {sorted(MEMO_FIELDS)})"
         )
 
-    normalized_fields: Dict[str, str] = {}
+    normalized_fields: Dict[str, Any] = {}
     for k, v in fields.items():
-        if v is None:
+        if k in MEMO_LIST_FIELDS:
+            # list[str] 専用フィールド (issue #187: gyoutai_themes)
+            if not isinstance(v, list):
+                raise TypeError(
+                    f"portfolio_shelve: memo[{k!r}] must be list[str], "
+                    f"got {type(v).__name__}"
+                )
+            if not all(isinstance(e, str) for e in v):
+                raise TypeError(
+                    f"portfolio_shelve: memo[{k!r}] must contain only str"
+                )
+            normalized_fields[k] = list(v)
+        elif v is None:
             normalized_fields[k] = ""
         elif isinstance(v, str):
             normalized_fields[k] = v
@@ -782,6 +829,9 @@ def update_memo(
                 f"portfolio_shelve: memo[{k!r}] must be str or None, "
                 f"got {type(v).__name__}"
             )
+
+    def _current_default(k: str) -> Any:
+        return [] if k in MEMO_LIST_FIELDS else ""
 
     path = _resolve_db_path(db_path)
     with _flock(db_path):
@@ -794,7 +844,7 @@ def update_memo(
             record = db[key]
             current_memo = record.get("memo", {}) or {}
             changed = any(
-                current_memo.get(k, "") != v
+                current_memo.get(k, _current_default(k)) != v
                 for k, v in normalized_fields.items()
             )
             if not changed:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1374,6 +1374,24 @@ def list_portfolio_with_indicators(records: List[Dict[str, Any]]) -> List[Dict[s
     return rows
 
 
+def collect_gyoutai_theme_choices(records: List[Dict[str, Any]]) -> List[str]:
+    """portfolio_shelve 全レコードの memo.gyoutai_themes をフラット化して候補リストを返す (issue #187)。
+
+    空要素除去・ユニーク化・アルファベット/五十音昇順ソート済み。
+    datalist の選択肢として使う想定。
+    """
+    seen = set()
+    for rec in records:
+        memo = rec.get("memo") or {}
+        for theme in (memo.get("gyoutai_themes") or []):
+            if not isinstance(theme, str):
+                continue
+            t = theme.strip()
+            if t:
+                seen.add(t)
+    return sorted(seen)
+
+
 def _format_tags(stock: Dict[str, Any]) -> str:
     """code_rank.csv「タグ」列と同じ表記を返す。
 

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -16,6 +16,7 @@ from flask import Blueprint, flash, jsonify, redirect, render_template, request,
 import portfolio
 import portfolio_shelve as ps
 from webapp.helpers import (
+    collect_gyoutai_theme_choices,
     compute_cell_styles,
     get_stock_data,
     list_portfolio_with_indicators,
@@ -217,14 +218,34 @@ def _extract_memo_fields_from_form(form) -> dict:
 
     抽出した値は textarea の改行 (\\r\\n / \\r) を \\n に正規化し、前後 strip する。
     MEMO_FIELDS 外のキーは無視 (form に紛れ込んでも reject しない)。
+
+    issue #187: gyoutai_themes は `gyoutai_themes_0`, `gyoutai_themes_1` の
+    スロット形式で受信し、空文字スロットを除去した list[str] に集約する。
     """
     fields = {}
     for field in ps.MEMO_FIELDS:
+        if field in ps.MEMO_LIST_FIELDS:
+            continue  # list 系はスロット展開ロジックで別途処理
         if field not in form:
             continue
         raw = form[field] or ""
         normalized = raw.replace("\r\n", "\n").replace("\r", "\n").strip()
         fields[field] = normalized
+
+    # gyoutai_themes_0, gyoutai_themes_1 をスロット展開して list 化 (issue #187)
+    themes_slot_keys = [
+        f"gyoutai_themes_{i}" for i in range(ps.GYOUTAI_THEMES_MAX_SLOTS)
+    ]
+    if any(k in form for k in themes_slot_keys):
+        themes: list = []
+        for k in themes_slot_keys:
+            if k not in form:
+                continue
+            v = (form[k] or "").strip()
+            if v:
+                themes.append(v)
+        fields["gyoutai_themes"] = themes
+
     return fields
 
 
@@ -295,6 +316,7 @@ def update_memo(code_s: str):
                     "last_research_update": (row.get("memo") or {}).get("last_research_update") or "—",
                     "stage": (row.get("memo") or {}).get("stage") or "—",
                     "gyoutai_theme": (row.get("memo") or {}).get("gyoutai_theme") or "",
+                    "gyoutai_themes": list((row.get("memo") or {}).get("gyoutai_themes") or []),
                 }
         return jsonify(body)
     flash(f"{code_s} のメモを保存しました", "info")
@@ -401,6 +423,12 @@ def dashboard():
     # 出さない。shelve が空のため transition / exclude を呼ぶと KeyError になる。
     transitions = [] if fallback_mode else _allowed_transitions_from(active_status)
 
+    # issue #187: datalist 候補は表示タブ/excluded と独立、shelve 内の全レコードから集計
+    if fallback_mode:
+        gyoutai_theme_choices: list = []
+    else:
+        gyoutai_theme_choices = collect_gyoutai_theme_choices(all_records_inc)
+
     return render_template(
         "portfolio_list.html",
         tabs=TABS,
@@ -411,4 +439,6 @@ def dashboard():
         transitions=transitions,
         status_label=STATUS_VALUE_TO_LABEL,
         fallback_mode=fallback_mode,
+        gyoutai_theme_choices=gyoutai_theme_choices,
+        gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
     )

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -151,14 +151,19 @@
           style="max-width:10em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
         <a href="/stock/{{ row.code_s }}">{{ row.stock_name }}</a>
       </td>
-      <td title="{{ row.memo.gyoutai_theme }} (クリックで編集)"
-          {% if not fallback_mode %}class="editable" data-code="{{ row.code_s }}" data-field="gyoutai_theme" data-multiline="1" data-full="{{ row.memo.gyoutai_theme or '' }}"{% endif %}
-          style="max-width:11em;line-height:1.2;font-size:0.85em;overflow:hidden;{% if not fallback_mode %}cursor:pointer;{% endif %}">
-        {% if row.memo.gyoutai_theme %}
-          {% for theme_line in row.memo.gyoutai_theme.split("\n")[:2] %}
-          <div style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ theme_line }}</div>
-          {% endfor %}
-        {% else %}—{% endif %}
+      <td class="gyoutai-themes-cell" data-code="{{ row.code_s }}"
+          style="max-width:11em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
+        {% set themes = row.memo.gyoutai_themes or [] %}
+        {% for i in range(gyoutai_themes_max_slots) %}
+        <input type="text"
+               list="gyoutai-theme-choices"
+               name="gyoutai_themes_{{ i }}"
+               value="{{ themes[i] if i < (themes|length) else '' }}"
+               data-slot="{{ i }}"
+               class="gyoutai-input"
+               placeholder="—"
+               {% if fallback_mode %}disabled{% endif %}>
+        {% endfor %}
       </td>
       <td style="{{ row.styles.rank or '' }}">{{ row.rank if row.rank is not none else "—" }}</td>
       <td style="{{ row.styles.sales_growth or '' }}">{{ row.sales_growth }}</td>
@@ -261,6 +266,34 @@
   </tbody>
 </table>
 </div>
+
+<datalist id="gyoutai-theme-choices">
+  {% for choice in gyoutai_theme_choices %}
+  <option value="{{ choice }}">
+  {% endfor %}
+</datalist>
+
+<style>
+.gyoutai-themes-cell { vertical-align: middle; }
+.gyoutai-themes-cell .gyoutai-input {
+  display: block;
+  width: 100%;
+  max-width: 11em;
+  height: 1.1em;
+  font-size: 1em;
+  line-height: 1;
+  padding: 0 2px;
+  margin: 0;
+  border: 1px solid transparent;
+  background: transparent;
+  font-family: inherit;
+  box-sizing: content-box;
+}
+.gyoutai-themes-cell .gyoutai-input:hover { border-color: #ddd; background: #fff; }
+.gyoutai-themes-cell .gyoutai-input:focus { outline: 1px solid #4285f4; background: #fff; }
+.gyoutai-themes-cell .gyoutai-input.saving { background: #fff8c4; }
+.gyoutai-themes-cell .gyoutai-input.error { background: #fce4e4; border-color: #d33; }
+</style>
 
 <script>
 // summary クリックで対応する .row-detail を展開
@@ -505,6 +538,58 @@ document.querySelectorAll('table details').forEach(function(d) {
         return;
       }
       startEdit(td);
+    });
+  });
+})();
+
+// ========== 業態・テーマ inline 編集 (issue #187) ==========
+// 既存 .editable とは別系統。input + datalist で常時編集可能、change/blur で POST。
+(function() {
+  function saveCell(td) {
+    var code = td.dataset.code;
+    if (!code) return;
+    var inputs = td.querySelectorAll('.gyoutai-input');
+    if (!inputs.length) return;
+
+    var fd = new FormData();
+    inputs.forEach(function(inp) { fd.append(inp.name, inp.value); });
+
+    inputs.forEach(function(inp) { inp.classList.add('saving'); inp.classList.remove('error'); });
+
+    fetch('/portfolio/' + encodeURIComponent(code) + '/memo', {
+      method: 'POST',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      body: fd,
+    }).then(function(r) {
+      return r.json().then(function(json) { return { ok: r.ok, json: json }; });
+    }).then(function(res) {
+      inputs.forEach(function(inp) { inp.classList.remove('saving'); });
+      if (!res.ok || !res.json || res.json.ok !== true) {
+        inputs.forEach(function(inp) { inp.classList.add('error'); });
+        var msg = (res.json && res.json.error) || 'gyoutai_themes 保存に失敗しました';
+        alert(msg);
+        return;
+      }
+      // サーバ返却値で input を再同期 (空スロット除去・順序を反映)
+      var themes = (res.json.display && res.json.display.gyoutai_themes) || [];
+      inputs.forEach(function(inp, i) {
+        inp.value = themes[i] != null ? themes[i] : '';
+      });
+    }).catch(function(err) {
+      inputs.forEach(function(inp) { inp.classList.remove('saving'); inp.classList.add('error'); });
+      alert('通信エラー: ' + err);
+    });
+  }
+
+  document.querySelectorAll('td.gyoutai-themes-cell').forEach(function(td) {
+    var inputs = td.querySelectorAll('.gyoutai-input');
+    inputs.forEach(function(inp) {
+      if (inp.disabled) return;
+      // datalist 選択 (change) / 自由入力後の blur で保存
+      inp.addEventListener('change', function() { saveCell(td); });
+      inp.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); inp.blur(); }
+      });
     });
   });
 })();

--- a/tests/test_migrate_gyoutai_theme_to_list.py
+++ b/tests/test_migrate_gyoutai_theme_to_list.py
@@ -1,0 +1,108 @@
+"""migrate_gyoutai_theme_to_list.py のテスト (issue #187)"""
+
+import pytest
+
+import portfolio_shelve as ps
+import migrate_gyoutai_theme_to_list as m
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_portfolio_shelve")
+
+
+def _set_legacy_gyoutai_theme(code_s: str, value: str, db_path: str) -> None:
+    """旧スキーマ (gyoutai_theme: str) を持つレコードを用意するヘルパー。
+
+    update_memo 経由で gyoutai_theme を直接書き込むことで、
+    新フィールド gyoutai_themes は [] のまま残る (移行前の状態)。
+    """
+    ps.add_to_watch(code_s, db_path=db_path)
+    ps.update_memo(code_s, {"gyoutai_theme": value}, db_path=db_path)
+
+
+class TestMigrateGyoutaiThemeToList:
+
+    def test_dry_run_does_not_modify(self, db_path):
+        _set_legacy_gyoutai_theme("4377", "半導体\nAI", db_path)
+        result = m.migrate_gyoutai_theme_to_list(apply=False, db_path=db_path)
+        assert result["total"] == 1
+        assert result["converted"] == 1
+        assert result["skipped"] == 0
+
+        # shelve は変化なし: gyoutai_theme は元の値、gyoutai_themes は空のまま
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["memo"]["gyoutai_theme"] == "半導体\nAI"
+        assert rec["memo"]["gyoutai_themes"] == []
+
+    def test_apply_converts_single_slot(self, db_path):
+        _set_legacy_gyoutai_theme("4377", "半導体", db_path)
+        result = m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        assert result["converted"] == 1
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["半導体"]
+        assert rec["memo"]["gyoutai_theme"] == ""  # 空文字に更新
+
+    def test_apply_converts_two_slots(self, db_path):
+        _set_legacy_gyoutai_theme("4377", "半導体\nAI", db_path)
+        m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["半導体", "AI"]
+
+    def test_apply_truncates_more_than_max(self, db_path):
+        # 3 つ以上 → 先頭 2 件に切り詰め
+        _set_legacy_gyoutai_theme("4377", "A\nB\nC\nD", db_path)
+        m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["A", "B"]
+
+    def test_strips_whitespace_and_skips_empty_lines(self, db_path):
+        _set_legacy_gyoutai_theme("4377", "  半導体  \n\n  AI  \n", db_path)
+        m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["半導体", "AI"]
+
+    def test_skips_record_with_empty_gyoutai_theme(self, db_path):
+        # 旧フィールドが空 → スキップ (新フィールドも空のまま)
+        ps.add_to_watch("4377", db_path=db_path)
+        result = m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        assert result["converted"] == 0
+        assert result["skipped"] == 1
+
+    def test_skips_record_with_existing_gyoutai_themes(self, db_path):
+        # 既に gyoutai_themes に値がある → スキップ (上書きしない)
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.update_memo(
+            "4377",
+            {"gyoutai_theme": "旧データ", "gyoutai_themes": ["新データ"]},
+            db_path=db_path,
+        )
+        result = m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        assert result["converted"] == 0
+        assert result["skipped"] == 1
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["新データ"]
+        # gyoutai_theme は触らない
+        assert rec["memo"]["gyoutai_theme"] == "旧データ"
+
+    def test_includes_excluded_records(self, db_path):
+        """codex P3 対応: excluded 銘柄も移行対象になる"""
+        _set_legacy_gyoutai_theme("4377", "半導体", db_path)
+        ps.exclude_from_universe("4377", reason="test", db_path=db_path)
+        result = m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        assert result["total"] == 1
+        assert result["converted"] == 1
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["半導体"]
+
+    def test_idempotent(self, db_path):
+        """2 回実行しても 2 回目は no-op"""
+        _set_legacy_gyoutai_theme("4377", "半導体\nAI", db_path)
+        m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        result = m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        assert result["converted"] == 0
+        assert result["skipped"] == 1
+
+    def test_empty_db(self, db_path):
+        result = m.migrate_gyoutai_theme_to_list(apply=True, db_path=db_path)
+        assert result == {"total": 0, "converted": 0, "skipped": 0}

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -72,7 +72,12 @@ class TestSchema:
     def test_create_memo_defaults(self):
         memo = ps.create_memo()
         assert set(memo.keys()) == ps.MEMO_FIELDS
-        assert all(v == "" for v in memo.values())
+        # list 系フィールドは [], それ以外は ""
+        for k, v in memo.items():
+            if k in ps.MEMO_LIST_FIELDS:
+                assert v == []
+            else:
+                assert v == ""
 
     def test_create_memo_partial(self):
         memo = ps.create_memo(gyoutai_theme="人材", trade_idea="押し目買い")
@@ -387,7 +392,9 @@ class TestUpdateMemo:
 
     def test_update_all_eight_fields(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
-        all_fields = {f: f"val_{f}" for f in ps.MEMO_FIELDS}
+        # list 系フィールド (gyoutai_themes) は別バリデーション経路なのでこのテストでは除外
+        str_fields = ps.MEMO_FIELDS - ps.MEMO_LIST_FIELDS
+        all_fields = {f: f"val_{f}" for f in str_fields}
         rec = ps.update_memo("4377", all_fields, db_path=db_path)
         for k, v in all_fields.items():
             assert rec["memo"][k] == v
@@ -437,6 +444,98 @@ class TestUpdateMemo:
         rec = ps.update_memo("215a", {"trade_idea": "X"}, db_path=db_path)
         assert rec["code_s"] == "215A"
         assert rec["memo"]["trade_idea"] == "X"
+
+
+class TestGyoutaiThemesField:
+    """issue #187: gyoutai_themes (list[str]) フィールドの読み書き / バリデーション。"""
+
+    def test_create_memo_defaults_empty_list(self):
+        memo = ps.create_memo()
+        assert memo["gyoutai_themes"] == []
+
+    def test_create_memo_with_explicit_list(self):
+        memo = ps.create_memo(gyoutai_themes=["半導体", "AI"])
+        assert memo["gyoutai_themes"] == ["半導体", "AI"]
+
+    def test_update_gyoutai_themes_saves_list(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        rec = ps.update_memo(
+            "4377", {"gyoutai_themes": ["半導体", "AI"]}, db_path=db_path
+        )
+        assert rec["memo"]["gyoutai_themes"] == ["半導体", "AI"]
+
+    def test_update_gyoutai_themes_empty_list_overwrites(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.update_memo("4377", {"gyoutai_themes": ["半導体"]}, db_path=db_path)
+        rec = ps.update_memo("4377", {"gyoutai_themes": []}, db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == []
+
+    def test_update_gyoutai_themes_partial_keeps_other_fields(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "X"}, db_path=db_path)
+        rec = ps.update_memo(
+            "4377", {"gyoutai_themes": ["AI"]}, db_path=db_path
+        )
+        assert rec["memo"]["gyoutai_themes"] == ["AI"]
+        assert rec["memo"]["trade_idea"] == "X"
+
+    def test_update_gyoutai_themes_rejects_non_list(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        with pytest.raises(TypeError):
+            ps.update_memo(
+                "4377", {"gyoutai_themes": "半導体\nAI"}, db_path=db_path
+            )
+
+    def test_update_gyoutai_themes_rejects_non_str_element(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        with pytest.raises(TypeError):
+            ps.update_memo(
+                "4377", {"gyoutai_themes": ["半導体", 123]}, db_path=db_path
+            )
+
+    def test_update_gyoutai_themes_no_diff_is_noop(self, db_path):
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.update_memo("4377", {"gyoutai_themes": ["AI"]}, db_path=db_path)
+        ps.update_memo("4377", {"gyoutai_themes": ["AI"]}, db_path=db_path)
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        memo_logs = [log for log in logs if log["action_type"] == "メモ更新"]
+        # 同じ値の更新は no-op、ログ追記は 1 回のみ
+        assert len(memo_logs) == 1
+
+    def test_legacy_record_without_gyoutai_themes_loads_as_empty_list(
+        self, db_path
+    ):
+        """旧データに gyoutai_themes フィールドがなくても、読み込み時に [] が補完される。"""
+        from db_shelve import ShelveDB
+
+        # 旧スキーマ (gyoutai_themes なし) で直接 shelve に書き込む
+        legacy_record = {
+            "code_s": "4377",
+            "status": "3監",
+            "registered_at": "2024-01-01T00:00:00+09:00",
+            "updated_at": "2024-01-01T00:00:00+09:00",
+            "memo": {
+                "gyoutai_theme": "半導体\nAI",
+                "trade_idea": "",
+                "watch_in_reason": "",
+                "inago_origin": "",
+                "takaichi_sensitivity": "",
+                "last_research_update": "",
+                "stage": "",
+                "jukyu_chart": "",
+            },
+            "excluded": False,
+        }
+        with ShelveDB(db_path) as db:
+            db["record:4377"] = legacy_record
+
+        rec = ps.get_record("4377", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == []
+
+        # list_records 経由でも補完される
+        recs = ps.list_records(db_path=db_path)
+        assert len(recs) == 1
+        assert recs[0]["memo"]["gyoutai_themes"] == []
 
 
 # ==================================================

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1546,3 +1546,42 @@ class TestProgressQuarterAndDiff:
         label, diff = helpers._progress_quarter_and_diff({"code_s": "0001"})
         assert label == "—"
         assert diff == "—"
+
+
+class TestCollectGyoutaiThemeChoices:
+    """issue #187: portfolio_shelve 全レコードから datalist 候補を集計する。"""
+
+    def test_flatten_and_unique_and_sort(self):
+        records = [
+            {"memo": {"gyoutai_themes": ["半導体", "AI"]}},
+            {"memo": {"gyoutai_themes": ["AI", "ロボット"]}},
+            {"memo": {"gyoutai_themes": ["半導体"]}},
+        ]
+        assert helpers.collect_gyoutai_theme_choices(records) == [
+            "AI",
+            "ロボット",
+            "半導体",
+        ]
+
+    def test_strips_whitespace_and_removes_empty(self):
+        records = [
+            {"memo": {"gyoutai_themes": [" 半導体 ", "", "  ", "AI"]}},
+        ]
+        assert helpers.collect_gyoutai_theme_choices(records) == ["AI", "半導体"]
+
+    def test_missing_gyoutai_themes_returns_empty(self):
+        records = [{"memo": {}}, {"memo": {"gyoutai_themes": None}}]
+        assert helpers.collect_gyoutai_theme_choices(records) == []
+
+    def test_missing_memo_returns_empty(self):
+        assert helpers.collect_gyoutai_theme_choices([{}]) == []
+
+    def test_empty_records_returns_empty(self):
+        assert helpers.collect_gyoutai_theme_choices([]) == []
+
+    def test_ignores_non_str_elements(self):
+        """defensive: 想定外の型 (None, int) が混入してもクラッシュしない"""
+        records = [
+            {"memo": {"gyoutai_themes": ["AI", None, 123, "半導体"]}},
+        ]
+        assert helpers.collect_gyoutai_theme_choices(records) == ["AI", "半導体"]

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -456,8 +456,10 @@ class TestFallbackJudgmentWithAllExcluded:
 class TestUpdateMemoPost:
 
     def test_memo_full_eight_fields_persist(self, client, portfolio_db_path):
-        """ブラウザ form と同じく全 8 項目を送ったら全部反映される"""
-        form_data = {field: f"val_{field}" for field in ps.MEMO_FIELDS}
+        """ブラウザ form と同じく str 系の全項目を送ったら全部反映される"""
+        # list 系フィールド (gyoutai_themes) は別 form name (gyoutai_themes_0/1) のため除外
+        str_fields = ps.MEMO_FIELDS - ps.MEMO_LIST_FIELDS
+        form_data = {field: f"val_{field}" for field in str_fields}
         resp = client.post("/portfolio/6324/memo", data=form_data)
         assert resp.status_code == 302
         rec = ps.get_record("6324", db_path=portfolio_db_path)
@@ -628,6 +630,81 @@ class TestUpdateMemoAjax:
         )
         assert resp.status_code == 302
         assert not resp.is_json
+
+
+# ==================================================
+# issue #187: gyoutai_themes スロット POST + dashboard 連動
+# ==================================================
+class TestGyoutaiThemesPost:
+    """gyoutai_themes_0/1 をスロット形式で受信し list に集約して保存される。"""
+
+    def test_post_two_slots_saves_as_list(self, client, portfolio_db_path):
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"gyoutai_themes_0": "半導体", "gyoutai_themes_1": "AI"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["半導体", "AI"]
+        # AJAX レスポンスの display にも list が含まれる
+        assert body["display"]["gyoutai_themes"] == ["半導体", "AI"]
+
+    def test_post_empty_slot_removed_order_preserved(self, client, portfolio_db_path):
+        # スロット 0 が空、1 にのみ値 → 順序維持で 1 件のみ保存
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"gyoutai_themes_0": "", "gyoutai_themes_1": "AI"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["AI"]
+
+    def test_post_both_empty_saves_empty_list(self, client, portfolio_db_path):
+        # 先に値をセットしておく
+        ps.update_memo(
+            "6324", {"gyoutai_themes": ["X"]}, db_path=portfolio_db_path
+        )
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"gyoutai_themes_0": "", "gyoutai_themes_1": ""},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["gyoutai_themes"] == []
+
+    def test_post_without_slot_keys_keeps_existing(self, client, portfolio_db_path):
+        # 部分更新セマンティクス: gyoutai_themes_* キーが POST に含まれない → 据え置き
+        ps.update_memo(
+            "6324", {"gyoutai_themes": ["既存"]}, db_path=portfolio_db_path
+        )
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"trade_idea": "X"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["既存"]
+        assert rec["memo"]["trade_idea"] == "X"
+
+    def test_dashboard_renders_datalist(self, client, portfolio_db_path):
+        # 候補集計が dashboard のテンプレに渡って HTML に含まれる
+        ps.update_memo(
+            "6324",
+            {"gyoutai_themes": ["半導体", "AI"]},
+            db_path=portfolio_db_path,
+        )
+        resp = client.get("/portfolio?status=hold")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'id="gyoutai-theme-choices"' in html
+        assert "半導体" in html
+        assert "AI" in html
 
 
 # ==================================================


### PR DESCRIPTION
## Summary
- `memo.gyoutai_theme` (改行区切り str) を `memo.gyoutai_themes` (`list[str]`) に構造化
- portfolio_list の業態・テーマ列に2スロットの `<input list>` + `<datalist>` を配置、既存値選択 + 自由入力での新規追加に対応
- 旧 `gyoutai_theme` を `list` に移行する 1 回限り migration (`migrate_gyoutai_theme_to_list.py`, 本番DB に apply 済み: 全 328 件中 86 件変換)

Closes #187

## 主な変更
- `scripts/portfolio_shelve.py`: `MEMO_FIELDS` に `gyoutai_themes` 追加、`update_memo()` の list[str] バリデーション、レコード読み込み時の欠損補完
- `scripts/webapp/helpers.py`: `collect_gyoutai_theme_choices()` 新設 (`include_excluded=True` の全エントリから集計、五十音/アルファベット昇順)
- `scripts/webapp/routes/portfolio.py`: GET `/portfolio` で datalist 候補を context に渡す、POST memo の `_extract_memo_fields_from_form()` を `gyoutai_themes_0/1` スロット展開対応に拡張
- `scripts/webapp/templates/portfolio_list.html`: gyoutai セルを input+datalist に置換、change イベントで自動保存する別系統 JS、CSS で行高調整
- `scripts/migrate_gyoutai_theme_to_list.py`: 新規移行スクリプト (`--apply` で本書き込み、`include_excluded=True` で全件処理)

## 後方互換
- 旧 `gyoutai_theme` は MEMO_FIELDS に残し、migration では空文字に更新するのみ。物理削除は別 issue で扱う
- 旧データに `gyoutai_themes` が無い場合は `get_record` / `list_records` の戻り値で `[]` を補完

## 設計判断 (codex P1/P2/P3 対応済み)
- update_memo: list 専用バリデーション (str/None は TypeError)
- datalist 集計: `include_excluded=True` の全エントリ (表示タブと独立)
- migration: `include_excluded=True` で除外銘柄も移行対象

## Test plan
- [x] ユニットテスト: `test_portfolio_shelve.py` / `test_webapp_helpers.py` / `test_webapp_portfolio_routes.py` / `test_migrate_gyoutai_theme_to_list.py` 計 307 件 pass
- [x] migration dry-run: 328 件中 86 件が変換対象 (1, 2 スロット、3つ以上は先頭2件に切り詰め)
- [x] migration apply: 本番DB 86 件変換、レガシー残ゼロ
- [x] ブラウザ E2E (Playwright): datalist 24件表示、既存値読込、自由入力 → 保存 → 反映を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)