### PR TITLE
portfolio: ページング/ソート廃止しフィルタを単一選択 + 業態テーマ select に簡略化

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1367,7 +1367,6 @@ def _gyoutai_first_line(row: Dict[str, Any]) -> str:
 
 def list_portfolio_with_indicators(
     records: List[Dict[str, Any]],
-    sort_key: str = "gyoutai",
 ) -> List[Dict[str, Any]]:
     """portfolio_shelve のレコード列に stocks_shelve から最新指標を補完する (Phase 3b)。
 
@@ -1376,8 +1375,6 @@ def list_portfolio_with_indicators(
 
     Args:
         records: portfolio_shelve.list_records の戻り値 (既に status 等で絞り込み済み)
-        sort_key: "gyoutai" (業態 1 行目昇順 → 順位昇順) / "rank" (順位昇順のみ)。
-                  不正値は "gyoutai" にフォールバック (issue #178)。
 
     Returns:
         各 dict: portfolio レコード + {stock_name, rank, kessanbi_md, per, market_cap,
@@ -1385,7 +1382,7 @@ def list_portfolio_with_indicators(
                                      quarter, progress_diff, trend_template, tags,
                                      theoretical_diff, gyoseki, indicators_raw,
                                      status_query, status_label}
-        sort_key に応じた並び順 (rank/業態が None/空の銘柄は末尾)。
+        並び順は業態 1 行目昇順 → 順位昇順 → コード (issue #215: 順位ソート廃止、空業態/None順位は末尾)。
     """
     if not records:
         return []
@@ -1409,17 +1406,14 @@ def list_portfolio_with_indicators(
         row["gyoutai_first"] = _gyoutai_first_line(row)
         rows.append(row)
 
-    if sort_key == "rank":
-        rows.sort(key=lambda r: (r.get("rank") is None, r.get("rank") or 0, r.get("code_s", "")))
-    else:
-        # 業態順: 業態 1 行目 (空は末尾) → 順位昇順 (None は末尾) → コード
-        rows.sort(key=lambda r: (
-            r["gyoutai_first"] == "",
-            r["gyoutai_first"],
-            r.get("rank") is None,
-            r.get("rank") or 0,
-            r.get("code_s", ""),
-        ))
+    # 業態順: 業態 1 行目 (空は末尾) → 順位昇順 (None は末尾) → コード
+    rows.sort(key=lambda r: (
+        r["gyoutai_first"] == "",
+        r["gyoutai_first"],
+        r.get("rank") is None,
+        r.get("rank") or 0,
+        r.get("code_s", ""),
+    ))
     return rows
 
 

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -1,6 +1,6 @@
-"""保有銘柄ダッシュボードルート (Phase 3b / issue #171, #175, #178, #186)。
+"""保有銘柄ダッシュボードルート (Phase 3b / issue #171, #175, #178, #186, #215)。
 
-GET  /portfolio?status=hold,semi&sort=rank&page=2 : フィルタ/ソート/ページング (issue #178)
+GET  /portfolio?status=hold&gyoutai_theme=半導体 : フィルタ (issue #215)
 POST /portfolio/add                              : 3監 への新規追加 / 除外済みの復活
 POST /portfolio/<code_s>/transition              : ステータス変更
 POST /portfolio/bulk-exclude                     : 2準/3監 銘柄をユニバースから除外 (一括)
@@ -10,9 +10,8 @@ portfolio_shelve のレコードに stocks_shelve から指標を補完して表
 書き込み API は txt 関連の状態を変えるもの (add/transition/bulk-exclude) のみ
 末尾で sync_to_my_watch_list_txt() を呼ぶ。memo 更新は txt 内容に影響しないため同期不要。
 
-issue #178: タブ構造を撤廃しフィルタ/ソート/ページングに再設計。POST 後の
-リダイレクトは hidden `return_query` (現状の URL クエリ全体) を尊重して
-直前のフィルタ状態に戻す。
+issue #215: ページング/ソートを廃止し、status は単一選択化、業態テーマ select を追加。
+業態テーマ指定時は status 無視で全銘柄から該当する業態/テーマだけを抽出する。
 """
 
 from typing import Optional
@@ -49,83 +48,52 @@ STATUS_VALUE_TO_LABEL = {
 }
 
 # フィルタ表示順 (左から右): (query, status_value, label)
-# issue #178: 旧 TABS から名称変更。タブではなくフィルタ checkbox の表示順を規定する。
+# issue #215: select の option 順序を規定する。
 STATUS_CHOICES = [
     ("hold", "1保", STATUS_VALUE_TO_LABEL["1保"]),
     ("semi", "2準", STATUS_VALUE_TO_LABEL["2準"]),
     ("watch", "3監", STATUS_VALUE_TO_LABEL["3監"]),
 ]
-DEFAULT_STATUS_QUERY = STATUS_CHOICES[0][0]  # "hold" — 引数なし時のデフォルト
-
-# issue #178: ページング設定 (1ページ件数)
-PORTFOLIO_PAGE_SIZE = 50
-
-# issue #178: 受理する sort key
-VALID_SORT_KEYS = ("gyoutai", "rank")
-DEFAULT_SORT_KEY = "gyoutai"
+DEFAULT_STATUS_QUERY = STATUS_CHOICES[0][0]  # "hold" — 書き込み POST 後フォールバック先
 
 
-def _parse_status_filter(args) -> list[str]:
-    """request.args (MultiDict) から status フィルタを内部値リスト (例: ["1保","2準"]) に変換する。
+def _parse_status_filter(args) -> Optional[str]:
+    """request.args から status フィルタを内部値 (例: "1保") に変換する (issue #215)。
 
-    2 つの送信形式を両方受理:
-      - カンマ区切り単一キー: `?status=hold,semi` (URL 直接指定・既存互換)
-      - 同名複数キー: `?status=hold&status=semi` (HTML form の checkbox 標準送信)
-
-    各値を小文字化・トリムし、STATUS_QUERY_TO_VALUE で内部値に変換。不正値は無視。
-    結果が空 (= 指定なし or 全不正値) は ["1保"] (デフォルト = 保有のみ)。
-    既存 URL `?status=hold` (単一値) は自然に ["1保"] に解決され、互換性維持。
+    省略・空文字・「すべて」(value="") は None を返し、ダッシュボード側で
+    「全ステータス表示」として扱う。`?status=hold,semi` のようなカンマ区切り
+    旧 URL は寛容処理し先頭値のみ採用する (issue #215 で複数選択は廃止)。
+    不正値は None (= 全件表示) にフォールバック。
     """
-    raw_values = args.getlist("status") if hasattr(args, "getlist") else []
-    flat: list[str] = []
-    for v in raw_values:
-        for piece in (v or "").split(","):
-            piece = piece.strip().lower()
-            if piece:
-                flat.append(piece)
-    statuses: list[str] = []
-    for q in flat:
-        st = STATUS_QUERY_TO_VALUE.get(q)
-        if st and st not in statuses:
-            statuses.append(st)
-    if not statuses:
-        statuses = [STATUS_QUERY_TO_VALUE[DEFAULT_STATUS_QUERY]]
-    return statuses
+    raw = (args.get("status") or "").strip().lower()
+    if not raw:
+        return None
+    # 旧 URL `?status=hold,semi` 互換: 先頭値だけ採用
+    first = raw.split(",")[0].strip()
+    return STATUS_QUERY_TO_VALUE.get(first)
 
 
-def _parse_sort(args) -> str:
-    """sort key を `gyoutai` / `rank` のいずれかに正規化。不正値は DEFAULT_SORT_KEY。"""
-    raw = (args.get("sort") or "").strip().lower()
-    return raw if raw in VALID_SORT_KEYS else DEFAULT_SORT_KEY
+def _parse_gyoutai_theme(args) -> Optional[str]:
+    """request.args から業態/テーマフィルタを取り出す (issue #215)。
 
-
-def _parse_page(args, total_pages: int) -> int:
-    """page 番号を 1..total_pages の整数に正規化。不正値・範囲外は端にクランプ。"""
-    raw = (args.get("page") or "").strip()
-    try:
-        page = int(raw)
-    except (ValueError, TypeError):
-        page = 1
-    if page < 1:
-        page = 1
-    if total_pages >= 1 and page > total_pages:
-        page = total_pages
-    return page
-
-
-def _build_query_string(statuses: list[str], sort_key: str, page: int) -> str:
-    """フィルタ・ソート・ページから URL クエリ文字列を組み立てる。
-
-    status はカンマ区切り単一キー形式 (`status=hold,semi`)、sort/page は単純キー。
-    POST → リダイレクトの戻り先として使う。
+    空文字・未指定は None を返す。値は前後空白除去のみで、後段で
+    `gyoutai_themes` リストとの完全一致判定に使う。
     """
-    queries = [STATUS_VALUE_TO_QUERY[s] for s in statuses if s in STATUS_VALUE_TO_QUERY]
+    raw = (args.get("gyoutai_theme") or "").strip()
+    return raw or None
+
+
+def _build_query_string(status: Optional[str], gyoutai_theme: Optional[str]) -> str:
+    """フィルタから URL クエリ文字列を組み立てる (issue #215)。
+
+    POST → リダイレクトの戻り先として使う。両方 None なら空文字を返し、
+    呼び出し側 (`_redirect_with_return_query`) でデフォルトに落ちる。
+    """
     params = []
-    if queries:
-        params.append(("status", ",".join(queries)))
-    params.append(("sort", sort_key))
-    if page > 1:
-        params.append(("page", str(page)))
+    if status and status in STATUS_VALUE_TO_QUERY:
+        params.append(("status", STATUS_VALUE_TO_QUERY[status]))
+    if gyoutai_theme:
+        params.append(("gyoutai_theme", gyoutai_theme))
     return urlencode(params)
 
 
@@ -161,11 +129,11 @@ def _redirect_with_return_query(
     default_status_query: str = DEFAULT_STATUS_QUERY,
     code_s: Optional[str] = None,
 ):
-    """POST フォームに埋め込まれた hidden `return_query` を尊重してリダイレクトする (issue #178)。
+    """POST フォームに埋め込まれた hidden `return_query` を尊重してリダイレクトする (issue #178, #215)。
 
-    return_query はクエリ文字列 (例: `status=hold,semi&sort=rank&page=2`) を
+    return_query はクエリ文字列 (例: `status=hold&gyoutai_theme=半導体`) を
     そのまま受け取り、URL に付与する。空 or 未指定なら `?status=<default>` に
-    フォールバック。これで POST 後も直前のフィルタ/ソート/ページが復元できる。
+    フォールバック。これで POST 後も直前のフィルタが復元できる。
 
     安全のため return_query から先頭の `?` を取り除き、改行や `#` も弾く
     (URL injection 防止)。
@@ -497,15 +465,16 @@ def _build_fallback_records() -> list[dict]:
 
 @portfolio_bp.route("/portfolio")
 def dashboard():
-    """フィルタ/ソート/ページング型ダッシュボード (issue #178)。
+    """フィルタ型ダッシュボード (issue #215 でページング/ソートは廃止)。
 
     URL クエリ:
-      status: hold,semi,watch のカンマ区切り or 同名複数キー (デフォルト=hold)
-      sort:   gyoutai (業態順, デフォルト) / rank (順位順)
-      page:   1始まり (デフォルト=1)、1ページ PORTFOLIO_PAGE_SIZE 件
+      status:        hold / semi / watch のいずれか単一 (省略時=全ステータス)
+      gyoutai_theme: 業態/テーマ名の完全一致 (省略時=全業態テーマ)
+                     指定時は status を無視して全銘柄から該当業態/テーマを抽出。
+    並び順は常時業態順。`sort` / `page` パラメータは silent に無視 (旧 URL 互換)。
     """
-    active_statuses = _parse_status_filter(request.args)
-    active_sort = _parse_sort(request.args)
+    active_status = _parse_status_filter(request.args)
+    active_gyoutai_theme = _parse_gyoutai_theme(request.args)
 
     # issue #186: fallback 判定は除外含む全件で行う (全件除外時の誤判定を避ける)。
     # 表示・件数カウントは除外を弾いた visible_records を使う。
@@ -516,43 +485,44 @@ def dashboard():
     else:
         visible_records = [r for r in all_records_inc if not r.get("excluded", False)]
 
-    # 件数 (フィルタ前): hold/semi/watch ごとに常に出す (UI チェックボックス横の表示用)
+    # 件数 (フィルタ前): hold/semi/watch ごとに常に出す (status select の option ラベル用)
     counts = {q: 0 for q, _, _ in STATUS_CHOICES}
     for r in visible_records:
         st = r.get("status")
         if st in STATUS_VALUE_TO_QUERY:
             counts[STATUS_VALUE_TO_QUERY[st]] += 1
 
-    filtered_records = [r for r in visible_records if r.get("status") in active_statuses]
-    rows_all = list_portfolio_with_indicators(filtered_records, sort_key=active_sort)
+    # issue #215: gyoutai_theme 指定時は status 無視で業態/テーマ完全一致のレコードのみ。
+    # 未指定時は status フィルタ (None なら全件)。
+    if active_gyoutai_theme:
+        filtered_records = [
+            r for r in visible_records
+            if active_gyoutai_theme in ((r.get("memo") or {}).get("gyoutai_themes") or [])
+        ]
+    elif active_status is None:
+        filtered_records = visible_records
+    else:
+        filtered_records = [r for r in visible_records if r.get("status") == active_status]
+    rows = list_portfolio_with_indicators(filtered_records)
 
-    total = len(rows_all)
-    total_pages = max(1, (total + PORTFOLIO_PAGE_SIZE - 1) // PORTFOLIO_PAGE_SIZE)
-    page = _parse_page(request.args, total_pages)
-    start = (page - 1) * PORTFOLIO_PAGE_SIZE
-    end = start + PORTFOLIO_PAGE_SIZE
-    rows = rows_all[start:end]
-
-    # 行ごとに transitions を埋める (issue #178: 複数 status 同時表示で、
-    # 各行が個別の遷移先候補を持つ必要があるため)。fallback 中は空。
+    # 行ごとに transitions を埋める。fallback 中は空。
     for row in rows:
         row["transitions"] = (
             [] if fallback_mode else _allowed_transitions_from(row.get("status", ""))
         )
 
-    # 削除モードの可否: 2準/3監 がフィルタに含まれる時のみ
+    # 削除モードの可否: 表示中の rows に 2準/3監 が含まれる時のみ
     delete_mode_allowed = (
         not fallback_mode
-        and any(s in active_statuses for s in ("2準", "3監"))
-        and bool(rows)
+        and any(row.get("status") in ("2準", "3監") for row in rows)
     )
 
-    # POST → リダイレクトの戻り先として使う現状クエリ (status/sort/page 全部)
-    return_query = _build_query_string(active_statuses, active_sort, page)
-    # テンプレートでチェック判定するための、active_statuses の query 形式リスト (例: ["hold","semi"])
-    active_status_queries = [
-        STATUS_VALUE_TO_QUERY[s] for s in active_statuses if s in STATUS_VALUE_TO_QUERY
-    ]
+    # POST → リダイレクトの戻り先として使う現状クエリ (status/gyoutai_theme)
+    return_query = _build_query_string(active_status, active_gyoutai_theme)
+    # テンプレートで select の selected 判定に使う、active_status の query 形式 (例: "hold")
+    active_status_query = (
+        STATUS_VALUE_TO_QUERY[active_status] if active_status in STATUS_VALUE_TO_QUERY else ""
+    )
 
     # issue #187: datalist 候補は表示フィルタ/excluded と独立、shelve 内の全レコードから集計
     if fallback_mode:
@@ -563,17 +533,11 @@ def dashboard():
     return render_template(
         "portfolio_list.html",
         status_choices=STATUS_CHOICES,
-        active_statuses=active_statuses,
-        active_status_queries=active_status_queries,
-        active_sort=active_sort,
+        active_status_query=active_status_query,
+        active_gyoutai_theme=active_gyoutai_theme or "",
         counts=counts,
         rows=rows,
-        total=total,
-        page=page,
-        total_pages=total_pages,
-        page_size=PORTFOLIO_PAGE_SIZE,
-        page_start=start + 1 if rows else 0,
-        page_end=start + len(rows),
+        total=len(rows),
         return_query=return_query,
         delete_mode_allowed=delete_mode_allowed,
         status_label=STATUS_VALUE_TO_LABEL,

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -126,14 +126,19 @@ def _sync_txt_safely() -> None:
 
 
 def _redirect_with_return_query(
-    default_status_query: str = DEFAULT_STATUS_QUERY,
+    default_status_query: Optional[str] = None,
     code_s: Optional[str] = None,
 ):
     """POST フォームに埋め込まれた hidden `return_query` を尊重してリダイレクトする (issue #178, #215)。
 
     return_query はクエリ文字列 (例: `status=hold&gyoutai_theme=半導体`) を
-    そのまま受け取り、URL に付与する。空 or 未指定なら `?status=<default>` に
-    フォールバック。これで POST 後も直前のフィルタが復元できる。
+    そのまま受け取り、URL に付与する。これで POST 後も直前のフィルタが復元できる。
+
+    空 or 未指定時の戻り先 (issue #215):
+      - `default_status_query=None` (デフォルト): 素の `/portfolio` (= 全件表示) に戻す。
+        引数なし /portfolio の全件状態からの POST を復元するためのフォールバック。
+      - `default_status_query="watch"` 等: `?status=<value>` を付与。`add()` から
+        追加直後の銘柄が見えるよう監視フィルタに切り替えたい場合に使う。
 
     安全のため return_query から先頭の `?` を取り除き、改行や `#` も弾く
     (URL injection 防止)。
@@ -154,7 +159,9 @@ def _redirect_with_return_query(
     base = url_for("portfolio.dashboard")
     if raw:
         return redirect(f"{base}?{raw}")
-    return redirect(f"{base}?status={default_status_query}")
+    if default_status_query:
+        return redirect(f"{base}?status={default_status_query}")
+    return redirect(base)
 
 
 def _is_fallback_mode() -> bool:

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -40,16 +40,6 @@
   .status-badge.status-hold  { background: #d4ead4; color: #285028; }
   .status-badge.status-semi  { background: #fdf0c0; color: #856100; }
   .status-badge.status-watch { background: #e2e2e2; color: #555; }
-  /* issue #178: ページネーション */
-  nav.pagination {
-    display: flex; gap: 0.6em; align-items: center; justify-content: center;
-    margin: 0.6em 0; font-size: 0.9em;
-  }
-  nav.pagination a, nav.pagination span.disabled {
-    padding: 0.3em 0.7em; border: 1px solid #d8dee6; border-radius: 3px;
-    text-decoration: none;
-  }
-  nav.pagination span.disabled { color: #bbb; background: #f8f8f8; }
   /* 一括削除アクションバー */
   #bulk-delete-bar {
     position: sticky; bottom: 0; z-index: 10;
@@ -96,33 +86,31 @@
 {% endif %}
 {% endwith %}
 
-{# issue #178: タブを撤廃しフィルタ/ソートバーに変更。GET で URL に反映する #}
+{# issue #215: フィルタは status / gyoutai_theme の単一選択 select 2 つ。onchange で即送信。 #}
 <form id="portfolio-filter-form" action="/portfolio" method="GET"
       style="display:flex;flex-wrap:wrap;gap:1.2em;align-items:center;margin-bottom:0.6em;padding:0.5em 0.6em;background:#f5f7fa;border:1px solid #d8dee6;border-radius:4px;font-size:0.9em;">
-  <span style="color:#666;">フィルタ</span>
-  {% for q, status_val, label in status_choices %}
-  <label style="display:inline-flex;align-items:center;gap:0.25em;margin:0;cursor:pointer;">
-    <input type="checkbox" name="status" value="{{ q }}" style="margin:0;"
-           {% if q in active_status_queries %}checked{% endif %}>
-    {{ label }} <span style="color:#999;font-size:0.85em;">({{ counts[q] }})</span>
+  <label style="display:inline-flex;align-items:center;gap:0.4em;margin:0;">
+    <span style="color:#666;">ステータス</span>
+    <select name="status" onchange="this.form.submit()" style="padding:0.2em 0.3em;font-size:0.9em;margin:0;">
+      <option value="">すべて</option>
+      {% for q, _, label in status_choices %}
+      <option value="{{ q }}" {% if q == active_status_query %}selected{% endif %}>{{ label }} ({{ counts[q] }})</option>
+      {% endfor %}
+    </select>
   </label>
-  {% endfor %}
-  <span style="color:#666;margin-left:0.6em;">ソート</span>
-  <label style="display:inline-flex;align-items:center;gap:0.25em;margin:0;cursor:pointer;">
-    <input type="radio" name="sort" value="gyoutai" style="margin:0;"
-           {% if active_sort == 'gyoutai' %}checked{% endif %}>業態順
+  <label style="display:inline-flex;align-items:center;gap:0.4em;margin:0;">
+    <span style="color:#666;">業態・テーマ</span>
+    <select name="gyoutai_theme" onchange="this.form.submit()" style="padding:0.2em 0.3em;font-size:0.9em;margin:0;max-width:18em;">
+      <option value="">すべて</option>
+      {% for choice in gyoutai_theme_choices %}
+      <option value="{{ choice }}" {% if choice == active_gyoutai_theme %}selected{% endif %}>{{ choice }}</option>
+      {% endfor %}
+    </select>
   </label>
-  <label style="display:inline-flex;align-items:center;gap:0.25em;margin:0;cursor:pointer;">
-    <input type="radio" name="sort" value="rank" style="margin:0;"
-           {% if active_sort == 'rank' %}checked{% endif %}>順位順
-  </label>
-  {# フィルタ/ソート変更時は page=1 にリセット (page hidden を出さない) #}
-  <button type="submit" style="padding:0.3em 0.8em;font-size:0.85em;margin:0;">絞り込み</button>
 </form>
 
 <p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">
-  {% if total > 0 %}{{ total }}件中 {{ page_start }}-{{ page_end }} 件表示
-  {% else %}0 件{% endif %}
+  {% if total > 0 %}{{ total }} 件表示{% else %}0 件{% endif %}
 </p>
 
 {% if not fallback_mode %}
@@ -180,9 +168,10 @@
   </thead>
   <tbody>
     {% for row in rows %}
-    {# issue #178: 業態順表示時、前行と業態 1 行目が異なる行は境界線を入れる。
-       row.gyoutai_first は helpers.list_portfolio_with_indicators が precompute 済み。 #}
-    <tr data-code="{{ row.code_s }}"{% if active_sort == 'gyoutai' and not loop.first and loop.previtem.gyoutai_first != row.gyoutai_first %} class="gyoutai-boundary"{% endif %}>
+    {# issue #178: 前行と業態 1 行目が異なる行は境界線を入れる。
+       row.gyoutai_first は helpers.list_portfolio_with_indicators が precompute 済み。
+       issue #215: ソート分岐廃止に伴い常時有効。 #}
+    <tr data-code="{{ row.code_s }}"{% if not loop.first and loop.previtem.gyoutai_first != row.gyoutai_first %} class="gyoutai-boundary"{% endif %}>
       {% if delete_mode_allowed %}
       {# codex 指摘 P2: 1保 は bulk_exclude() で reject されるため checkbox を出さない #}
       <td class="bulk-col">
@@ -319,25 +308,6 @@
   </tbody>
 </table>
 </div>
-
-{# issue #178: ページネーション (1ページしかなければ非表示)。
-   page だけ差し替えるため、build_pagination_url マクロで status/sort のみ持つベースを使う。 #}
-{% set pagination_base = 'status=' + (active_status_queries|join(',')) + '&sort=' + active_sort %}
-{% if total_pages > 1 %}
-<nav class="pagination">
-  {% if page > 1 %}
-    <a href="?{{ pagination_base }}{% if page > 2 %}&page={{ page - 1 }}{% endif %}">‹ 前</a>
-  {% else %}
-    <span class="disabled">‹ 前</span>
-  {% endif %}
-  <span>{{ page }} / {{ total_pages }}</span>
-  {% if page < total_pages %}
-    <a href="?{{ pagination_base }}&page={{ page + 1 }}">次 ›</a>
-  {% else %}
-    <span class="disabled">次 ›</span>
-  {% endif %}
-</nav>
-{% endif %}
 
 <datalist id="gyoutai-theme-choices">
   {% for choice in gyoutai_theme_choices %}

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1596,10 +1596,11 @@ class TestCollectGyoutaiThemeChoices:
 
 
 class TestListPortfolioWithIndicators:
-    """list_portfolio_with_indicators の sort_key / status_query / status_label 検証 (issue #178)。
+    """list_portfolio_with_indicators の業態順ソート / status_query / status_label 検証 (issue #178, #215)。
 
     外部参照 (_bulk_get_stock_data, _bulk_resolve_stock_names, compute_cell_styles) は
     monkeypatch でスタブし、並び順とフィールド埋めだけを検証する。
+    issue #215: 順位ソートを廃止し業態順固定。sort_key 引数は撤廃済み。
     """
 
     @pytest.fixture
@@ -1625,26 +1626,17 @@ class TestListPortfolioWithIndicators:
             self._make("0002", "1保", rank=10, themes=["半導体"]),
             self._make("0003", "1保", rank=5, themes=["人材"]),
         ]
-        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
+        rows = helpers.list_portfolio_with_indicators(records)
         # 業態順 (人材→半導体) かつ業態内は rank 昇順
         assert [r["code_s"] for r in rows] == ["0003", "0001", "0002"]
 
-    def test_sort_by_rank_only(self, stub_externals):
-        records = [
-            self._make("0001", "1保", rank=30, themes=["人材"]),
-            self._make("0002", "1保", rank=10, themes=["半導体"]),
-            self._make("0003", "1保", rank=5, themes=["人材"]),
-        ]
-        rows = helpers.list_portfolio_with_indicators(records, sort_key="rank")
-        assert [r["code_s"] for r in rows] == ["0003", "0002", "0001"]
-
-    def test_empty_gyoutai_goes_to_end_under_gyoutai_sort(self, stub_externals):
+    def test_empty_gyoutai_goes_to_end(self, stub_externals):
         records = [
             self._make("0001", "1保", rank=10, themes=[]),
             self._make("0002", "1保", rank=20, themes=["半導体"]),
             self._make("0003", "1保", rank=5, themes=None),
         ]
-        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
+        rows = helpers.list_portfolio_with_indicators(records)
         # 半導体が先頭、空 themes は末尾 (末尾内は rank 昇順)
         assert [r["code_s"] for r in rows] == ["0002", "0003", "0001"]
 
@@ -1654,17 +1646,17 @@ class TestListPortfolioWithIndicators:
             self._make("0001", "1保", rank=10, themes=["AI", "人材"]),
             self._make("0002", "1保", rank=20, themes=["人材", "AI"]),
         ]
-        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
+        rows = helpers.list_portfolio_with_indicators(records)
         # 0001 の themes[0]=AI が先、0002 の themes[0]=人材 が後
         assert [r["code_s"] for r in rows] == ["0001", "0002"]
 
     def test_status_query_label_filled(self, stub_externals):
         records = [
-            self._make("0001", "1保"),
-            self._make("0002", "2準"),
-            self._make("0003", "3監"),
+            self._make("0001", "1保", rank=1, themes=["A"]),
+            self._make("0002", "2準", rank=2, themes=["B"]),
+            self._make("0003", "3監", rank=3, themes=["C"]),
         ]
-        rows = helpers.list_portfolio_with_indicators(records, sort_key="rank")
+        rows = helpers.list_portfolio_with_indicators(records)
         by_code = {r["code_s"]: r for r in rows}
         assert by_code["0001"]["status_query"] == "hold"
         assert by_code["0001"]["status_label"] == "保有"

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -338,14 +338,16 @@ class TestBulkExclude:
         assert "status=semi" in loc
         assert "gyoutai_theme=" in loc
 
-    def test_bulk_exclude_empty_return_query_falls_back_to_default(self, client, portfolio_db_path):
-        """return_query 未指定はデフォルト ?status=hold にリダイレクト (issue #178)"""
+    def test_bulk_exclude_empty_return_query_falls_back_to_all(self, client, portfolio_db_path):
+        """return_query 未指定は素の /portfolio (= 全件表示) にリダイレクト (issue #215)"""
         resp = client.post(
             "/portfolio/bulk-exclude",
             data={"codes": "6324"},
         )
         assert resp.status_code == 302
-        assert "status=hold" in resp.headers["Location"]
+        loc = resp.headers["Location"]
+        # /portfolio に戻る (status= 等のフィルタクエリは付かない)
+        assert loc.endswith("/portfolio")
 
     def test_bulk_exclude_empty_codes_flash_error(self, client, portfolio_db_path):
         resp = client.post("/portfolio/bulk-exclude", data={})
@@ -984,10 +986,11 @@ class TestReturnQueryRedirect:
             data={"new_status": "1保", "return_query": "status=hold\n#evil"},
         )
         assert resp.status_code == 302
-        # return_query が空相当の扱い → デフォルト ?status=hold
+        # return_query が空相当の扱い → 素の /portfolio (= 全件表示、issue #215)
         loc = resp.headers["Location"]
-        assert "status=hold" in loc
+        assert loc.endswith("/portfolio")
         assert "evil" not in loc
+        assert "%0A" not in loc
         assert "%0A" not in loc
 
 

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -92,47 +92,50 @@ def client(app):
 
 
 class TestDashboardGet:
-    """GET /portfolio タブ表示"""
+    """GET /portfolio フィルタ表示 (issue #215: ステータス単一選択 + 全件デフォルト)"""
 
-    def test_dashboard_default_tab_is_hold(self, client):
+    def test_dashboard_default_shows_all(self, client):
+        """引数なし = 全ステータス表示 (issue #215)"""
         resp = client.get("/portfolio")
         assert resp.status_code == 200
         html = resp.data.decode()
-        # 1保 (アズーム) が表示される
-        assert "アズーム" in html
-        # 2準 / 3監 の銘柄は表示されない (タブで絞り込み)
-        assert "ハーモニック" not in html
-        assert "トヨタ" not in html
+        assert "アズーム" in html       # 1保
+        assert "トヨタ" in html         # 2準
+        assert "ハーモニック" in html    # 3監
 
-    def test_dashboard_watch_tab(self, client):
+    def test_dashboard_watch_filter(self, client):
         resp = client.get("/portfolio?status=watch")
         assert resp.status_code == 200
         html = resp.data.decode()
         assert "ハーモニック" in html
         assert "アズーム" not in html
 
-    def test_dashboard_semi_tab(self, client):
+    def test_dashboard_semi_filter(self, client):
         resp = client.get("/portfolio?status=semi")
         assert resp.status_code == 200
         html = resp.data.decode()
         assert "トヨタ" in html
         assert "アズーム" not in html
 
-    def test_dashboard_unknown_status_falls_back_to_hold(self, client):
+    def test_dashboard_unknown_status_falls_back_to_all(self, client):
+        """不正値は None 扱い = 全件表示 (issue #215)"""
         resp = client.get("/portfolio?status=invalid")
         assert resp.status_code == 200
         html = resp.data.decode()
+        # 全件 = 1保/2準/3監 全部表示
         assert "アズーム" in html
+        assert "トヨタ" in html
+        assert "ハーモニック" in html
 
-    def test_dashboard_shows_tab_counts(self, client):
+    def test_dashboard_shows_status_counts(self, client):
+        """status select の option ラベルに件数が出ている"""
         resp = client.get("/portfolio")
         html = resp.data.decode()
-        # 各タブの件数が出ている (3 件登録: 1 / 1 / 1)
-        # タブ表示の数字を全て検証するのは見栄えに依存するので最低限件数行を確認
-        assert "1 件" in html or "(1)" in html or ">1<" in html
+        # select option の "保有 (1)" / "準保有 (1)" / "監視 (1)" のような表示
+        assert "(1)" in html
 
     def test_dashboard_shows_indicators(self, client):
-        """1保 タブで PER / モメンタム / 順位等の指標が表示される"""
+        """保有フィルタで PER / モメンタム / 順位等の指標が表示される"""
         resp = client.get("/portfolio?status=hold")
         html = resp.data.decode()
         # アズームの指標 (PER は二桁なので整数表記: 30)
@@ -325,15 +328,15 @@ class TestBulkExclude:
             assert rec["excluded"] is True
 
     def test_bulk_exclude_redirects_to_return_query(self, client, portfolio_db_path):
-        """return_query=status=hold,semi&sort=rank なら同じクエリにリダイレクト (issue #178)"""
+        """return_query=status=semi&gyoutai_theme=半導体 なら同じクエリにリダイレクト (issue #215)"""
         resp = client.post(
             "/portfolio/bulk-exclude",
-            data={"codes": "7203", "return_query": "status=hold,semi&sort=rank"},
+            data={"codes": "7203", "return_query": "status=semi&gyoutai_theme=半導体"},
         )
         assert resp.status_code == 302
         loc = resp.headers["Location"]
-        assert "status=hold,semi" in loc
-        assert "sort=rank" in loc
+        assert "status=semi" in loc
+        assert "gyoutai_theme=" in loc
 
     def test_bulk_exclude_empty_return_query_falls_back_to_default(self, client, portfolio_db_path):
         """return_query 未指定はデフォルト ?status=hold にリダイレクト (issue #178)"""
@@ -844,153 +847,87 @@ class TestFallbackFromTxt:
 # ==================================================
 # issue #178: フィルタ / ソート / ページング / status badge / return_query
 # ==================================================
-class TestDashboardFilterSortPaging:
-    """GET /portfolio?status=...&sort=...&page=... の検証 (issue #178)"""
+class TestDashboardFilter:
+    """GET /portfolio フィルタ仕様 (issue #215)"""
 
-    def test_default_shows_hold_only(self, client):
-        """引数なし = 保有のみ (1保) を表示"""
+    def test_default_shows_all(self, client):
+        """引数なし = 全ステータス表示"""
         resp = client.get("/portfolio")
-        html = resp.data.decode()
-        assert "アズーム" in html      # 1保
-        assert "ハーモニック" not in html  # 3監
-        assert "トヨタ" not in html      # 2準
-
-    def test_multi_status_filter_csv(self, client):
-        """?status=hold,semi (カンマ区切り) で 1保 + 2準 を表示"""
-        resp = client.get("/portfolio?status=hold,semi")
-        html = resp.data.decode()
-        assert "アズーム" in html
-        assert "トヨタ" in html
-        assert "ハーモニック" not in html
-
-    def test_multi_status_filter_repeated(self, client):
-        """?status=hold&status=semi (HTML form 送信形式) で 1保 + 2準 を表示"""
-        resp = client.get("/portfolio?status=hold&status=semi")
-        html = resp.data.decode()
-        assert "アズーム" in html
-        assert "トヨタ" in html
-        assert "ハーモニック" not in html
-
-    def test_multi_status_filter_mixed(self, client):
-        """カンマ区切りと同名複数キーが混在しても merge される (issue #178 codex 指摘)"""
-        resp = client.get("/portfolio?status=hold,xxx&status=watch")
-        html = resp.data.decode()
-        assert "アズーム" in html      # hold
-        assert "ハーモニック" in html   # watch
-        assert "トヨタ" not in html      # semi は含まれていない
-
-    def test_all_status_filter(self, client):
-        """全件指定で 3 銘柄全部表示"""
-        resp = client.get("/portfolio?status=hold,semi,watch")
         html = resp.data.decode()
         assert "アズーム" in html
         assert "トヨタ" in html
         assert "ハーモニック" in html
 
     def test_legacy_url_status_hold_still_works(self, client):
-        """既存 URL ?status=hold (単一値) が引き続き動作 (issue #178 互換性)"""
+        """既存 URL ?status=hold (単一値) は引き続き保有のみ表示"""
         resp = client.get("/portfolio?status=hold")
         html = resp.data.decode()
         assert "アズーム" in html
         assert "ハーモニック" not in html
 
-    def test_invalid_status_falls_back_to_default(self, client):
-        """不正値だけのフィルタはデフォルト = hold にフォールバック"""
-        resp = client.get("/portfolio?status=invalid")
+    def test_legacy_csv_status_uses_first_value(self, client):
+        """旧 URL ?status=hold,semi は寛容処理で先頭値 hold のみ採用 (issue #215)"""
+        resp = client.get("/portfolio?status=hold,semi")
         html = resp.data.decode()
         assert "アズーム" in html
+        # semi も watch も表示されない (先頭の hold のみ)
+        assert "トヨタ" not in html
+        assert "ハーモニック" not in html
 
-    def test_status_badge_visible_in_all_filter(self, client):
+    def test_legacy_sort_param_silently_ignored(self, client):
+        """旧 URL ?sort=rank&page=2 が混ざっても 200 で全件返る (issue #215 silent 無視)"""
+        resp = client.get("/portfolio?sort=rank&page=2")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "アズーム" in html
+        assert "トヨタ" in html
+        assert "ハーモニック" in html
+
+    def test_invalid_status_falls_back_to_all(self, client):
+        """不正値だけのフィルタは全件表示にフォールバック (None 扱い)"""
+        resp = client.get("/portfolio?status=invalid")
+        html = resp.data.decode()
+        # 全件 = 1保/2準/3監 全部
+        assert "アズーム" in html
+        assert "トヨタ" in html
+        assert "ハーモニック" in html
+
+    def test_status_badge_visible_in_all_view(self, client):
         """全件表示時、ステータス badge (保有/準保有/監視) が HTML に出る"""
-        resp = client.get("/portfolio?status=hold,semi,watch")
+        resp = client.get("/portfolio")
         html = resp.data.decode()
         assert 'class="status-badge status-hold"' in html
         assert 'class="status-badge status-semi"' in html
         assert 'class="status-badge status-watch"' in html
 
-    def test_sort_rank_orders_by_rank(self, client):
-        """?sort=rank で順位昇順 (業態無視)。fixture: 3496=50, 7203=200, 6324=612"""
-        resp = client.get("/portfolio?status=hold,semi,watch&sort=rank")
+    def test_gyoutai_theme_filter_applies(
+        self, client, portfolio_db_path
+    ):
+        """?gyoutai_theme=<value> で memo.gyoutai_themes に該当値を持つ銘柄のみ表示"""
+        # fixture: 3496 (1保) に "ロボット" テーマを付与
+        ps.update_memo("3496", {"gyoutai_themes": ["ロボット"]}, db_path=portfolio_db_path)
+        resp = client.get("/portfolio?gyoutai_theme=ロボット")
         html = resp.data.decode()
-        # 表示位置で並び順を判定 (3496 が 7203 より前、7203 が 6324 より前)
-        i_3496 = html.find('data-code="3496"')
-        i_7203 = html.find('data-code="7203"')
-        i_6324 = html.find('data-code="6324"')
-        assert i_3496 != -1 and i_7203 != -1 and i_6324 != -1
-        assert i_3496 < i_7203 < i_6324
+        assert "アズーム" in html        # 3496 該当
+        assert "トヨタ" not in html       # 7203 非該当
+        assert "ハーモニック" not in html  # 6324 非該当
 
-    def test_sort_gyoutai_default(self, client):
-        """sort 未指定はデフォルト gyoutai (radio が checked になっている)"""
-        import re
-        resp = client.get("/portfolio?status=hold")
+    def test_gyoutai_theme_overrides_status(
+        self, client, portfolio_db_path
+    ):
+        """?status=hold&gyoutai_theme=X 指定時は status 無視で X 該当銘柄全件を表示"""
+        # fixture: 7203 (2準) に "ロボット" テーマを付与 (status=hold とは異なる)
+        ps.update_memo("7203", {"gyoutai_themes": ["ロボット"]}, db_path=portfolio_db_path)
+        resp = client.get("/portfolio?status=hold&gyoutai_theme=ロボット")
         html = resp.data.decode()
-        # gyoutai radio タグ内に checked が含まれ、rank radio タグ内には含まれないこと
-        gyoutai_radio = re.search(r'<input[^>]*name="sort"[^>]*value="gyoutai"[^>]*>', html)
-        rank_radio = re.search(r'<input[^>]*name="sort"[^>]*value="rank"[^>]*>', html)
-        assert gyoutai_radio is not None and "checked" in gyoutai_radio.group(0)
-        assert rank_radio is not None and "checked" not in rank_radio.group(0)
-
-    def test_pagination_disabled_when_under_page_size(self, client):
-        """総件数がページサイズ以内ならページネーション nav は出ない"""
-        resp = client.get("/portfolio?status=hold,semi,watch")
-        html = resp.data.decode()
-        # 全 3 件 <= 50 なので pagination nav は出ない
-        assert 'class="pagination"' not in html
-
-    def test_pagination_invalid_page_falls_back(self, client):
-        """?page=abc は 1 にフォールバック (例外を投げない)"""
-        resp = client.get("/portfolio?status=hold&page=abc")
-        assert resp.status_code == 200
-        assert "アズーム" in resp.data.decode()
-
-    def test_pagination_zero_page_falls_back(self, client):
-        """?page=0 は 1 にフォールバック"""
-        resp = client.get("/portfolio?status=hold&page=0")
-        assert resp.status_code == 200
-
-    def test_pagination_overflow_page_clamped(self, client, monkeypatch):
-        """総ページ数を超えた page 指定は最終ページにクランプ"""
-        # ページサイズを 1 に下げて 3 銘柄を 3 ページに分割
-        from webapp.routes import portfolio as portfolio_routes
-        monkeypatch.setattr(portfolio_routes, "PORTFOLIO_PAGE_SIZE", 1)
-        resp = client.get("/portfolio?status=hold,semi,watch&sort=rank&page=999")
-        html = resp.data.decode()
-        # 最終ページ (page=3) には 6324 (rank=612) のみ
-        assert 'data-code="6324"' in html
-        assert 'data-code="3496"' not in html
-        assert 'data-code="7203"' not in html
-
-    def test_pagination_actually_paginates(self, client, monkeypatch):
-        """ページサイズを下げた状態で 1 ページ目が 1 件、2 ページ目で違う 1 件"""
-        from webapp.routes import portfolio as portfolio_routes
-        monkeypatch.setattr(portfolio_routes, "PORTFOLIO_PAGE_SIZE", 1)
-        # rank 順: 3496 (50) → 7203 (200) → 6324 (612)
-        resp1 = client.get("/portfolio?status=hold,semi,watch&sort=rank&page=1")
-        html1 = resp1.data.decode()
-        assert 'data-code="3496"' in html1
-        assert 'data-code="7203"' not in html1
-
-        resp2 = client.get("/portfolio?status=hold,semi,watch&sort=rank&page=2")
-        html2 = resp2.data.decode()
-        assert 'data-code="7203"' in html2
-        assert 'data-code="3496"' not in html2
-
-        # ページネーション nav が出ている (total_pages=3)
-        assert 'class="pagination"' in html2
-
-    def test_filter_form_does_not_emit_page_hidden(self, client):
-        """フィルタ form 内に page の hidden が無い (= submit 時に page=1 にリセット)"""
-        resp = client.get("/portfolio?status=hold&page=2")
-        html = resp.data.decode()
-        # フィルタ form 部分を抽出して page hidden が無いことを確認
-        form_start = html.find('id="portfolio-filter-form"')
-        form_end = html.find('</form>', form_start)
-        form_html = html[form_start:form_end]
-        assert 'name="page"' not in form_html
+        # status=hold (1保) を指定しているが gyoutai_theme 優先で 7203 (2準) が表示される
+        assert "トヨタ" in html
+        # 1保 のアズーム (ロボット未付与) は出ない
+        assert "アズーム" not in html
 
 
 class TestReturnQueryRedirect:
-    """POST 後の return_query によるリダイレクト先復元 (issue #178)"""
+    """POST 後の return_query によるリダイレクト先復元 (issue #178, #215 で形式変更)"""
 
     def test_transition_redirects_with_return_query(self, client):
         """transition POST 時、return_query が反映される"""
@@ -999,25 +936,23 @@ class TestReturnQueryRedirect:
             data={
                 "new_status": "3監",
                 "reason": "test",
-                "return_query": "status=hold,semi&sort=rank",
+                "return_query": "status=hold&gyoutai_theme=半導体",
             },
         )
         assert resp.status_code == 302
         loc = resp.headers["Location"]
-        assert "status=hold,semi" in loc
-        assert "sort=rank" in loc
+        assert "status=hold" in loc
+        assert "gyoutai_theme=" in loc
 
     def test_memo_redirects_with_return_query(self, client):
         """memo POST 時、return_query が反映される"""
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "X", "return_query": "status=watch&sort=rank&page=2"},
+            data={"trade_idea": "X", "return_query": "status=watch"},
         )
         assert resp.status_code == 302
         loc = resp.headers["Location"]
         assert "status=watch" in loc
-        assert "sort=rank" in loc
-        assert "page=2" in loc
 
     def test_add_default_status_query_is_watch(self, client, stocks_db_path):
         """add は return_query 未指定時、デフォルトで watch にリダイレクト (追加直後の確認用)"""
@@ -1034,7 +969,7 @@ class TestReturnQueryRedirect:
         add() の default_status_query='watch' フォールバックを効かせる。
         """
         import re
-        resp = client.get("/portfolio?status=hold&sort=gyoutai")
+        resp = client.get("/portfolio?status=hold")
         html = resp.data.decode()
         # 追加フォーム部分を抽出 (action="/portfolio/add" の form タグ)
         m = re.search(r'<form[^>]*action="/portfolio/add"[^>]*>(.*?)</form>', html, re.DOTALL)
@@ -1123,10 +1058,10 @@ class TestDeleteCheckboxScope:
     """削除モードのチェックボックスは 2準/3監 行のみに表示される (codex 指摘 P2)"""
 
     def test_1ho_row_has_no_checkbox_in_mixed_filter(self, client):
-        """status=hold,semi,watch の混在表示で、1保 (3496) 行には checkbox が無く、
-        2準 (7203) と 3監 (6324) 行には checkbox が出る"""
+        """全件表示 (引数なし) で、1保 (3496) 行には checkbox が無く、
+        2準 (7203) と 3監 (6324) 行には checkbox が出る (issue #215 で全件 = 引数なし)"""
         import re
-        resp = client.get("/portfolio?status=hold,semi,watch")
+        resp = client.get("/portfolio")
         html = resp.data.decode()
         # 各銘柄行を抽出 (data-code="XXXX" から次の </tr> まで)
         for code, has_checkbox in [


### PR DESCRIPTION
## Summary

- ページング (50件/page) とソートラジオ (業態順/順位順) を全廃 → 全件表示・業態順固定
- ステータスフィルタを単一選択 select に変更 (「すべて / 保有 / 準保有 / 監視」)
- 業態・テーマ統合 select を追加 (`gyoutai_theme_choices` を流用、フラットな単一選択)
- 業態テーマ指定時は status を無視して全銘柄から該当業態/テーマだけを抽出
- 旧 URL `?status=hold,semi&sort=rank&page=2` は寛容処理 (先頭値採用 + 未知パラメータ silent 無視)

Closes #215

## Test plan

- [x] `pytest tests/test_webapp_portfolio_routes.py tests/test_webapp_helpers.py -x` (248 件パス)
- [x] `/portfolio` 引数なし: 328 件全件・業態順・業態境界線あり (26 本)
- [x] ステータス select で「保有」: 28 件、URL `?status=hold&gyoutai_theme=`
- [x] 業態テーマ select で「AIサービス」(status=hold 設定後): 9 件、status 無視で 1保/2準/3監 混在
- [x] 旧 URL `?status=hold,semi&sort=rank&page=2`: 先頭値 hold のみ採用、sort/page silent 無視
- [x] ページネーション nav が DOM から消えている
- [x] inline 編集 datalist 候補 (26 件) 健在
- [x] return_query に `status=hold` が埋め込まれ、POST 後復元可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)