### PR TITLE
portfolio: テーブルヘッダを sticky 化しスクロール時も列名を保持

### DIFF
--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -18,6 +18,11 @@
     max-width: 4em;
     word-break: break-word;
     overflow-wrap: anywhere;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: var(--pico-background-color);
+    box-shadow: 0 1px 0 #d8dee6;
   }
   /* 数値・短文列は明示的に狭くする */
   table.portfolio-list td.num { text-align: right; }
@@ -143,7 +148,7 @@
 {% endif %}
 
 {% if rows %}
-<div style="overflow-x:auto;">
+<div style="overflow:auto;max-height:80vh;">
 <table class="portfolio-list">
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
- 保有銘柄ダッシュボード (`/portfolio`) で下のほうの銘柄を見るとき、列名が画面外に消えて何の列かわからなくなる問題を解消。
- thead を `position: sticky` で領域上端に固定。
- ラッパー div を `overflow-x:auto` → `overflow:auto; max-height:80vh;` に変更し、テーブル領域内でスクロール。
  - `overflow-x:auto` は祖先に containing block を作って sticky を妨げるため、内部スクロール構造に変更。
  - 横方向のはみ出しも同じ div 内で横スクロール可能。

## Test plan
- [x] `/portfolio` を開きスクロール → thead が領域上端で固定される
- [x] inline 編集 (memo, gyoutai_themes, stage) がヘッダと重ならず動作する
- [x] 横スクロールも同じ div 内で動く
- [ ] 業態境界線 (gyoutai-boundary) がヘッダ下のシャドウと喧嘩しないか目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)