### PR TITLE
feat: 銘柄ページに会社HPリンク追加 (手動上書き対応) (issue #208)

### DIFF
--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -84,6 +84,7 @@ RECORD_FIELDS = frozenset(
         "snapshots",
         "analysis_date_raw",
         "kessan_date_raw",
+        "corporate_url_override",
     }
 )
 
@@ -253,6 +254,7 @@ def create_research_record(
     snapshots: Optional[List[Dict[str, Any]]] = None,
     analysis_date_raw: str = "",
     kessan_date_raw: str = "",
+    corporate_url_override: str = "",
 ) -> Dict[str, Any]:
     """銘柄調査レコードのひな型 dict を生成する。
 
@@ -295,6 +297,7 @@ def create_research_record(
         "snapshots": snaps,
         "analysis_date_raw": analysis_date_raw,
         "kessan_date_raw": kessan_date_raw,
+        "corporate_url_override": corporate_url_override,
     }
 
 
@@ -509,6 +512,8 @@ def get_research_record(
                 if key not in entry:
                     entry[key] = False
             entry["post_price_changes"] = normalize_kessan_post_price_changes(entry)
+        if "corporate_url_override" not in record:
+            record["corporate_url_override"] = ""
     return record
 
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -344,21 +344,35 @@ def save_ir_comments(code_s: str, form_data: dict) -> None:
         upsert_research_record(record)
 
 
-def save_corporate_url_override(code_s: str, url: str) -> None:
+def save_corporate_url_override(code_s: str, url: str) -> str:
     """会社HP URL の手動上書きを保存する (issue #208)。
 
     空文字を渡すと上書きをクリアする (デフォルトに戻る)。
+    入力値が stocks_shelve.corporate_url と同一の場合も、上書きとして固定すると
+    今後の corporate_url 自動更新を遮断してしまうため、空文字扱い (= デフォルト
+    継続) として保存する。
     URL は事前にバリデーション済みであることを呼び出し側で保証する。
+
+    Returns:
+        実際に保存された値 (空文字なら override クリア、それ以外なら上書き値)。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
+
+    cleaned = url.strip()
+    if cleaned:
+        stock = get_stock_data(normalized) or {}
+        default_url = (stock.get("corporate_url") or "").strip()
+        if default_url and cleaned == default_url:
+            cleaned = ""
 
     with _flock():
         record = get_research_record(normalized)
         if record is None:
             raise ValueError(f"レコード未登録: {normalized}")
-        record["corporate_url_override"] = url.strip()
+        record["corporate_url_override"] = cleaned
         upsert_research_record(record)
+    return cleaned
 
 
 # =======================================================

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -344,6 +344,23 @@ def save_ir_comments(code_s: str, form_data: dict) -> None:
         upsert_research_record(record)
 
 
+def save_corporate_url_override(code_s: str, url: str) -> None:
+    """会社HP URL の手動上書きを保存する (issue #208)。
+
+    空文字を渡すと上書きをクリアする (デフォルトに戻る)。
+    URL は事前にバリデーション済みであることを呼び出し側で保証する。
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+
+    with _flock():
+        record = get_research_record(normalized)
+        if record is None:
+            raise ValueError(f"レコード未登録: {normalized}")
+        record["corporate_url_override"] = url.strip()
+        upsert_research_record(record)
+
+
 # =======================================================
 # 市場データ / 決算カレンダー用ヘルパー (issue #127)
 # =======================================================

--- a/scripts/webapp/routes/memo.py
+++ b/scripts/webapp/routes/memo.py
@@ -56,8 +56,10 @@ def post_corporate_url(code_s: str):
         )
         return redirect(url_for("detail.stock_detail", code_s=code_s))
     try:
-        save_corporate_url_override(code_s, url)
-        if url:
+        # save_corporate_url_override は入力値がデフォルトと一致した場合に
+        # 空文字 (= override クリア) として保存し、その実値を返す
+        saved = save_corporate_url_override(code_s, url)
+        if saved:
             flash(f"会社HPリンクを更新しました ({code_s})", "info")
         else:
             flash(f"会社HPリンクをデフォルトに戻しました ({code_s})", "info")

--- a/scripts/webapp/routes/memo.py
+++ b/scripts/webapp/routes/memo.py
@@ -1,14 +1,20 @@
 """
 メモ保存ルート。
 
-POST /stock/<code_s>/memo       : 手動メモ保存
-POST /stock/<code_s>/shikiho    : 四季報保存
-POST /stock/<code_s>/ir_comment : IR分析コメント一括保存
+POST /stock/<code_s>/memo           : 手動メモ保存
+POST /stock/<code_s>/shikiho        : 四季報保存
+POST /stock/<code_s>/ir_comment     : IR分析コメント一括保存
+POST /stock/<code_s>/corporate_url  : 会社HP URL 上書き保存/クリア (issue #208)
 """
 
-from flask import Blueprint, request, redirect, url_for
+from flask import Blueprint, flash, request, redirect, url_for
 
-from webapp.helpers import save_memo, save_shikiho, save_ir_comments
+from webapp.helpers import (
+    save_memo,
+    save_shikiho,
+    save_ir_comments,
+    save_corporate_url_override,
+)
 
 memo_bp = Blueprint("memo", __name__)
 
@@ -31,4 +37,30 @@ def post_shikiho(code_s: str):
 def post_ir_comment(code_s: str):
     """IR分析コメント一括保存 -> 302リダイレクト。"""
     save_ir_comments(code_s, request.form)
+    return redirect(url_for("detail.stock_detail", code_s=code_s))
+
+
+@memo_bp.route("/stock/<code_s>/corporate_url", methods=["POST"])
+def post_corporate_url(code_s: str):
+    """会社HP URL の手動上書き保存/クリア -> flash + 302リダイレクト (issue #208)。
+
+    空文字なら上書きをクリア (デフォルトに戻る)。
+    http/https 以外で始まる URL は flash error で拒否する。
+    """
+    url = request.form.get("url", "").strip()
+    if url and not (url.startswith("http://") or url.startswith("https://")):
+        flash(
+            f"会社HPリンクの保存に失敗しました ({code_s}): "
+            "URL は http:// または https:// で始めてください",
+            "error",
+        )
+        return redirect(url_for("detail.stock_detail", code_s=code_s))
+    try:
+        save_corporate_url_override(code_s, url)
+        if url:
+            flash(f"会社HPリンクを更新しました ({code_s})", "info")
+        else:
+            flash(f"会社HPリンクをデフォルトに戻しました ({code_s})", "info")
+    except Exception as e:  # noqa: BLE001
+        flash(f"会社HPリンクの保存に失敗しました ({code_s}): {e}", "error")
     return redirect(url_for("detail.stock_detail", code_s=code_s))

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -56,11 +56,36 @@
         <button type="submit" title="業績・指標・株価などの最新データを再取得します"
                 style="display:inline-block;width:auto !important;padding:0.05em 0.5em;font-size:0.8em;margin:0;background:transparent;border:1px solid #ccc;color:#666;border-radius:3px;cursor:pointer;">再取得</button>
       </form>
+      {# issue #208: 会社HP URL の手動上書き対応。stocks_shelve.corporate_url を既定、record.corporate_url_override で上書き #}
+      {% set _override = record.corporate_url_override or '' %}
+      {% set _default_url = (stock or {}).get('corporate_url') or '' %}
+      {% set _display_url = _override or _default_url %}
+      {% set _is_override = _override != '' %}
       <div>
         <a href="https://kabutan.jp/stock/chart?code={{ record.code_s }}&time=w" target="_blank" rel="noopener noreferrer">チャート</a>
         | <a href="https://kabutan.jp/stock/finance?code={{ record.code_s }}" target="_blank" rel="noopener noreferrer">業績</a>
         | <a href="https://finance.yahoo.co.jp/quote/{{ record.code_s }}.T/forum" target="_blank" rel="noopener noreferrer">掲示板</a>
+        {% if _display_url %}
+        | <a href="{{ _display_url }}" target="_blank" rel="noopener noreferrer">会社HP{% if _is_override %}✎{% endif %}</a>
+        {% endif %}
+        <form method="POST" action="/stock/{{ record.code_s }}/corporate_url" id="corp-url-form-{{ record.code_s }}" style="display:inline;">
+          <input type="hidden" name="url" id="corp-url-input-{{ record.code_s }}">
+          <button type="button" title="会社HPリンクの上書きを編集 (空欄でデフォルトに戻す)"
+                  data-code="{{ record.code_s }}" data-current="{{ _display_url }}"
+                  onclick="editCorpUrl(this)"
+                  style="display:inline-block;width:auto !important;padding:0.05em 0.3em;font-size:0.8em;margin:0 0 0 0.2em;background:transparent;border:1px solid #ccc;color:#666;border-radius:3px;cursor:pointer;">✎</button>
+        </form>
       </div>
+      <script>
+      function editCorpUrl(btn) {
+        var codeS = btn.dataset.code;
+        var current = btn.dataset.current || "";
+        var input = window.prompt("会社HP URL（空欄でデフォルトに戻す）", current);
+        if (input === null) return;  // Cancel
+        document.getElementById('corp-url-input-' + codeS).value = input;
+        document.getElementById('corp-url-form-' + codeS).submit();
+      }
+      </script>
       {% if not portfolio_status_query and not portfolio_fallback_mode %}
       <div style="margin-top:0.4em;">
         <button type="button" class="outline" style="padding:0.2em 0.7em;font-size:0.85em;margin:0;"

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -71,7 +71,7 @@
         <form method="POST" action="/stock/{{ record.code_s }}/corporate_url" id="corp-url-form-{{ record.code_s }}" style="display:inline;">
           <input type="hidden" name="url" id="corp-url-input-{{ record.code_s }}">
           <button type="button" title="会社HPリンクの上書きを編集 (空欄でデフォルトに戻す)"
-                  data-code="{{ record.code_s }}" data-current="{{ _display_url }}"
+                  data-code="{{ record.code_s }}" data-current="{{ _override }}"
                   onclick="editCorpUrl(this)"
                   style="display:inline-block;width:auto !important;padding:0.05em 0.3em;font-size:0.8em;margin:0 0 0 0.2em;background:transparent;border:1px solid #ccc;color:#666;border-radius:3px;cursor:pointer;">✎</button>
         </form>

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -901,3 +901,40 @@ class TestDateYyMDayPrecision:
         rs.validate_date_yy_m("25.11")
         assert rs.date_yy_m_sort_key("26.1") == (26, 1, 0)
         assert rs.date_yy_m_sort_key("25.11") == (25, 11, 0)
+
+
+class TestCorporateUrlOverride:
+    """corporate_url_override フィールド (issue #208) のテスト"""
+
+    def test_corporate_url_override_defaults_to_empty(self):
+        """create_research_record の戻り値に空文字で含まれる"""
+        rec = rs.create_research_record("3496", "アズーム")
+        assert rec["corporate_url_override"] == ""
+
+    def test_corporate_url_override_passes_through(self):
+        """create_research_record に渡した値が保持される"""
+        rec = rs.create_research_record(
+            "3496", "アズーム", corporate_url_override="https://example.com/ir",
+        )
+        assert rec["corporate_url_override"] == "https://example.com/ir"
+
+    def test_get_research_record_backfills_corporate_url_override(self, db_path):
+        """旧形式 (corporate_url_override 無) のレコードは読込時に空文字で補完される"""
+        rec = rs.create_research_record("3496", "アズーム")
+        del rec["corporate_url_override"]  # 旧形式を模倣
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["corporate_url_override"] == ""
+
+    def test_corporate_url_override_roundtrip(self, db_path):
+        """upsert → get で値が往復する"""
+        rec = rs.create_research_record(
+            "3496", "アズーム", corporate_url_override="https://example.com/ir",
+        )
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["corporate_url_override"] == "https://example.com/ir"
+
+    def test_record_fields_includes_corporate_url_override(self):
+        """RECORD_FIELDS に corporate_url_override が含まれる"""
+        assert "corporate_url_override" in rs.RECORD_FIELDS

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -473,6 +473,33 @@ class TestCorporateUrlPostRoutes:
         # 9999 は detail 取得時に 404 になるためリダイレクト先で flash 確認は省略
         # (flash は session に保存されるので次のリクエストで消費される)
 
+    def test_corporate_url_post_does_not_pin_default_url(self, client, db_path, monkeypatch):
+        """既定URLと同じ値を保存しても override に固定化されない (codex review対応)
+
+        ✎ を開いてそのまま OK しただけで stocks_shelve 側の corporate_url が
+        自動更新で変わっても銘柄詳細に反映されなくなる事故を防ぐ。
+        """
+        # 3496 の stocks_shelve.corporate_url をテスト用に固定
+        from webapp import helpers as _h
+        original = _h.get_stock_data
+        def patched(code_s):
+            data = dict(original(code_s) or {})
+            data["corporate_url"] = "https://example.com/default"
+            return data
+        monkeypatch.setattr(_h, "get_stock_data", patched)
+
+        resp = client.post("/stock/3496/corporate_url", data={
+            "url": "https://example.com/default",  # 既定値と同一
+        })
+        assert resp.status_code == 302
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        # override は空のまま (デフォルト継続)
+        assert loaded["corporate_url_override"] == ""
+
+        follow = client.get("/stock/3496")
+        html = follow.data.decode()
+        assert "会社HPリンクをデフォルトに戻しました (3496)" in html
+
     def test_detail_hides_corporate_link_when_no_url(self, client, db_path, monkeypatch):
         """corporate_url も corporate_url_override も空のときリンク要素自体が出ない"""
         # 3496 の override は空のまま、stock の corporate_url を空に置き換え

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -413,6 +413,90 @@ class TestRefreshPostRoutes:
         assert "background:#ffeaea" in html
 
 
+class TestCorporateUrlPostRoutes:
+    """POST /stock/<code_s>/corporate_url のテスト (issue #208)"""
+
+    def test_corporate_url_post_saves_override(self, client, db_path):
+        """正常 URL を渡すと record.corporate_url_override が更新され info flash が出る"""
+        resp = client.post("/stock/3496/corporate_url", data={
+            "url": "https://example.com/ir",
+        })
+        assert resp.status_code == 302
+        assert "/stock/3496" in resp.headers["Location"]
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["corporate_url_override"] == "https://example.com/ir"
+
+        follow = client.get("/stock/3496")
+        html = follow.data.decode()
+        assert "会社HPリンクを更新しました (3496)" in html
+        assert "background:#eaffea" in html
+
+    def test_corporate_url_post_empty_clears_override(self, client, db_path):
+        """空文字を渡すと上書きがクリアされ「デフォルトに戻しました」flash が出る"""
+        # 事前に上書きを入れておく
+        rec = rs.get_research_record("3496", db_path=db_path)
+        rec["corporate_url_override"] = "https://old.example.com"
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        resp = client.post("/stock/3496/corporate_url", data={"url": ""})
+        assert resp.status_code == 302
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["corporate_url_override"] == ""
+
+        follow = client.get("/stock/3496")
+        html = follow.data.decode()
+        assert "会社HPリンクをデフォルトに戻しました (3496)" in html
+
+    def test_corporate_url_post_rejects_invalid_scheme(self, client, db_path):
+        """http/https 以外で始まる URL は error flash で拒否し、record は変更されない"""
+        resp = client.post("/stock/3496/corporate_url", data={
+            "url": "javascript:alert(1)",
+        })
+        assert resp.status_code == 302
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["corporate_url_override"] == ""  # 変更されない
+
+        follow = client.get("/stock/3496")
+        html = follow.data.decode()
+        assert "会社HPリンクの保存に失敗しました (3496)" in html
+        assert "http://" in html or "https://" in html  # エラーメッセージ本文
+        assert "background:#ffeaea" in html
+
+    def test_corporate_url_post_handles_unregistered_record(self, client):
+        """research_shelve 未登録の銘柄コードでは error flash で 302 リダイレクトする"""
+        # 9999 は populated_db で登録していない
+        resp = client.post("/stock/9999/corporate_url", data={
+            "url": "https://example.com",
+        })
+        assert resp.status_code == 302
+        assert "/stock/9999" in resp.headers["Location"]
+        # 9999 は detail 取得時に 404 になるためリダイレクト先で flash 確認は省略
+        # (flash は session に保存されるので次のリクエストで消費される)
+
+    def test_detail_hides_corporate_link_when_no_url(self, client, db_path, monkeypatch):
+        """corporate_url も corporate_url_override も空のときリンク要素自体が出ない"""
+        # 3496 の override は空のまま、stock の corporate_url を空に置き換え
+        from webapp import helpers as _h
+        original = _h.get_stock_data
+        def patched(code_s):
+            data = dict(original(code_s) or {})
+            data["corporate_url"] = ""
+            return data
+        monkeypatch.setattr(_h, "get_stock_data", patched)
+        # detail.py 側も同じ helpers を import 経由で参照しているか確認のため
+        # routes.detail の名前空間にも patch を当てる
+        from webapp.routes import detail as _d
+        monkeypatch.setattr(_d, "get_stock_data", patched)
+
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        # 「会社HP」ラベルが出ていない (リンク要素ごと非表示)
+        assert ">会社HP<" not in html
+        assert ">会社HP✎<" not in html
+        # ✎ ボタン (上書き入口) は常に表示される
+        assert 'action="/stock/3496/corporate_url"' in html
+
+
 class TestKessanCommentApiContract:
     """GET/POST /api/kessan_comment のレスポンス契約 (issue #133)
 

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -473,6 +473,24 @@ class TestCorporateUrlPostRoutes:
         # 9999 は detail 取得時に 404 になるためリダイレクト先で flash 確認は省略
         # (flash は session に保存されるので次のリクエストで消費される)
 
+    def test_detail_button_data_current_uses_override_not_display_url(self, client, db_path):
+        """✎ ボタンの data-current は override のみを参照する (既定URLは入れない)
+
+        prompt のデフォルト表示に既定URLが流れ込むと、ユーザーが ✎ を開いて
+        そのまま OK するだけで既定URLが override として固定化されてしまう。
+        data-current は実際の override 値のみを渡す必要がある。
+        """
+        # 上書き無し: data-current は空文字
+        html = client.get("/stock/3496").data.decode()
+        assert 'data-current=""' in html
+
+        # 上書き有り: data-current は override 値
+        rec = rs.get_research_record("3496", db_path=db_path)
+        rec["corporate_url_override"] = "https://example.com/ir"
+        rs.upsert_research_record(rec, db_path=db_path)
+        html = client.get("/stock/3496").data.decode()
+        assert 'data-current="https://example.com/ir"' in html
+
     def test_corporate_url_post_does_not_pin_default_url(self, client, db_path, monkeypatch):
         """既定URLと同じ値を保存しても override に固定化されない (codex review対応)
 


### PR DESCRIPTION
## Summary
- `stocks_shelve.corporate_url` を既定リンクとして銘柄詳細ページに表示
- ✎ ボタンから `window.prompt` で URL を上書きでき、上書き済みはラベル「会社HP✎」で判別可能
- 空文字を返すとデフォルトに戻る / `http://` または `https://` 以外は flash error で拒否
- `research_shelve` に新規フィールド `corporate_url_override` を追加（旧レコードは空文字で補完）

Closes #208

## 実装メモ
- `save_corporate_url_override()` は `save_memo` の `_flock → get → mutate → upsert` パターンを踏襲
- `POST /stock/<code_s>/corporate_url` は既存 `memo_bp` に同居（新 Blueprint 不要）
- 実装中の修正: 当初 `onclick="editCorpUrl('{{ code_s }}', {{ url|tojson }})"` で組んだが、`tojson` 出力の `"` が HTML 属性区切りと衝突して JS が途中で切れていた → `data-current` 属性に URL を渡し、JS 側で `dataset` から読む方式に修正

## Test plan
- [x] `pytest tests/test_research_shelve.py::TestCorporateUrlOverride -v` (5件 pass)
- [x] `pytest tests/test_webapp_routes.py::TestCorporateUrlPostRoutes -v` (5件 pass)
  - 正常 URL 保存 / 空文字でクリア / `javascript:` 拒否 / 未登録レコード / リンク非表示
- [x] ブラウザで以下を確認:
  - デフォルト URL でリンク表示 (`/stock/1301` → `https://www.kyokuyo.co.jp/`)
  - ✎ → URL 入力 → ラベル「会社HP✎」+ href が新 URL に切り替わる
  - ✎ → 空文字 → ラベル「会社HP」+ href がデフォルトに戻る
  - ✎ → `javascript:alert(1)` → 302 で拒否、DB 変更なし
- [ ] レビュアー側で `corporate_url` も override も空の銘柄でリンク非表示・✎ボタン残存を確認
- [ ] レビュアー側で prompt の Cancel ボタンで何も起きないこと確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)