### PR TITLE
issue #197 PTS: 値下がりページ取得と複数ページ対応に拡張

### DIFF
--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -739,9 +739,14 @@ def convert_kabutan_pts_html(html, max_rows=20):
         # 通常終値は m.group(4)、PTS株価を使用
         kabuka = m.group(5)
         try:
-            zenjitsuhi = re.search(r'<span class="up">(.*)</span>', m.group(6)).group(1)
+            zenjitsuhi = re.search(
+                r'<span class="(?:up|down)">(.*)</span>', m.group(6)
+            ).group(1)
             zenjitsuhi_per = (
-                re.search(r'<span class="up">(.*)</span>', m.group(7)).group(1) + "%"
+                re.search(
+                    r'<span class="(?:up|down)">(.*)</span>', m.group(7)
+                ).group(1)
+                + "%"
             )
         except AttributeError:
             zenjitsuhi = 0
@@ -1183,8 +1188,44 @@ def get_todays_shintakane(force=False):
 #     return False
 
 
+URL_KABUTAN_PTS_UP = "https://kabutan.jp/warning/pts_night_price_increase"
+URL_KABUTAN_PTS_DOWN = "https://kabutan.jp/warning/pts_night_price_decrease"
+
+
+def _fetch_pts_page_html(base_url, page, cache_dir):
+    """株探PTSランキングの指定ページHTMLを取得して返す
+
+    page=1 はクエリパラメータなし、page>=2 は ?page=N を付ける。
+    page=1 のキャッシュ判定だけ既存仕様を踏襲(当日分のキャッシュがあれば使う)。
+    """
+    url = base_url if page == 1 else f"{base_url}?page={page}"
+    use_cache = False
+    try:
+        latest_html = file_read(os.path.join(cache_dir, get_http_cachname(url)))
+        latest_date_m = re.search(
+            r'<div class="meigara_count">.*(\d\d\d\d)年(\d\d)月(\d\d)日.*?</div>',
+            latest_html,
+            re.S,
+        )
+        cach_dt = datetime(
+            int(latest_date_m.group(1)),
+            int(latest_date_m.group(2)),
+            int(latest_date_m.group(3)),
+        )
+        use_cache = cach_dt.date() >= get_price_day(datetime.today()).date()
+        log_debug("株探PTS キャッシュ：", url, cach_dt, use_cache)
+    except (IOError, OSError, AttributeError):
+        use_cache = False
+    return http_get_html(url, use_cache=use_cache, cache_dir=cache_dir)
+
+
 def get_todays_pts(force=False):
-    """本日のPTSナイトランキングを株探から取得し、CSVに保存する"""
+    """本日のPTSナイトランキングを株探から取得し、CSVに保存する
+
+    値上がり page=1, page=2(各 max_rows=30) と値下がり page=1(max_rows=15)
+    を統合した 1 ファイルに保存する。rank は値上がり 1〜N → 値下がり N+1〜M で連番。
+    日付は値上がり page=1 の `<div class="meigara_count">` から取得。
+    """
     log_print("=" * 30)
     log_print("PTSナイトランキングを更新します・・")
     latest_csv, _ = get_latest_pts_fname()
@@ -1204,34 +1245,13 @@ def get_todays_pts(force=False):
             return
 
     log_print("----> 株探からPTSランキングを取得します・・")
-    URL_KABUTAN_PTS = "https://kabutan.jp/warning/pts_night_price_increase"
     cache_dir = os.path.join(DATA_DIR, "today_stocks", "html_cache")
-    # キャッシュ判定
-    try:
-        latest_html = file_read(
-            os.path.join(cache_dir, get_http_cachname(URL_KABUTAN_PTS))
-        )
-        # 更新日付をヘッダーから取得
-        latest_date_m = re.search(
-            r'<div class="meigara_count">.*(\d\d\d\d)年(\d\d)月(\d\d)日.*?</div>',
-            latest_html,
-            re.S,
-        )
-        cach_dt = datetime(
-            int(latest_date_m.group(1)),
-            int(latest_date_m.group(2)),
-            int(latest_date_m.group(3)),
-        )
-        useCache = cach_dt.date() >= get_price_day(datetime.today()).date()
-        log_debug("株探PTS キャッシュ：", cach_dt, useCache)
-    except (IOError, OSError, AttributeError):
-        useCache = False
 
-    html = http_get_html(URL_KABUTAN_PTS, use_cache=useCache, cache_dir=cache_dir)
-    # 更新日付を取得
+    # 値上がり page=1 を取得し、日付ヘッダーを抽出
+    html_up_p1 = _fetch_pts_page_html(URL_KABUTAN_PTS_UP, 1, cache_dir)
     date_m = re.search(
         r'<div class="meigara_count">.*(\d\d\d\d)年(\d\d)月(\d\d)日.*?</div>',
-        html,
+        html_up_p1,
         re.S,
     )
     if not date_m:
@@ -1240,14 +1260,31 @@ def get_todays_pts(force=False):
     date = date_m.group(1)[-2:] + date_m.group(2) + date_m.group(3)
     log_debug("株探PTS更新日：", date)
 
-    rows = convert_kabutan_pts_html(html)
+    # 値上がり page=2 と値下がり page=1 を取得
+    html_up_p2 = _fetch_pts_page_html(URL_KABUTAN_PTS_UP, 2, cache_dir)
+    html_down_p1 = _fetch_pts_page_html(URL_KABUTAN_PTS_DOWN, 1, cache_dir)
 
-    # CSVに保存
+    # パース (値上がり 2 ページ合算で max_rows=30、値下がり 1 ページで max_rows=15)
+    up_rows = convert_kabutan_pts_html(html_up_p1, max_rows=30)
+    remaining_up = max(0, 30 - len(up_rows))
+    if remaining_up > 0:
+        up_rows += convert_kabutan_pts_html(html_up_p2, max_rows=remaining_up)
+    down_rows = convert_kabutan_pts_html(html_down_p1, max_rows=15)
+
+    # rank を値上がり 1..N → 値下がり N+1..M で連番に振り直す
+    merged_rows = []
+    for i, row in enumerate(up_rows + down_rows, start=1):
+        row[0] = str(i)
+        merged_rows.append(row)
+
     csv_fname = os.path.join(DATA_DIR, "today_stocks", "pts_" + date + ".csv")
     with open(csv_fname, "w", encoding="utf-8") as f:
         csv_w = csv.writer(f)
-        csv_w.writerows(rows)
-    log_print("今日のPTSランキングを%sに保存しました" % csv_fname)
+        csv_w.writerows(merged_rows)
+    log_print(
+        "今日のPTSランキングを%sに保存しました (値上がり%d件・値下がり%d件)"
+        % (csv_fname, len(up_rows), len(down_rows))
+    )
     _archive_old_csvs("pts")
     log_print("<---- 取得完了")
 

--- a/tests/test_shintakane.py
+++ b/tests/test_shintakane.py
@@ -361,11 +361,13 @@ class TestParseKessanHtml:
 # convert_kabutan_pts_html（株探・PTSナイトランキング）
 # ==================================================
 
-def _make_kabutan_pts_table(*rows_data):
+def _make_kabutan_pts_table(*rows_data, direction="up"):
     """株探・PTSランキングHTMLのテーブルを生成する
 
     rows_data: (code, name, market, trade_close, pts_price, zenjitsuhi, zenjitsuhi_per, volume) のタプル
+    direction: "up" (値上がりページ) または "down" (値下がりページ) で span class を切替
     """
+    span_cls = direction
     rows_html = ""
     for code, name, market, trade_close, pts_price, zenjitsuhi, zenjitsuhi_per, volume in rows_data:
         rows_html += (
@@ -377,8 +379,8 @@ def _make_kabutan_pts_table(*rows_data):
             f'<td class="chart_icon"><a href="/stock/chart?code={code}"></a></td>\n'
             f'<td>{trade_close}</td>\n'
             f'<td>{pts_price}</td>\n'
-            f'<td class="w61"><span class="up">{zenjitsuhi}</span></td>\n'
-            f'<td class="w50"><span class="up">{zenjitsuhi_per}</span>%</td>\n'
+            f'<td class="w61"><span class="{span_cls}">{zenjitsuhi}</span></td>\n'
+            f'<td class="w50"><span class="{span_cls}">{zenjitsuhi_per}</span>%</td>\n'
             f'<td>{volume}</td>\n'
             f'<td>16.5</td>\n'
             f'<td>6.42</td>\n'
@@ -428,31 +430,16 @@ class TestConvertKabutanPtsHtml:
         assert len(rows) == 1
         assert "446A" in rows[0][1]
 
-    def test_下落銘柄はスキップされる(self):
-        """spanにupクラスがない場合、zenjitsuhi=0になる"""
-        html = (
-            '<table class="stock_table st_market">'
-            '<tr>\n'
-            '<td class="tac"><a href="/stock/?code=1234">1234</a></td>\n'
-            '<th scope="row" class="tal">テスト銘柄</th>\n'
-            '<td class="tac">東Ｐ</td>\n'
-            '<td class="gaiyou_icon"><a href="/stock/?code=1234"></a></td>\n'
-            '<td class="chart_icon"><a href="/stock/chart?code=1234"></a></td>\n'
-            '<td>1,000</td>\n'
-            '<td>950</td>\n'
-            '<td class="w61"><span class="down">-50</span></td>\n'
-            '<td class="w50"><span class="down">-5.00</span>%</td>\n'
-            '<td>100,000</td>\n'
-            '<td>10.0</td>\n'
-            '<td>1.00</td>\n'
-            '<td>3.00</td>\n'
-            '</tr>\n'
-            '</table>'
+    def test_下落銘柄もパースされる(self):
+        """値下がりページの span class="down" でもマイナス符号付きで抽出される"""
+        html = _make_kabutan_pts_table(
+            ("1234", "テスト銘柄", "東Ｐ", "1,000", "950", "-50", "-5.00", "100,000"),
+            direction="down",
         )
         rows = shintakane.convert_kabutan_pts_html(html)
         assert len(rows) == 1
-        assert rows[0][5] == 0  # zenjitsuhi
-        assert rows[0][6] == 0  # zenjitsuhi_per
+        assert rows[0][5] == "-50"  # zenjitsuhi (マイナス符号付き)
+        assert rows[0][6] == "-5.00%"  # zenjitsuhi_per (マイナス符号付き)
 
     def test_空テーブル(self):
         html = '<table class="stock_table st_market"></table>'
@@ -497,3 +484,151 @@ class TestSearchFromcsvPts:
         """存在しないファイルは空リストを返す"""
         result = shintakane.search_fromcsv_pts("/nonexistent/file.csv")
         assert result == []
+
+
+# ==================================================
+# get_todays_pts 統合テスト
+# ==================================================
+def _make_pts_page_html(*rows_data, direction="up", date_str="2026年05月13日"):
+    """日付ヘッダー付きの PTS ページ HTML を組み立てる"""
+    table = _make_kabutan_pts_table(*rows_data, direction=direction)
+    header = f'<div class="meigara_count">{date_str} 23:30現在 100銘柄</div>'
+    return header + table
+
+
+class TestGetTodaysPts:
+    """get_todays_pts の統合テスト(複数ページ取得 + 値下がり統合 + rank連番)"""
+
+    def test_値上がり2ページと値下がり1ページを統合してCSVに保存する(
+        self, tmp_path, monkeypatch
+    ):
+        # 値上がり page=1 (15 銘柄)
+        up_p1_data = [
+            (f"{i:04d}", f"上1_{i}", "東Ｐ", "1,000", "1,100", "+100", "+10.00", "10,000")
+            for i in range(1000, 1015)
+        ]
+        # 値上がり page=2 (15 銘柄)
+        up_p2_data = [
+            (f"{i:04d}", f"上2_{i}", "東Ｐ", "1,000", "1,100", "+50", "+5.00", "10,000")
+            for i in range(2000, 2015)
+        ]
+        # 値下がり page=1 (10 銘柄、出来高 1000 以上で全件残る想定)
+        down_p1_data = [
+            (f"{i:04d}", f"下_{i}", "東Ｐ", "1,000", "900", "-100", "-10.00", "10,000")
+            for i in range(3000, 3010)
+        ]
+
+        html_up_p1 = _make_pts_page_html(*up_p1_data, direction="up")
+        html_up_p2 = _make_pts_page_html(*up_p2_data, direction="up")
+        html_down_p1 = _make_pts_page_html(*down_p1_data, direction="down")
+
+        # DATA_DIR を tmp_path に差し替え、today_stocks/html_cache を準備
+        data_dir = tmp_path
+        (data_dir / "today_stocks" / "html_cache").mkdir(parents=True)
+        monkeypatch.setattr(shintakane, "DATA_DIR", str(data_dir))
+
+        # キャッシュ判定スキップ用に latest_pts_fname を None にする
+        monkeypatch.setattr(
+            shintakane, "get_latest_pts_fname", lambda: (None, None)
+        )
+        # アーカイブ処理は対象外
+        monkeypatch.setattr(shintakane, "_archive_old_csvs", lambda kind: None)
+
+        # http_get_html を URL ごとに振り分けるモックに差し替え
+        calls = []
+
+        def fake_http_get_html(url, use_cache=False, cache_dir=None):
+            calls.append(url)
+            if "pts_night_price_increase" in url and "page=2" in url:
+                return html_up_p2
+            if "pts_night_price_increase" in url:
+                return html_up_p1
+            if "pts_night_price_decrease" in url:
+                return html_down_p1
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(shintakane, "http_get_html", fake_http_get_html)
+
+        shintakane.get_todays_pts(force=True)
+
+        # 3 URL すべて取得されている
+        assert any("pts_night_price_increase" in u and "page" not in u for u in calls)
+        assert any("pts_night_price_increase" in u and "page=2" in u for u in calls)
+        assert any("pts_night_price_decrease" in u for u in calls)
+
+        # 出力 CSV を読み戻して検証
+        csv_path = data_dir / "today_stocks" / "pts_260513.csv"
+        assert csv_path.exists()
+        import csv as _csv
+
+        with open(csv_path, encoding="utf-8") as f:
+            rows = list(_csv.reader(f))
+
+        # 値上がり 30 + 値下がり 10 = 40 行
+        assert len(rows) == 40
+
+        # rank が 1..40 の連番
+        assert [r[0] for r in rows] == [str(i) for i in range(1, 41)]
+
+        # 値下がり行(rank 31..40)は zenjitsuhi_per がマイナス符号付き
+        for r in rows[30:]:
+            assert r[6].startswith("-"), f"値下がり行のはず: {r}"
+
+        # 値上がり行(rank 1..30)は zenjitsuhi_per がプラス符号
+        for r in rows[:30]:
+            assert r[6].startswith("+"), f"値上がり行のはず: {r}"
+
+    def test_値上がりpage1が薄商いで埋まらない場合page2で補完する(
+        self, tmp_path, monkeypatch
+    ):
+        # page1: 15 件中 5 件のみ出来高 1000 以上、残り 10 件は薄商いで除外
+        up_p1_data = [
+            (f"{i:04d}", f"上1_{i}", "東Ｐ", "1,000", "1,100", "+100", "+10.00", "10,000")
+            for i in range(1000, 1005)
+        ] + [
+            (f"{i:04d}", f"薄_{i}", "東Ｐ", "1,000", "1,100", "+100", "+10.00", "500")
+            for i in range(1100, 1110)
+        ]
+        # page2: 全件出来高 1000 以上
+        up_p2_data = [
+            (f"{i:04d}", f"上2_{i}", "東Ｐ", "1,000", "1,100", "+50", "+5.00", "10,000")
+            for i in range(2000, 2015)
+        ]
+        # 値下がりは空(値上がり補完シナリオに集中)
+        down_p1_data = []
+
+        html_up_p1 = _make_pts_page_html(*up_p1_data, direction="up")
+        html_up_p2 = _make_pts_page_html(*up_p2_data, direction="up")
+        html_down_p1 = _make_pts_page_html(*down_p1_data, direction="down")
+
+        data_dir = tmp_path
+        (data_dir / "today_stocks" / "html_cache").mkdir(parents=True)
+        monkeypatch.setattr(shintakane, "DATA_DIR", str(data_dir))
+        monkeypatch.setattr(
+            shintakane, "get_latest_pts_fname", lambda: (None, None)
+        )
+        monkeypatch.setattr(shintakane, "_archive_old_csvs", lambda kind: None)
+
+        def fake_http_get_html(url, use_cache=False, cache_dir=None):
+            if "pts_night_price_increase" in url and "page=2" in url:
+                return html_up_p2
+            if "pts_night_price_increase" in url:
+                return html_up_p1
+            if "pts_night_price_decrease" in url:
+                return html_down_p1
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(shintakane, "http_get_html", fake_http_get_html)
+
+        shintakane.get_todays_pts(force=True)
+
+        import csv as _csv
+
+        csv_path = data_dir / "today_stocks" / "pts_260513.csv"
+        with open(csv_path, encoding="utf-8") as f:
+            rows = list(_csv.reader(f))
+
+        # 値上がり: page1 から 5 + page2 から 15 = 20 件
+        assert len(rows) == 20
+        # rank 連番
+        assert [r[0] for r in rows] == [str(i) for i in range(1, 21)]


### PR DESCRIPTION
## Summary

- 値上がり page=1, page=2 (max_rows=30) と値下がり page=1 (max_rows=15) を取得して 1 ファイルに統合保存
- パーサー `convert_kabutan_pts_html` を `<span class=\"(?:up|down)\">` 両対応に修正(値下がりも符号付きで抽出)
- rank を値上がり 1..N → 値下がり N+1..M で連番に振り直す
- ヘルパー `_fetch_pts_page_html` を追加してページ別キャッシュ判定を共通化

## なぜ

これまで `pts_night_price_increase` の 1 ページ目しか取得しておらず、薄商いフィルタ後に 12〜14 件しか拾えていなかった。引け後決算でPTSが大きく下がる銘柄 (例: SUMCO 1Q赤字 → PTS -20% 級) は値上がりランキングには載らないため、決算ショックを `決算日セクション` で表示できていなかった。

実取得検証 (2026-05-13):
- 値上がり 27 件 + 値下がり 13 件 = 計 40 件
- SUMCO (3436) を rank 30 で `-18.62%` として捕捉成功

## Test plan

- [x] `pytest tests/test_shintakane.py -v` — 32 件全通過
- [x] `pytest tests/ -m 'not local_db and not live_html'` — 既存日付依存テスト 1 件 (`test_today_card_appears_between_recent_past_and_future`) のみ失敗、これは main でも同様に失敗しており本変更とは無関係
- [x] 実取得: `python -c "import shintakane; shintakane.get_todays_pts(force=True)"` で `pts_260513.csv` 生成、値上がり 27 件・値下がり 13 件・SUMCO捕捉確認
- [x] CSV 7 列目 (zenjitsuhi_per) のマイナス符号付き行を `awk -F, '$7 ~ /^"?-/'` で確認
- [x] webapp 表示: `market.html:83` で `pcp.startswith('-')` 判定済み、値下がりは `rate-neg` (青) で表示される(既に対応済み)

## テスト追加内容

- `TestConvertKabutanPtsHtml::test_下落銘柄もパースされる` — 値下がりHTMLから符号付き文字列が抽出される
- `TestGetTodaysPts::test_値上がり2ページと値下がり1ページを統合してCSVに保存する` — 3 URL 取得 + rank 連番 + 40 行出力
- `TestGetTodaysPts::test_値上がりpage1が薄商いで埋まらない場合page2で補完する` — max_rows ロジック検証

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)