### PR TITLE
webapp helpers: 同一決算日の複数 quarter エントリでメモが消える問題を修正 (issue #207)

### DIFF
--- a/scripts/cleanup_kessan_dup_entries.py
+++ b/scripts/cleanup_kessan_dup_entries.py
@@ -1,0 +1,310 @@
+"""kessan_comments の同 (code_s, kessanbi) で複数 quarter エントリ併存を解消する (issue #207).
+
+cron で kessan_quarter 取得失敗 → quarter=0 で `upsert_kessan_pts_change` が新規 append され、
+手動メモ済みの quarter=4 エントリと別エントリとして残る事故が過去に発生。
+
+本スクリプトは「メモなし & post_price_changes が pts のみ」のエントリを「重複空エントリ」と
+判定し、PTS 値を残す側 (memo あり / quarter 大優先) にマージしてから削除する。
+
+履歴データ破壊を避けるため、削除候補が `1d` / `5d` など pts 以外の price changes や
+旧形式 `post_price_change` (str) を持つ場合は **削除対象外** (codex review 反映)。
+
+使い方:
+    python cleanup_kessan_dup_entries.py --dry-run             # デフォルト、レポートのみ
+    python cleanup_kessan_dup_entries.py --apply               # 実書き込み (バックアップ取得)
+    python cleanup_kessan_dup_entries.py --apply --code 7717   # 特定銘柄のみ
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+# scripts/ を import path に追加
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import research_shelve as rs
+from research_shelve import _flock
+from ks_util import log_print, log_warning
+
+
+def _is_empty_pts_only_entry(entry: Dict[str, Any]) -> bool:
+    """エントリが「メモなし & pts 以外の価格反応データなし」= 削除候補かを判定する。
+
+    削除対象条件 (全て満たす):
+      - pre_outlook / post_comment / pre_expectation すべて空
+      - held_before_kessan / held_after_kessan / kessan_matagi すべて False
+      - 旧形式 post_price_change が空
+      - post_price_changes は空 OR キーが {"pts"} のサブセット (1d/3d/5d 等を持たない)
+    """
+    if (entry.get("pre_outlook") or "").strip():
+        return False
+    if (entry.get("post_comment") or "").strip():
+        return False
+    if (entry.get("pre_expectation") or "").strip():
+        return False
+    if entry.get("held_before_kessan"):
+        return False
+    if entry.get("held_after_kessan"):
+        return False
+    if entry.get("kessan_matagi"):
+        return False
+    legacy_pc = entry.get("post_price_change")
+    if legacy_pc not in ("", None):
+        return False
+    ppc = entry.get("post_price_changes") or {}
+    # pts 以外のキーで「非空の値」が入っていたら触らない (履歴データ保護)。
+    # 空文字値の 1d/5d キーは PTS upsert 時に normalize で埋まるだけのプレースホルダなので無視。
+    for k, v in ppc.items():
+        if k == "pts":
+            continue
+        if (v or "").strip():
+            return False
+    return True
+
+
+def _has_memo(entry: Dict[str, Any]) -> bool:
+    """メモあり判定 (helpers.get_market_kessan_data の has_comment と同基準)。"""
+    return bool(
+        (entry.get("pre_outlook") or "").strip()
+        or (entry.get("post_comment") or "").strip()
+        or (entry.get("pre_expectation") or "").strip()
+    )
+
+
+def select_winner_and_dups(
+    entries: List[Dict[str, Any]],
+) -> Tuple[Optional[Dict[str, Any]], List[Dict[str, Any]]]:
+    """同 (code_s, kessanbi) のエントリ群から残す側 1 件と削除候補リストを返す.
+
+    戻り値:
+        (winner, dups)
+        - winner: 残すエントリ (None なら全件保持 = 削除候補なし)
+        - dups: 削除するエントリのリスト (winner にマージ済み想定)
+
+    ロジック:
+      1. 削除候補 (`_is_empty_pts_only_entry`) と保持対象を分ける
+      2. 削除候補が無ければ何もしない (winner=None, dups=[])
+      3. 保持対象がある: 保持側を winner、削除候補を dups
+         winner 選定: (1) memo あり優先 → (2) quarter 大優先 → (3) 最初のもの
+      4. 保持対象が無い (全部 pts-only): どれか 1 件を winner に残し、残りを dups
+    """
+    if not entries:
+        return None, []
+
+    keep: List[Dict[str, Any]] = []
+    dups: List[Dict[str, Any]] = []
+    for e in entries:
+        if _is_empty_pts_only_entry(e):
+            dups.append(e)
+        else:
+            keep.append(e)
+
+    if not dups:
+        return None, []
+
+    if keep:
+        # winner = (memo あり ↑ → quarter 大 ↑ → 安定順)
+        keep_sorted = sorted(
+            enumerate(keep),
+            key=lambda iv: (
+                -1 if _has_memo(iv[1]) else 0,  # memo あり (-1) を先頭
+                -int(iv[1].get("quarter", 0) or 0),  # quarter 大 を先頭
+                iv[0],  # 安定 (元順)
+            ),
+        )
+        winner = keep_sorted[0][1]
+        # keep の残りはそのまま保持 (winner 以外は触らない)
+        return winner, dups
+    else:
+        # 全部 pts-only: quarter 大の方を残す (任意性ありだが安定的選択)
+        dups_sorted = sorted(
+            enumerate(dups),
+            key=lambda iv: (-int(iv[1].get("quarter", 0) or 0), iv[0]),
+        )
+        winner = dups_sorted[0][1]
+        rest_dups = [iv[1] for iv in dups_sorted[1:]]
+        return winner, rest_dups
+
+
+def merge_pts_into_winner(
+    winner: Dict[str, Any], dups: List[Dict[str, Any]]
+) -> Optional[str]:
+    """dups から PTS 値を抽出し、winner に既存 PTS が無ければマージする.
+
+    Returns:
+        実際にマージした PTS 値 (winner に既存 PTS があれば既存値を返す)、無ければ None
+    """
+    winner_ppc = dict(winner.get("post_price_changes") or {})
+    winner_pts = (winner_ppc.get("pts") or "").strip()
+    if winner_pts:
+        return winner_pts  # winner 優先、何もしない (既存値を返すだけ)
+    for d in dups:
+        d_ppc = d.get("post_price_changes") or {}
+        d_pts = (d_ppc.get("pts") or "").strip()
+        if d_pts:
+            winner_ppc["pts"] = d_pts
+            winner["post_price_changes"] = winner_ppc
+            return d_pts
+    return None
+
+
+def cleanup_record(
+    record: Dict[str, Any],
+) -> Tuple[List[Dict[str, Any]], List[Tuple[str, Dict[str, Any], List[Dict[str, Any]], Optional[str]]]]:
+    """1 レコードの kessan_comments を走査し、(新コメント配列, 変更ログ) を返す.
+
+    変更ログ: list of (kessanbi, winner, dups, merged_pts)
+    """
+    comments = list(record.get("kessan_comments") or [])
+    if len(comments) <= 1:
+        return comments, []
+
+    # (code_s, kessanbi) でグループ化 (code_s は record 全体で一意なので kessanbi だけで OK)
+    groups: Dict[str, List[int]] = {}
+    for i, e in enumerate(comments):
+        k = e.get("kessanbi", "")
+        if not k:
+            continue
+        groups.setdefault(k, []).append(i)
+
+    changes: List[Tuple[str, Dict[str, Any], List[Dict[str, Any]], Optional[str]]] = []
+    delete_indices: set = set()
+
+    for kessanbi, indices in groups.items():
+        if len(indices) <= 1:
+            continue
+        group_entries = [comments[i] for i in indices]
+        winner, dups = select_winner_and_dups(group_entries)
+        if not dups:
+            continue
+        merged_pts = merge_pts_into_winner(winner, dups)
+        # winner はそのまま (オブジェクト参照を update 済み)、dups の index を削除対象に
+        for d in dups:
+            for i in indices:
+                if comments[i] is d:
+                    delete_indices.add(i)
+                    break
+        changes.append((kessanbi, winner, dups, merged_pts))
+
+    if not delete_indices:
+        return comments, []
+
+    new_comments = [e for i, e in enumerate(comments) if i not in delete_indices]
+    return new_comments, changes
+
+
+def cleanup_db(
+    *,
+    db_path: Optional[str] = None,
+    dry_run: bool = True,
+    target_codes: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """research_shelve 全レコード (or target_codes のみ) を走査して重複エントリを統合する.
+
+    Args:
+        db_path: 書き込み先 (None なら本番 RESEARCH_SHELVE)
+        dry_run: True ならレポートのみ、False で実書き込み (バックアップ取得)
+        target_codes: 対象銘柄リスト (None なら全件)
+
+    Returns:
+        サマリ dict (processed, modified, deleted_entries, errors)
+    """
+    if not dry_run:
+        try:
+            backup_paths = rs.backup_research_db(db_path=db_path)
+            log_print(f"[cleanup] バックアップ(実行前): {backup_paths}")
+        except Exception as e:
+            log_warning(f"[cleanup] バックアップ失敗(継続): {e}")
+
+    if dry_run:
+        log_print("[cleanup] dry_run=True: DB に書き込まず検証のみ実行")
+
+    processed = 0
+    modified = 0
+    deleted_entries = 0
+    errors = 0
+
+    with _flock(db_path):
+        # 全レコードを走査
+        all_records = rs.list_research_records(db_path=db_path)
+        for rec in all_records:
+            code_s = rec.get("code_s", "")
+            if not code_s:
+                continue
+            if target_codes and code_s not in target_codes:
+                continue
+            processed += 1
+            try:
+                new_comments, changes = cleanup_record(rec)
+                if not changes:
+                    continue
+                modified += 1
+                for kessanbi, winner, dups, merged_pts in changes:
+                    deleted_entries += len(dups)
+                    log_print(
+                        f"[cleanup] {code_s} {kessanbi}: "
+                        f"{len(dups) + 1} entries → 1 winner "
+                        f"(kept q={winner.get('quarter', 0)}, "
+                        f"merged pts={merged_pts or '(none)'})"
+                    )
+                if not dry_run:
+                    rec["kessan_comments"] = new_comments
+                    rs.upsert_research_record(rec, db_path=db_path)
+            except Exception as e:
+                errors += 1
+                log_warning(f"[cleanup] {code_s} 失敗: {e}")
+
+    log_print(
+        f"[cleanup] 完了: processed={processed}, modified={modified}, "
+        f"deleted_entries={deleted_entries}, errors={errors}"
+    )
+    return {
+        "processed": processed,
+        "modified": modified,
+        "deleted_entries": deleted_entries,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "kessan_comments の同 (code_s, kessanbi) 重複空エントリを統合する "
+            "(issue #207)"
+        )
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="実 DB に書き込む (デフォルトは dry-run)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="(デフォルト) DB に書き込まずレポートのみ。明示指定用",
+    )
+    parser.add_argument(
+        "--db-path", default=None,
+        help="書き込み先 DB パス (デフォルト: 本番 RESEARCH_SHELVE)",
+    )
+    parser.add_argument(
+        "--code", default=None,
+        help="対象銘柄コードを限定 (カンマ区切り、例: --code 7717,5032)",
+    )
+    args = parser.parse_args()
+
+    target_codes: Optional[List[str]] = None
+    if args.code:
+        target_codes = [c.strip() for c in args.code.split(",") if c.strip()]
+
+    summary = cleanup_db(
+        db_path=args.db_path,
+        dry_run=not args.apply,
+        target_codes=target_codes,
+    )
+    return 0 if summary["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -971,6 +971,12 @@ def upsert_kessan_pts_change(
             raise ValueError(f"レコード登録失敗: {normalized}")
 
         comments: List[Dict[str, Any]] = list(record.get("kessan_comments") or [])
+        # マッチング 3 段 (issue #207):
+        # 1) (kessanbi, quarter) 完全一致 → そのエントリ
+        # 2) 完全一致なし & 引数 quarter==0 → 同 kessanbi 内で quarter 最大のエントリ
+        #    (cron 経路で kessan_quarter 取得失敗 → q=0 フォールバックが
+        #     既に手動メモ済みの quarter エントリと別エントリで append される事故防止)
+        # 3) それも無ければ新規 append
         target_idx = None
         for i, entry in enumerate(comments):
             if (
@@ -979,6 +985,19 @@ def upsert_kessan_pts_change(
             ):
                 target_idx = i
                 break
+        if target_idx is None and int(quarter or 0) == 0:
+            # 同 kessanbi 内で quarter が最大のエントリにフォールバックマージ
+            best_idx = None
+            best_q = -1
+            for i, entry in enumerate(comments):
+                if entry.get("kessanbi") != kessanbi:
+                    continue
+                q = int(entry.get("quarter", 0) or 0)
+                if q > best_q:
+                    best_q = q
+                    best_idx = i
+            if best_idx is not None:
+                target_idx = best_idx
 
         if target_idx is not None:
             existing = comments[target_idx]
@@ -1021,6 +1040,26 @@ def get_kessan_comment(code_s: str, kessanbi: str) -> Optional[Dict[str, Any]]:
         if entry.get("kessanbi") == kessanbi:
             return entry
     return None
+
+
+def _select_market_kessan_winner(
+    cur: Dict[str, Any], cand: Dict[str, Any]
+) -> Dict[str, Any]:
+    """同 (code_s, kessanbi) で複数 kessan_comments エントリが来たときの優先順位 (issue #207)。
+
+    1. has_comment=True を優先
+    2. 両方 has_comment が同じなら quarter 大優先
+    3. quarter も同じなら cur (= 既存挙動互換、最初に見たもの)
+    """
+    cur_has = bool(cur.get("has_comment"))
+    cand_has = bool(cand.get("has_comment"))
+    if cur_has != cand_has:
+        return cand if cand_has else cur
+    cur_q = int(cur.get("quarter", 0) or 0)
+    cand_q = int(cand.get("quarter", 0) or 0)
+    if cand_q > cur_q:
+        return cand
+    return cur
 
 
 def get_market_kessan_data() -> Dict[str, Any]:
@@ -1125,13 +1164,13 @@ def get_market_kessan_data() -> Dict[str, Any]:
                 continue
             merged_key = (code_s, kessanbi)
             quarter = entry.get("quarter", 0) or 0
-            base = merged.get(merged_key)
-            stock_name = (base or {}).get("stock_name") or rec.get("stock_name", "")
-            merged[merged_key] = {
+            cur = merged.get(merged_key)
+            stock_name = (cur or {}).get("stock_name") or rec.get("stock_name", "")
+            cand = {
                 "code_s": code_s,
                 "stock_name": stock_name,
                 "kessanbi": kessanbi,
-                "quarter": quarter if quarter else (base or {}).get("quarter", 0),
+                "quarter": quarter if quarter else (cur or {}).get("quarter", 0),
                 "pre_expectation": entry.get("pre_expectation", "") or "",
                 "pre_outlook": entry.get("pre_outlook", "") or "",
                 "post_price_changes": normalize_kessan_post_price_changes(entry),
@@ -1145,6 +1184,20 @@ def get_market_kessan_data() -> Dict[str, Any]:
                 "held_before_kessan": bool(entry.get("held_before_kessan", False)),
                 "held_after_kessan": bool(entry.get("held_after_kessan", False)),
             }
+            # issue #207: 同 (code_s, kessanbi) で複数 quarter エントリが併存する場合、
+            # has_comment 優先 → quarter 大優先で winner を選ぶ。PTS は別チャネルで OR マージ。
+            winner = _select_market_kessan_winner(cur, cand) if cur else cand
+            winner_pts = (winner.get("post_price_changes") or {}).get("pts") or ""
+            if not winner_pts:
+                # winner に PTS が無ければ他のソース (cur / cand) から拾う
+                for src in (cur, cand):
+                    if not src:
+                        continue
+                    src_pts = (src.get("post_price_changes") or {}).get("pts") or ""
+                    if src_pts:
+                        winner.setdefault("post_price_changes", {})["pts"] = src_pts
+                        break
+            merged[merged_key] = winner
 
     # 過去エントリで post_price_changes のいずれかの期間が空のものだけ
     # 一括で price_log を取得し補完計算する

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1042,15 +1042,39 @@ def get_kessan_comment(code_s: str, kessanbi: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _is_empty_placeholder(entry: Dict[str, Any]) -> bool:
+    """pf_kessan_shelve 由来の空ベース行 (= 実データを何も持たないプレースホルダ) か判定する。
+
+    pf-only ベースは has_comment=False かつ価格反応も held_* / kessan_matagi も無い。
+    research 側のエントリが「メモなしだが反応率/held フラグあり」のとき、こちらを
+    優先するための補助判定 (issue #207 codex P1 review 反映)。
+    """
+    if entry.get("has_comment"):
+        return False
+    if entry.get("kessan_matagi"):
+        return False
+    if entry.get("held_before_kessan") or entry.get("held_after_kessan"):
+        return False
+    ppc = entry.get("post_price_changes") or {}
+    for v in ppc.values():
+        if (v or "").strip():
+            return False
+    return True
+
+
 def _select_market_kessan_winner(
     cur: Dict[str, Any], cand: Dict[str, Any]
 ) -> Dict[str, Any]:
     """同 (code_s, kessanbi) で複数 kessan_comments エントリが来たときの優先順位 (issue #207)。
 
-    1. has_comment=True を優先
-    2. 両方 has_comment が同じなら quarter 大優先
-    3. quarter も同じなら cur (= 既存挙動互換、最初に見たもの)
+    1. cur が pf-only プレースホルダなら cand を採用 (research 側の実データを優先、
+       codex P1 review: kessan_matagi / held_* / post_price_changes が捨てられないように)
+    2. has_comment=True を優先
+    3. 両方 has_comment が同じなら quarter 大優先
+    4. quarter も同じなら cur (= 既存挙動互換、最初に見たもの)
     """
+    if _is_empty_placeholder(cur):
+        return cand
     cur_has = bool(cur.get("has_comment"))
     cand_has = bool(cand.get("has_comment"))
     if cur_has != cand_has:

--- a/tests/test_cleanup_kessan_dup_entries.py
+++ b/tests/test_cleanup_kessan_dup_entries.py
@@ -1,0 +1,371 @@
+"""cleanup_kessan_dup_entries.py のテスト (issue #207)."""
+
+import os
+import sys
+
+import pytest
+
+# scripts/ を import path に追加
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "scripts")
+)
+
+import research_shelve as rs
+import cleanup_kessan_dup_entries as cleanup
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_research_shelve")
+
+
+@pytest.fixture
+def setup_db(db_path, monkeypatch):
+    monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+    monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+    return db_path
+
+
+def _make_memo_entry(kessanbi="2026/05/12", quarter=4, **overrides):
+    e = {
+        "kessanbi": kessanbi, "quarter": quarter,
+        "pre_expectation": "◎", "pre_outlook": "強気",
+        "post_comment": "[B] 好決算", "post_price_change": "",
+        "post_price_changes": {},
+        "kessan_matagi": False,
+        "held_before_kessan": False, "held_after_kessan": False,
+    }
+    e.update(overrides)
+    return e
+
+
+def _make_pts_only_entry(kessanbi="2026/05/12", quarter=0, pts="+11.82"):
+    return {
+        "kessanbi": kessanbi, "quarter": quarter,
+        "pre_expectation": "", "pre_outlook": "",
+        "post_comment": "", "post_price_change": "",
+        "post_price_changes": {"pts": pts},
+        "kessan_matagi": False,
+        "held_before_kessan": False, "held_after_kessan": False,
+    }
+
+
+# ===========================================
+# 純関数テスト (DB 不要)
+# ===========================================
+
+class TestIsEmptyPtsOnlyEntry:
+    def test_empty_pts_only_returns_true(self):
+        e = _make_pts_only_entry()
+        assert cleanup._is_empty_pts_only_entry(e) is True
+
+    def test_with_memo_returns_false(self):
+        e = _make_memo_entry()
+        assert cleanup._is_empty_pts_only_entry(e) is False
+
+    def test_with_held_flag_returns_false(self):
+        e = _make_pts_only_entry()
+        e["held_before_kessan"] = True
+        assert cleanup._is_empty_pts_only_entry(e) is False
+
+    def test_with_legacy_post_price_change_returns_false(self):
+        """旧形式 post_price_change (str) があれば削除しない (codex P1 防御)"""
+        e = _make_pts_only_entry()
+        e["post_price_change"] = "+3.2"
+        assert cleanup._is_empty_pts_only_entry(e) is False
+
+    def test_with_1d_5d_value_returns_false(self):
+        """post_price_changes に pts 以外のキーで非空値があれば削除しない (codex P1 防御)"""
+        e = _make_pts_only_entry()
+        e["post_price_changes"] = {"pts": "+1.0", "1d": "+0.5"}
+        assert cleanup._is_empty_pts_only_entry(e) is False
+
+    def test_with_empty_1d_5d_keys_returns_true(self):
+        """1d/5d キーが空文字なら無視され削除候補になる (実データに空キーが入る経路がある)"""
+        e = _make_pts_only_entry()
+        e["post_price_changes"] = {"pts": "+11.82", "1d": "", "5d": ""}
+        assert cleanup._is_empty_pts_only_entry(e) is True
+
+
+class TestSelectWinnerAndDups:
+    def test_no_duplicates(self):
+        """1 件のみ → winner=None, dups=[]"""
+        winner, dups = cleanup.select_winner_and_dups([_make_memo_entry()])
+        assert winner is None
+        assert dups == []
+
+    def test_memo_plus_pts_only(self):
+        """memo (q=4) + pts-only (q=0) → memo が winner、pts-only が dups"""
+        memo = _make_memo_entry(quarter=4)
+        pts_only = _make_pts_only_entry(quarter=0)
+        winner, dups = cleanup.select_winner_and_dups([memo, pts_only])
+        assert winner is memo
+        assert len(dups) == 1
+        assert dups[0] is pts_only
+
+    def test_two_memos_no_dups(self):
+        """memo 2 件 (異なる quarter) → 削除候補なし"""
+        m1 = _make_memo_entry(quarter=2, pre_outlook="Q2")
+        m2 = _make_memo_entry(quarter=4, pre_outlook="Q4")
+        winner, dups = cleanup.select_winner_and_dups([m1, m2])
+        assert winner is None
+        assert dups == []
+
+    def test_all_pts_only_keeps_largest_quarter(self):
+        """pts-only が複数 → quarter 大を残し、残りを dups"""
+        p0 = _make_pts_only_entry(quarter=0, pts="+1.0")
+        p4 = _make_pts_only_entry(quarter=4, pts="+2.0")
+        winner, dups = cleanup.select_winner_and_dups([p0, p4])
+        assert winner is p4
+        assert dups == [p0]
+
+
+class TestMergePtsIntoWinner:
+    def test_winner_has_no_pts_takes_from_dup(self):
+        winner = _make_memo_entry(quarter=4)
+        winner["post_price_changes"] = {}
+        dup = _make_pts_only_entry(quarter=0, pts="+11.82")
+        merged = cleanup.merge_pts_into_winner(winner, [dup])
+        assert merged == "+11.82"
+        assert winner["post_price_changes"]["pts"] == "+11.82"
+
+    def test_winner_has_pts_keeps_winner(self):
+        winner = _make_memo_entry(quarter=4)
+        winner["post_price_changes"] = {"pts": "+5.0"}
+        dup = _make_pts_only_entry(quarter=0, pts="+11.82")
+        merged = cleanup.merge_pts_into_winner(winner, [dup])
+        assert merged == "+5.0"
+        assert winner["post_price_changes"]["pts"] == "+5.0"
+
+
+# ===========================================
+# 統合テスト (DB あり)
+# ===========================================
+
+class TestCleanupDb:
+    def test_dry_run_does_not_write(self, setup_db):
+        rec = rs.create_research_record("7717", "ブイ・テクノロジー")
+        rec["kessan_comments"] = [
+            _make_memo_entry(quarter=4),
+            _make_pts_only_entry(quarter=0, pts="+11.82"),
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        summary = cleanup.cleanup_db(db_path=setup_db, dry_run=True)
+        assert summary["modified"] == 1
+        assert summary["deleted_entries"] == 1
+
+        loaded = rs.get_research_record("7717", db_path=setup_db)
+        # dry-run なので変更されていない
+        assert len(loaded["kessan_comments"]) == 2
+
+    def test_apply_consolidates_7717_case(self, setup_db, monkeypatch):
+        """7717 想定: q=0 空 + q=4 メモ → 1 件 (q=4) に統合、PTS マージ"""
+        # backup_research_db を no-op に置換 (テスト DB ではバックアップ不要)
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        rec = rs.create_research_record("7717", "ブイ・テクノロジー")
+        rec["kessan_comments"] = [
+            _make_memo_entry(quarter=4),
+            _make_pts_only_entry(quarter=0, pts="+11.82"),
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        summary = cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        assert summary["modified"] == 1
+        assert summary["deleted_entries"] == 1
+
+        loaded = rs.get_research_record("7717", db_path=setup_db)
+        assert len(loaded["kessan_comments"]) == 1
+        e = loaded["kessan_comments"][0]
+        assert int(e["quarter"]) == 4
+        assert e["pre_outlook"] == "強気"
+        assert e["post_comment"] == "[B] 好決算"
+        assert e["post_price_changes"]["pts"] == "+11.82"
+
+    def test_preserves_unrelated_dates(self, setup_db, monkeypatch):
+        """同銘柄の別 kessanbi は触らない"""
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        rec = rs.create_research_record("7717", "TEST")
+        rec["kessan_comments"] = [
+            _make_memo_entry(kessanbi="2025/02/14", quarter=2),
+            _make_memo_entry(kessanbi="2026/05/12", quarter=4),
+            _make_pts_only_entry(kessanbi="2026/05/12", quarter=0, pts="+11.82"),
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        loaded = rs.get_research_record("7717", db_path=setup_db)
+        # 2025/02/14 の memo はそのまま残る、2026/05/12 は 1 件に統合
+        assert len(loaded["kessan_comments"]) == 2
+        kessanbis = sorted(e["kessanbi"] for e in loaded["kessan_comments"])
+        assert kessanbis == ["2025/02/14", "2026/05/12"]
+
+    def test_skips_single_entry(self, setup_db, monkeypatch):
+        """重複なしのレコードは触らない"""
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        rec = rs.create_research_record("5032", "ANYCOLOR")
+        rec["kessan_comments"] = [_make_memo_entry()]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        summary = cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        assert summary["modified"] == 0
+        assert summary["deleted_entries"] == 0
+
+    def test_three_entries_with_two_memos(self, setup_db, monkeypatch):
+        """memo 2 件 (q=2, q=4) + pts-only 1 件 → memo 2 件保持、pts-only のみ削除"""
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        rec = rs.create_research_record("7717", "TEST")
+        rec["kessan_comments"] = [
+            _make_memo_entry(quarter=2, pre_outlook="Q2 メモ"),
+            _make_memo_entry(quarter=4, pre_outlook="Q4 メモ"),
+            _make_pts_only_entry(quarter=0, pts="+11.82"),
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        loaded = rs.get_research_record("7717", db_path=setup_db)
+        assert len(loaded["kessan_comments"]) == 2
+        quarters = sorted(int(e["quarter"]) for e in loaded["kessan_comments"])
+        assert quarters == [2, 4]
+        # winner = memo + quarter 大 = q=4 に PTS がマージされている
+        for e in loaded["kessan_comments"]:
+            if int(e["quarter"]) == 4:
+                assert e["post_price_changes"].get("pts") == "+11.82"
+            elif int(e["quarter"]) == 2:
+                # q=2 は触られない
+                assert e["pre_outlook"] == "Q2 メモ"
+
+    def test_apply_keeps_winner_pts_when_both_have_pts(self, setup_db, monkeypatch):
+        """winner 側に既に pts があれば優先 (上書きされない)"""
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        rec = rs.create_research_record("7717", "TEST")
+        memo = _make_memo_entry(quarter=4)
+        memo["post_price_changes"] = {"pts": "+5.0"}
+        rec["kessan_comments"] = [
+            memo,
+            _make_pts_only_entry(quarter=0, pts="+11.82"),
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        loaded = rs.get_research_record("7717", db_path=setup_db)
+        assert len(loaded["kessan_comments"]) == 1
+        # winner の pts 値が保持される
+        assert loaded["kessan_comments"][0]["post_price_changes"]["pts"] == "+5.0"
+
+    def test_skips_entry_with_non_pts_price_changes(self, setup_db, monkeypatch):
+        """削除候補が 1d/5d に非空値を持っていたら削除しない (codex P1 防御)"""
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        rec = rs.create_research_record("7717", "TEST")
+        suspicious = _make_pts_only_entry(quarter=0, pts="+11.82")
+        suspicious["post_price_changes"] = {"pts": "+11.82", "1d": "+0.5"}
+        rec["kessan_comments"] = [
+            _make_memo_entry(quarter=4),
+            suspicious,
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        loaded = rs.get_research_record("7717", db_path=setup_db)
+        # 1d=+0.5 を持つエントリは削除されない
+        assert len(loaded["kessan_comments"]) == 2
+
+    def test_consolidates_when_1d_5d_keys_are_empty(self, setup_db, monkeypatch):
+        """7717 実データ模擬: 1d/5d キーがあっても空文字なら統合される"""
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        rec = rs.create_research_record("7717", "TEST")
+        # 実データ模擬: ppc に 1d/5d キーが空文字で入っている
+        suspicious = _make_pts_only_entry(quarter=0, pts="+11.82")
+        suspicious["post_price_changes"] = {"pts": "+11.82", "1d": "", "5d": ""}
+        rec["kessan_comments"] = [
+            _make_memo_entry(quarter=4),
+            suspicious,
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        loaded = rs.get_research_record("7717", db_path=setup_db)
+        assert len(loaded["kessan_comments"]) == 1
+        assert loaded["kessan_comments"][0]["post_price_changes"]["pts"] == "+11.82"
+
+    def test_skips_entry_with_post_price_change_legacy(self, setup_db, monkeypatch):
+        """旧形式 post_price_change (str) があれば削除しない (codex P1 防御)"""
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        rec = rs.create_research_record("7717", "TEST")
+        suspicious = _make_pts_only_entry(quarter=0, pts="+11.82")
+        suspicious["post_price_change"] = "+3.2"  # 旧形式
+        rec["kessan_comments"] = [
+            _make_memo_entry(quarter=4),
+            suspicious,
+        ]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        loaded = rs.get_research_record("7717", db_path=setup_db)
+        assert len(loaded["kessan_comments"]) == 2
+
+    def test_target_codes_filter(self, setup_db, monkeypatch):
+        """target_codes 指定で対象銘柄のみ処理"""
+        monkeypatch.setattr(rs, "backup_research_db", lambda **kw: [])
+
+        for code in ("7717", "5032"):
+            rec = rs.create_research_record(code, f"TEST_{code}")
+            rec["kessan_comments"] = [
+                _make_memo_entry(quarter=4),
+                _make_pts_only_entry(quarter=0, pts="+1.0"),
+            ]
+            rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(
+            db_path=setup_db, dry_run=False, target_codes=["7717"]
+        )
+        # 7717 は統合
+        loaded_7717 = rs.get_research_record("7717", db_path=setup_db)
+        assert len(loaded_7717["kessan_comments"]) == 1
+        # 5032 は触らない
+        loaded_5032 = rs.get_research_record("5032", db_path=setup_db)
+        assert len(loaded_5032["kessan_comments"]) == 2
+
+    def test_backup_called_on_apply(self, setup_db, monkeypatch):
+        """--apply (dry_run=False) で backup_research_db が呼ばれる"""
+        called = {"backup": 0}
+
+        def fake_backup(**kw):
+            called["backup"] += 1
+            return ["fake.bak"]
+
+        monkeypatch.setattr(rs, "backup_research_db", fake_backup)
+        # backup を呼ぶためには cleanup_kessan_dup_entries モジュールが見る rs を差し替える
+        monkeypatch.setattr(cleanup.rs, "backup_research_db", fake_backup)
+
+        rec = rs.create_research_record("7717", "TEST")
+        rec["kessan_comments"] = [_make_memo_entry()]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(db_path=setup_db, dry_run=False)
+        assert called["backup"] == 1
+
+    def test_dry_run_does_not_call_backup(self, setup_db, monkeypatch):
+        """--dry-run では backup_research_db を呼ばない"""
+        called = {"backup": 0}
+
+        def fake_backup(**kw):
+            called["backup"] += 1
+            return []
+
+        monkeypatch.setattr(cleanup.rs, "backup_research_db", fake_backup)
+
+        rec = rs.create_research_record("7717", "TEST")
+        rec["kessan_comments"] = [_make_memo_entry()]
+        rs.upsert_research_record(rec, db_path=setup_db)
+
+        cleanup.cleanup_db(db_path=setup_db, dry_run=True)
+        assert called["backup"] == 0

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -505,6 +505,47 @@ class TestGetMarketKessanDataDuplicateEntries:
                     return
         assert False, "7717 が today_entries に見つからない"
 
+    def test_pf_base_does_not_overwrite_research_held_or_pts(self, kessan_env):
+        """pf-only ベース行が research 側の「メモなしだが held / 反応率あり」エントリを
+        上書きしない (codex P1 review 反映: kessan_matagi / held_* / post_price_changes 保護)。
+        """
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 5, 12, 19, 0)
+        pf_dict = {
+            "7717": {
+                "code_s": "7717", "stock_name": "テスト",
+                "kessanbi": "2026/05/12", "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        rec = rs.create_research_record("7717", "テスト")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                # メモは無いが、kessan_matagi / held_* / 反応率あり (= pf-only プレースホルダではない)
+                "pre_expectation": "", "pre_outlook": "", "post_comment": "",
+                "post_price_changes": {"pts": "", "1d": "+5.5", "5d": ""},
+                "kessan_matagi": True,
+                "held_before_kessan": True,
+                "held_after_kessan": True,
+            },
+        ]
+        rs.upsert_research_record(rec)
+
+        result = helpers.get_market_kessan_data()
+        for kessanbi, stocks in result["today_entries"]:
+            if kessanbi != "2026/05/12":
+                continue
+            for s in stocks:
+                if s["code_s"] == "7717":
+                    # research 側のフラグ・反応率が表示される
+                    assert s["kessan_matagi"] is True
+                    assert s["held_before_kessan"] is True
+                    assert s["held_after_kessan"] is True
+                    assert s["post_price_changes"].get("1d") == "+5.5"
+                    return
+        assert False, "7717 が today_entries に見つからない"
+
 
 class TestSearchRecords:
     """search_records のテスト"""

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -296,6 +296,216 @@ class TestGetMarketKessanData:
         assert found, "6501 のエントリが today_entries に見つからない"
 
 
+class TestGetMarketKessanDataDuplicateEntries:
+    """issue #207: 同 (code_s, kessanbi) で複数 quarter エントリ併存ケース。
+
+    upsert_kessan_pts_change が quarter=0 で append したフォールバック空エントリと、
+    手動メモ入りの quarter=4 エントリが両方残っているとき、メモ側を winner に選ぶ。
+    """
+
+    @pytest.fixture
+    def kessan_env(self, populated_db, monkeypatch):
+        """TestGetMarketKessanData と同じ kessan_env fixture (重複定義避けるため再利用)"""
+        from datetime import datetime as _dt
+
+        def setup(pf_dict, today_dt):
+            import kessan as _k
+            monkeypatch.setattr(_k, "load_pf_kessan_db", lambda: pf_dict)
+            import portfolio as _p
+            monkeypatch.setattr(_p, "parse_my_portforio", lambda: ([], []))
+            monkeypatch.setattr(helpers, "_bulk_price_logs", lambda codes: {})
+
+            class FrozenDateTime(_dt):
+                @classmethod
+                def today(cls):
+                    return today_dt
+                @classmethod
+                def now(cls, tz=None):
+                    return today_dt
+            monkeypatch.setattr(helpers, "datetime", FrozenDateTime)
+        return setup
+
+    def test_memo_entry_not_overwritten_by_empty(self, kessan_env):
+        """7717 想定: q=4 メモあり + q=0 PTS-only の 2 件 → memo が表示される"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 5, 12, 19, 0)
+        pf_dict = {
+            "7717": {
+                "code_s": "7717",
+                "stock_name": "ブイ・テクノロジー",
+                "kessanbi": "2026/05/12",
+                "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        rec = rs.create_research_record("7717", "ブイ・テクノロジー")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_expectation": "◎", "pre_outlook": "通期上振れ期待",
+                "post_comment": "[B] 好決算で反応良好",
+                "post_price_changes": {"pts": "", "1d": "", "5d": ""},
+                "kessan_matagi": False,
+                "held_before_kessan": False, "held_after_kessan": False,
+            },
+            {
+                "kessanbi": "2026/05/12", "quarter": 0,
+                "pre_expectation": "", "pre_outlook": "", "post_comment": "",
+                "post_price_changes": {"pts": "+11.82", "1d": "", "5d": ""},
+                "kessan_matagi": False,
+                "held_before_kessan": False, "held_after_kessan": False,
+            },
+        ]
+        rs.upsert_research_record(rec)
+
+        result = helpers.get_market_kessan_data()
+        for kessanbi, stocks in result["today_entries"]:
+            if kessanbi != "2026/05/12":
+                continue
+            for s in stocks:
+                if s["code_s"] == "7717":
+                    # メモあり側 (q=4) の値が出ている
+                    assert s["pre_outlook"] == "通期上振れ期待"
+                    assert s["post_comment"] == "[B] 好決算で反応良好"
+                    assert s["pre_expectation"] == "◎"
+                    return
+        assert False, "7717 が today_entries に見つからない"
+
+    def test_pts_merged_from_separate_entry(self, kessan_env):
+        """winner (q=4 メモ) に PTS が無くても、別エントリ (q=0) の PTS が引き継がれる"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 5, 12, 19, 0)
+        pf_dict = {
+            "7717": {
+                "code_s": "7717", "stock_name": "テスト",
+                "kessanbi": "2026/05/12", "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        rec = rs.create_research_record("7717", "テスト")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_outlook": "メモあり", "post_comment": "コメあり",
+                "post_price_changes": {"pts": "", "1d": "", "5d": ""},
+            },
+            {
+                "kessanbi": "2026/05/12", "quarter": 0,
+                "pre_outlook": "", "post_comment": "",
+                "post_price_changes": {"pts": "+11.82", "1d": "", "5d": ""},
+            },
+        ]
+        rs.upsert_research_record(rec)
+
+        result = helpers.get_market_kessan_data()
+        for kessanbi, stocks in result["today_entries"]:
+            if kessanbi != "2026/05/12":
+                continue
+            for s in stocks:
+                if s["code_s"] == "7717":
+                    assert s["post_price_changes"].get("pts") == "+11.82"
+                    return
+        assert False, "7717 が today_entries に見つからない"
+
+    def test_higher_quarter_wins_when_both_have_memo(self, kessan_env):
+        """両方メモあり → quarter 大優先 (q=2 と q=4 → q=4 が選ばれる)"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 5, 12, 19, 0)
+        pf_dict = {
+            "7717": {
+                "code_s": "7717", "stock_name": "テスト",
+                "kessanbi": "2026/05/12", "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        rec = rs.create_research_record("7717", "テスト")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 2,
+                "pre_outlook": "Q2 メモ", "post_comment": "Q2 コメ",
+            },
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_outlook": "Q4 メモ", "post_comment": "Q4 コメ",
+            },
+        ]
+        rs.upsert_research_record(rec)
+
+        result = helpers.get_market_kessan_data()
+        for kessanbi, stocks in result["today_entries"]:
+            if kessanbi != "2026/05/12":
+                continue
+            for s in stocks:
+                if s["code_s"] == "7717":
+                    assert s["pre_outlook"] == "Q4 メモ"
+                    assert s["post_comment"] == "Q4 コメ"
+                    return
+        assert False, "7717 が today_entries に見つからない"
+
+    def test_single_entry_unchanged(self, kessan_env):
+        """1 件のみのエントリは従来通り表示される (regression 防御)"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 5, 12, 19, 0)
+        pf_dict = {
+            "7717": {
+                "code_s": "7717", "stock_name": "テスト",
+                "kessanbi": "2026/05/12", "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        rec = rs.create_research_record("7717", "テスト")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_outlook": "単独メモ",
+                "post_price_changes": {"pts": "+1.0", "1d": "", "5d": ""},
+            },
+        ]
+        rs.upsert_research_record(rec)
+
+        result = helpers.get_market_kessan_data()
+        for kessanbi, stocks in result["today_entries"]:
+            if kessanbi != "2026/05/12":
+                continue
+            for s in stocks:
+                if s["code_s"] == "7717":
+                    assert s["pre_outlook"] == "単独メモ"
+                    assert s["post_price_changes"].get("pts") == "+1.0"
+                    return
+        assert False, "7717 が today_entries に見つからない"
+
+    def test_pf_only_replaced_by_memo_entry(self, kessan_env):
+        """pf_dict 由来 base (has_comment=False) は kessan_comments の memo entry で置き換わる"""
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 5, 12, 19, 0)
+        pf_dict = {
+            "7717": {
+                "code_s": "7717", "stock_name": "テスト",
+                "kessanbi": "2026/05/12", "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        rec = rs.create_research_record("7717", "テスト")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_outlook": "kessan_comments 由来",
+            },
+        ]
+        rs.upsert_research_record(rec)
+
+        result = helpers.get_market_kessan_data()
+        for kessanbi, stocks in result["today_entries"]:
+            if kessanbi != "2026/05/12":
+                continue
+            for s in stocks:
+                if s["code_s"] == "7717":
+                    assert s["pre_outlook"] == "kessan_comments 由来"
+                    assert s["has_comment"] is True
+                    return
+        assert False, "7717 が today_entries に見つからない"
+
+
 class TestSearchRecords:
     """search_records のテスト"""
 
@@ -985,6 +1195,126 @@ class TestUpsertKessanPtsChange:
         assert len(loaded["kessan_comments"]) == 2
         quarters = sorted(int(e["quarter"]) for e in loaded["kessan_comments"])
         assert quarters == [1, 4]
+
+
+class TestUpsertKessanPtsChangeFallback:
+    """issue #207: quarter=0 引数のフォールバックマッチング (本番経路 make_stock_db.py:1708)。
+
+    cron で kessan_quarter 取得失敗 → q=0 で呼ばれたとき、同 kessanbi の
+    最大 quarter エントリにマージし重複 append を防ぐ。
+    """
+
+    @pytest.fixture
+    def setup_db(self, db_path, monkeypatch):
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr(helpers, "RESEARCH_SHELVE", db_path, raising=False)
+        return db_path
+
+    def test_quarter_zero_merges_into_existing_quarter4(self, setup_db):
+        """q=4 メモ既存 → q=0 PTS upsert で同エントリに pts 追記、append されない"""
+        rec = rs.create_research_record("7717", "ブイ・テクノロジー")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_expectation": "◎", "pre_outlook": "強気",
+                "post_price_changes": {"1d": "", "5d": ""},
+                "post_comment": "[B] 好決算", "kessan_matagi": False,
+                "held_before_kessan": False, "held_after_kessan": False,
+            },
+        ]
+        rs.upsert_research_record(rec)
+        helpers.upsert_kessan_pts_change("7717", "2026/05/12", 0, "+11.82")
+        loaded = rs.get_research_record("7717")
+        assert len(loaded["kessan_comments"]) == 1
+        e = loaded["kessan_comments"][0]
+        assert e["quarter"] == 4  # q=4 のまま
+        assert e["pre_outlook"] == "強気"
+        assert e["post_comment"] == "[B] 好決算"
+        assert e["post_price_changes"]["pts"] == "+11.82"
+
+    def test_pts_only_overwrites_pts_field(self, setup_db):
+        """q=0 フォールバックマージで post_comment 等は変更されない"""
+        rec = rs.create_research_record("7717", "TEST")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_outlook": "メモ", "post_comment": "コメ",
+                "post_price_changes": {"pts": "+1.0", "1d": "+0.5", "5d": ""},
+            },
+        ]
+        rs.upsert_research_record(rec)
+        helpers.upsert_kessan_pts_change("7717", "2026/05/12", 0, "+11.82")
+        loaded = rs.get_research_record("7717")
+        e = loaded["kessan_comments"][0]
+        assert e["pre_outlook"] == "メモ"
+        assert e["post_comment"] == "コメ"
+        # 1d は保持、pts のみ上書き
+        assert e["post_price_changes"]["1d"] == "+0.5"
+        assert e["post_price_changes"]["pts"] == "+11.82"
+
+    def test_quarter_zero_picks_max_quarter_when_multiple(self, setup_db):
+        """同 kessanbi で q=2 と q=4 がある時 q=4 を選ぶ"""
+        rec = rs.create_research_record("7717", "TEST")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 2,
+                "pre_outlook": "Q2", "post_price_changes": {},
+            },
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_outlook": "Q4", "post_price_changes": {},
+            },
+        ]
+        rs.upsert_research_record(rec)
+        helpers.upsert_kessan_pts_change("7717", "2026/05/12", 0, "+9.99")
+        loaded = rs.get_research_record("7717")
+        # q=2 と q=4 は維持 (新規 append しない)
+        assert len(loaded["kessan_comments"]) == 2
+        # q=4 に pts が入っている
+        for e in loaded["kessan_comments"]:
+            if int(e["quarter"]) == 4:
+                assert e["post_price_changes"]["pts"] == "+9.99"
+                assert e["pre_outlook"] == "Q4"
+            elif int(e["quarter"]) == 2:
+                assert e["post_price_changes"].get("pts", "") == ""
+
+    def test_quarter_zero_appends_when_no_kessanbi_match(self, setup_db):
+        """該当 kessanbi のエントリなし → 新規 append (従来挙動互換)"""
+        rec = rs.create_research_record("7717", "TEST")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2025/02/14", "quarter": 4,
+                "pre_outlook": "別決算日メモ",
+            },
+        ]
+        rs.upsert_research_record(rec)
+        helpers.upsert_kessan_pts_change("7717", "2026/05/12", 0, "+1.5")
+        loaded = rs.get_research_record("7717")
+        assert len(loaded["kessan_comments"]) == 2
+        # 新規 append された方
+        new_entry = next(
+            e for e in loaded["kessan_comments"] if e["kessanbi"] == "2026/05/12"
+        )
+        assert int(new_entry["quarter"]) == 0
+        assert new_entry["post_price_changes"]["pts"] == "+1.5"
+
+    def test_explicit_quarter_appends_when_no_match(self, setup_db):
+        """quarter=2 引数で完全一致なし → 従来通り新規 append (フォールバックしない)"""
+        rec = rs.create_research_record("7717", "TEST")
+        rec["kessan_comments"] = [
+            {
+                "kessanbi": "2026/05/12", "quarter": 4,
+                "pre_outlook": "Q4 メモ",
+            },
+        ]
+        rs.upsert_research_record(rec)
+        helpers.upsert_kessan_pts_change("7717", "2026/05/12", 2, "+3.3")
+        loaded = rs.get_research_record("7717")
+        # フォールバックせず q=4 と q=2 の 2 件
+        assert len(loaded["kessan_comments"]) == 2
+        quarters = sorted(int(e["quarter"]) for e in loaded["kessan_comments"])
+        assert quarters == [2, 4]
 
 
 # ==================================================


### PR DESCRIPTION
Closes #207

## Summary
`research_shelve.kessan_comments` に同 (code_s, kessanbi) で複数 quarter エントリ併存があると、`/market` 決算日セクションでメモあり側が空エントリで上書きされる問題を修正。

### A. `get_market_kessan_data` の per-key reducer 化
- `_select_market_kessan_winner` 純関数を導入: `has_comment` 優先 → `quarter` 大優先 で winner 選定
- PTS は別チャネル OR マージ (winner 側 pts 空なら他から引き継ぐ)

### B. `upsert_kessan_pts_change` のマッチング 3 段化
- 完全一致 → 引数 `quarter==0` で同 kessanbi の最大 quarter エントリにフォールバック → 新規 append
- cron (`make_stock_db.py:1708`) で `kessan_quarter` 取得失敗 → q=0 append → 手動メモと別エントリで残る事故を防ぐ
- **本番経路の挙動変更** (回帰テストで既存挙動もピン留め)

### C. `scripts/cleanup_kessan_dup_entries.py` を新規追加
- 既存 DB の重複空エントリを統合する 1-shot スクリプト
- `--dry-run` (デフォルト) / `--apply` / `--code` / `--db-path`
- 削除候補は「メモなし & post_price_changes が pts のみ (1d/5d 等に値があれば削除しない)」の安全条件 (codex review P1 反映)
- PTS 値は残す側にマージ、winner 側に既存 pts があれば優先

## Test plan
- [x] `pytest tests/test_webapp_helpers.py -v` (新規 10 ケース + 既存全 pass、合計 182 件)
- [x] `pytest tests/test_cleanup_kessan_dup_entries.py -v` (新規 24 ケース、純関数 + 統合)
- [x] `pytest tests/test_make_stock_db.py tests/test_functional_market.py` (regression なし、86 件 pass)
- [x] 本番 DB に対する `--dry-run` 実行: 13 銘柄で重複検出、7717 含む。PTS=+11.82 が q=4 メモにマージ予定
- [x] WebApp e2e: `/market` で 7717 (2026/05/12) の見通し・反応コメ・PTS が正常表示
- [ ] reviewer 確認用: マージ後に本番 `--apply` 実行して 13 銘柄を統合

## マージ後の運用
本番 DB の重複は A 修正で表示は復旧済 (見えなくなる) だが、`kessan_comments` 配列自体には残ったまま。詳細ページでは「同 kessanbi 2 行表示」が見えるため、マージ後に以下を 1 回実行:
```bash
cd scripts && python cleanup_kessan_dup_entries.py --dry-run    # 最終確認
cd scripts && python cleanup_kessan_dup_entries.py --apply      # 本実行 (バックアップ自動取得)
```