### PR TITLE
webapp detail: 業態・テーマを分析日と同じ行に inline 表示・AJAX 即時保存 (issue #205)

### DIFF
--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -13,6 +13,7 @@ from webapp.helpers import (
     get_stock_data,
     get_disclosures,
     has_recent_disclosure,
+    collect_gyoutai_theme_choices,
 )
 from webapp.routes.portfolio import (
     STATUS_VALUE_TO_LABEL,
@@ -80,6 +81,18 @@ def stock_detail(code_s: str):
         _allowed_transitions_from(portfolio_status) if portfolio_status else []
     )
 
+    # issue #205: 業態・テーマ inline 編集用の context
+    # memo は None や非 dict (旧データ等) を許容する仕様 (_normalize_loaded_memo)
+    # なので、dict 以外は空 dict として扱う
+    _memo = (portfolio_record or {}).get("memo")
+    if not isinstance(_memo, dict):
+        _memo = {}
+    gyoutai_themes = _memo.get("gyoutai_themes") or []
+    gyoutai_theme_choices = (
+        collect_gyoutai_theme_choices(ps.list_records(include_excluded=True))
+        if not portfolio_fallback_mode else []
+    )
+
     return render_template(
         "detail.html",
         record=record,
@@ -92,4 +105,7 @@ def stock_detail(code_s: str):
         portfolio_status_query=portfolio_status_query,
         portfolio_fallback_mode=portfolio_fallback_mode,
         portfolio_transitions=portfolio_transitions,
+        gyoutai_themes=gyoutai_themes,
+        gyoutai_theme_choices=gyoutai_theme_choices,
+        gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
     )

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -377,7 +377,8 @@ def update_memo(code_s: str):
         if is_ajax:
             return jsonify({"ok": False, "error": f"不正な銘柄コード: {e}"}), 400
         flash(f"不正な銘柄コード: {e}", "error")
-        return _redirect_with_return_query()
+        # issue #205: code_s を渡し、return_to=detail なら詳細ページへ戻す
+        return _redirect_with_return_query(code_s=code_s)
 
     fields = _extract_memo_fields_from_form(request.form)
 
@@ -388,12 +389,12 @@ def update_memo(code_s: str):
         if is_ajax:
             return jsonify({"ok": False, "error": msg}), 404
         flash(msg, "error")
-        return _redirect_with_return_query()
+        return _redirect_with_return_query(code_s=code_s)
     except (ValueError, TypeError) as e:
         if is_ajax:
             return jsonify({"ok": False, "error": str(e)}), 400
         flash(str(e), "error")
-        return _redirect_with_return_query()
+        return _redirect_with_return_query(code_s=code_s)
 
     if is_ajax:
         # 保存後の row を再構築して、更新済みフィールドと styles を返す
@@ -414,7 +415,7 @@ def update_memo(code_s: str):
                 }
         return jsonify(body)
     flash(f"{code_s} のメモを保存しました", "info")
-    return _redirect_with_return_query()
+    return _redirect_with_return_query(code_s=code_s)
 
 
 @portfolio_bp.route("/portfolio/add", methods=["POST"])

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -25,6 +25,26 @@
     <div class="meta">
       分析日: <input class="editable-field inline-date" type="text" name="analysis_date_raw" value="{{ record.analysis_date_raw or '' }}" data-form="memo" form="memo-form" placeholder="MM/DD" style="width:5em;display:inline;padding:0.1em 0.3em;font-size:0.9em;">
       {% if stock.kessanbi %} | 決算日: {{ stock.kessanbi[2:] }}{% endif %}
+      {# issue #205: 業態・テーマを同じ行に配置。change/blur で AJAX 即時保存 (portfolio_list と同方式) #}
+      {% if portfolio_status_query and not portfolio_fallback_mode %}
+      | <span class="gyoutai-themes-inline" data-code="{{ record.code_s }}">
+        業態・テーマ:
+        {% for i in range(gyoutai_themes_max_slots) %}
+        <input type="text"
+               list="gyoutai-theme-choices"
+               class="gyoutai-input-detail"
+               name="gyoutai_themes_{{ i }}"
+               value="{{ gyoutai_themes[i] if i < (gyoutai_themes|length) else '' }}"
+               placeholder="—"
+               style="font-size:0.9em;padding:0.1em 0.3em;width:8em;margin:0 0.1em;border:1px solid #ddd;">
+        {% endfor %}
+      </span>
+      <datalist id="gyoutai-theme-choices">
+        {% for choice in gyoutai_theme_choices %}
+        <option value="{{ choice }}">
+        {% endfor %}
+      </datalist>
+      {% endif %}
       <div>
         <a href="https://kabutan.jp/stock/chart?code={{ record.code_s }}&time=w" target="_blank" rel="noopener noreferrer">チャート</a>
         | <a href="https://kabutan.jp/stock/finance?code={{ record.code_s }}" target="_blank" rel="noopener noreferrer">業績</a>
@@ -423,6 +443,10 @@
   margin: 0;
   padding: 0.4em 1em;
 }
+/* issue #205: 業態・テーマ inline edit (AJAX 即時保存) の状態表示 */
+.gyoutai-input-detail.saving { background: #fff8c4; }
+.gyoutai-input-detail.error { background: #fce4e4; border-color: #d33; }
+.gyoutai-input-detail:focus { outline: 1px solid #4285f4; }
 </style>
 
 <script>
@@ -441,6 +465,47 @@ document.addEventListener('keydown', function(e) {
     if (m && m.style.display !== 'none') closePortfolioModal();
   }
 });
+
+// issue #205: 業態・テーマの change/blur で AJAX 即時保存 (portfolio_list.html と同方式)
+(function() {
+  var wrap = document.querySelector('.gyoutai-themes-inline');
+  if (!wrap) return;
+  var code = wrap.dataset.code;
+  if (!code) return;
+  var inputs = wrap.querySelectorAll('.gyoutai-input-detail');
+
+  function save() {
+    var fd = new FormData();
+    inputs.forEach(function(inp) { fd.append(inp.name, inp.value); });
+    inputs.forEach(function(inp) { inp.classList.add('saving'); inp.classList.remove('error'); });
+    fetch('/portfolio/' + encodeURIComponent(code) + '/memo', {
+      method: 'POST',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      body: fd,
+    }).then(function(r) {
+      return r.json().then(function(json) { return { ok: r.ok, json: json }; });
+    }).then(function(res) {
+      inputs.forEach(function(inp) { inp.classList.remove('saving'); });
+      if (!res.ok || !res.json || res.json.ok !== true) {
+        inputs.forEach(function(inp) { inp.classList.add('error'); });
+        alert((res.json && res.json.error) || '業態・テーマの保存に失敗しました');
+        return;
+      }
+      var themes = (res.json.display && res.json.display.gyoutai_themes) || [];
+      inputs.forEach(function(inp, i) { inp.value = themes[i] != null ? themes[i] : ''; });
+    }).catch(function(err) {
+      inputs.forEach(function(inp) { inp.classList.remove('saving'); inp.classList.add('error'); });
+      alert('通信エラー: ' + err);
+    });
+  }
+
+  inputs.forEach(function(inp) {
+    inp.addEventListener('change', save);
+    inp.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') { e.preventDefault(); inp.blur(); }
+    });
+  });
+})();
 </script>
 {% endif %}
 {% endblock %}

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -573,3 +573,140 @@ class TestMarketRouteKessanCard:
         html = resp.data.decode()
         # data-is-past="1" で past 扱い (反応コメ枠が出る)
         assert 'data-is-past="1"' in html
+
+
+class TestDetailGyoutaiThemes:
+    """issue #205: 銘柄詳細ページの業態・テーマ inline 編集 (AJAX 即時保存)。
+
+    既存 portfolio.update_memo (POST /portfolio/<code_s>/memo) を AJAX で再利用。
+    保存ボタンは無く、change/blur で即送信する portfolio_list.html と同方式。
+    """
+
+    @pytest.fixture
+    def portfolio_app(self, db_path, tmp_path, monkeypatch):
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+
+        rec_3496 = rs.create_research_record("3496", "アズーム", overall_rating="A")
+        rs.upsert_research_record(rec_3496, db_path=db_path)
+        rec_1234 = rs.create_research_record("1234", "テスト未登録", overall_rating="B")
+        rs.upsert_research_record(rec_1234, db_path=db_path)
+
+        ps.add_to_watch("3496", reason="テスト用", db_path=portfolio_db)
+        ps.transition_status("3496", "1保", reason="テスト用 1保 へ", db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        return app, portfolio_db
+
+    @pytest.fixture
+    def portfolio_client(self, portfolio_app):
+        app, _ = portfolio_app
+        return app.test_client()
+
+    def test_registered_stock_renders_inline_inputs(self, portfolio_client):
+        """登録済銘柄: 業態・テーマ inline edit (data-code 付き wrapper + 2 input) が出る"""
+        html = portfolio_client.get("/stock/3496").data.decode()
+        assert 'class="gyoutai-themes-inline" data-code="3496"' in html
+        assert 'name="gyoutai_themes_0"' in html
+        assert 'name="gyoutai_themes_1"' in html
+        # AJAX 化したので保存ボタンは無い、form タグも無い
+        assert "action=\"/portfolio/3496/memo\"" not in html
+
+    def test_registered_stock_renders_datalist(self, portfolio_client):
+        """datalist#gyoutai-theme-choices が出る (候補は空でもタグは描画)"""
+        html = portfolio_client.get("/stock/3496").data.decode()
+        assert '<datalist id="gyoutai-theme-choices">' in html
+
+    def test_existing_themes_prefilled(self, portfolio_app):
+        """事前に保存したテーマが input value にプリフィルされる"""
+        import portfolio_shelve as ps
+        app, portfolio_db = portfolio_app
+        ps.update_memo("3496", {"gyoutai_themes": ["AI", "半導体"]}, db_path=portfolio_db)
+
+        html = app.test_client().get("/stock/3496").data.decode()
+        assert 'value="AI"' in html
+        assert 'value="半導体"' in html
+
+    def test_unregistered_stock_hides_inline_inputs(self, portfolio_client):
+        """未登録銘柄では inline edit (gyoutai_themes_0 input) が出ない"""
+        html = portfolio_client.get("/stock/1234").data.decode()
+        assert 'name="gyoutai_themes_0"' not in html
+        assert 'class="gyoutai-themes-inline"' not in html
+
+    def test_ajax_post_returns_json_with_themes(self, portfolio_app):
+        """X-Requested-With 付き POST → 200 + JSON、display.gyoutai_themes に保存値が返る"""
+        app, _ = portfolio_app
+        client = app.test_client()
+        resp = client.post(
+            "/portfolio/3496/memo",
+            data={"gyoutai_themes_0": "新規テーマ", "gyoutai_themes_1": ""},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["display"]["gyoutai_themes"] == ["新規テーマ"]
+
+    def test_ajax_post_persists(self, portfolio_app):
+        """AJAX POST 後、portfolio_shelve.memo.gyoutai_themes に反映される"""
+        import portfolio_shelve as ps
+        app, portfolio_db = portfolio_app
+        client = app.test_client()
+        client.post(
+            "/portfolio/3496/memo",
+            data={"gyoutai_themes_0": "新規テーマ", "gyoutai_themes_1": ""},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        rec = ps.get_record("3496", db_path=portfolio_db)
+        assert (rec.get("memo") or {}).get("gyoutai_themes") == ["新規テーマ"]
+
+    def test_ajax_post_clears_when_all_empty(self, portfolio_app):
+        """既存テーマあり → 全スロット空文字 AJAX POST → gyoutai_themes が空 list に"""
+        import portfolio_shelve as ps
+        app, portfolio_db = portfolio_app
+        ps.update_memo("3496", {"gyoutai_themes": ["AI", "半導体"]}, db_path=portfolio_db)
+
+        client = app.test_client()
+        client.post(
+            "/portfolio/3496/memo",
+            data={"gyoutai_themes_0": "", "gyoutai_themes_1": ""},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        rec = ps.get_record("3496", db_path=portfolio_db)
+        assert (rec.get("memo") or {}).get("gyoutai_themes") == []
+
+    def test_detail_renders_when_memo_is_not_dict(self, portfolio_app, monkeypatch):
+        """memo が None / 非 dict の旧データでも詳細ページが 500 にならない (codex P2)。
+
+        _normalize_loaded_memo は非 dict の memo を素通しするので、
+        portfolio_record["memo"] が None になり得る。`get("memo", {}).get(...)` は
+        memo キーが存在し値が None だと AttributeError を投げるため、
+        詳細ページ側で dict ガードが必要。
+
+        ps.get_record をモンキーパッチして memo=None のレコードを返させる。
+        """
+        import portfolio_shelve as ps
+        app, portfolio_db = portfolio_app
+
+        original_get = ps.get_record
+
+        def patched_get(code_s, db_path=None):
+            rec = original_get(code_s, db_path=db_path)
+            if rec and code_s == "3496":
+                rec = dict(rec)
+                rec["memo"] = None
+            return rec
+
+        monkeypatch.setattr(ps, "get_record", patched_get)
+
+        # GET /stock/3496 で 500 にならないこと
+        resp = app.test_client().get("/stock/3496")
+        assert resp.status_code == 200
+        # 業態・テーマ inline edit (input) は出る (空値で)
+        html = resp.data.decode()
+        assert 'name="gyoutai_themes_0"' in html


### PR DESCRIPTION
Closes #205

## Summary
- 銘柄詳細ページに業態・テーマの inline edit を追加 (change/blur で AJAX 即時保存)
- レイアウトは分析日/決算日と同じ `.meta` 行に統合、保存ボタンは廃止
- ポートフォリオ未登録銘柄では UI ごと非表示
- 既存 `POST /portfolio/<code_s>/memo` を AJAX で再利用、新ルート無し
- 副次修正: `portfolio.update_memo` の `_redirect_with_return_query()` に `code_s=code_s` を付与し `return_to=detail` 経路を尊重 (既存バグ)
- codex P2 修正: memo が None / 非 dict の旧データでも詳細ページが 500 にならないよう dict ガード

## Test plan
- [x] `pytest tests/test_webapp_routes.py::TestDetailGyoutaiThemes -v` (新規 8 ケース全 pass)
- [x] `pytest -k "portfolio or memo or detail"` (240 件 pass、regression なし)
- [x] WebApp e2e: 登録済 421A の詳細ページから業態・テーマを変更 → AJAX 保存 → portfolio_list で反映確認
- [x] 未登録銘柄 (1380) で UI が出ないこと確認
- [ ] reviewer 確認用: memo=None の旧データを持つ銘柄でも詳細ページが 200 を返すこと