### PR TITLE
webapp 検索: 1件のみヒット時は詳細ページへ直接ジャンプ

### DIFF
--- a/scripts/webapp/routes/search.py
+++ b/scripts/webapp/routes/search.py
@@ -41,6 +41,10 @@ def index():
         if code_s:
             records = [r for r in records if code_s.upper() in r.get("code_s", "")]
 
+    # コード/銘柄名検索で1件のみヒットした場合は詳細ページへ直接ジャンプ
+    if (q or code_s) and len(records) == 1:
+        return redirect(url_for("detail.stock_detail", code_s=records[0]["code_s"]))
+
     return render_template(
         "search.html",
         records=records,

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -91,11 +91,28 @@ class TestSearchRoute:
         assert "0 件" in html
 
     def test_index_filter_by_code(self, client):
+        # 1件のみヒットする場合は詳細ページへリダイレクト
         resp = client.get("/?code_s=3496")
-        assert "アズーム" in resp.data.decode()
+        assert resp.status_code == 302
+        assert "/stock/3496" in resp.headers["Location"]
 
         resp = client.get("/?code_s=9999")
         assert "アズーム" not in resp.data.decode()
+
+    def test_index_single_hit_redirects_to_detail(self, client):
+        """汎用検索 q で1件のみヒットしたら詳細ページへ直接ジャンプ"""
+        resp = client.get("/?q=3496")
+        assert resp.status_code == 302
+        assert "/stock/3496" in resp.headers["Location"]
+
+        resp = client.get("/?q=アズーム")
+        assert resp.status_code == 302
+        assert "/stock/3496" in resp.headers["Location"]
+
+    def test_index_multiple_hits_shows_list(self, client):
+        """複数ヒットする検索は一覧ページのまま"""
+        resp = client.get("/?q=テスト")  # "アズーム" の "テストメモ" と "空テスト" 両方にヒット
+        assert resp.status_code == 200
 
 
 class TestDetailRoute:


### PR DESCRIPTION
## Summary
- ナビの汎用検索 (`q`) または コード絞り込み (`code_s`) で結果が 1 件しかない場合、検索一覧を経由せず `/stock/<code_s>` へリダイレクト
- `rating` / `keyword` 単独フィルタは一覧用途のため対象外（既存挙動を維持）

## Test plan
- [x] `pytest tests/test_webapp_routes.py::TestSearchRoute -v` で 6 件すべて pass
  - `test_index_filter_by_code` を新仕様（302 + Location ヘッダ）に更新
  - `test_index_single_hit_redirects_to_detail` / `test_index_multiple_hits_shows_list` を新規追加
- [ ] ローカル webapp で銘柄コード/銘柄名検索を実行し、1件ヒット時にそのまま詳細画面が開くことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)