### PR TITLE
issue #195 webapp: 詳細ページから保有ステータス変更モーダル + confirm 撤廃

### DIFF
--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -53,6 +53,11 @@ def stock_detail(code_s: str):
     ]
 
     portfolio_record = ps.get_record(code_s)
+    # issue #195 (codex P2): excluded=True は未登録扱い。
+    # 復活は /portfolio/add の add_to_watch() 復活パスに任せる (transition では excluded フラグが下がらず
+    # 「変更したつもりがユニバースから除外されたまま」になる事故を防ぐ)
+    if portfolio_record and portfolio_record.get("excluded"):
+        portfolio_record = None
     portfolio_status = portfolio_record.get("status") if portfolio_record else None
     # shelve 未移行環境のフォールバック: shelve が空のとき my_watch_list.txt 経由の所属を見る
     # (portfolio.parse_my_portforio は shelve 空時に txt フォールバックする)

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -14,7 +14,11 @@ from webapp.helpers import (
     get_disclosures,
     has_recent_disclosure,
 )
-from webapp.routes.portfolio import STATUS_VALUE_TO_LABEL, STATUS_VALUE_TO_QUERY
+from webapp.routes.portfolio import (
+    STATUS_VALUE_TO_LABEL,
+    STATUS_VALUE_TO_QUERY,
+    _allowed_transitions_from,
+)
 from research_shelve import VALID_RATINGS
 
 detail_bp = Blueprint("detail", __name__)
@@ -52,7 +56,9 @@ def stock_detail(code_s: str):
     portfolio_status = portfolio_record.get("status") if portfolio_record else None
     # shelve 未移行環境のフォールバック: shelve が空のとき my_watch_list.txt 経由の所属を見る
     # (portfolio.parse_my_portforio は shelve 空時に txt フォールバックする)
-    portfolio_fallback_mode = not ps.list_records()
+    # issue #186: 全レコードが excluded=True の状態を fallback と誤判定しないよう
+    # include_excluded=True で取得する (portfolio.py の _is_fallback_mode と同じ判定)
+    portfolio_fallback_mode = not ps.list_records(include_excluded=True)
     if portfolio_status is None and portfolio_fallback_mode:
         try:
             watch, possess = portfolio.parse_my_portforio()
@@ -64,6 +70,10 @@ def stock_detail(code_s: str):
             portfolio_status = "3監"
     portfolio_status_label = STATUS_VALUE_TO_LABEL.get(portfolio_status) if portfolio_status else None
     portfolio_status_query = STATUS_VALUE_TO_QUERY.get(portfolio_status) if portfolio_status else None
+    # issue #195: モーダル内 select 用の遷移先 [(label, value), ...]。未登録は空リスト。
+    portfolio_transitions = (
+        _allowed_transitions_from(portfolio_status) if portfolio_status else []
+    )
 
     return render_template(
         "detail.html",
@@ -76,4 +86,5 @@ def stock_detail(code_s: str):
         portfolio_status_label=portfolio_status_label,
         portfolio_status_query=portfolio_status_query,
         portfolio_fallback_mode=portfolio_fallback_mode,
+        portfolio_transitions=portfolio_transitions,
     )

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -15,6 +15,7 @@ issue #178: タブ構造を撤廃しフィルタ/ソート/ページングに再
 直前のフィルタ状態に戻す。
 """
 
+from typing import Optional
 from urllib.parse import urlencode
 
 from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
@@ -156,7 +157,10 @@ def _sync_txt_safely() -> None:
         flash(f"my_watch_list.txt 同期に失敗: {e}", "error")
 
 
-def _redirect_with_return_query(default_status_query: str = DEFAULT_STATUS_QUERY):
+def _redirect_with_return_query(
+    default_status_query: str = DEFAULT_STATUS_QUERY,
+    code_s: Optional[str] = None,
+):
     """POST フォームに埋め込まれた hidden `return_query` を尊重してリダイレクトする (issue #178)。
 
     return_query はクエリ文字列 (例: `status=hold,semi&sort=rank&page=2`) を
@@ -165,7 +169,14 @@ def _redirect_with_return_query(default_status_query: str = DEFAULT_STATUS_QUERY
 
     安全のため return_query から先頭の `?` を取り除き、改行や `#` も弾く
     (URL injection 防止)。
+
+    issue #195: hidden `return_to=detail` かつ呼出側が `code_s` を渡している
+    ときは詳細ページ (`/stock/<code_s>`) にリダイレクトする。`code_s` 未指定
+    経路では従来のダッシュボード復帰にフォールバック (url_for build error 防御)。
     """
+    if code_s and (request.form.get("return_to") or "").strip() == "detail":
+        return redirect(url_for("detail.stock_detail", code_s=code_s))
+
     raw = (request.form.get("return_query") or "").strip()
     if raw.startswith("?"):
         raw = raw[1:]
@@ -272,23 +283,23 @@ def transition(code_s: str):
         ps.validate_code_s(code_s)
     except (ValueError, TypeError) as e:
         flash(f"不正な銘柄コード: {e}", "error")
-        return _redirect_with_return_query()
+        return _redirect_with_return_query(code_s=code_s)
 
     if new_status not in ps.VALID_STATUSES:
         flash(f"不正なステータス: {new_status!r}", "error")
-        return _redirect_with_return_query()
+        return _redirect_with_return_query(code_s=code_s)
 
     try:
         ps.transition_status(code_s, new_status, reason=reason)
     except KeyError as e:
         flash(f"レコード未登録: {e}", "error")
-        return _redirect_with_return_query()
+        return _redirect_with_return_query(code_s=code_s)
     except (ValueError, TypeError) as e:
         flash(str(e), "error")
-        return _redirect_with_return_query()
+        return _redirect_with_return_query(code_s=code_s)
 
     _sync_txt_safely()
-    return _redirect_with_return_query()
+    return _redirect_with_return_query(code_s=code_s)
 
 
 def _extract_memo_fields_from_form(form) -> dict:
@@ -421,6 +432,9 @@ def add():
 
     # 追加直後は監視リストを見たいので、return_query 未指定時のデフォルトは watch。
     code_s = (request.form.get("code_s") or "").strip()
+    # issue #195: 詳細モーダルから理由を受け取れるように引数化。
+    # 未送信フォーム (portfolio ダッシュボード追加) では空文字 → 従来の "WebApp 追加" にフォールバック。
+    reason = (request.form.get("reason") or "").strip() or "WebApp 追加"
     if not code_s:
         flash("銘柄コードが空です", "error")
         return _redirect_with_return_query(default_status_query="watch")
@@ -446,10 +460,10 @@ def add():
             return _redirect_with_return_query(default_status_query="watch")
 
     try:
-        ps.add_to_watch(normalized, reason="WebApp 追加")
+        ps.add_to_watch(normalized, reason=reason)
     except ValueError as e:
         flash(str(e), "error")
-        return _redirect_with_return_query(default_status_query="watch")
+        return _redirect_with_return_query(default_status_query="watch", code_s=normalized)
 
     _sync_txt_safely()
     name_for_flash = resolve_stock_name(normalized)
@@ -457,7 +471,7 @@ def add():
         flash(f"{normalized} {name_for_flash} をユニバースに復活しました".rstrip(), "info")
     else:
         flash(f"{normalized} {name_for_flash} を監視に追加しました".rstrip(), "info")
-    return _redirect_with_return_query(default_status_query="watch")
+    return _redirect_with_return_query(default_status_query="watch", code_s=normalized)
 
 
 def _build_fallback_records() -> list[dict]:

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -12,7 +12,13 @@
       <small style="color:#888;font-size:0.5em;">{{ record.code_s }}</small>
       {{ record.stock_name or '' }}
       {% if portfolio_status_query %}
-      <span class="portfolio-badge portfolio-badge-{{ portfolio_status_query }}">{{ portfolio_status_label }}</span>
+        {% if portfolio_fallback_mode %}
+        {# フォールバック中は書き込み不可なので静的バッジ #}
+        <span class="portfolio-badge portfolio-badge-{{ portfolio_status_query }}">{{ portfolio_status_label }}</span>
+        {% else %}
+        <button type="button" class="portfolio-badge portfolio-badge-{{ portfolio_status_query }} portfolio-badge-button"
+                onclick="openPortfolioModal()" aria-label="保有ステータスを変更">{{ portfolio_status_label }}</button>
+        {% endif %}
       {% endif %}
     </h1>
     {% if stock.overview %}<div style="color:#555;font-size:0.85em;margin-bottom:0.2em;">{{ stock.overview }}</div>{% endif %}
@@ -24,6 +30,12 @@
         | <a href="https://kabutan.jp/stock/finance?code={{ record.code_s }}" target="_blank" rel="noopener noreferrer">業績</a>
         | <a href="https://finance.yahoo.co.jp/quote/{{ record.code_s }}.T/forum" target="_blank" rel="noopener noreferrer">掲示板</a>
       </div>
+      {% if not portfolio_status_query and not portfolio_fallback_mode %}
+      <div style="margin-top:0.4em;">
+        <button type="button" class="outline" style="padding:0.2em 0.7em;font-size:0.85em;margin:0;"
+                onclick="openPortfolioModal()">+ 監視に追加</button>
+      </div>
+      {% endif %}
       {% if portfolio_fallback_mode and not portfolio_status_query %}
       <div style="margin-top:0.4em;">
         <span style="color:#a07000;font-size:0.85em;">portfolio_shelve 未移行モード</span>
@@ -299,4 +311,136 @@
     </table>
   {% endif %}
 </div>
+
+{# ===== 保有ステータス変更モーダル (issue #195) ===== #}
+{% if not portfolio_fallback_mode %}
+<div id="portfolio-modal" class="portfolio-modal-overlay" style="display:none;" onclick="closePortfolioModalOnOverlay(event)">
+  <div class="portfolio-modal-content" role="dialog" aria-labelledby="portfolio-modal-title">
+    <div class="portfolio-modal-header">
+      <strong id="portfolio-modal-title">
+        {{ record.code_s }} {{ record.stock_name or '' }}
+      </strong>
+      <button type="button" class="portfolio-modal-close" onclick="closePortfolioModal()" aria-label="閉じる">×</button>
+    </div>
+    {% if portfolio_status_query %}
+    {# 登録済: ステータス遷移フォーム #}
+    <form method="POST" action="{{ url_for('portfolio.transition', code_s=record.code_s) }}" class="portfolio-modal-body">
+      <input type="hidden" name="return_to" value="detail">
+      <p style="margin:0 0 0.6em 0;">現在: <strong>{{ portfolio_status_label }}</strong></p>
+      {% if portfolio_transitions %}
+      <label style="display:block;margin-bottom:0.6em;">
+        変更先:
+        <select name="new_status" required style="margin-left:0.4em;">
+          {% for label, value in portfolio_transitions %}
+          <option value="{{ value }}">{{ label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label style="display:block;margin-bottom:0.6em;">
+        理由 (任意):
+        <textarea name="reason" rows="2" style="width:100%;margin-top:0.2em;" placeholder="例: 業績下振れ"></textarea>
+      </label>
+      <div class="portfolio-modal-actions">
+        <button type="button" class="secondary" onclick="closePortfolioModal()">キャンセル</button>
+        <button type="submit">変更する</button>
+      </div>
+      {% else %}
+      <p style="color:#888;">許可された遷移先がありません。</p>
+      <div class="portfolio-modal-actions">
+        <button type="button" class="secondary" onclick="closePortfolioModal()">閉じる</button>
+      </div>
+      {% endif %}
+    </form>
+    {% else %}
+    {# 未登録: 監視追加フォーム #}
+    <form method="POST" action="{{ url_for('portfolio.add') }}" class="portfolio-modal-body">
+      <input type="hidden" name="code_s" value="{{ record.code_s }}">
+      <input type="hidden" name="return_to" value="detail">
+      <p style="margin:0 0 0.6em 0;">この銘柄は未登録です。監視に追加します。</p>
+      <label style="display:block;margin-bottom:0.6em;">
+        理由 (任意):
+        <textarea name="reason" rows="2" style="width:100%;margin-top:0.2em;" placeholder="例: 高値ブレイク候補"></textarea>
+      </label>
+      <div class="portfolio-modal-actions">
+        <button type="button" class="secondary" onclick="closePortfolioModal()">キャンセル</button>
+        <button type="submit">監視に追加</button>
+      </div>
+    </form>
+    {% endif %}
+  </div>
+</div>
+
+<style>
+.portfolio-badge-button {
+  border: none;
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+  padding: 0.1em 0.5em;
+}
+.portfolio-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.portfolio-modal-content {
+  background: #fff;
+  border-radius: 6px;
+  padding: 1em 1.2em;
+  width: min(420px, 90vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+.portfolio-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.8em;
+  padding-bottom: 0.4em;
+  border-bottom: 1px solid #eee;
+}
+.portfolio-modal-close {
+  background: none;
+  border: none;
+  font-size: 1.4em;
+  cursor: pointer;
+  padding: 0 0.3em;
+  line-height: 1;
+  color: #888;
+}
+.portfolio-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5em;
+  margin-top: 0.5em;
+}
+.portfolio-modal-actions button {
+  margin: 0;
+  padding: 0.4em 1em;
+}
+</style>
+
+<script>
+function openPortfolioModal() {
+  document.getElementById('portfolio-modal').style.display = 'flex';
+}
+function closePortfolioModal() {
+  document.getElementById('portfolio-modal').style.display = 'none';
+}
+function closePortfolioModalOnOverlay(e) {
+  if (e.target.id === 'portfolio-modal') closePortfolioModal();
+}
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'Escape') {
+    var m = document.getElementById('portfolio-modal');
+    if (m && m.style.display !== 'none') closePortfolioModal();
+  }
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -301,8 +301,7 @@
                   {% endfor %}
                 </select>
                 <textarea name="reason" placeholder="理由 (任意)" rows="2" style="font-size:0.85em;padding:0.3em;margin:0;"></textarea>
-                <button type="submit" style="padding:0.3em 0.6em;font-size:0.85em;margin:0;"
-                        onclick="return confirm('{{ row.code_s }} のステータスを変更しますか?')">変更</button>
+                <button type="submit" style="padding:0.3em 0.6em;font-size:0.85em;margin:0;">変更</button>
               </form>
               {% endif %}
               {# 削除はテーブル上部の「削除モード」 (issue #186) で一括処理する #}

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -1056,6 +1056,69 @@ class TestReturnQueryRedirect:
         assert "%0A" not in loc
 
 
+class TestReturnToDetail:
+    """issue #195: 詳細ページからの POST は /stock/<code_s> に戻る"""
+
+    def test_transition_with_return_to_detail_redirects_to_stock_page(self, client):
+        """transition + return_to=detail → /stock/<code_s>"""
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "3監", "return_to": "detail"},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/stock/3496")
+
+    def test_transition_without_return_to_detail_keeps_dashboard(self, client):
+        """return_to が無いときは従来通り dashboard に戻る (回帰)"""
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "3監", "return_query": "status=hold"},
+        )
+        assert resp.status_code == 302
+        assert "/portfolio" in resp.headers["Location"]
+        assert "/stock/" not in resp.headers["Location"]
+
+    def test_add_with_return_to_detail_redirects_to_stock_page(
+        self, client, stocks_db_path
+    ):
+        """add + return_to=detail → /stock/<normalized code_s>"""
+        with ShelveDB(stocks_db_path) as db:
+            db["8035"] = {"code_s": "8035", "stock_name": "東京エレクトロン"}
+        resp = client.post(
+            "/portfolio/add",
+            data={"code_s": "8035", "return_to": "detail"},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/stock/8035")
+
+    def test_add_persists_reason_from_form(
+        self, client, portfolio_db_path, stocks_db_path
+    ):
+        """add は form の reason を action_log に保存する (codex 指摘 #3)"""
+        with ShelveDB(stocks_db_path) as db:
+            db["8035"] = {"code_s": "8035", "stock_name": "東京エレクトロン"}
+        client.post(
+            "/portfolio/add",
+            data={"code_s": "8035", "reason": "高値ブレイク候補", "return_to": "detail"},
+        )
+        logs = ps.list_action_logs("8035", db_path=portfolio_db_path)
+        assert any(a.get("reason") == "高値ブレイク候補" for a in logs), (
+            f"reason がログに残らず: logs={logs}"
+        )
+
+    def test_add_falls_back_to_default_reason_when_empty(
+        self, client, portfolio_db_path, stocks_db_path
+    ):
+        """reason 未送信 (= 空文字 or キー無し) は従来通り 'WebApp 追加' で記録"""
+        with ShelveDB(stocks_db_path) as db:
+            db["8035"] = {"code_s": "8035", "stock_name": "東京エレクトロン"}
+        client.post("/portfolio/add", data={"code_s": "8035"})
+        logs = ps.list_action_logs("8035", db_path=portfolio_db_path)
+        assert any(a.get("reason") == "WebApp 追加" for a in logs), (
+            f"デフォルト reason 'WebApp 追加' が記録されていない: logs={logs}"
+        )
+
+
 class TestDeleteCheckboxScope:
     """削除モードのチェックボックスは 2準/3監 行のみに表示される (codex 指摘 P2)"""
 

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -181,6 +181,46 @@ class TestDetailPortfolioModal:
         assert "portfolio-badge-button" in html
         assert "openPortfolioModal()" in html
 
+    def test_excluded_record_treated_as_unregistered(self, db_path, tmp_path, monkeypatch):
+        """除外済み (excluded=True) は未登録扱い: バッジ/transition モーダルは出さず、
+        「+ 監視に追加」ボタン + /portfolio/add モーダルを出す (codex P2)。
+
+        理由: transition_status() は excluded フラグを下げないため、
+        除外済み銘柄に対して遷移を実行しても portfolio 一覧 / txt 同期から
+        除外されたまま = ユーザーは「変更したつもり」になる事故を防ぐ。
+        復活は /portfolio/add の add_to_watch() 復活パスに任せる。
+        """
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+
+        rec = rs.create_research_record("9999", "除外テスト", overall_rating="C")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        # 9999 を 3監 として追加 → ユニバース除外する
+        ps.add_to_watch("9999", reason="テスト用", db_path=portfolio_db)
+        ps.exclude_from_universe("9999", reason="テスト用 除外", db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        client = app.test_client()
+        resp = client.get("/stock/9999")
+        html = resp.data.decode()
+
+        # 除外済みなのでバッジ button や transition モーダルは出ない
+        # (CSS 定義文字列と区別するため <button タグにマッチさせる)
+        import re
+        assert not re.search(r'<button[^>]*class="[^"]*portfolio-badge', html), (
+            "除外済み銘柄でもバッジ button が描画されている"
+        )
+        assert 'action="/portfolio/9999/transition"' not in html
+        # 代わりに add (復活) モーダルが出る
+        assert "+ 監視に追加" in html
+        assert 'action="/portfolio/add"' in html
+
 
 class TestDetailKessanHistory:
     """GET /stock/<code_s> の決算コメント履歴セクションのテスト (issue #131)"""

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -117,6 +117,71 @@ class TestDetailRoute:
         assert resp.status_code == 404
 
 
+class TestDetailPortfolioModal:
+    """issue #195: 詳細ページにポートフォリオステータス変更モーダルを描画する。
+
+    portfolio_shelve を tmp_path に差し替えた fixture で、登録済/未登録両ケースを検証。
+    本テストは module 内の app fixture を共有しつつ、必要な portfolio_shelve も差し替える。
+    """
+
+    @pytest.fixture
+    def portfolio_app(self, db_path, tmp_path, monkeypatch):
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+
+        # research_shelve: 3496 (登録済 1保 用) と 1234 (未登録 = portfolio に入れない) を登録
+        rec_3496 = rs.create_research_record("3496", "アズーム", overall_rating="A")
+        rs.upsert_research_record(rec_3496, db_path=db_path)
+        rec_1234 = rs.create_research_record("1234", "テスト未登録", overall_rating="B")
+        rs.upsert_research_record(rec_1234, db_path=db_path)
+
+        # portfolio_shelve: 3496 を 1保 として登録
+        ps.add_to_watch("3496", reason="テスト用", db_path=portfolio_db)
+        ps.transition_status("3496", "1保", reason="テスト用 1保 へ", db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        return app
+
+    @pytest.fixture
+    def portfolio_client(self, portfolio_app):
+        return portfolio_app.test_client()
+
+    def test_registered_stock_renders_modal_form(self, portfolio_client):
+        """登録済銘柄: モーダル DOM (transition POST フォーム + return_to=detail hidden) が出る"""
+        resp = portfolio_client.get("/stock/3496")
+        html = resp.data.decode()
+        assert 'id="portfolio-modal"' in html
+        assert 'action="/portfolio/3496/transition"' in html
+        assert 'name="return_to" value="detail"' in html
+
+    def test_registered_stock_has_transition_options(self, portfolio_client):
+        """登録済銘柄 (1保): _allowed_transitions_from('1保') の遷移先 (2準) が select に含まれる"""
+        resp = portfolio_client.get("/stock/3496")
+        html = resp.data.decode()
+        # 1保 からは 2準 (売却) への遷移が許可されている
+        assert 'value="2準"' in html
+
+    def test_unregistered_stock_shows_add_button(self, portfolio_client):
+        """未登録銘柄 (research_shelve には存在): 「+ 監視に追加」ボタン + add POST モーダルが出る"""
+        resp = portfolio_client.get("/stock/1234")
+        html = resp.data.decode()
+        assert "+ 監視に追加" in html
+        assert 'action="/portfolio/add"' in html
+        assert 'name="return_to" value="detail"' in html
+
+    def test_registered_badge_is_clickable_button(self, portfolio_client):
+        """登録済バッジは button 要素になっている (onclick=openPortfolioModal)"""
+        resp = portfolio_client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "portfolio-badge-button" in html
+        assert "openPortfolioModal()" in html
+
+
 class TestDetailKessanHistory:
     """GET /stock/<code_s> の決算コメント履歴セクションのテスト (issue #131)"""
 


### PR DESCRIPTION
Closes #195

## Summary

- 詳細ページ (`/stock/<code_s>`) の保有バッジを clickable button にし、クリックでステータス変更モーダルを開く
- 未登録銘柄 (research_shelve には存在 / portfolio 未登録) では「+ 監視に追加」ボタン + add モーダルを表示
- 変更/追加完了後は詳細ページに留まる (hidden `return_to=detail` で transition/add ハンドラの redirect 先を切替)
- portfolio ダッシュボードのステータス変更 `confirm()` ダイアログを撤廃 (理由 textarea で代替)。bulk-exclude は据え置き
- `add()` の `reason` をフォーム引数化 (詳細モーダルで任意入力)

## codex プランレビュー対応

`.claude/rules/codex-plan-review.md` に従い 3 ラウンドの codex レビューを実施し、以下の重大指摘を全て解消:
1. フォールバックモードでの誤導線 → モーダル UI を抑止
2. `return_to=detail` の `code_s` 未指定経路で 500 リスク → `code_s` 引数を必須化、未指定はダッシュボードにフォールバック
3. `add()` の reason ハードコードでユーザー入力消失 → フォーム引数化

## simplify レビュー対応

3 エージェント (reuse / quality / efficiency) 並列レビューで以下を修正:
- `transition()` バリデーション失敗時にも `code_s=code_s` を渡し一貫性確保
- `detail.py` の `list_records()` に `include_excluded=True` 追加 (issue #186 整合)

## Test plan

- [x] `pytest tests/test_webapp_portfolio_routes.py tests/test_webapp_routes.py tests/test_webapp_helpers.py` → 287 passed (1 failed は pre-existing 無関係)
- [x] 新規テスト追加: `TestReturnToDetail` (5件) + `TestDetailPortfolioModal` (4件)
- [x] ブラウザ動作確認 (playwright):
  - 登録済バッジ (1保) クリック → モーダル表示、select に「準保有 (売却)」「監視」
  - 未登録銘柄 → 「+ 監視に追加」 → モーダル → form action `/portfolio/add` + return_to=detail hidden
  - portfolio ダッシュボードの変更ボタン 26件すべて onclick=null (confirm 撤廃確認)
  - bulk-exclude の confirm は JS 内に残存 (据え置き)

🤖 Generated with [Claude Code](https://claude.com/claude-code)