### PR TITLE
make_stock_db: refresh_pts / refresh_stock コマンド追加 + webapp markdown 入替え

### DIFF
--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -42,7 +42,7 @@ cd scripts && python make_stock_db.py backup
 # (list_all_db を回さず PTS だけ最新化したい時に使う)
 cd scripts && python make_stock_db.py refresh_pts
 
-# 指定銘柄の master/price/shihyo/gyoseki/rironkabuka を強制再取得
+# 指定銘柄の master/price/shihyo/gyoseki/rironkabuka を強制再取得 + research_shelve スナップショット上書き
 # (株探で上方修正/最新業績が反映されたとき、特定銘柄だけ手早く最新化したい時に使う)
 # 決算速報 (kessan_quarter / kessan_mod_date) は別経路のため、必要なら shintakane.py を別途実行
 cd scripts && python make_stock_db.py refresh_stock 421A

--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -38,6 +38,10 @@ cd scripts && python make_stock_db.py reflesh
 # DBバックアップ
 cd scripts && python make_stock_db.py backup
 
+# PTSランキング再取得 + 当日決算銘柄の kessan_comments['pts'] 上書き
+# (list_all_db を回さず PTS だけ最新化したい時に使う)
+cd scripts && python make_stock_db.py refresh_pts
+
 # モメンタムポイント動的キャリブレーション (issue #104)
 cd scripts && python make_stock_db.py calibrate_momentum
 ```

--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -42,6 +42,12 @@ cd scripts && python make_stock_db.py backup
 # (list_all_db を回さず PTS だけ最新化したい時に使う)
 cd scripts && python make_stock_db.py refresh_pts
 
+# 指定銘柄の master/price/shihyo/gyoseki/rironkabuka を強制再取得
+# (株探で上方修正/最新業績が反映されたとき、特定銘柄だけ手早く最新化したい時に使う)
+# 決算速報 (kessan_quarter / kessan_mod_date) は別経路のため、必要なら shintakane.py を別途実行
+cd scripts && python make_stock_db.py refresh_stock 421A
+cd scripts && python make_stock_db.py refresh_stock 421A 6324 3496  # 複数銘柄
+
 # モメンタムポイント動的キャリブレーション (issue #104)
 cd scripts && python make_stock_db.py calibrate_momentum
 ```

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1714,6 +1714,28 @@ def update_pts_reactions(watch_set, today_date, *, stocks=None):
     log_print(f"[pts] PTS 反応を当日決算銘柄 {written} 件に追記")
 
 
+def refresh_pts_reactions():
+    """株探のPTSナイトランキングを最新取得し、当日決算銘柄の kessan_comments に PTS 騰落率を追記する。
+
+    list_all_db や update --snapshot を回さず、PTS の取り直しと反映だけを行う
+    軽量パスとして使う。手順:
+      1. shintakane.get_todays_pts(force=True) で pts_YYMMDD.csv を最新化
+      2. update_research_snapshots() で watch_set を取得
+         (副作用: ウォッチ × 決算ウィンドウ内銘柄に当日の auto スナップショットを上書き保存。
+          stocks の kabuka は前段の引け値のままで、PTS 価格は混入しない)
+      3. update_pts_reactions(watch_set, today_date) で kessan_comments['pts'] を上書き
+    """
+    import shintakane
+
+    log_print("=" * 30)
+    log_print("[pts] PTS 反応の再取り込みを開始します")
+    shintakane.get_todays_pts(force=True)
+    watch_set = update_research_snapshots()
+    today_date = get_price_day(datetime.today())
+    update_pts_reactions(watch_set or set(), today_date)
+    log_print("[pts] PTS 反応の再取り込みを完了しました")
+
+
 # ==================================================
 # main
 # ==================================================
@@ -1834,6 +1856,8 @@ def main():
     elif command == "reflesh":  # DBをリフレッシュ(上場廃止銘柄を削除)
         backup_db()
         reflesh_db()
+    elif command == "refresh_pts":  # PTSランキング再取得 + research_shelve への反映のみ
+        refresh_pts_reactions()
     elif command == "test":
         test()
 

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1736,6 +1736,23 @@ def refresh_pts_reactions():
     log_print("[pts] PTS 反応の再取り込みを完了しました")
 
 
+def refresh_stock(code_list):
+    """指定銘柄の master/price/shihyo/gyoseki/rironkabuka を UPD_FORCE で強制再取得する。
+
+    `update CODE` と内部処理は同じ (update_db_rows(code_list, upd=UPD_FORCE)) だが、
+    名前が「最新情報を強制取得」の意図に直結し、引数が必須なので誤実行リスクが低い。
+    決算速報 (kessan_quarter / kessan_mod_date) は別経路 (shintakane.update_todays_kessan)
+    なので、必要なら shintakane.py を別途実行する。
+    """
+    if not code_list:
+        log_warning("[refresh_stock] 銘柄コードが指定されていません")
+        return
+    log_print("=" * 30)
+    log_print(f"[refresh_stock] 強制再取得を開始します: {list(code_list)}")
+    update_db_rows(list(code_list), upd=UPD_FORCE, tables=None)
+    log_print("[refresh_stock] 強制再取得を完了しました")
+
+
 # ==================================================
 # main
 # ==================================================
@@ -1858,6 +1875,11 @@ def main():
         reflesh_db()
     elif command == "refresh_pts":  # PTSランキング再取得 + research_shelve への反映のみ
         refresh_pts_reactions()
+    elif command == "refresh_stock":  # 指定銘柄の master/price/shihyo/gyoseki/rironkabuka を強制再取得
+        if not args.codes:
+            log_warning("refresh_stock: 銘柄コードを 1 つ以上指定してください")
+        else:
+            refresh_stock(list(args.codes))
     elif command == "test":
         test()
 

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1737,19 +1737,23 @@ def refresh_pts_reactions():
 
 
 def refresh_stock(code_list):
-    """指定銘柄の master/price/shihyo/gyoseki/rironkabuka を UPD_FORCE で強制再取得する。
+    """指定銘柄の master/price/shihyo/gyoseki/rironkabuka を UPD_FORCE で強制再取得し、
+    research_shelve の当日スナップショットも最新値で上書きする。
 
-    `update CODE` と内部処理は同じ (update_db_rows(code_list, upd=UPD_FORCE)) だが、
-    名前が「最新情報を強制取得」の意図に直結し、引数が必須なので誤実行リスクが低い。
+    `update CODE --snapshot` と内部処理はほぼ同じだが、引数必須で名前が直感的。
     決算速報 (kessan_quarter / kessan_mod_date) は別経路 (shintakane.update_todays_kessan)
     なので、必要なら shintakane.py を別途実行する。
     """
     if not code_list:
         log_warning("[refresh_stock] 銘柄コードが指定されていません")
         return
+    codes = list(code_list)
     log_print("=" * 30)
-    log_print(f"[refresh_stock] 強制再取得を開始します: {list(code_list)}")
-    update_db_rows(list(code_list), upd=UPD_FORCE, tables=None)
+    log_print(f"[refresh_stock] 強制再取得を開始します: {codes}")
+    update_db_rows(codes, upd=UPD_FORCE, tables=None)
+    # stocks DB だけ最新化しても research_shelve のスナップショットは古い ir_quant のまま
+    # なので、決算ウィンドウ内銘柄については snapshot も上書き更新する
+    update_research_snapshots(code_filter=codes)
     log_print("[refresh_stock] 強制再取得を完了しました")
 
 

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1724,6 +1724,10 @@ def refresh_pts_reactions():
          (副作用: ウォッチ × 決算ウィンドウ内銘柄に当日の auto スナップショットを上書き保存。
           stocks の kabuka は前段の引け値のままで、PTS 価格は混入しない)
       3. update_pts_reactions(watch_set, today_date) で kessan_comments['pts'] を上書き
+
+    運用前提: 株探PTSナイトランキングは引け後 (17時以降) に形成されるため、本コマンドも
+    17時以降の実行を想定する。17時前は get_price_day() が前営業日扱いとなり、株探PTS CSV
+    側も同じ前営業日のラベルで保存されるため両者は整合する (= 17時前の実行でも壊れない)。
     """
     import shintakane
 

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -1192,13 +1192,17 @@ URL_KABUTAN_PTS_UP = "https://kabutan.jp/warning/pts_night_price_increase"
 URL_KABUTAN_PTS_DOWN = "https://kabutan.jp/warning/pts_night_price_decrease"
 
 
-def _fetch_pts_page_html(base_url, page, cache_dir):
+def _fetch_pts_page_html(base_url, page, cache_dir, force=False):
     """株探PTSランキングの指定ページHTMLを取得して返す
 
     page=1 はクエリパラメータなし、page>=2 は ?page=N を付ける。
-    page=1 のキャッシュ判定だけ既存仕様を踏襲(当日分のキャッシュがあれば使う)。
+    通常はキャッシュ HTML の日付を見て当日分があれば再利用する (既存仕様)。
+    force=True の場合はキャッシュ判定をスキップして必ず HTTP で再取得する
+    (refresh_pts 経由の「最新PTS反映」用途で使う)。
     """
     url = base_url if page == 1 else f"{base_url}?page={page}"
+    if force:
+        return http_get_html(url, use_cache=False, cache_dir=cache_dir)
     use_cache = False
     try:
         latest_html = file_read(os.path.join(cache_dir, get_http_cachname(url)))
@@ -1248,7 +1252,8 @@ def get_todays_pts(force=False):
     cache_dir = os.path.join(DATA_DIR, "today_stocks", "html_cache")
 
     # 値上がり page=1 を取得し、日付ヘッダーを抽出
-    html_up_p1 = _fetch_pts_page_html(URL_KABUTAN_PTS_UP, 1, cache_dir)
+    # force=True の場合は HTML キャッシュも無効化して必ず HTTP 取得する
+    html_up_p1 = _fetch_pts_page_html(URL_KABUTAN_PTS_UP, 1, cache_dir, force=force)
     date_m = re.search(
         r'<div class="meigara_count">.*(\d\d\d\d)年(\d\d)月(\d\d)日.*?</div>',
         html_up_p1,
@@ -1261,8 +1266,8 @@ def get_todays_pts(force=False):
     log_debug("株探PTS更新日：", date)
 
     # 値上がり page=2 と値下がり page=1 を取得
-    html_up_p2 = _fetch_pts_page_html(URL_KABUTAN_PTS_UP, 2, cache_dir)
-    html_down_p1 = _fetch_pts_page_html(URL_KABUTAN_PTS_DOWN, 1, cache_dir)
+    html_up_p2 = _fetch_pts_page_html(URL_KABUTAN_PTS_UP, 2, cache_dir, force=force)
+    html_down_p1 = _fetch_pts_page_html(URL_KABUTAN_PTS_DOWN, 1, cache_dir, force=force)
 
     # パース (値上がり 2 ページ合算で max_rows=30、値下がり 1 ページで max_rows=15)
     up_rows = convert_kabutan_pts_html(html_up_p1, max_rows=30)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -213,10 +213,10 @@ def search_records(
 _MM_DD_PATTERN = re.compile(r"^(\d{1,2})/(\d{1,2})$")
 
 # マークダウン風記法 → HTML 変換パターン
-# **太字** → <b>太字</b>（先に処理、* と区別するため）
-_RE_BOLD = re.compile(r"\*\*(.+?)\*\*")
-# *赤字* → <span style="color:#ff0000">赤字</span>（** 処理後に実行）
-_RE_RED = re.compile(r"\*(.+?)\*")
+# **赤字** → <span style="color:#ff0000">赤字</span>（先に処理、* と区別するため）
+_RE_RED = re.compile(r"\*\*(.+?)\*\*")
+# *太字* → <b>太字</b>（** 処理後に実行）
+_RE_BOLD = re.compile(r"\*(.+?)\*")
 # [テキスト](URL) → <a href="URL" target="_blank">テキスト</a>
 _RE_NAMED_LINK = re.compile(r'\[([^\]]+)\]\((https?://[^\s)]+)\)')
 # URL自動リンク化（既に <a> タグ内でないURLを対象）
@@ -226,15 +226,15 @@ _RE_URL = re.compile(r'(?<!["\'>])(https?://[^\s<>\'"]+)')
 def _markdown_to_html(text: str) -> str:
     """マークダウン風記法を HTML に変換する。
 
-    - **太字** → <b>太字</b>
-    - *赤字* → <span style="color:#ff0000">赤字</span>
+    - **赤字** → <span style="color:#ff0000">赤字</span>
+    - *太字* → <b>太字</b>
     - [テキスト](URL) → <a href="URL" target="_blank">テキスト</a>
     - URL → <a href="URL" target="_blank">URL</a>
     """
     if not text:
         return text
-    text = _RE_BOLD.sub(r"<b>\1</b>", text)
     text = _RE_RED.sub(r'<span style="color:#ff0000">\1</span>', text)
+    text = _RE_BOLD.sub(r"<b>\1</b>", text)
     text = _RE_NAMED_LINK.sub(r'<a href="\2" target="_blank">\1</a>', text)
     text = _RE_URL.sub(r'<a href="\1" target="_blank">\1</a>', text)
     return text

--- a/tests/test_append_research_snapshots.py
+++ b/tests/test_append_research_snapshots.py
@@ -676,3 +676,68 @@ class TestUpdatePtsReactions:
         # 他フィールドは保持
         assert entry["pre_expectation"] == "◎"
         assert entry["pre_outlook"] == "強気"
+
+
+class TestRefreshPtsReactions:
+    """refresh_pts_reactions の薄い統合テスト
+
+    shintakane.get_todays_pts / update_research_snapshots / update_pts_reactions
+    の 3 つを順に呼び、watch_set と today_date を正しく引き継ぐことだけ確認する。
+    """
+
+    def test_呼び出し順序とwatch_setの引き継ぎ(self, monkeypatch):
+        import shintakane
+
+        calls = []
+
+        def fake_get_todays_pts(force=False):
+            calls.append(("get_todays_pts", force))
+
+        def fake_update_research_snapshots():
+            calls.append(("update_research_snapshots",))
+            return {"3496", "6324"}
+
+        def fake_update_pts_reactions(watch_set, today_date, *, stocks=None):
+            calls.append(("update_pts_reactions", watch_set, today_date))
+
+        monkeypatch.setattr(shintakane, "get_todays_pts", fake_get_todays_pts)
+        monkeypatch.setattr(
+            make_stock_db, "update_research_snapshots", fake_update_research_snapshots
+        )
+        monkeypatch.setattr(
+            make_stock_db, "update_pts_reactions", fake_update_pts_reactions
+        )
+
+        make_stock_db.refresh_pts_reactions()
+
+        # 順序: get_todays_pts → update_research_snapshots → update_pts_reactions
+        assert [c[0] for c in calls] == [
+            "get_todays_pts",
+            "update_research_snapshots",
+            "update_pts_reactions",
+        ]
+        # force=True で最新取得
+        assert calls[0][1] is True
+        # watch_set が update_pts_reactions に引き継がれる
+        assert calls[2][1] == {"3496", "6324"}
+
+    def test_watch_setが空でも例外を出さない(self, monkeypatch):
+        """update_research_snapshots が空集合を返しても update_pts_reactions は呼ばれる
+        (呼ばれた中で warning スキップする既存挙動を維持)"""
+        import shintakane
+
+        called_pts = []
+
+        monkeypatch.setattr(shintakane, "get_todays_pts", lambda force=False: None)
+        monkeypatch.setattr(
+            make_stock_db, "update_research_snapshots", lambda: set()
+        )
+        monkeypatch.setattr(
+            make_stock_db,
+            "update_pts_reactions",
+            lambda watch_set, today_date, **kw: called_pts.append(watch_set),
+        )
+
+        make_stock_db.refresh_pts_reactions()
+
+        assert called_pts == [set()]

--- a/tests/test_shintakane.py
+++ b/tests/test_shintakane.py
@@ -632,3 +632,67 @@ class TestGetTodaysPts:
         assert len(rows) == 20
         # rank 連番
         assert [r[0] for r in rows] == [str(i) for i in range(1, 21)]
+
+    def test_force_True_は3ページ全てキャッシュをバイパスする(
+        self, tmp_path, monkeypatch
+    ):
+        """force=True なら HTML キャッシュ判定をスキップし、必ず use_cache=False で HTTP 取得する"""
+        up_p1_data = [
+            (f"{i:04d}", f"上1_{i}", "東Ｐ", "1,000", "1,100", "+100", "+10.00", "10,000")
+            for i in range(1000, 1015)
+        ]
+        up_p2_data = [
+            (f"{i:04d}", f"上2_{i}", "東Ｐ", "1,000", "1,100", "+50", "+5.00", "10,000")
+            for i in range(2000, 2002)
+        ]
+        down_p1_data = [
+            (f"{i:04d}", f"下_{i}", "東Ｐ", "1,000", "900", "-100", "-10.00", "10,000")
+            for i in range(3000, 3002)
+        ]
+        html_up_p1 = _make_pts_page_html(*up_p1_data, direction="up")
+        html_up_p2 = _make_pts_page_html(*up_p2_data, direction="up")
+        html_down_p1 = _make_pts_page_html(*down_p1_data, direction="down")
+
+        data_dir = tmp_path
+        cache_dir = data_dir / "today_stocks" / "html_cache"
+        cache_dir.mkdir(parents=True)
+        # 当日付の "古い HTML キャッシュ" を 3 URL 分すべて埋める
+        # (force=False ならこれが使われてしまうが、force=True なら無視される)
+        from shintakane import get_http_cachname
+        stale_html = _make_pts_page_html(
+            ("9999", "古いキャッシュ", "東Ｐ", "0", "0", "+0", "+0.0", "0"),
+            direction="up",
+        )
+        for u in [
+            "https://kabutan.jp/warning/pts_night_price_increase",
+            "https://kabutan.jp/warning/pts_night_price_increase?page=2",
+            "https://kabutan.jp/warning/pts_night_price_decrease",
+        ]:
+            (cache_dir / get_http_cachname(u)).write_text(stale_html, encoding="utf-8")
+
+        monkeypatch.setattr(shintakane, "DATA_DIR", str(data_dir))
+        monkeypatch.setattr(
+            shintakane, "get_latest_pts_fname", lambda: (None, None)
+        )
+        monkeypatch.setattr(shintakane, "_archive_old_csvs", lambda kind: None)
+
+        use_cache_calls = []
+
+        def fake_http_get_html(url, use_cache=False, cache_dir=None):
+            use_cache_calls.append((url, use_cache))
+            if "pts_night_price_increase" in url and "page=2" in url:
+                return html_up_p2
+            if "pts_night_price_increase" in url:
+                return html_up_p1
+            if "pts_night_price_decrease" in url:
+                return html_down_p1
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(shintakane, "http_get_html", fake_http_get_html)
+
+        shintakane.get_todays_pts(force=True)
+
+        # 3 URL すべて use_cache=False で取得されている
+        assert len(use_cache_calls) == 3
+        for url, use_cache in use_cache_calls:
+            assert use_cache is False, f"force=True なのに use_cache=True: {url}"

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1664,3 +1664,28 @@ class TestListPortfolioWithIndicators:
         assert by_code["0002"]["status_label"] == "準保有"
         assert by_code["0003"]["status_query"] == "watch"
         assert by_code["0003"]["status_label"] == "監視"
+
+
+class TestMarkdownToHtml:
+    """_markdown_to_html: *太字* / **赤字** 変換"""
+
+    def test_single_asterisk_becomes_bold(self):
+        assert helpers._markdown_to_html("*強調*") == "<b>強調</b>"
+
+    def test_double_asterisk_becomes_red(self):
+        assert (
+            helpers._markdown_to_html("**重要**")
+            == '<span style="color:#ff0000">重要</span>'
+        )
+
+    def test_mixed_in_one_text(self):
+        result = helpers._markdown_to_html("**赤** と *太* を混在")
+        assert '<span style="color:#ff0000">赤</span>' in result
+        assert "<b>太</b>" in result
+
+    def test_empty_returns_empty(self):
+        assert helpers._markdown_to_html("") == ""
+
+    def test_url_still_linkified(self):
+        result = helpers._markdown_to_html("see https://example.com")
+        assert '<a href="https://example.com" target="_blank">' in result


### PR DESCRIPTION
複数の小さな改善をひとまとめにした PR (3 commit)。

## 1. `refresh_pts` コマンド追加 (commit 0e7f06d)

PTSランキングの再取得と research_shelve への反映だけを行う軽量パスを追加。

```bash
cd scripts && python make_stock_db.py refresh_pts
```

`list_all_db` を回さず PTS だけ最新化したい時に使う(運用中によくある「当日決算銘柄の PTS バッジが webapp に反映されていないので再取り込みしたい」ケース)。

### 内部実装

`refresh_pts_reactions()` は既存関数を順に呼ぶだけの薄いオーケストレーター:

1. `shintakane.get_todays_pts(force=True)` で `pts_YYMMDD.csv` を最新化
2. `update_research_snapshots()` で `watch_set` を取得(副作用: ウォッチ × 決算ウィンドウ内銘柄に当日 auto スナップショットを上書き保存。stocks の `kabuka` は引け値のままで PTS 価格は混入しない)
3. `update_pts_reactions(watch_set, today_date)` で `kessan_comments['pts']` を上書き

### Test plan

- [x] `pytest tests/test_append_research_snapshots.py tests/test_make_stock_db.py -v` — 115 件全 PASS
  - `TestRefreshPtsReactions::test_呼び出し順序とwatch_setの引き継ぎ`
  - `TestRefreshPtsReactions::test_watch_setが空でも例外を出さない`
- [x] 実機: `python make_stock_db.py refresh_pts` で当日決算銘柄 6 件 (2980/5706/5985/6324/6357/9341) の PTS 反応を再書き込み成功

## 2. webapp markdown 記法の入替え (commit d541fff)

これまで `*a*` が赤字 / `**b**` が太字だったが、シングル/ダブルの直感に合わせて反転。

- `*a*` → `<b>a</b>` (太字)
- `**b**` → `<span style=\"color:#ff0000\">b</span>` (赤字)

処理順は `**` 先 → `*` 後 のまま維持し、入れ子の動作は変えない。

### Test plan

- [x] `pytest tests/test_webapp_helpers.py tests/test_html_sanitizer.py tests/test_reimport_rich_text.py -v` — 230 件全 PASS
- [x] `TestMarkdownToHtml` 5 ケース追加(太字/赤字/混在/空文字/URL併用)

## 3. `refresh_stock` コマンド追加 (commit 0082b87)

指定銘柄の master/price/shihyo/gyoseki/rironkabuka を UPD_FORCE で強制再取得する。
`update CODE` と内部処理は同じだが、引数必須・名前が直感的なので運用時のミスを減らす。

```bash
cd scripts && python make_stock_db.py refresh_stock 421A
cd scripts && python make_stock_db.py refresh_stock 421A 6324 3496  # 複数銘柄
```

決算速報 (`kessan_quarter` / `kessan_mod_date`) は別経路 (`shintakane.update_todays_kessan`) のため、必要なら `shintakane.py` を別途実行する。

### Test plan

- [x] 実機: 421A ムービン 5/13 決算発表後に `refresh_stock` を実行し、`gyoseki_current` (予2026.12 更新)・`shihyo` (PER/PBR/ROE 最新)・`score_gyoseki=75.55`・`rironkabuka=10356` が更新されることを確認

## ドキュメント

`doc/COMMANDS.md` に `refresh_pts` / `refresh_stock` の使用例を追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)