### PR TITLE
issue #178 portfolio: タブ廃止 → フィルタ/ソート/ページング構造に再設計

### DIFF
--- a/.claude/plans/issue-178-portfolio-redesign.md
+++ b/.claude/plans/issue-178-portfolio-redesign.md
@@ -1,0 +1,232 @@
+# issue #178: 保有銘柄ダッシュボード再設計 (タブ廃止 → フィルタ/ソート/ページング)
+
+## 背景・要件確定
+
+issue 本文 (#178) と追加コメントを踏まえ、以下で確定:
+
+- **基本要件**: 保有銘柄の一覧比較 (業態・テーマ別に PER/成長率を見比べる)
+- **デフォルト表示**: 保有 (1保) のみ
+- **件数対策**: ページング (50件/ページ)
+- **状態保持**: URL のみ (localStorage / Cookie は使わない)
+- **ソート軸**: 業態順 (デフォルト) / 順位順 の2択のみ (列ヘッダ汎用ソートは別 issue 送り)
+
+issue 178 原案からの差分:
+- デフォルトを「全件」→「保有のみ」に変更 (一覧比較の主対象は保有銘柄)
+- ページング (`?page=N`, 50件/ページ) を追加 (重さ対策)
+
+## URL 設計
+
+```
+/portfolio                              # デフォルト: 保有のみ + 業態順 + 1ページ目
+/portfolio?status=hold,semi             # 保有+準保有
+/portfolio?status=hold,semi,watch       # 全件
+/portfolio?sort=rank                    # 保有 + 順位順
+/portfolio?status=hold,semi&page=2      # 2ページ目
+/portfolio?status=hold                  # 既存 URL (互換性維持)
+```
+
+- `status` 未指定 = `hold` (現状デフォルトと同じ。互換性維持)
+- `status` は **2 つの送信形式を両方受理**して内部で正規化:
+  - カンマ区切り単一キー: `?status=hold,semi` (URL 直接指定・既存互換)
+  - 同名複数キー: `?status=hold&status=semi` (HTML form の checkbox 標準送信形式)
+  - サーバ側は `request.args.getlist("status")` で全値取得 → 各値をカンマでさらに split → flat 化 → 不正値除去
+  - 実装ヘルパ: `_parse_status_filter(args: MultiDict) -> list[str]` (引数を文字列ではなく MultiDict にする)
+- `sort` 未指定 = `gyoutai`。値は `gyoutai` / `rank` のみ受理、他は `gyoutai` にフォールバック
+- `page` 未指定 = 1。1未満や非数値は 1 にフォールバック。最大ページ数を超えたら最終ページ
+- 1ページ50件固定 (定数)
+
+## UI
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 保有銘柄ダッシュボード                            [管理]    │
+│                                                              │
+│ [フィルタ] ☑保有(8) ☐準保有(87) ☐監視(38)               │
+│ [ソート]  ●業態順 ○順位順         [絞り込み]             │
+│                                                              │
+│ 8件中 1-8 件表示                                             │
+│                                                              │
+│ ┌──┬───┬───┬─────┬─────┬───┬─...                          │
+│ │ │コード│銘柄│業態  │状態 │順位│                          │
+│ │  │      │    │      │     │    │                          │
+│ ...                                                          │
+│                                                              │
+│                          [<<前]  1/1  [次>>]                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- フィルタは checkbox (3個) + ラジオ (2個) の `<form method="GET">`。submit ボタン「絞り込み」を1つ
+- フィルタ/ソート変更時は `page=1` にリセット (form 側で page input を出さない or hidden=1)
+- 件数表示: `{total}件中 {start}-{end} 件表示`
+- ステータス列 (badge: 保有=緑/準保有=黄/監視=灰) を**常時表示**。デフォルトが保有のみでも、複数選択した瞬間に必要になるため
+- ページネーション: 前/次のリンクと「現ページ/総ページ」表示。総1ページならボタン非表示
+- 業態順時のみ、業態境界 (前行と業態 1 行目が異なる) に区切り線 (`border-top: 1px solid #ddd`)。区切り判定はページ内で完結 (ページ跨ぎは無視)
+
+## 実装影響
+
+### 変更: `scripts/webapp/routes/portfolio.py`
+
+- `STATUS_QUERY_TO_VALUE` は維持 (status query → 内部値の変換に引き続き使う)
+- `TABS` / `DEFAULT_TAB` 定数を削除
+- `_resolve_status_query()` を削除し、新規 `_parse_status_filter(args) -> list[str]` を追加
+  - 引数は `request.args` (MultiDict)
+  - `args.getlist("status")` で取得した各値をさらにカンマ split → flat 化 → trim → 小文字化
+  - `STATUS_QUERY_TO_VALUE` で内部値 (1保/2準/3監) に変換、不正値は無視
+  - 結果が空 (= status 指定なし or 全不正値) は `["1保"]` (デフォルト)
+  - 例:
+    - `?status=hold,semi` → `["1保","2準"]`
+    - `?status=hold&status=semi` → `["1保","2準"]`
+    - `?status=hold,xxx&status=watch` → `["1保","3監"]`
+    - `?` (なし) → `["1保"]`
+- 新規 `_parse_sort(query: str) -> str` 追加。`gyoutai` / `rank` のいずれか
+- 新規 `_parse_page(query: str, total_pages: int) -> int` 追加
+- 新規 `_paginate(rows, page, per_page=50) -> tuple[list, int, int, int]` (rows_slice, page, total_pages, total)
+- `_redirect_to_current_tab()` を `_redirect_with_filters()` 相当に置き換え or 削除
+  - memo / transition 後のリダイレクトは「フィルタ・ソート・ページ」を保持して戻したい
+  - フォーム POST 側で hidden に現状のクエリを持たせてサーバへ送り、リダイレクト先の URL に反映する
+  - (簡易案) hidden に `return_query` を入れ、サーバがそのまま `?...` を付ける
+- `dashboard()` 改修:
+  - status / sort / page を解析
+  - records → status フィルタ → sort → ページング の順に処理
+  - counts はフィルタ前の visible_records から集計 (常に hold/semi/watch の3つを返す)
+  - transitions は「複数 status 選択」だと一意の current が決まらない → 詳細行の操作 UI 側 (展開後) でその銘柄個別の status 基準で出すよう、template に渡すデータ構造を変更:
+    - 旧: `transitions=[(label, value), ...]` (active タブの status を前提)
+    - 新: 各 row に `row.transitions=[(label, value), ...]` を埋める (row.status から導出)
+- POST ハンドラ (transition / memo / bulk-exclude / add) のリダイレクト先:
+  - 既存は `?status=hold|semi|watch` 単数値で返していた
+  - 新仕様では「直前のフィルタ状態を維持して戻す」のが理想だが、実装簡素化のため**最小修正**:
+    - フォームに hidden `return_query` (例: `status=hold,semi&sort=rank&page=2`) を出し、サーバはそれを `?` に繋いでリダイレクト
+    - hidden が無い場合は `/portfolio` (デフォルト = 保有のみ) にフォールバック
+  - bulk-exclude の `return_to=hold|semi|watch` は廃止し、上記 `return_query` 方式に統一
+
+### 変更: `scripts/webapp/templates/portfolio_list.html`
+
+- タブ `<nav>` ブロック (line 73-85) を**フィルタバー form** に置換
+  - checkbox×3 (hold/semi/watch) + radio×2 (gyoutai/rank) + submit
+  - `name="status" value="hold"` の checkbox 3つ
+    - HTML 標準では同名 checkbox は `?status=hold&status=semi` 形式で送信される
+    - サーバは `getlist("status")` で受け、URL 設計セクションで規定したカンマ区切り形式と両方受理する正規化を通す
+  - `name="sort"` の radio 2つ
+  - 件数は label 内 `<span>{{ counts.hold }}</span>` で表示
+- thead に**ステータス列**を追加 (`<th>状態</th>`)。コード列の左 or 右
+- tbody の各 tr に**ステータス badge セル**追加: `<td><span class="status-badge status-{{ row.status_query }}">{{ row.status_label }}</span></td>`
+  - CSS: `.status-hold { background:#cfc; color:#060 }` `.status-semi { background:#ffc; color:#860 }` `.status-watch { background:#ddd; color:#666 }`
+- 業態順時のみ業態境界に区切り線:
+  ```jinja
+  {% if active_sort == 'gyoutai' and not loop.first %}
+    {% set prev_first = (loop.previtem.memo.gyoutai_themes or [''])[0] %}
+    {% set curr_first = (row.memo.gyoutai_themes or [''])[0] %}
+    {% if prev_first != curr_first %}
+      style="border-top:2px solid #bbb;"
+    {% endif %}
+  {% endif %}
+  ```
+  (実装は class を切り替えるほうが綺麗。詳細は実装時調整)
+- ページネーションを `<table>` の下に追加:
+  ```html
+  <nav class="pagination">
+    {% if page > 1 %}<a href="?{{ prev_query }}">< 前</a>{% endif %}
+    <span>{{ page }} / {{ total_pages }}</span>
+    {% if page < total_pages %}<a href="?{{ next_query }}">次 ></a>{% endif %}
+  </nav>
+  ```
+  total_pages == 1 のときはナビ全体を非表示
+- 各 row の操作 UI (transition セレクタ) は `row.transitions` を使うよう変更
+- 削除モード (bulk-exclude) は「watch / semi がフィルタに含まれる時のみ表示」に条件変更
+  - 旧: `{% if active_query in ("watch", "semi") and rows %}`
+  - 新: `{% if ('2準' in active_statuses or '3監' in active_statuses) and rows %}`
+- 「管理」パネル内の `return_to` hidden を `return_query` (現状の URL クエリ全体) に置換
+- 各 form (transition / memo / bulk-exclude) に hidden `return_query` を追加
+
+### 変更: `scripts/webapp/helpers.py`
+
+- `list_portfolio_with_indicators(records, sort_key="gyoutai")`:
+  - `sort_key` 引数を追加
+  - `sort_key == "rank"` → 既存の rank 昇順 (None 末尾)
+  - `sort_key == "gyoutai"` → 業態 1 行目昇順 → 順位昇順 (両 None は末尾)
+  - 各 row に `status_query` (例: "hold") と `status_label` (例: "保有") を埋める
+  - 各 row に `transitions: list[tuple[str,str]]` を埋める (status から導出)
+  - (transitions 計算は portfolio.py 側のヘルパに残し、helpers では status_query/label のみ埋める案も可。実装時に判断)
+- 業態の取り出しヘルパを切り出す:
+  ```python
+  def _gyoutai_first_line(row: dict) -> str:
+      themes = (row.get("memo") or {}).get("gyoutai_themes") or []
+      return themes[0].strip() if themes and themes[0] else ""
+  ```
+
+### 削除
+
+- `TABS`, `DEFAULT_TAB` 定数 (portfolio.py)
+- `_resolve_status_query()` (portfolio.py) — 単一値前提なので不要
+- bulk-exclude の `return_to` 仕様 → `return_query` 方式に統一
+
+## テスト
+
+### 変更: `tests/test_webapp_portfolio_routes.py`
+
+- 既存タブテストを更新:
+  - `test_dashboard_default_tab_is_hold` → `test_dashboard_default_shows_hold_only`
+  - `test_dashboard_watch_tab` → `test_dashboard_status_watch_filter`
+  - `test_dashboard_unknown_status_falls_back_to_hold` → 同名で挙動維持確認 (デフォルトが hold のため)
+- 新規:
+  - `test_dashboard_multi_status_filter_csv`: `?status=hold,semi` (カンマ区切り) で両方表示
+  - `test_dashboard_multi_status_filter_repeated`: `?status=hold&status=semi` (HTML form 送信形式) で両方表示
+  - `test_dashboard_multi_status_filter_mixed`: `?status=hold,xxx&status=watch` (混在 + 不正値混入) で hold + watch 表示
+  - `test_dashboard_all_status_filter`: `?status=hold,semi,watch` で全件
+  - `test_dashboard_sort_gyoutai_orders_by_first_line`: 業態 1 行目順
+  - `test_dashboard_sort_rank_orders_by_rank`: 順位順 + 業態無視
+  - `test_dashboard_pagination_first_page`: per_page=50 で50件まで表示 (fixture を増やすか、page_size を test 用に小さく差し替え)
+  - `test_dashboard_pagination_second_page`: `?page=2` で次の50件
+  - `test_dashboard_pagination_invalid_page_falls_back`: `?page=0` `?page=abc` `?page=999` の挙動
+  - `test_dashboard_status_badge_visible`: status 列・badge HTML が出る
+  - `test_dashboard_filter_form_resets_page_on_submit`: フィルタ form に page hidden が無い (or 1 を出す)
+  - `test_legacy_url_status_hold_still_works`: `?status=hold` (単一値) が動作
+- 既存の transition / memo / bulk-exclude テスト:
+  - hidden `return_query` 付きでテストし、リダイレクト先がそれを反映するか検証
+  - 既存テストが `?status=watch` 等を期待している箇所を調整
+  - bulk-exclude の `return_to` テスト 2 件を `return_query` 方式に書き換え
+
+### 変更: `tests/test_webapp_helpers.py`
+
+- 新規:
+  - `test_list_portfolio_sort_by_gyoutai_then_rank`: 業態順、二次キー rank
+  - `test_list_portfolio_sort_by_rank_only`: 順位順
+  - `test_list_portfolio_empty_gyoutai_goes_to_end`: 空業態は末尾
+  - `test_list_portfolio_gyoutai_uses_first_line_only`: gyoutai_themes[0] のみで判定 (改行なしの list なので 1 件目)
+  - `test_list_portfolio_status_query_label_filled`: row に status_query / status_label が入る
+
+## スコープ外 (issue 178 と同じ)
+
+- 業態自体のフィルタ (例: 「人材」業態だけ抽出)
+- 列ヘッダクリック式の汎用ソート
+- 業態テーマの正規化
+- 色分け (#177 で並行対応)
+- localStorage / Cookie での状態保持 (URL のみで十分と判断)
+
+## 実装順序 (検証ポイント付き)
+
+1. **helpers.py** 改修: `list_portfolio_with_indicators(sort_key=...)` + status_query/label 埋め
+   - 検証: `pytest tests/test_webapp_helpers.py -v` 新規テスト緑
+2. **portfolio.py** 改修: status 複数解析 / sort / page / counts 集計 / 各 row.transitions
+   - 検証: `pytest tests/test_webapp_portfolio_routes.py -v` 既存緑 + 新規緑
+3. **portfolio_list.html** 改修: フィルタバー / ステータス列 / ページネーション / return_query hidden
+   - 検証: ブラウザ目視 (`python -m webapp.app`)
+     - `/portfolio` でデフォルト保有のみ
+     - チェック切替で URL 変化、件数変化
+     - ソート切替で並び順変化、業態境界の区切り線
+     - 50件超えた場合のページング (fixture を増やすか、テストで一時的に per_page=2 等で確認)
+     - transition/memo/bulk-exclude 後に元の filter/sort/page に戻る
+4. テスト全実行 + simplify レビュー
+
+## リスク・懸念
+
+- **transitions が row 単位になる影響**: 既存の template は「アクティブタブの status から transitions を1つ計算してフォームに埋める」構造。新仕様では各 row が独自の status を持つため row.transitions が必要。template の transitions 利用箇所を確認して書き換える。
+- **return_query の URL 組立**: hidden に raw クエリ文字列を入れるとエスケープに注意。Flask の `url_for` + `request.args.to_dict(flat=False)` を使うほうが安全。実装時に検討。
+- **ページネーションのテスト fixture**: 既存 fixture は3件しか登録していない。50件超のページング検証には fixture を増やすか、`PORTFOLIO_PAGE_SIZE` を環境変数 or アプリ config で差し替え可能にして test 側で 2 等に下げるのが現実的。後者を推奨。
+- **業態境界の判定**: ページ跨ぎを無視するため「ページ内最初の行は border 無し」になる。これは仕様として許容。
+
+## 関連
+
+- 親: #168 (Phase 3 全体)
+- 直前: #171 (Phase 3b 一覧ダッシュボード) / PR #176 — 構造変更の対象
+- 兄弟: #175 (memo 編集), #177 (色分け), #186 (削除モード), #187 (業態テーマ構造化)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1338,7 +1338,38 @@ def _bulk_resolve_stock_names(code_list: List[str]) -> Dict[str, str]:
     return result
 
 
-def list_portfolio_with_indicators(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+# issue #178: status 内部値 → URL クエリ / 表示ラベルの対応表 (helpers 内部利用のみ)。
+# routes/portfolio.py の同名定数とは独立に保持し、循環 import を避ける。
+_PORTFOLIO_STATUS_QUERY = {
+    "1保": "hold",
+    "2準": "semi",
+    "3監": "watch",
+}
+_PORTFOLIO_STATUS_LABEL = {
+    "1保": "保有",
+    "2準": "準保有",
+    "3監": "監視",
+}
+
+
+def _gyoutai_first_line(row: Dict[str, Any]) -> str:
+    """row の memo.gyoutai_themes の先頭要素を返す (issue #178 業態順ソート用)。
+
+    空 list / 先頭が空文字 / themes 自体が無い場合は "" を返す。
+    """
+    themes = (row.get("memo") or {}).get("gyoutai_themes") or []
+    if not themes:
+        return ""
+    head = themes[0]
+    if not isinstance(head, str):
+        return ""
+    return head.strip()
+
+
+def list_portfolio_with_indicators(
+    records: List[Dict[str, Any]],
+    sort_key: str = "gyoutai",
+) -> List[Dict[str, Any]]:
     """portfolio_shelve のレコード列に stocks_shelve から最新指標を補完する (Phase 3b)。
 
     銘柄名は portfolio_shelve に保存されていないため stocks_shelve / research_shelve から
@@ -1346,13 +1377,16 @@ def list_portfolio_with_indicators(records: List[Dict[str, Any]]) -> List[Dict[s
 
     Args:
         records: portfolio_shelve.list_records の戻り値 (既に status 等で絞り込み済み)
+        sort_key: "gyoutai" (業態 1 行目昇順 → 順位昇順) / "rank" (順位昇順のみ)。
+                  不正値は "gyoutai" にフォールバック (issue #178)。
 
     Returns:
         各 dict: portfolio レコード + {stock_name, rank, kessanbi_md, per, market_cap,
                                      dividend, rs, sales_growth, profit_growth,
                                      quarter, progress_diff, trend_template, tags,
-                                     theoretical_diff, gyoseki, indicators_raw}
-        rank 昇順 (rank が None の銘柄は末尾)。
+                                     theoretical_diff, gyoseki, indicators_raw,
+                                     status_query, status_label}
+        sort_key に応じた並び順 (rank/業態が None/空の銘柄は末尾)。
     """
     if not records:
         return []
@@ -1368,9 +1402,25 @@ def list_portfolio_with_indicators(records: List[Dict[str, Any]]) -> List[Dict[s
         row["stock_name"] = name_map.get(code_s, "") or rec.get("stock_name", "")  # 旧データ互換
         row.update(_extract_indicators_for_portfolio(stock_map.get(code_s, {})))
         row["styles"] = compute_cell_styles(row, today=today)
+        # issue #178: ステータス列 (badge) 表示用の query / label を埋める
+        status = rec.get("status", "")
+        row["status_query"] = _PORTFOLIO_STATUS_QUERY.get(status, "")
+        row["status_label"] = _PORTFOLIO_STATUS_LABEL.get(status, status)
+        # issue #178: 業態境界判定用 (template から再計算しないで済むよう)
+        row["gyoutai_first"] = _gyoutai_first_line(row)
         rows.append(row)
 
-    rows.sort(key=lambda r: (r.get("rank") is None, r.get("rank") or 0, r.get("code_s", "")))
+    if sort_key == "rank":
+        rows.sort(key=lambda r: (r.get("rank") is None, r.get("rank") or 0, r.get("code_s", "")))
+    else:
+        # 業態順: 業態 1 行目 (空は末尾) → 順位昇順 (None は末尾) → コード
+        rows.sort(key=lambda r: (
+            r["gyoutai_first"] == "",
+            r["gyoutai_first"],
+            r.get("rank") is None,
+            r.get("rank") or 0,
+            r.get("code_s", ""),
+        ))
     return rows
 
 

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -1,15 +1,21 @@
-"""保有銘柄ダッシュボードルート (Phase 3b / issue #171, issue #175, issue #186)。
+"""保有銘柄ダッシュボードルート (Phase 3b / issue #171, #175, #178, #186)。
 
-GET  /portfolio?status=hold|semi|watch  : 3 タブ式ダッシュボード
-POST /portfolio/add                     : 3監 への新規追加 / 除外済みの復活
-POST /portfolio/<code_s>/transition     : ステータス変更
-POST /portfolio/bulk-exclude            : 3監 銘柄をユニバースから除外 (一括)
-POST /portfolio/<code_s>/memo           : memo 部分更新 (issue #175)
+GET  /portfolio?status=hold,semi&sort=rank&page=2 : フィルタ/ソート/ページング (issue #178)
+POST /portfolio/add                              : 3監 への新規追加 / 除外済みの復活
+POST /portfolio/<code_s>/transition              : ステータス変更
+POST /portfolio/bulk-exclude                     : 2準/3監 銘柄をユニバースから除外 (一括)
+POST /portfolio/<code_s>/memo                    : memo 部分更新 (issue #175)
 
 portfolio_shelve のレコードに stocks_shelve から指標を補完して表示する。
 書き込み API は txt 関連の状態を変えるもの (add/transition/bulk-exclude) のみ
 末尾で sync_to_my_watch_list_txt() を呼ぶ。memo 更新は txt 内容に影響しないため同期不要。
+
+issue #178: タブ構造を撤廃しフィルタ/ソート/ページングに再設計。POST 後の
+リダイレクトは hidden `return_query` (現状の URL クエリ全体) を尊重して
+直前のフィルタ状態に戻す。
 """
+
+from urllib.parse import urlencode
 
 from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
 
@@ -41,21 +47,85 @@ STATUS_VALUE_TO_LABEL = {
     "3監": "監視",
 }
 
-# タブ表示順 (左から右): (query, status_value, label)
-TABS = [
+# フィルタ表示順 (左から右): (query, status_value, label)
+# issue #178: 旧 TABS から名称変更。タブではなくフィルタ checkbox の表示順を規定する。
+STATUS_CHOICES = [
     ("hold", "1保", STATUS_VALUE_TO_LABEL["1保"]),
     ("semi", "2準", STATUS_VALUE_TO_LABEL["2準"]),
     ("watch", "3監", STATUS_VALUE_TO_LABEL["3監"]),
 ]
-DEFAULT_TAB = TABS[0][0]
+DEFAULT_STATUS_QUERY = STATUS_CHOICES[0][0]  # "hold" — 引数なし時のデフォルト
+
+# issue #178: ページング設定 (1ページ件数)
+PORTFOLIO_PAGE_SIZE = 50
+
+# issue #178: 受理する sort key
+VALID_SORT_KEYS = ("gyoutai", "rank")
+DEFAULT_SORT_KEY = "gyoutai"
 
 
-def _resolve_status_query(query: str) -> tuple[str, str]:
-    """クエリ文字列を (正規化クエリ, status 値) に変換。不明値は DEFAULT_TAB。"""
-    q = (query or "").strip().lower()
-    if q not in STATUS_QUERY_TO_VALUE:
-        q = DEFAULT_TAB
-    return q, STATUS_QUERY_TO_VALUE[q]
+def _parse_status_filter(args) -> list[str]:
+    """request.args (MultiDict) から status フィルタを内部値リスト (例: ["1保","2準"]) に変換する。
+
+    2 つの送信形式を両方受理:
+      - カンマ区切り単一キー: `?status=hold,semi` (URL 直接指定・既存互換)
+      - 同名複数キー: `?status=hold&status=semi` (HTML form の checkbox 標準送信)
+
+    各値を小文字化・トリムし、STATUS_QUERY_TO_VALUE で内部値に変換。不正値は無視。
+    結果が空 (= 指定なし or 全不正値) は ["1保"] (デフォルト = 保有のみ)。
+    既存 URL `?status=hold` (単一値) は自然に ["1保"] に解決され、互換性維持。
+    """
+    raw_values = args.getlist("status") if hasattr(args, "getlist") else []
+    flat: list[str] = []
+    for v in raw_values:
+        for piece in (v or "").split(","):
+            piece = piece.strip().lower()
+            if piece:
+                flat.append(piece)
+    statuses: list[str] = []
+    for q in flat:
+        st = STATUS_QUERY_TO_VALUE.get(q)
+        if st and st not in statuses:
+            statuses.append(st)
+    if not statuses:
+        statuses = [STATUS_QUERY_TO_VALUE[DEFAULT_STATUS_QUERY]]
+    return statuses
+
+
+def _parse_sort(args) -> str:
+    """sort key を `gyoutai` / `rank` のいずれかに正規化。不正値は DEFAULT_SORT_KEY。"""
+    raw = (args.get("sort") or "").strip().lower()
+    return raw if raw in VALID_SORT_KEYS else DEFAULT_SORT_KEY
+
+
+def _parse_page(args, total_pages: int) -> int:
+    """page 番号を 1..total_pages の整数に正規化。不正値・範囲外は端にクランプ。"""
+    raw = (args.get("page") or "").strip()
+    try:
+        page = int(raw)
+    except (ValueError, TypeError):
+        page = 1
+    if page < 1:
+        page = 1
+    if total_pages >= 1 and page > total_pages:
+        page = total_pages
+    return page
+
+
+def _build_query_string(statuses: list[str], sort_key: str, page: int) -> str:
+    """フィルタ・ソート・ページから URL クエリ文字列を組み立てる。
+
+    status はカンマ区切り単一キー形式 (`status=hold,semi`)、sort/page は単純キー。
+    POST → リダイレクトの戻り先として使う。
+    """
+    queries = [STATUS_VALUE_TO_QUERY[s] for s in statuses if s in STATUS_VALUE_TO_QUERY]
+    params = []
+    if queries:
+        params.append(("status", ",".join(queries)))
+    params.append(("sort", sort_key))
+    if page > 1:
+        params.append(("page", str(page)))
+    return urlencode(params)
 
 
 def _allowed_transitions_from(current: str) -> list[tuple[str, str]]:
@@ -86,14 +156,26 @@ def _sync_txt_safely() -> None:
         flash(f"my_watch_list.txt 同期に失敗: {e}", "error")
 
 
-def _redirect_to_current_tab(code_s: str, fallback_query: str = "watch"):
-    """code_s の現在ステータスのタブにリダイレクトする。
+def _redirect_with_return_query(default_status_query: str = DEFAULT_STATUS_QUERY):
+    """POST フォームに埋め込まれた hidden `return_query` を尊重してリダイレクトする (issue #178)。
 
-    エラー時に元タブに戻すための共通処理。レコードが取れない場合は fallback。
+    return_query はクエリ文字列 (例: `status=hold,semi&sort=rank&page=2`) を
+    そのまま受け取り、URL に付与する。空 or 未指定なら `?status=<default>` に
+    フォールバック。これで POST 後も直前のフィルタ/ソート/ページが復元できる。
+
+    安全のため return_query から先頭の `?` を取り除き、改行や `#` も弾く
+    (URL injection 防止)。
     """
-    current = ps.get_record(code_s) or {}
-    current_query = STATUS_VALUE_TO_QUERY.get(current.get("status"), fallback_query)
-    return redirect(url_for("portfolio.dashboard", status=current_query))
+    raw = (request.form.get("return_query") or "").strip()
+    if raw.startswith("?"):
+        raw = raw[1:]
+    # URL fragment / 改行は弾く (生のフォーム値をそのまま付ける防御)
+    if any(ch in raw for ch in ("\n", "\r", "#", " ")):
+        raw = ""
+    base = url_for("portfolio.dashboard")
+    if raw:
+        return redirect(f"{base}?{raw}")
+    return redirect(f"{base}?status={default_status_query}")
 
 
 def _is_fallback_mode() -> bool:
@@ -110,15 +192,19 @@ def _is_fallback_mode() -> bool:
     return not ps.list_records(include_excluded=True)
 
 
-def _reject_when_fallback(redirect_query: str = "watch"):
-    """フォールバック中なら flash + redirect を返す。そうでなければ None。"""
+def _reject_when_fallback():
+    """フォールバック中なら flash + redirect を返す。そうでなければ None。
+
+    issue #178: redirect_query 引数を廃止し、戻り先は hidden return_query (or デフォルト)
+    に統一する。
+    """
     if _is_fallback_mode():
         flash(
             "portfolio_shelve 未移行モードのため、書き込み操作は無効です。"
             "Phase 3a 移行スクリプト (migrate_my_watch_list_to_shelve.py) を実行してください。",
             "error",
         )
-        return redirect(url_for("portfolio.dashboard", status=redirect_query))
+        return _redirect_with_return_query()
     return None
 
 
@@ -126,23 +212,20 @@ def _reject_when_fallback(redirect_query: str = "watch"):
 def bulk_exclude():
     """2準/3監 銘柄を一括でユニバースから除外する (物理削除はしない)。
 
-    フォーム: codes=<code1>&codes=<code2>... / reason=<任意> / return_to=<hold|semi|watch>
+    フォーム: codes=<code1>&codes=<code2>... / reason=<任意> / return_query=<URLクエリ>
     部分成功許容。1保 が混入していたら該当のみ flash error で報告し、2準/3監 のみ除外を実行する。
-    return_to はリダイレクト先タブ。不正値は watch にフォールバック。
+    issue #178: 旧 return_to=hold|semi|watch を return_query (hidden) に置換。
     """
-    rejected = _reject_when_fallback(redirect_query="watch")
+    rejected = _reject_when_fallback()
     if rejected is not None:
         return rejected
 
     codes = [c.strip() for c in request.form.getlist("codes") if c and c.strip()]
     reason = (request.form.get("reason") or "").strip()
-    return_to = (request.form.get("return_to") or "watch").strip()
-    if return_to not in STATUS_QUERY_TO_VALUE:
-        return_to = "watch"
 
     if not codes:
         flash("除外対象が指定されていません", "error")
-        return redirect(url_for("portfolio.dashboard", status=return_to))
+        return _redirect_with_return_query()
 
     success: list[str] = []
     failures: list[str] = []
@@ -168,7 +251,7 @@ def bulk_exclude():
         flash(f"{len(success)} 件をユニバースから除外しました ({', '.join(success)})", "info")
     if failures:
         flash("除外できなかったコードがあります: " + " / ".join(failures), "error")
-    return redirect(url_for("portfolio.dashboard", status=return_to))
+    return _redirect_with_return_query()
 
 
 @portfolio_bp.route("/portfolio/<code_s>/transition", methods=["POST"])
@@ -189,23 +272,23 @@ def transition(code_s: str):
         ps.validate_code_s(code_s)
     except (ValueError, TypeError) as e:
         flash(f"不正な銘柄コード: {e}", "error")
-        return redirect(url_for("portfolio.dashboard"))
+        return _redirect_with_return_query()
 
     if new_status not in ps.VALID_STATUSES:
         flash(f"不正なステータス: {new_status!r}", "error")
-        return redirect(url_for("portfolio.dashboard"))
+        return _redirect_with_return_query()
 
     try:
         ps.transition_status(code_s, new_status, reason=reason)
     except KeyError as e:
         flash(f"レコード未登録: {e}", "error")
-        return redirect(url_for("portfolio.dashboard"))
+        return _redirect_with_return_query()
     except (ValueError, TypeError) as e:
         flash(str(e), "error")
-        return _redirect_to_current_tab(code_s, fallback_query=DEFAULT_TAB)
+        return _redirect_with_return_query()
 
     _sync_txt_safely()
-    return redirect(url_for("portfolio.dashboard", status=STATUS_VALUE_TO_QUERY[new_status]))
+    return _redirect_with_return_query()
 
 
 def _extract_memo_fields_from_form(form) -> dict:
@@ -283,7 +366,7 @@ def update_memo(code_s: str):
         if is_ajax:
             return jsonify({"ok": False, "error": f"不正な銘柄コード: {e}"}), 400
         flash(f"不正な銘柄コード: {e}", "error")
-        return redirect(url_for("portfolio.dashboard"))
+        return _redirect_with_return_query()
 
     fields = _extract_memo_fields_from_form(request.form)
 
@@ -294,12 +377,12 @@ def update_memo(code_s: str):
         if is_ajax:
             return jsonify({"ok": False, "error": msg}), 404
         flash(msg, "error")
-        return redirect(url_for("portfolio.dashboard"))
+        return _redirect_with_return_query()
     except (ValueError, TypeError) as e:
         if is_ajax:
             return jsonify({"ok": False, "error": str(e)}), 400
         flash(str(e), "error")
-        return _redirect_to_current_tab(code_s, fallback_query=DEFAULT_TAB)
+        return _redirect_with_return_query()
 
     if is_ajax:
         # 保存後の row を再構築して、更新済みフィールドと styles を返す
@@ -320,7 +403,7 @@ def update_memo(code_s: str):
                 }
         return jsonify(body)
     flash(f"{code_s} のメモを保存しました", "info")
-    return _redirect_to_current_tab(code_s, fallback_query=DEFAULT_TAB)
+    return _redirect_with_return_query()
 
 
 @portfolio_bp.route("/portfolio/add", methods=["POST"])
@@ -332,20 +415,21 @@ def add():
     - portfolio_shelve に excluded=True で存在 → 復活 (stocks_shelve チェック skip)
     - portfolio_shelve に excluded=False で存在 → 既登録扱い、ValueError flash
     """
-    rejected = _reject_when_fallback(redirect_query="watch")
+    rejected = _reject_when_fallback()
     if rejected is not None:
         return rejected
 
+    # 追加直後は監視リストを見たいので、return_query 未指定時のデフォルトは watch。
     code_s = (request.form.get("code_s") or "").strip()
     if not code_s:
         flash("銘柄コードが空です", "error")
-        return redirect(url_for("portfolio.dashboard"))
+        return _redirect_with_return_query(default_status_query="watch")
 
     try:
         ps.validate_code_s(code_s)
     except (ValueError, TypeError) as e:
         flash(f"不正な銘柄コード: {e}", "error")
-        return redirect(url_for("portfolio.dashboard"))
+        return _redirect_with_return_query(default_status_query="watch")
 
     normalized = ps.normalize_code_s(code_s)
 
@@ -359,13 +443,13 @@ def add():
                 f"{normalized} は stocks_shelve に未登録のコードです。先に銘柄DBへの登録が必要です。",
                 "error",
             )
-            return redirect(url_for("portfolio.dashboard", status="watch"))
+            return _redirect_with_return_query(default_status_query="watch")
 
     try:
         ps.add_to_watch(normalized, reason="WebApp 追加")
     except ValueError as e:
         flash(str(e), "error")
-        return redirect(url_for("portfolio.dashboard", status="watch"))
+        return _redirect_with_return_query(default_status_query="watch")
 
     _sync_txt_safely()
     name_for_flash = resolve_stock_name(normalized)
@@ -373,7 +457,7 @@ def add():
         flash(f"{normalized} {name_for_flash} をユニバースに復活しました".rstrip(), "info")
     else:
         flash(f"{normalized} {name_for_flash} を監視に追加しました".rstrip(), "info")
-    return redirect(url_for("portfolio.dashboard", status="watch"))
+    return _redirect_with_return_query(default_status_query="watch")
 
 
 def _build_fallback_records() -> list[dict]:
@@ -399,8 +483,15 @@ def _build_fallback_records() -> list[dict]:
 
 @portfolio_bp.route("/portfolio")
 def dashboard():
-    """3 タブ式ダッシュボード。"""
-    active_query, active_status = _resolve_status_query(request.args.get("status", DEFAULT_TAB))
+    """フィルタ/ソート/ページング型ダッシュボード (issue #178)。
+
+    URL クエリ:
+      status: hold,semi,watch のカンマ区切り or 同名複数キー (デフォルト=hold)
+      sort:   gyoutai (業態順, デフォルト) / rank (順位順)
+      page:   1始まり (デフォルト=1)、1ページ PORTFOLIO_PAGE_SIZE 件
+    """
+    active_statuses = _parse_status_filter(request.args)
+    active_sort = _parse_sort(request.args)
 
     # issue #186: fallback 判定は除外含む全件で行う (全件除外時の誤判定を避ける)。
     # 表示・件数カウントは除外を弾いた visible_records を使う。
@@ -411,19 +502,45 @@ def dashboard():
     else:
         visible_records = [r for r in all_records_inc if not r.get("excluded", False)]
 
-    counts = {q: 0 for q, _, _ in TABS}
+    # 件数 (フィルタ前): hold/semi/watch ごとに常に出す (UI チェックボックス横の表示用)
+    counts = {q: 0 for q, _, _ in STATUS_CHOICES}
     for r in visible_records:
         st = r.get("status")
         if st in STATUS_VALUE_TO_QUERY:
             counts[STATUS_VALUE_TO_QUERY[st]] += 1
 
-    active_records = [r for r in visible_records if r.get("status") == active_status]
-    rows = list_portfolio_with_indicators(active_records)
-    # フォールバック中は書き込み UI (ステータス変更フォーム / 削除モード) を
-    # 出さない。shelve が空のため transition / exclude を呼ぶと KeyError になる。
-    transitions = [] if fallback_mode else _allowed_transitions_from(active_status)
+    filtered_records = [r for r in visible_records if r.get("status") in active_statuses]
+    rows_all = list_portfolio_with_indicators(filtered_records, sort_key=active_sort)
 
-    # issue #187: datalist 候補は表示タブ/excluded と独立、shelve 内の全レコードから集計
+    total = len(rows_all)
+    total_pages = max(1, (total + PORTFOLIO_PAGE_SIZE - 1) // PORTFOLIO_PAGE_SIZE)
+    page = _parse_page(request.args, total_pages)
+    start = (page - 1) * PORTFOLIO_PAGE_SIZE
+    end = start + PORTFOLIO_PAGE_SIZE
+    rows = rows_all[start:end]
+
+    # 行ごとに transitions を埋める (issue #178: 複数 status 同時表示で、
+    # 各行が個別の遷移先候補を持つ必要があるため)。fallback 中は空。
+    for row in rows:
+        row["transitions"] = (
+            [] if fallback_mode else _allowed_transitions_from(row.get("status", ""))
+        )
+
+    # 削除モードの可否: 2準/3監 がフィルタに含まれる時のみ
+    delete_mode_allowed = (
+        not fallback_mode
+        and any(s in active_statuses for s in ("2準", "3監"))
+        and bool(rows)
+    )
+
+    # POST → リダイレクトの戻り先として使う現状クエリ (status/sort/page 全部)
+    return_query = _build_query_string(active_statuses, active_sort, page)
+    # テンプレートでチェック判定するための、active_statuses の query 形式リスト (例: ["hold","semi"])
+    active_status_queries = [
+        STATUS_VALUE_TO_QUERY[s] for s in active_statuses if s in STATUS_VALUE_TO_QUERY
+    ]
+
+    # issue #187: datalist 候補は表示フィルタ/excluded と独立、shelve 内の全レコードから集計
     if fallback_mode:
         gyoutai_theme_choices: list = []
     else:
@@ -431,12 +548,20 @@ def dashboard():
 
     return render_template(
         "portfolio_list.html",
-        tabs=TABS,
-        active_query=active_query,
-        active_status=active_status,
+        status_choices=STATUS_CHOICES,
+        active_statuses=active_statuses,
+        active_status_queries=active_status_queries,
+        active_sort=active_sort,
         counts=counts,
         rows=rows,
-        transitions=transitions,
+        total=total,
+        page=page,
+        total_pages=total_pages,
+        page_size=PORTFOLIO_PAGE_SIZE,
+        page_start=start + 1 if rows else 0,
+        page_end=start + len(rows),
+        return_query=return_query,
+        delete_mode_allowed=delete_mode_allowed,
         status_label=STATUS_VALUE_TO_LABEL,
         fallback_mode=fallback_mode,
         gyoutai_theme_choices=gyoutai_theme_choices,

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -24,6 +24,27 @@
   /* 削除モード時のみチェックボックス列を表示 */
   .bulk-col { display: none; }
   body.delete-mode .bulk-col { display: table-cell; }
+  /* issue #178: 業態順表示時の業態境界線 */
+  table.portfolio-list tr.gyoutai-boundary > td { border-top: 2px solid #bbb; }
+  /* issue #178: ステータス badge */
+  .status-badge {
+    display: inline-block; padding: 0.05em 0.4em;
+    border-radius: 3px; font-size: 0.85em; line-height: 1.3;
+    white-space: nowrap;
+  }
+  .status-badge.status-hold  { background: #d4ead4; color: #285028; }
+  .status-badge.status-semi  { background: #fdf0c0; color: #856100; }
+  .status-badge.status-watch { background: #e2e2e2; color: #555; }
+  /* issue #178: ページネーション */
+  nav.pagination {
+    display: flex; gap: 0.6em; align-items: center; justify-content: center;
+    margin: 0.6em 0; font-size: 0.9em;
+  }
+  nav.pagination a, nav.pagination span.disabled {
+    padding: 0.3em 0.7em; border: 1px solid #d8dee6; border-radius: 3px;
+    text-decoration: none;
+  }
+  nav.pagination span.disabled { color: #bbb; background: #f8f8f8; }
   /* 一括削除アクションバー */
   #bulk-delete-bar {
     position: sticky; bottom: 0; z-index: 10;
@@ -70,33 +91,47 @@
 {% endif %}
 {% endwith %}
 
-<nav style="margin-bottom:1em;">
-  <ul style="display:flex;gap:0.5em;list-style:none;padding:0;margin:0;border-bottom:1px solid #ddd;">
-    {% for q, status_val, label in tabs %}
-    <li>
-      <a href="/portfolio?status={{ q }}"
-         style="display:inline-block;padding:0.5em 1em;text-decoration:none;
-                {% if q == active_query %}border-bottom:2px solid #06c;font-weight:bold;{% else %}color:#666;{% endif %}">
-        {{ label }} <span style="color:#999;font-size:0.85em;">{{ counts[q] }}</span>
-      </a>
-    </li>
-    {% endfor %}
-  </ul>
-</nav>
+{# issue #178: タブを撤廃しフィルタ/ソートバーに変更。GET で URL に反映する #}
+<form id="portfolio-filter-form" action="/portfolio" method="GET"
+      style="display:flex;flex-wrap:wrap;gap:1.2em;align-items:center;margin-bottom:0.6em;padding:0.5em 0.6em;background:#f5f7fa;border:1px solid #d8dee6;border-radius:4px;font-size:0.9em;">
+  <span style="color:#666;">フィルタ</span>
+  {% for q, status_val, label in status_choices %}
+  <label style="display:inline-flex;align-items:center;gap:0.25em;margin:0;cursor:pointer;">
+    <input type="checkbox" name="status" value="{{ q }}" style="margin:0;"
+           {% if q in active_status_queries %}checked{% endif %}>
+    {{ label }} <span style="color:#999;font-size:0.85em;">({{ counts[q] }})</span>
+  </label>
+  {% endfor %}
+  <span style="color:#666;margin-left:0.6em;">ソート</span>
+  <label style="display:inline-flex;align-items:center;gap:0.25em;margin:0;cursor:pointer;">
+    <input type="radio" name="sort" value="gyoutai" style="margin:0;"
+           {% if active_sort == 'gyoutai' %}checked{% endif %}>業態順
+  </label>
+  <label style="display:inline-flex;align-items:center;gap:0.25em;margin:0;cursor:pointer;">
+    <input type="radio" name="sort" value="rank" style="margin:0;"
+           {% if active_sort == 'rank' %}checked{% endif %}>順位順
+  </label>
+  {# フィルタ/ソート変更時は page=1 にリセット (page hidden を出さない) #}
+  <button type="submit" style="padding:0.3em 0.8em;font-size:0.85em;margin:0;">絞り込み</button>
+</form>
 
-<p style="font-size:0.85em;color:#666;">{{ rows|length }} 件</p>
+<p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">
+  {% if total > 0 %}{{ total }}件中 {{ page_start }}-{{ page_end }} 件表示
+  {% else %}0 件{% endif %}
+</p>
 
 {% if not fallback_mode %}
 <div id="manage-panel" style="display:none;">
   <form action="/portfolio/add" method="POST" class="portfolio-add-form">
+    <input type="hidden" name="return_query" value="{{ return_query }}">
     <label>コード <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
     <button type="submit">追加</button>
   </form>
-  {% if active_query in ("watch", "semi") and rows %}
+  {% if delete_mode_allowed %}
   <button type="button" id="toggle-delete-mode">削除モード</button>
   {% endif %}
 </div>
-{% if active_query in ("watch", "semi") and rows %}
+{% if delete_mode_allowed %}
 <div id="bulk-delete-bar" style="display:none;">
   <span><strong id="selected-count">0</strong> 件選択中</span>
   <button type="button" id="bulk-delete-execute" class="contrast">削除 (ユニバース除外)</button>
@@ -110,10 +145,11 @@
 <table class="portfolio-list">
   <thead>
     <tr>
-      {% if active_query in ("watch", "semi") and not fallback_mode %}<th class="bulk-col"></th>{% endif %}
+      {% if delete_mode_allowed %}<th class="bulk-col"></th>{% endif %}
       <th></th>
       <th>コード</th>
       <th>銘柄名</th>
+      <th>状態</th>
       <th>業態・テーマ</th>
       <th>順位</th>
       <th>売上成長(%)</th>
@@ -137,9 +173,11 @@
   </thead>
   <tbody>
     {% for row in rows %}
-    <tr data-code="{{ row.code_s }}">
-      {% if active_query in ("watch", "semi") and not fallback_mode %}
-      <td class="bulk-col"><input type="checkbox" class="bulk-cb" value="{{ row.code_s }}"></td>
+    {# issue #178: 業態順表示時、前行と業態 1 行目が異なる行は境界線を入れる。
+       row.gyoutai_first は helpers.list_portfolio_with_indicators が precompute 済み。 #}
+    <tr data-code="{{ row.code_s }}"{% if active_sort == 'gyoutai' and not loop.first and loop.previtem.gyoutai_first != row.gyoutai_first %} class="gyoutai-boundary"{% endif %}>
+      {% if delete_mode_allowed %}
+      <td class="bulk-col"><input type="checkbox" class="bulk-cb" value="{{ row.code_s }}" data-status="{{ row.status }}"></td>
       {% endif %}
       <td>
         <details>
@@ -151,6 +189,7 @@
           style="max-width:10em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
         <a href="/stock/{{ row.code_s }}">{{ row.stock_name }}</a>
       </td>
+      <td><span class="status-badge status-{{ row.status_query }}">{{ row.status_label }}</span></td>
       <td class="gyoutai-themes-cell" data-code="{{ row.code_s }}"
           style="max-width:11em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
         {% set themes = row.memo.gyoutai_themes or [] %}
@@ -194,7 +233,8 @@
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      <td colspan="{% if active_query in ('watch', 'semi') and not fallback_mode %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
+      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 #}
+      <td colspan="{% if delete_mode_allowed %}24{% else %}23{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">
@@ -206,6 +246,7 @@
             {% if not fallback_mode %}
             <form action="/portfolio/{{ row.code_s }}/memo" method="POST"
                   style="display:flex;flex-direction:column;gap:0.4em;margin:0.3em 0 0 0;font-size:0.85em;">
+              <input type="hidden" name="return_query" value="{{ return_query }}">
               {# 業態・テーマ / 更新日 / ステージ は表内 inline 編集に移動 (issue #177) #}
               {% for field, label in [
                   ("watch_in_reason", "IN 理由"),
@@ -243,11 +284,12 @@
           <div style="flex:0 0 240px;">
             <strong style="font-size:0.85em;color:#666;">操作</strong>
             <div style="display:flex;flex-direction:column;gap:0.5em;margin-top:0.3em;font-size:0.85em;">
-              {% if transitions %}
+              {% if row.transitions %}
               <form action="/portfolio/{{ row.code_s }}/transition" method="POST" style="display:flex;flex-direction:column;gap:0.3em;margin:0;">
+                <input type="hidden" name="return_query" value="{{ return_query }}">
                 <label style="font-size:0.85em;color:#666;">ステータス変更</label>
                 <select name="new_status" style="padding:0.3em;font-size:0.85em;margin:0;">
-                  {% for label, value in transitions %}
+                  {% for label, value in row.transitions %}
                   <option value="{{ value }}">{{ label }}</option>
                   {% endfor %}
                 </select>
@@ -266,6 +308,25 @@
   </tbody>
 </table>
 </div>
+
+{# issue #178: ページネーション (1ページしかなければ非表示)。
+   page だけ差し替えるため、build_pagination_url マクロで status/sort のみ持つベースを使う。 #}
+{% set pagination_base = 'status=' + (active_status_queries|join(',')) + '&sort=' + active_sort %}
+{% if total_pages > 1 %}
+<nav class="pagination">
+  {% if page > 1 %}
+    <a href="?{{ pagination_base }}{% if page > 2 %}&page={{ page - 1 }}{% endif %}">‹ 前</a>
+  {% else %}
+    <span class="disabled">‹ 前</span>
+  {% endif %}
+  <span>{{ page }} / {{ total_pages }}</span>
+  {% if page < total_pages %}
+    <a href="?{{ pagination_base }}&page={{ page + 1 }}">次 ›</a>
+  {% else %}
+    <span class="disabled">次 ›</span>
+  {% endif %}
+</nav>
+{% endif %}
 
 <datalist id="gyoutai-theme-choices">
   {% for choice in gyoutai_theme_choices %}
@@ -619,13 +680,13 @@ document.querySelectorAll('table details').forEach(function(d) {
 // ========== 削除モード = ユニバース除外一括 ==========
 (function() {
   var toggle = document.getElementById('toggle-delete-mode');
-  if (!toggle) return;  // watch/semi タブ以外では何もしない
+  if (!toggle) return;  // delete_mode_allowed=false のフィルタでは何もしない
   var bar = document.getElementById('bulk-delete-bar');
   var countEl = document.getElementById('selected-count');
   var execBtn = document.getElementById('bulk-delete-execute');
   var cancelBtn = document.getElementById('bulk-delete-cancel');
-  // 現在のタブ (active_query) を Jinja で埋め込んで JS から参照
-  var returnTo = {{ active_query | tojson }};
+  // issue #178: 現状のフィルタ/ソート/ページ全体 (return_query) を Jinja で埋め込んで JS から参照
+  var returnQuery = {{ return_query | tojson }};
 
   function refresh() {
     var checked = document.querySelectorAll('.bulk-cb:checked');
@@ -654,7 +715,7 @@ document.querySelectorAll('table details').forEach(function(d) {
     if (!confirm(codes.length + ' 件をユニバースから除外します。よろしいですか?')) return;
     var fd = new FormData();
     codes.forEach(function(c) { fd.append('codes', c); });
-    fd.append('return_to', returnTo);
+    fd.append('return_query', returnQuery);
     fetch('/portfolio/bulk-exclude', { method: 'POST', body: fd })
       .then(function(r) {
         if (r.redirected) location.href = r.url;

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -179,7 +179,12 @@
        row.gyoutai_first は helpers.list_portfolio_with_indicators が precompute 済み。 #}
     <tr data-code="{{ row.code_s }}"{% if active_sort == 'gyoutai' and not loop.first and loop.previtem.gyoutai_first != row.gyoutai_first %} class="gyoutai-boundary"{% endif %}>
       {% if delete_mode_allowed %}
-      <td class="bulk-col"><input type="checkbox" class="bulk-cb" value="{{ row.code_s }}" data-status="{{ row.status }}"></td>
+      {# codex 指摘 P2: 1保 は bulk_exclude() で reject されるため checkbox を出さない #}
+      <td class="bulk-col">
+        {% if row.status in ('2準', '3監') %}
+        <input type="checkbox" class="bulk-cb" value="{{ row.code_s }}" data-status="{{ row.status }}">
+        {% endif %}
+      </td>
       {% endif %}
       <td>
         <details>

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -122,8 +122,10 @@
 
 {% if not fallback_mode %}
 <div id="manage-panel" style="display:none;">
+  {# 追加フォームには return_query を入れない。
+     現在のフィルタが保有のみだと、追加された 3監 銘柄が見えなくなるため、
+     add() 側の default_status_query="watch" フォールバックを効かせる (codex 指摘 P2)。 #}
   <form action="/portfolio/add" method="POST" class="portfolio-add-form">
-    <input type="hidden" name="return_query" value="{{ return_query }}">
     <label>コード <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
     <button type="submit">追加</button>
   </form>

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1585,3 +1585,82 @@ class TestCollectGyoutaiThemeChoices:
             {"memo": {"gyoutai_themes": ["AI", None, 123, "半導体"]}},
         ]
         assert helpers.collect_gyoutai_theme_choices(records) == ["AI", "半導体"]
+
+
+class TestListPortfolioWithIndicators:
+    """list_portfolio_with_indicators の sort_key / status_query / status_label 検証 (issue #178)。
+
+    外部参照 (_bulk_get_stock_data, _bulk_resolve_stock_names, compute_cell_styles) は
+    monkeypatch でスタブし、並び順とフィールド埋めだけを検証する。
+    """
+
+    @pytest.fixture
+    def stub_externals(self, monkeypatch):
+        """rank を rec から直接読めるよう _extract_indicators_for_portfolio もスタブ。"""
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: {c: {} for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: f"name_{c}" for c in codes})
+        monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
+        # _extract_indicators_for_portfolio は rec の rank を上書きしないよう空 dict を返す
+        monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
+
+    def _make(self, code_s, status, rank=None, themes=None):
+        return {
+            "code_s": code_s,
+            "status": status,
+            "rank": rank,
+            "memo": {"gyoutai_themes": themes or []},
+        }
+
+    def test_sort_by_gyoutai_then_rank(self, stub_externals):
+        records = [
+            self._make("0001", "1保", rank=30, themes=["人材"]),
+            self._make("0002", "1保", rank=10, themes=["半導体"]),
+            self._make("0003", "1保", rank=5, themes=["人材"]),
+        ]
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
+        # 業態順 (人材→半導体) かつ業態内は rank 昇順
+        assert [r["code_s"] for r in rows] == ["0003", "0001", "0002"]
+
+    def test_sort_by_rank_only(self, stub_externals):
+        records = [
+            self._make("0001", "1保", rank=30, themes=["人材"]),
+            self._make("0002", "1保", rank=10, themes=["半導体"]),
+            self._make("0003", "1保", rank=5, themes=["人材"]),
+        ]
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="rank")
+        assert [r["code_s"] for r in rows] == ["0003", "0002", "0001"]
+
+    def test_empty_gyoutai_goes_to_end_under_gyoutai_sort(self, stub_externals):
+        records = [
+            self._make("0001", "1保", rank=10, themes=[]),
+            self._make("0002", "1保", rank=20, themes=["半導体"]),
+            self._make("0003", "1保", rank=5, themes=None),
+        ]
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
+        # 半導体が先頭、空 themes は末尾 (末尾内は rank 昇順)
+        assert [r["code_s"] for r in rows] == ["0002", "0003", "0001"]
+
+    def test_gyoutai_uses_first_line_only(self, stub_externals):
+        """themes[0] のみで判定 (themes[1] 以降は無視)"""
+        records = [
+            self._make("0001", "1保", rank=10, themes=["AI", "人材"]),
+            self._make("0002", "1保", rank=20, themes=["人材", "AI"]),
+        ]
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
+        # 0001 の themes[0]=AI が先、0002 の themes[0]=人材 が後
+        assert [r["code_s"] for r in rows] == ["0001", "0002"]
+
+    def test_status_query_label_filled(self, stub_externals):
+        records = [
+            self._make("0001", "1保"),
+            self._make("0002", "2準"),
+            self._make("0003", "3監"),
+        ]
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="rank")
+        by_code = {r["code_s"]: r for r in rows}
+        assert by_code["0001"]["status_query"] == "hold"
+        assert by_code["0001"]["status_label"] == "保有"
+        assert by_code["0002"]["status_query"] == "semi"
+        assert by_code["0002"]["status_label"] == "準保有"
+        assert by_code["0003"]["status_query"] == "watch"
+        assert by_code["0003"]["status_label"] == "監視"

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -1027,6 +1027,21 @@ class TestReturnQueryRedirect:
         assert resp.status_code == 302
         assert "status=watch" in resp.headers["Location"]
 
+    def test_add_form_does_not_emit_return_query_hidden(self, client):
+        """追加フォームは hidden return_query を出さない (codex 指摘 P2)。
+
+        追加された 3監 銘柄を見えなくしないため、現在のフィルタを引き継がず
+        add() の default_status_query='watch' フォールバックを効かせる。
+        """
+        import re
+        resp = client.get("/portfolio?status=hold&sort=gyoutai")
+        html = resp.data.decode()
+        # 追加フォーム部分を抽出 (action="/portfolio/add" の form タグ)
+        m = re.search(r'<form[^>]*action="/portfolio/add"[^>]*>(.*?)</form>', html, re.DOTALL)
+        assert m is not None, "追加フォームが見つからない"
+        form_inner = m.group(1)
+        assert 'name="return_query"' not in form_inner
+
     def test_return_query_with_unsafe_chars_falls_back(self, client):
         """改行や # を含む return_query はフォールバック (URL injection 防止)"""
         resp = client.post(

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -1054,3 +1054,38 @@ class TestReturnQueryRedirect:
         assert "status=hold" in loc
         assert "evil" not in loc
         assert "%0A" not in loc
+
+
+class TestDeleteCheckboxScope:
+    """削除モードのチェックボックスは 2準/3監 行のみに表示される (codex 指摘 P2)"""
+
+    def test_1ho_row_has_no_checkbox_in_mixed_filter(self, client):
+        """status=hold,semi,watch の混在表示で、1保 (3496) 行には checkbox が無く、
+        2準 (7203) と 3監 (6324) 行には checkbox が出る"""
+        import re
+        resp = client.get("/portfolio?status=hold,semi,watch")
+        html = resp.data.decode()
+        # 各銘柄行を抽出 (data-code="XXXX" から次の </tr> まで)
+        for code, has_checkbox in [
+            ("3496", False),  # 1保 → checkbox 無し
+            ("7203", True),   # 2準 → checkbox あり
+            ("6324", True),   # 3監 → checkbox あり
+        ]:
+            m = re.search(
+                rf'<tr data-code="{code}"[^>]*>(.*?)</tr>', html, re.DOTALL
+            )
+            assert m is not None, f"行 {code} が見つからない"
+            row_inner = m.group(1)
+            checkbox_present = 'class="bulk-cb"' in row_inner
+            assert checkbox_present == has_checkbox, (
+                f"行 {code} の checkbox 期待値 {has_checkbox} だが実際は {checkbox_present}"
+            )
+
+    def test_no_checkbox_when_only_hold_filter(self, client):
+        """status=hold のみ (削除可能ステータスなし) なら delete_mode_allowed=False で
+        bulk-col 列自体出ない"""
+        resp = client.get("/portfolio?status=hold")
+        html = resp.data.decode()
+        assert 'class="bulk-cb"' not in html
+        # bulk-col の th も出ない (delete_mode_allowed が False)
+        assert 'class="bulk-col"' not in html

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -324,23 +324,25 @@ class TestBulkExclude:
             assert rec is not None
             assert rec["excluded"] is True
 
-    def test_bulk_exclude_redirects_to_return_to(self, client, portfolio_db_path):
-        """return_to=semi なら /portfolio?status=semi にリダイレクト"""
+    def test_bulk_exclude_redirects_to_return_query(self, client, portfolio_db_path):
+        """return_query=status=hold,semi&sort=rank なら同じクエリにリダイレクト (issue #178)"""
         resp = client.post(
             "/portfolio/bulk-exclude",
-            data={"codes": "7203", "return_to": "semi"},
+            data={"codes": "7203", "return_query": "status=hold,semi&sort=rank"},
         )
         assert resp.status_code == 302
-        assert "status=semi" in resp.headers["Location"]
+        loc = resp.headers["Location"]
+        assert "status=hold,semi" in loc
+        assert "sort=rank" in loc
 
-    def test_bulk_exclude_invalid_return_to_falls_back(self, client, portfolio_db_path):
-        """不正な return_to は watch にフォールバック"""
+    def test_bulk_exclude_empty_return_query_falls_back_to_default(self, client, portfolio_db_path):
+        """return_query 未指定はデフォルト ?status=hold にリダイレクト (issue #178)"""
         resp = client.post(
             "/portfolio/bulk-exclude",
-            data={"codes": "6324", "return_to": "evil"},
+            data={"codes": "6324"},
         )
         assert resp.status_code == 302
-        assert "status=watch" in resp.headers["Location"]
+        assert "status=hold" in resp.headers["Location"]
 
     def test_bulk_exclude_empty_codes_flash_error(self, client, portfolio_db_path):
         resp = client.post("/portfolio/bulk-exclude", data={})
@@ -837,3 +839,203 @@ class TestFallbackFromTxt:
         assert resp.status_code == 302
         # shelve は空のまま (memo 更新で 1 件作られたら fallback 解除事故が起きる)
         assert ps.list_records(db_path=portfolio_db_path) == []
+
+
+# ==================================================
+# issue #178: フィルタ / ソート / ページング / status badge / return_query
+# ==================================================
+class TestDashboardFilterSortPaging:
+    """GET /portfolio?status=...&sort=...&page=... の検証 (issue #178)"""
+
+    def test_default_shows_hold_only(self, client):
+        """引数なし = 保有のみ (1保) を表示"""
+        resp = client.get("/portfolio")
+        html = resp.data.decode()
+        assert "アズーム" in html      # 1保
+        assert "ハーモニック" not in html  # 3監
+        assert "トヨタ" not in html      # 2準
+
+    def test_multi_status_filter_csv(self, client):
+        """?status=hold,semi (カンマ区切り) で 1保 + 2準 を表示"""
+        resp = client.get("/portfolio?status=hold,semi")
+        html = resp.data.decode()
+        assert "アズーム" in html
+        assert "トヨタ" in html
+        assert "ハーモニック" not in html
+
+    def test_multi_status_filter_repeated(self, client):
+        """?status=hold&status=semi (HTML form 送信形式) で 1保 + 2準 を表示"""
+        resp = client.get("/portfolio?status=hold&status=semi")
+        html = resp.data.decode()
+        assert "アズーム" in html
+        assert "トヨタ" in html
+        assert "ハーモニック" not in html
+
+    def test_multi_status_filter_mixed(self, client):
+        """カンマ区切りと同名複数キーが混在しても merge される (issue #178 codex 指摘)"""
+        resp = client.get("/portfolio?status=hold,xxx&status=watch")
+        html = resp.data.decode()
+        assert "アズーム" in html      # hold
+        assert "ハーモニック" in html   # watch
+        assert "トヨタ" not in html      # semi は含まれていない
+
+    def test_all_status_filter(self, client):
+        """全件指定で 3 銘柄全部表示"""
+        resp = client.get("/portfolio?status=hold,semi,watch")
+        html = resp.data.decode()
+        assert "アズーム" in html
+        assert "トヨタ" in html
+        assert "ハーモニック" in html
+
+    def test_legacy_url_status_hold_still_works(self, client):
+        """既存 URL ?status=hold (単一値) が引き続き動作 (issue #178 互換性)"""
+        resp = client.get("/portfolio?status=hold")
+        html = resp.data.decode()
+        assert "アズーム" in html
+        assert "ハーモニック" not in html
+
+    def test_invalid_status_falls_back_to_default(self, client):
+        """不正値だけのフィルタはデフォルト = hold にフォールバック"""
+        resp = client.get("/portfolio?status=invalid")
+        html = resp.data.decode()
+        assert "アズーム" in html
+
+    def test_status_badge_visible_in_all_filter(self, client):
+        """全件表示時、ステータス badge (保有/準保有/監視) が HTML に出る"""
+        resp = client.get("/portfolio?status=hold,semi,watch")
+        html = resp.data.decode()
+        assert 'class="status-badge status-hold"' in html
+        assert 'class="status-badge status-semi"' in html
+        assert 'class="status-badge status-watch"' in html
+
+    def test_sort_rank_orders_by_rank(self, client):
+        """?sort=rank で順位昇順 (業態無視)。fixture: 3496=50, 7203=200, 6324=612"""
+        resp = client.get("/portfolio?status=hold,semi,watch&sort=rank")
+        html = resp.data.decode()
+        # 表示位置で並び順を判定 (3496 が 7203 より前、7203 が 6324 より前)
+        i_3496 = html.find('data-code="3496"')
+        i_7203 = html.find('data-code="7203"')
+        i_6324 = html.find('data-code="6324"')
+        assert i_3496 != -1 and i_7203 != -1 and i_6324 != -1
+        assert i_3496 < i_7203 < i_6324
+
+    def test_sort_gyoutai_default(self, client):
+        """sort 未指定はデフォルト gyoutai (radio が checked になっている)"""
+        import re
+        resp = client.get("/portfolio?status=hold")
+        html = resp.data.decode()
+        # gyoutai radio タグ内に checked が含まれ、rank radio タグ内には含まれないこと
+        gyoutai_radio = re.search(r'<input[^>]*name="sort"[^>]*value="gyoutai"[^>]*>', html)
+        rank_radio = re.search(r'<input[^>]*name="sort"[^>]*value="rank"[^>]*>', html)
+        assert gyoutai_radio is not None and "checked" in gyoutai_radio.group(0)
+        assert rank_radio is not None and "checked" not in rank_radio.group(0)
+
+    def test_pagination_disabled_when_under_page_size(self, client):
+        """総件数がページサイズ以内ならページネーション nav は出ない"""
+        resp = client.get("/portfolio?status=hold,semi,watch")
+        html = resp.data.decode()
+        # 全 3 件 <= 50 なので pagination nav は出ない
+        assert 'class="pagination"' not in html
+
+    def test_pagination_invalid_page_falls_back(self, client):
+        """?page=abc は 1 にフォールバック (例外を投げない)"""
+        resp = client.get("/portfolio?status=hold&page=abc")
+        assert resp.status_code == 200
+        assert "アズーム" in resp.data.decode()
+
+    def test_pagination_zero_page_falls_back(self, client):
+        """?page=0 は 1 にフォールバック"""
+        resp = client.get("/portfolio?status=hold&page=0")
+        assert resp.status_code == 200
+
+    def test_pagination_overflow_page_clamped(self, client, monkeypatch):
+        """総ページ数を超えた page 指定は最終ページにクランプ"""
+        # ページサイズを 1 に下げて 3 銘柄を 3 ページに分割
+        from webapp.routes import portfolio as portfolio_routes
+        monkeypatch.setattr(portfolio_routes, "PORTFOLIO_PAGE_SIZE", 1)
+        resp = client.get("/portfolio?status=hold,semi,watch&sort=rank&page=999")
+        html = resp.data.decode()
+        # 最終ページ (page=3) には 6324 (rank=612) のみ
+        assert 'data-code="6324"' in html
+        assert 'data-code="3496"' not in html
+        assert 'data-code="7203"' not in html
+
+    def test_pagination_actually_paginates(self, client, monkeypatch):
+        """ページサイズを下げた状態で 1 ページ目が 1 件、2 ページ目で違う 1 件"""
+        from webapp.routes import portfolio as portfolio_routes
+        monkeypatch.setattr(portfolio_routes, "PORTFOLIO_PAGE_SIZE", 1)
+        # rank 順: 3496 (50) → 7203 (200) → 6324 (612)
+        resp1 = client.get("/portfolio?status=hold,semi,watch&sort=rank&page=1")
+        html1 = resp1.data.decode()
+        assert 'data-code="3496"' in html1
+        assert 'data-code="7203"' not in html1
+
+        resp2 = client.get("/portfolio?status=hold,semi,watch&sort=rank&page=2")
+        html2 = resp2.data.decode()
+        assert 'data-code="7203"' in html2
+        assert 'data-code="3496"' not in html2
+
+        # ページネーション nav が出ている (total_pages=3)
+        assert 'class="pagination"' in html2
+
+    def test_filter_form_does_not_emit_page_hidden(self, client):
+        """フィルタ form 内に page の hidden が無い (= submit 時に page=1 にリセット)"""
+        resp = client.get("/portfolio?status=hold&page=2")
+        html = resp.data.decode()
+        # フィルタ form 部分を抽出して page hidden が無いことを確認
+        form_start = html.find('id="portfolio-filter-form"')
+        form_end = html.find('</form>', form_start)
+        form_html = html[form_start:form_end]
+        assert 'name="page"' not in form_html
+
+
+class TestReturnQueryRedirect:
+    """POST 後の return_query によるリダイレクト先復元 (issue #178)"""
+
+    def test_transition_redirects_with_return_query(self, client):
+        """transition POST 時、return_query が反映される"""
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={
+                "new_status": "3監",
+                "reason": "test",
+                "return_query": "status=hold,semi&sort=rank",
+            },
+        )
+        assert resp.status_code == 302
+        loc = resp.headers["Location"]
+        assert "status=hold,semi" in loc
+        assert "sort=rank" in loc
+
+    def test_memo_redirects_with_return_query(self, client):
+        """memo POST 時、return_query が反映される"""
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"trade_idea": "X", "return_query": "status=watch&sort=rank&page=2"},
+        )
+        assert resp.status_code == 302
+        loc = resp.headers["Location"]
+        assert "status=watch" in loc
+        assert "sort=rank" in loc
+        assert "page=2" in loc
+
+    def test_add_default_status_query_is_watch(self, client, stocks_db_path):
+        """add は return_query 未指定時、デフォルトで watch にリダイレクト (追加直後の確認用)"""
+        with ShelveDB(stocks_db_path) as db:
+            db["8035"] = {"code_s": "8035", "stock_name": "東京エレクトロン"}
+        resp = client.post("/portfolio/add", data={"code_s": "8035"})
+        assert resp.status_code == 302
+        assert "status=watch" in resp.headers["Location"]
+
+    def test_return_query_with_unsafe_chars_falls_back(self, client):
+        """改行や # を含む return_query はフォールバック (URL injection 防止)"""
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "1保", "return_query": "status=hold\n#evil"},
+        )
+        assert resp.status_code == 302
+        # return_query が空相当の扱い → デフォルト ?status=hold
+        loc = resp.headers["Location"]
+        assert "status=hold" in loc
+        assert "evil" not in loc
+        assert "%0A" not in loc


### PR DESCRIPTION
## Summary
- **タブ廃止**: 保有/準保有/監視の3タブを撤廃し、checkbox フィルタ + radio ソート + ページネーションに再設計
- **デフォルト = 保有のみ**: 業態・テーマ別の比較が主用途のため、保有銘柄から始める仕様 (issue 178 原案からの差分、ユーザー判断)
- **ページング**: 50件/ページ。引数なし (?page=N) で URL 反映、フィルタ/ソート切替時は page リセット
- **状態保持は URL のみ**: localStorage / Cookie 不使用。POST 後は hidden \`return_query\` で直前のフィルタ/ソート/ページを復元

## 仕様詳細
### URL 設計
\`\`\`
/portfolio                              # デフォルト: 保有のみ + 業態順 + 1ページ目
/portfolio?status=hold,semi             # 保有+準保有 (カンマ区切り)
/portfolio?status=hold&status=semi      # 同上 (HTML form 標準形式、両方受理)
/portfolio?sort=rank                    # 順位順
/portfolio?status=hold,semi,watch&page=2 # 全件 2ページ目
/portfolio?status=hold                  # 既存 URL (互換性維持)
\`\`\`

### UI
- フィルタバー (上部): \`☑保有(N) ☐準保有(N) ☐監視(N)\` + ソート radio + 「絞り込み」submit
- ステータス列 (新設): 保有=緑 / 準保有=黄 / 監視=灰の badge
- 業態順表示時は業態境界に border-top、順位順では境界線なし
- ページネーション: 1ページに収まるとき非表示

### 互換性
- 既存 \`?status=hold\` (単一値) はそのまま動作
- bulk-exclude の旧 \`return_to=hold|semi|watch\` は \`return_query\` 方式に統一

## 主な変更ファイル
- \`scripts/webapp/routes/portfolio.py\`: \`_parse_status_filter\` (csv/repeated 両対応) / \`_parse_sort\` / \`_parse_page\` / \`_redirect_with_return_query\`、dashboard 改修
- \`scripts/webapp/helpers.py\`: \`list_portfolio_with_indicators(sort_key=\"gyoutai\"|\"rank\")\`、各 row に \`status_query/status_label/gyoutai_first\` を埋め込み
- \`scripts/webapp/templates/portfolio_list.html\`: タブ → フィルタバー、ステータス列、業態境界 border、ページネーション、各 form に hidden \`return_query\`

## Test plan
- [x] 単体: \`pytest tests/test_webapp_helpers.py tests/test_webapp_portfolio_routes.py\` 244 件全緑
- [x] 新規 24 ケース追加: フィルタ (csv/repeated/混在/不正値)、ソート (gyoutai/rank/デフォルト)、ページング (有効/不正/オーバーフロー/page リセット)、status badge、return_query 復元、URL injection 防御
- [x] E2E ブラウザ目視: デフォルト保有のみ表示、複数フィルタ、ページ移動、ソート切替、業態境界 border、status badge

## スコープ外 (issue 178 原案明記)
- 業態自体のフィルタ
- 列ヘッダクリック式の汎用ソート
- 業態テーマの正規化
- localStorage / Cookie での状態保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)