### PR TITLE
feat: 銘柄詳細ページに「再取得」ボタンを追加 (issue #203)

### DIFF
--- a/scripts/webapp/__init__.py
+++ b/scripts/webapp/__init__.py
@@ -23,6 +23,7 @@ def create_app() -> Flask:
     from webapp.routes.search import search_bp
     from webapp.routes.detail import detail_bp
     from webapp.routes.memo import memo_bp
+    from webapp.routes.refresh import refresh_bp
     from webapp.routes.market import market_bp
     from webapp.routes.disclosure import disclosure_bp
     from webapp.routes.portfolio import portfolio_bp
@@ -30,6 +31,7 @@ def create_app() -> Flask:
     app.register_blueprint(search_bp)
     app.register_blueprint(detail_bp)
     app.register_blueprint(memo_bp)
+    app.register_blueprint(refresh_bp)
     app.register_blueprint(market_bp)
     app.register_blueprint(disclosure_bp)
     app.register_blueprint(portfolio_bp)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1334,9 +1334,9 @@ def get_market_kessan_data() -> Dict[str, Any]:
         reverse=True,
     )
     # 過去7日間は常時表示、それ以前は details で折りたたみ
-    # 30日より前の決算は表示しない (履歴が貯まり続けるとDOM/メモリが肥大化するため)
+    # 90日 (約1四半期) より前の決算は表示しない (履歴が貯まり続けるとDOM/メモリが肥大化するため)
     recent_cutoff = base_day - timedelta(days=7)
-    older_cutoff = base_day - timedelta(days=30)
+    older_cutoff = base_day - timedelta(days=90)
     recent_past_entries: List = []
     older_past_entries: List = []
     for kv in past_entries_all:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1352,7 +1352,10 @@ def get_market_kessan_data() -> Dict[str, Any]:
         "base_day": base_day,
         "future_entries": future_entries,
         "today_entries": today_entries,
-        "past_entries": past_entries_all,  # 後方互換
+        # 後方互換: 90日カットオフ後の全過去エントリ (空状態判定で使うため
+        # recent + older を合成。past_entries_all をそのまま返すと、90日超
+        # しか無いケースで空状態メッセージが出ず画面が空白になる)
+        "past_entries": recent_past_entries + older_past_entries,
         "recent_past_entries": recent_past_entries,
         "older_past_entries": older_past_entries,
     }

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1334,11 +1334,15 @@ def get_market_kessan_data() -> Dict[str, Any]:
         reverse=True,
     )
     # 過去7日間は常時表示、それ以前は details で折りたたみ
+    # 30日より前の決算は表示しない (履歴が貯まり続けるとDOM/メモリが肥大化するため)
     recent_cutoff = base_day - timedelta(days=7)
+    older_cutoff = base_day - timedelta(days=30)
     recent_past_entries: List = []
     older_past_entries: List = []
     for kv in past_entries_all:
         dt = _parse_kessanbi(kv[0]) or date.min
+        if dt < older_cutoff:
+            continue
         if dt >= recent_cutoff:
             recent_past_entries.append(kv)
         else:

--- a/scripts/webapp/routes/refresh.py
+++ b/scripts/webapp/routes/refresh.py
@@ -1,0 +1,24 @@
+"""
+銘柄データ再取得ルート。
+
+POST /stock/<code_s>/refresh : make_stock_db.refresh_stock([code_s]) を同期実行
+"""
+
+from flask import Blueprint, flash, redirect, url_for
+
+refresh_bp = Blueprint("refresh", __name__)
+
+
+@refresh_bp.route("/stock/<code_s>/refresh", methods=["POST"])
+def post_refresh(code_s: str):
+    """master/price/shihyo/gyoseki/rironkabuka + research_shelve を強制再取得して flash 後にリダイレクト。"""
+    try:
+        # make_stock_db は scipy/yfinance 等の重依存を持つため、WebApp 起動時に
+        # 巻き添えで落ちないようルート呼び出し時に遅延 import する
+        from make_stock_db import refresh_stock
+
+        refresh_stock([code_s])
+        flash(f"再取得しました ({code_s})", "info")
+    except Exception as e:
+        flash(f"再取得に失敗しました ({code_s}): {e}", "error")
+    return redirect(url_for("detail.stock_detail", code_s=code_s))

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -2,6 +2,13 @@
 {% block title %}[{{ record.code_s }}] {{ record.stock_name or '' }} - 銘柄詳細 | Shintakane Research{% endblock %}
 
 {% block content %}
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+  {% for category, message in messages %}
+  <div style="padding:0.5em 1em;margin-bottom:1em;border-radius:4px;font-size:0.9em;{% if category == 'error' %}background:#ffeaea;color:#c00;border:1px solid #fcc;{% else %}background:#eaffea;color:#060;border:1px solid #cfc;{% endif %}">{{ message }}</div>
+  {% endfor %}
+{% endif %}
+{% endwith %}
 {# ===== 1. ヘッダー ===== #}
 <div class="stock-header">
   <div class="left">
@@ -45,6 +52,10 @@
         {% endfor %}
       </datalist>
       {% endif %}
+      <form method="POST" action="/stock/{{ record.code_s }}/refresh" style="display:inline;margin-left:0.5em;">
+        <button type="submit" title="業績・指標・株価などの最新データを再取得します"
+                style="display:inline-block;width:auto !important;padding:0.05em 0.5em;font-size:0.8em;margin:0;background:transparent;border:1px solid #ccc;color:#666;border-radius:3px;cursor:pointer;">再取得</button>
+      </form>
       <div>
         <a href="https://kabutan.jp/stock/chart?code={{ record.code_s }}&time=w" target="_blank" rel="noopener noreferrer">チャート</a>
         | <a href="https://kabutan.jp/stock/finance?code={{ record.code_s }}" target="_blank" rel="noopener noreferrer">業績</a>

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -255,6 +255,30 @@ class TestGetMarketKessanData:
         assert "2026/01/26" not in recent_keys
         assert "2026/01/26" not in older_keys
 
+    def test_past_entries_excludes_kessan_older_than_90_days(self, kessan_env):
+        """past_entries (空状態判定で使う後方互換キー) も90日カットオフ後の値を返す
+
+        market.html の空状態判定 `not future_entries and not past_entries` が
+        90日超の決算しかないケースで誤って False になり、カードも空状態メッセージも
+        出ない画面破綻を防ぐ。
+        """
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 4, 27, 19, 0)  # base_day=4/27
+        pf_dict = {
+            # 91日前のみ → 90日カットオフで past_entries は空になるべき
+            "9984": {
+                "code_s": "9984", "stock_name": "91日前のみ",
+                "kessanbi": "2026/01/26", "kessan_quarter": 3,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        result = helpers.get_market_kessan_data()
+        # past_entries も past_entries_all ではなく90日カットオフ後 = 空
+        assert result["past_entries"] == []
+        assert result["future_entries"] == []
+        # 空状態メッセージが出る条件 (not future and not past) を満たす
+        assert not result["future_entries"] and not result["past_entries"]
+
     def test_kessan_before_17_uses_previous_day_as_today(self, kessan_env):
         """17時前は base_day=前日。前日決算カードを当日扱い (today_entries) にする"""
         from datetime import datetime as _dt

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -225,6 +225,36 @@ class TestGetMarketKessanData:
         assert "2026/04/28" not in past_keys
         assert "2026/04/28" not in today_keys
 
+    def test_kessan_older_than_30_days_is_dropped(self, kessan_env):
+        """30日より前の過去決算は recent_past/older_past いずれにも含まれない
+
+        履歴蓄積による DOM/メモリ肥大化を防ぐためのカットオフ (issue #203 議論)。
+        """
+        from datetime import datetime as _dt
+        today_dt = _dt(2026, 4, 27, 19, 0)  # base_day=4/27
+        pf_dict = {
+            # 8日前 (4/19): older_past に入る (recent_cutoff=4/20 より古い)
+            "6501": {
+                "code_s": "6501", "stock_name": "8日前",
+                "kessanbi": "2026/04/19", "kessan_quarter": 4,
+            },
+            # 31日前 (3/27): older_cutoff=3/28 より古いので drop される
+            "9984": {
+                "code_s": "9984", "stock_name": "31日前",
+                "kessanbi": "2026/03/27", "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        result = helpers.get_market_kessan_data()
+        recent_keys = [k for k, _ in result["recent_past_entries"]]
+        older_keys = [k for k, _ in result["older_past_entries"]]
+        # 8日前は older_past
+        assert "2026/04/19" in older_keys
+        assert "2026/04/19" not in recent_keys
+        # 31日前は両方に入らない (drop)
+        assert "2026/03/27" not in recent_keys
+        assert "2026/03/27" not in older_keys
+
     def test_kessan_before_17_uses_previous_day_as_today(self, kessan_env):
         """17時前は base_day=前日。前日決算カードを当日扱い (today_entries) にする"""
         from datetime import datetime as _dt

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -225,8 +225,8 @@ class TestGetMarketKessanData:
         assert "2026/04/28" not in past_keys
         assert "2026/04/28" not in today_keys
 
-    def test_kessan_older_than_30_days_is_dropped(self, kessan_env):
-        """30日より前の過去決算は recent_past/older_past いずれにも含まれない
+    def test_kessan_older_than_90_days_is_dropped(self, kessan_env):
+        """90日 (約1四半期) より前の過去決算は recent_past/older_past いずれにも含まれない
 
         履歴蓄積による DOM/メモリ肥大化を防ぐためのカットオフ (issue #203 議論)。
         """
@@ -238,10 +238,10 @@ class TestGetMarketKessanData:
                 "code_s": "6501", "stock_name": "8日前",
                 "kessanbi": "2026/04/19", "kessan_quarter": 4,
             },
-            # 31日前 (3/27): older_cutoff=3/28 より古いので drop される
+            # 91日前 (1/26): older_cutoff=1/27 より古いので drop される
             "9984": {
-                "code_s": "9984", "stock_name": "31日前",
-                "kessanbi": "2026/03/27", "kessan_quarter": 4,
+                "code_s": "9984", "stock_name": "91日前",
+                "kessanbi": "2026/01/26", "kessan_quarter": 3,
             },
         }
         kessan_env(pf_dict, today_dt)
@@ -251,9 +251,9 @@ class TestGetMarketKessanData:
         # 8日前は older_past
         assert "2026/04/19" in older_keys
         assert "2026/04/19" not in recent_keys
-        # 31日前は両方に入らない (drop)
-        assert "2026/03/27" not in recent_keys
-        assert "2026/03/27" not in older_keys
+        # 91日前は両方に入らない (drop)
+        assert "2026/01/26" not in recent_keys
+        assert "2026/01/26" not in older_keys
 
     def test_kessan_before_17_uses_previous_day_as_today(self, kessan_env):
         """17時前は base_day=前日。前日決算カードを当日扱い (today_entries) にする"""

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -363,6 +363,56 @@ class TestIrCommentPostRoutes:
         assert "IR更新済み" in html
 
 
+class TestRefreshPostRoutes:
+    """POST /stock/<code_s>/refresh のテスト (issue #203)
+
+    本体は `from make_stock_db import refresh_stock` を関数内で行うため、
+    sys.modules に make_stock_db スタブを差し込んで実体呼び出しを避ける。
+    """
+
+    def test_refresh_post_redirects_with_info_flash(self, client, monkeypatch):
+        import sys
+        import types
+
+        calls = []
+        stub = types.ModuleType("make_stock_db")
+        stub.refresh_stock = lambda codes: calls.append(list(codes))
+        monkeypatch.setitem(sys.modules, "make_stock_db", stub)
+
+        resp = client.post("/stock/3496/refresh")
+        assert resp.status_code == 302
+        assert "/stock/3496" in resp.headers["Location"]
+        assert calls == [["3496"]]
+
+        # follow redirect で flash 文言を検証 (info: 緑系背景)
+        follow = client.get("/stock/3496")
+        html = follow.data.decode()
+        assert "再取得しました (3496)" in html
+        assert "background:#eaffea" in html
+
+    def test_refresh_post_handles_exception_with_error_flash(self, client, monkeypatch):
+        import sys
+        import types
+
+        def raise_boom(_codes):
+            raise RuntimeError("boom")
+
+        stub = types.ModuleType("make_stock_db")
+        stub.refresh_stock = raise_boom
+        monkeypatch.setitem(sys.modules, "make_stock_db", stub)
+
+        resp = client.post("/stock/3496/refresh")
+        # 500 にならず 302 でリダイレクトされること
+        assert resp.status_code == 302
+        assert "/stock/3496" in resp.headers["Location"]
+
+        follow = client.get("/stock/3496")
+        html = follow.data.decode()
+        assert "再取得に失敗しました (3496)" in html
+        assert "boom" in html
+        assert "background:#ffeaea" in html
+
+
 class TestKessanCommentApiContract:
     """GET/POST /api/kessan_comment のレスポンス契約 (issue #133)
 


### PR DESCRIPTION
## Summary

### 1. 銘柄詳細ページに「再取得」ボタン追加 (issue #203 本体)
- `make_stock_db.refresh_stock([code_s])` をワンクリックで同期実行
- CLI に戻らず master / price / shihyo / gyoseki / rironkabuka + research_shelve スナップショットを最新化
- 例外は flash error に吸収し 500 にしない

### 2. market ページ「さらに前の決算」を90日 (1Q) カットオフ (issue #203 議論で追加)
- `older_past_entries` が無制限だったため、履歴蓄積で DOM/メモリが肥大化するリスクを解消
- 決算は四半期ごとなので 1Q (90日) 分は遡れるよう設定

Closes #203

## 実装メモ
- `scripts/webapp/routes/refresh.py` を新規追加。`make_stock_db` は scipy/yfinance 等の重依存を持つため、WebApp 起動時の単一障害点にしないよう関数内で lazy import
- ボタンは業態・テーマ inline 入力の隣に配置。picocss の `button[type="submit"]` がデフォルトで `width:100%` になるため `width:auto !important` で上書きしコンパクトに
- `title` 属性で「業績・指標・株価などの最新データを再取得します」の tooltip を表示
- `detail.html` には flash 表示ブロックが無かったので `portfolio_list.html` の既存パターンをコピーして追加
- market カットオフは `recent_cutoff` (-7日) と `older_cutoff` (-90日) の二段構成

## Test plan
- [x] `pytest tests/test_webapp_routes.py -v` で新規追加 2 件 (info / error) を含め pass
- [x] `pytest tests/test_webapp_helpers.py -v` で90日カットオフテスト 1 件を含め 183 pass
  - (既存 1 件 `TestMarketRouteKessanCard::test_today_card_appears_between_recent_past_and_future` は日付ハードコード起因の pre-existing failure。本 PR と無関係)
- [x] ブラウザで `/stock/1301` を開き「再取得」押下 → 302 → 200 リダイレクトで「再取得しました (1301)」flash が表示、`research_shelve` のスナップショットが更新されることをサーバーログで確認
- [x] 同日内に 2 回押しても `_merge_snapshot()` の既存挙動でスナップショット数が増えないこと
- [x] レイアウト: 分析日・決算日・業態テーマと同じ行に収まること
- [ ] レビュアー側で異常系（存在しない銘柄コード等）を一度叩いて、500 でなく赤い error flash が出ることを確認
- [ ] /market ページで「さらに前の決算を表示」をクリックし、90日以内のカードのみ表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)