### PR TITLE
feat: 株価+RSライン統合チャート (詳細ページ + portfolio) (issue #227)

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1901,14 +1901,17 @@ def _asc_series_from_log(log: List, count: int) -> List[float]:
 
 
 def _format_total_change(values: List[float], window: int) -> str:
-    """末尾 window 点における先頭→末尾の合計騰落率を +X.X% / — に整形。
+    """末尾 window 営業日 (offset) における合計騰落率を +X.X% / — に整形。
 
-    例: values=[100, 110, 120] → "+20.0%"
+    window=5 なら「5営業日前→今日」の変化なので、内部では window+1 点を取り
+    tail[0]→tail[-1] を計算する。既存の (20,5) 指標 (offset=5) と一致させる。
+    データ不足時は取得できるだけ取って計算する (例: 3点しかなくて window=5 → 全3点)。
     データ不足や 0除算の場合は "—"。
     """
-    if not values or len(values) < 2:
+    if not values or len(values) < 2 or window <= 0:
         return "—"
-    tail = values[-window:] if window > 0 and len(values) > window else values
+    needed = window + 1
+    tail = values[-needed:] if len(values) > needed else values
     base = tail[0]
     if base == 0:
         return "—"
@@ -2001,13 +2004,17 @@ def build_price_rs_chart_mini(
     inner_w = width - pad_x * 2
     inner_h = height - pad_y * 2
 
-    # 3 点: t-20 (= asc[0]), t-5 (= asc[-_SPARK_RECENT] 相当, 末尾から5本目), t-0 (= asc[-1])
+    # 3 点: t-20 (= asc[0]), t-5 (= 5 営業日前, asc[-(_SPARK_RECENT+1)]), t-0 (= asc[-1])
+    # _SPARK_RECENT=5 は「営業日数(offset)」の意味なので、点としては末尾から 6 本目を指す。
     def _three_points(asc: List[float]) -> Optional[List[float]]:
         if len(asc) < 2:
             return None
-        # 末尾 (今日), 5本前 (無ければ asc の中央), 先頭 (=t-20)
+        # 末尾 (今日), 5営業日前 (無ければ asc の中央), 先頭 (=t-20)
         t0 = asc[-1]
-        t5 = asc[-_SPARK_RECENT] if len(asc) >= _SPARK_RECENT else asc[len(asc) // 2]
+        if len(asc) >= _SPARK_RECENT + 1:
+            t5 = asc[-(_SPARK_RECENT + 1)]
+        else:
+            t5 = asc[len(asc) // 2]
         t20 = asc[0]
         return [t20, t5, t0]
 
@@ -2124,10 +2131,18 @@ def build_price_rs_chart_full(
     # (IBD MarketSmith 風: 線が重なって見えるが、上下に分かれているので形の違いが読める)
 
     # 軸ガイド: 20日前/5日前/今日 の縦線 (両パネルにまたがる)
+    # _SPARK_RECENT=5 は「5営業日前」= 末尾から 6 点目なので step*5 引く。
+    # 短期履歴 (5営業日分も無い銘柄) では 5日ガイドが viewBox 左に飛び出すため、
+    # x_t5 を pad_x 以上にクランプし、t20 と重なるならガイド線を省略する。
     x_today = pad_x + inner_w
-    x_t5 = pad_x + inner_w - step * (_SPARK_RECENT - 1)
     x_t20 = pad_x
-    for gx in (x_t20, x_t5, x_today):
+    x_t5_raw = pad_x + inner_w - step * _SPARK_RECENT
+    x_t5 = max(x_t5_raw, pad_x)
+    show_t5_guide = x_t5_raw >= pad_x + 1  # t20 とほぼ重なる場合は省略
+    guide_xs = [x_t20, x_today]
+    if show_t5_guide:
+        guide_xs.insert(1, x_t5)
+    for gx in guide_xs:
         parts.append(
             f'<line x1="{gx:.1f}" y1="{pad_y_top}" x2="{gx:.1f}" y2="{pad_y_top + inner_h}" '
             f'stroke="#e0e0e0" stroke-width="0.5"/>'
@@ -2137,9 +2152,10 @@ def build_price_rs_chart_full(
     # 相当しか描画しないので、左端ラベルも表示窓内の最古日 (= 描画範囲の左端)
     # に合わせる必要がある。price_log が _SPARK_LOOKBACK を超える場合に
     # 「全履歴の最古日」が出る回帰を防ぐ。
+    # _SPARK_RECENT=5 営業日前なので price_log[5] (= 6本目) を参照する。
     try:
         today_label = price_log[0][0].strftime("%m/%d") if price_log else ""
-        t5_idx = min(_SPARK_RECENT - 1, len(price_log) - 1) if price_log else -1
+        t5_idx = min(_SPARK_RECENT, len(price_log) - 1) if price_log else -1
         t20_idx = min(_SPARK_LOOKBACK - 1, len(price_log) - 1) if price_log else -1
         t5_label = price_log[t5_idx][0].strftime("%m/%d") if t5_idx >= 0 else ""
         t20_label = price_log[t20_idx][0].strftime("%m/%d") if t20_idx >= 0 else ""
@@ -2149,9 +2165,10 @@ def build_price_rs_chart_full(
     parts.append(
         f'<text x="{x_t20:.1f}" y="{label_y}" font-size="9" fill="#888" text-anchor="start">{t20_label}</text>'
     )
-    parts.append(
-        f'<text x="{x_t5:.1f}" y="{label_y}" font-size="9" fill="#888" text-anchor="middle">{t5_label}</text>'
-    )
+    if show_t5_guide and t5_label:
+        parts.append(
+            f'<text x="{x_t5:.1f}" y="{label_y}" font-size="9" fill="#888" text-anchor="middle">{t5_label}</text>'
+        )
     parts.append(
         f'<text x="{x_today:.1f}" y="{label_y}" font-size="9" fill="#888" text-anchor="end">{today_label}</text>'
     )
@@ -2168,10 +2185,12 @@ def build_price_rs_chart_full(
     # 株価と RS が同じ動きでも上下別エリアに描かれるので、形の対比が見やすい。
 
     # 株価パネル
+    # _SPARK_RECENT=5 は「直近5営業日 (offset 5)」なので、点としては 6 点窓を取る
+    _recent_pts = _SPARK_RECENT + 1
     price_slope_full = compute_slope_per_day(price_asc) if len(price_asc) >= 2 else None
     price_slope_recent = (
-        compute_slope_per_day(price_asc[-_SPARK_RECENT:])
-        if len(price_asc) >= _SPARK_RECENT
+        compute_slope_per_day(price_asc[-_recent_pts:])
+        if len(price_asc) >= _recent_pts
         else None
     )
     price_dir_full = _slope_direction(price_slope_full)
@@ -2186,9 +2205,9 @@ def build_price_rs_chart_full(
         full_points = list(zip(xs_price, ys_price))
         # 20日全体 (薄)
         parts.append(_svg_polyline(full_points, _PRICE_FADED[price_dir_full], 1.5))
-        # 末尾5日 (濃)
-        if len(full_points) >= _SPARK_RECENT:
-            recent_points = full_points[-_SPARK_RECENT:]
+        # 直近5営業日 (濃, 6点窓)
+        if len(full_points) >= _recent_pts:
+            recent_points = full_points[-_recent_pts:]
             parts.append(_svg_polyline(recent_points, _PRICE_COLORS[price_dir_recent], 2.2))
         # 末尾マーカー
         parts.append(_svg_circle(full_points[-1][0], full_points[-1][1], 2.5, _PRICE_COLORS[price_dir_recent]))
@@ -2217,8 +2236,8 @@ def build_price_rs_chart_full(
     # RSパネル
     rs_slope_full = compute_slope_per_day(rs_asc) if len(rs_asc) >= 2 else None
     rs_slope_recent = (
-        compute_slope_per_day(rs_asc[-_SPARK_RECENT:])
-        if len(rs_asc) >= _SPARK_RECENT
+        compute_slope_per_day(rs_asc[-_recent_pts:])
+        if len(rs_asc) >= _recent_pts
         else None
     )
     rs_dir_full = _slope_direction(rs_slope_full)
@@ -2231,9 +2250,9 @@ def build_price_rs_chart_full(
         full_points = list(zip(xs_rs, ys_rs))
         # 20日全体 (薄, 点線)
         parts.append(_svg_polyline(full_points, _RS_FADED[rs_dir_full], 1.0, dasharray="2,2"))
-        # 末尾5日 (濃, 点線)
-        if len(full_points) >= _SPARK_RECENT:
-            recent_points = full_points[-_SPARK_RECENT:]
+        # 直近5営業日 (濃, 点線, 6点窓)
+        if len(full_points) >= _recent_pts:
+            recent_points = full_points[-_recent_pts:]
             parts.append(
                 _svg_polyline(recent_points, _RS_COLORS[rs_dir_recent], 1.5, dasharray="2,1")
             )

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1506,12 +1506,24 @@ def list_portfolio_with_indicators(
     stock_map = _bulk_get_stock_data(code_list)
     name_map = _bulk_resolve_stock_names(code_list)
     today = date.today()  # 全 row 共通の基準日 (issue #177)
+
+    # issue #227: 株価 + RSライン 統合チャート用に market_db を1回だけロード。
+    # 失敗時は None で進める (株価のみのチャートが描画される)
+    try:
+        from make_market_db import get_market_db  # 遅延 import (循環回避)
+        market_db = get_market_db()
+    except Exception:  # noqa: BLE001
+        market_db = None
+
     rows: List[Dict[str, Any]] = []
     for rec in records:
         code_s = rec.get("code_s", "")
         row = dict(rec)
         row["stock_name"] = name_map.get(code_s, "") or rec.get("stock_name", "")  # 旧データ互換
-        row.update(_extract_indicators_for_portfolio(stock_map.get(code_s, {})))
+        stock = stock_map.get(code_s, {})
+        row.update(_extract_indicators_for_portfolio(stock))
+        # issue #227: 3点ミニチャート (svg + tooltip)
+        row["price_rs_chart"] = build_stock_chart_payload(stock, market_db, mode="mini")
         row["styles"] = compute_cell_styles(row, today=today)
         # issue #178: ステータス列 (badge) 表示用の query / label を埋める
         status = rec.get("status", "")
@@ -1742,6 +1754,547 @@ def _gyoseki_quarity_expr_safe(stock: Dict[str, Any]) -> str:
         return get_gyoseki_quarity_expr(stock) or ""
     except Exception:
         return ""
+
+
+# ==================================================
+# 株価 + RSライン 統合スパークライン (issue #227)
+# ==================================================
+# オニール式 IBD の RS ライン (個別株価/TOPIX 比率) を価格チャートに重ねる。
+# 単位は非表示で「方向だけ見せる」思想に従い、各系列を min-max で 0-1 に
+# 正規化してから同じ viewBox に描画する。
+#
+# - portfolio: 80x24px 3点 (t-20, t-5, t-0) の簡易チャート
+# - detail   : 400x120px 20点フルチャート + 軸ガイド
+
+_SPARK_LOOKBACK = 20  # 分析対象営業日数 (price_log の有効長)
+_SPARK_RECENT = 5     # 末尾強調期間
+# compute_rs_line_new_high は rs_line[1:lookback+1] と比較するため、
+# rs_line の長さ >= lookback+1 を要求する。銘柄の price_log が約19本しかなく
+# TOPIX との日付重なりで rs_line もほぼ19本に揃うため、lookback=18 とすることで
+# 「過去18営業日との比較で最高 = 約1ヶ月で最高」を判定する。
+_SPARK_RS_NEW_HIGH_LOOKBACK = 18
+
+# 配色: 株価 (緑=上昇/赤=下降/灰=横ばい)、RS (青=上昇/オレンジ=下降/灰=横ばい)
+_PRICE_COLORS = {"up": "#2e7d32", "down": "#c62828", "flat": "#999"}
+_PRICE_FADED = {"up": "#a5d6a7", "down": "#ef9a9a", "flat": "#ccc"}
+_RS_COLORS = {"up": "#1976d2", "down": "#ef6c00", "flat": "#999"}
+_RS_FADED = {"up": "#90caf9", "down": "#ffcc80", "flat": "#ccc"}
+_BLUE_DOT = "#1976d2"
+
+_FLAT_THRESHOLD_PERCENT_PER_DAY = 0.05  # 傾き |x| < 0.05%/日 は flat 扱い
+
+
+def compute_slope_per_day(values: List[float]) -> Optional[float]:
+    """末尾 n 点の線形回帰の傾きを末尾値で正規化した %/日 を返す。
+
+    values は時系列の昇順 (古い→新しい) を期待する。
+    n < 2 や末尾値が 0 の場合は None。
+    """
+    if not values or len(values) < 2:
+        return None
+    last = values[-1]
+    if not last:
+        return None
+    n = len(values)
+    xs = list(range(n))
+    mean_x = sum(xs) / n
+    mean_y = sum(values) / n
+    numerator = sum((xs[i] - mean_x) * (values[i] - mean_y) for i in range(n))
+    denominator = sum((xs[i] - mean_x) ** 2 for i in range(n))
+    if denominator == 0:
+        return None
+    slope_abs = numerator / denominator
+    return (slope_abs / last) * 100.0
+
+
+def _slope_direction(slope_pct_per_day: Optional[float]) -> str:
+    """傾き %/日 を up/down/flat に分類する。None は flat 扱い。"""
+    if slope_pct_per_day is None:
+        return "flat"
+    if slope_pct_per_day > _FLAT_THRESHOLD_PERCENT_PER_DAY:
+        return "up"
+    if slope_pct_per_day < -_FLAT_THRESHOLD_PERCENT_PER_DAY:
+        return "down"
+    return "flat"
+
+
+def normalize_minmax(values: List[float], height: float) -> List[float]:
+    """min-max 正規化して SVG y 座標 (0 = top, height = bottom) に変換する。
+
+    定数列 (min == max) は height/2 (中央) 一定で返す。
+    SVG は y が下向きなので、最大値が上に来るよう反転する。
+    """
+    if not values:
+        return []
+    lo = min(values)
+    hi = max(values)
+    if hi == lo:
+        return [height / 2.0] * len(values)
+    span = hi - lo
+    return [height - (v - lo) / span * height for v in values]
+
+
+def to_log_scale(values: List[float]) -> List[float]:
+    """株価を対数軸で表示するため自然対数に変換 (IBD MarketSmith 準拠)。
+
+    対数軸では +X% の動きが価格レンジに関係なく同じ縦距離になるため、
+    急騰急落銘柄でも「率」として正しい形が見える。
+    0 以下の値や空入力は空リストを返す。
+    """
+    import math
+    if not values:
+        return []
+    if any(v <= 0 for v in values):
+        return []
+    return [math.log(v) for v in values]
+
+
+def to_base_index(values: List[float]) -> List[float]:
+    """先頭値を 1.0 とする倍率列に変換する。
+
+    各値を values[0] で割って [1.0, 1.05, 0.98, ...] のような形にする。
+    issue #227: 株価と RSライン を共通スケールで重ねる前段。
+    先頭値が 0 や負、または values が空なら空リストを返す。
+    """
+    if not values or values[0] <= 0:
+        return []
+    base = values[0]
+    return [v / base for v in values]
+
+
+def normalize_shared_y(
+    series_list: List[List[float]], height: float
+) -> List[List[float]]:
+    """複数系列を共通スケールで SVG y 座標に変換する (issue #227)。
+
+    各系列を to_base_index で「先頭=1.0」に揃えた後、全系列の min-max を
+    共通に取って同じ y 範囲に落とす。これにより:
+      - 期間先頭が完全に揃う (両線が同じ位置から始まる)
+      - 期間内の増減幅の差がそのまま線の上下差として見える
+    定数列のみで構成される場合は中央線一定で返す。
+    """
+    indexed = [to_base_index(s) for s in series_list]
+    valid_points: List[float] = []
+    for s in indexed:
+        valid_points.extend(s)
+    if not valid_points:
+        return [[] for _ in series_list]
+    lo = min(valid_points)
+    hi = max(valid_points)
+    if hi == lo:
+        return [[height / 2.0] * len(s) for s in indexed]
+    span = hi - lo
+    return [
+        [height - (v - lo) / span * height for v in s] if s else []
+        for s in indexed
+    ]
+
+
+def _asc_series_from_log(log: List, count: int) -> List[float]:
+    """price_log / rs_line のような (date, value) タプル列 (新しい順) から
+    末尾 count 件を時系列昇順 (古い→新しい) の値だけのリストにする。"""
+    if not log:
+        return []
+    sliced = log[:count]
+    # 入力は新しい順。逆順にして昇順にする
+    return [float(v) for _, v in reversed(sliced) if v is not None]
+
+
+def _format_total_change(values: List[float], window: int) -> str:
+    """末尾 window 点における先頭→末尾の合計騰落率を +X.X% / — に整形。
+
+    例: values=[100, 110, 120] → "+20.0%"
+    データ不足や 0除算の場合は "—"。
+    """
+    if not values or len(values) < 2:
+        return "—"
+    tail = values[-window:] if window > 0 and len(values) > window else values
+    base = tail[0]
+    if base == 0:
+        return "—"
+    pct = (tail[-1] - base) / base * 100
+    return f"{pct:+.1f}%"
+
+
+def _build_chart_tooltip(
+    price_values: List[float],
+    rs_values: List[float],
+    has_blue_dot: bool,
+) -> str:
+    """チャート tooltip (title 属性向け) を生成する。
+
+    20日 / 5日 の合計騰落率を見せる。平均ではなく合計なので、期間内の動きが
+    そのまま % で読める (例: 「20日で +5%, 5日で -26%」のような乖離パターンが分かる)。
+    """
+    lines = [
+        f"株価: 20日 {_format_total_change(price_values, _SPARK_LOOKBACK)}, "
+        f"5日 {_format_total_change(price_values, _SPARK_RECENT)}",
+        f"RSライン: 20日 {_format_total_change(rs_values, _SPARK_LOOKBACK)}, "
+        f"5日 {_format_total_change(rs_values, _SPARK_RECENT)}",
+    ]
+    if has_blue_dot:
+        lines.append("新高値: ●")
+    return "\n".join(lines)
+
+
+def _svg_polyline(points: List[tuple], color: str, width: float, dasharray: Optional[str] = None) -> str:
+    """polyline 1 本を SVG 文字列で返す (points が 2 点未満は空文字)。"""
+    if len(points) < 2:
+        return ""
+    pts = " ".join(f"{x:.1f},{y:.1f}" for x, y in points)
+    dash = f' stroke-dasharray="{dasharray}"' if dasharray else ""
+    return (
+        f'<polyline points="{pts}" fill="none" '
+        f'stroke="{color}" stroke-width="{width}"{dash} '
+        f'stroke-linecap="round" stroke-linejoin="round"/>'
+    )
+
+
+def _svg_circle(cx: float, cy: float, r: float, color: str) -> str:
+    return f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="{r}" fill="{color}"/>'
+
+
+def _format_price_axis(value: float) -> str:
+    """株価軸ラベル (円)。1000円超は K 表記、それ以下は整数。"""
+    if value >= 10000:
+        return f"{value / 1000:.1f}K"
+    if value >= 1000:
+        return f"{int(round(value))}"
+    return f"{value:.1f}"
+
+
+def _format_pct_axis(pct: float) -> str:
+    """RS変化率ラベル (%)。+/- 付き、絶対値10%未満は小数1桁、それ以上は整数。"""
+    if abs(pct) < 10:
+        return f"{pct:+.1f}%"
+    return f"{pct:+.0f}%"
+
+
+def build_price_rs_chart_mini(
+    price_log: List,
+    rs_line: List,
+    has_blue_dot: bool,
+    width: int = 80,
+    height: int = 24,
+) -> tuple:
+    """portfolio 用 3 点 (t-20, t-5, t-0) 簡易チャート SVG と tooltip を返す。
+
+    Args:
+        price_log: stocks_shelve['price_log'] (新しい順 [(date, close), ...])
+        rs_line  : compute_rs_line() 戻り値 (新しい順 [(date, ratio), ...])
+        has_blue_dot: RSライン新高値ならTrue
+        width / height: SVG サイズ
+
+    Returns:
+        (svg_str, tooltip_str). データ不足 (各系列 2 点未満) なら SVG は "—"。
+    """
+    price_asc = _asc_series_from_log(price_log, _SPARK_LOOKBACK)
+    rs_asc = _asc_series_from_log(rs_line, _SPARK_LOOKBACK)
+
+    if len(price_asc) < 2 and len(rs_asc) < 2:
+        return ("—", "")
+
+    tooltip = _build_chart_tooltip(price_asc, rs_asc, has_blue_dot)
+
+    pad_x = 4
+    pad_y = 3
+    inner_w = width - pad_x * 2
+    inner_h = height - pad_y * 2
+
+    # 3 点: t-20 (= asc[0]), t-5 (= asc[-_SPARK_RECENT] 相当, 末尾から5本目), t-0 (= asc[-1])
+    def _three_points(asc: List[float]) -> Optional[List[float]]:
+        if len(asc) < 2:
+            return None
+        # 末尾 (今日), 5本前 (無ければ asc の中央), 先頭 (=t-20)
+        t0 = asc[-1]
+        t5 = asc[-_SPARK_RECENT] if len(asc) >= _SPARK_RECENT else asc[len(asc) // 2]
+        t20 = asc[0]
+        return [t20, t5, t0]
+
+    price_pts_raw = _three_points(price_asc)
+    rs_pts_raw = _three_points(rs_asc)
+
+    # x 座標は等間隔 3 点
+    xs = [pad_x, pad_x + inner_w / 2, pad_x + inner_w]
+
+    price_slope_full = compute_slope_per_day(price_asc) if len(price_asc) >= 2 else None
+    rs_slope_full = compute_slope_per_day(rs_asc) if len(rs_asc) >= 2 else None
+    price_dir = _slope_direction(price_slope_full)
+    rs_dir = _slope_direction(rs_slope_full)
+
+    # 上下棲み分け: 上 60% = 株価, 下 40% = RS (mini なのでパネルギャップは最小)
+    panel_gap = 1
+    price_panel_h = (inner_h - panel_gap) * 0.6
+    rs_panel_h = (inner_h - panel_gap) * 0.4
+    price_panel_top = pad_y
+    rs_panel_top = pad_y + price_panel_h + panel_gap
+
+    parts = [f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" width="{width}" height="{height}">']
+
+    # 株価 (実線, 主役) - 上パネル
+    # 対数軸: +X% の動きが価格レンジに関係なく同じ縦距離になる (IBD準拠)
+    if price_pts_raw is not None:
+        log_price = to_log_scale(price_pts_raw)
+        if log_price:
+            ys = normalize_minmax(log_price, price_panel_h)
+            ys = [y + price_panel_top for y in ys]
+            points = list(zip(xs, ys))
+            parts.append(_svg_polyline(points, _PRICE_COLORS[price_dir], 1.5))
+            # 末尾点マーカー
+            parts.append(_svg_circle(points[-1][0], points[-1][1], 1.6, _PRICE_COLORS[price_dir]))
+
+    # RSライン (点線, 副役) - 下パネル
+    if rs_pts_raw is not None:
+        ys = normalize_minmax(rs_pts_raw, rs_panel_h)
+        ys = [y + rs_panel_top for y in ys]
+        points = list(zip(xs, ys))
+        parts.append(_svg_polyline(points, _RS_COLORS[rs_dir], 1.0, dasharray="2,1"))
+        # 末尾点: Blue Dot or 通常マーカー
+        if has_blue_dot:
+            parts.append(_svg_circle(points[-1][0], points[-1][1], 2.5, _BLUE_DOT))
+        else:
+            parts.append(_svg_circle(points[-1][0], points[-1][1], 1.4, _RS_COLORS[rs_dir]))
+
+    parts.append("</svg>")
+    return ("".join(parts), tooltip)
+
+
+def build_price_rs_chart_full(
+    price_log: List,
+    rs_line: List,
+    has_blue_dot: bool,
+    width: int = 400,
+    height: int = 120,
+) -> tuple:
+    """詳細ページ用 20 点フルチャート SVG と tooltip を返す。
+
+    IBD MarketSmith 風の上下オフセットレイアウト (仕切り線なし):
+      - 株価は上 70% の縦範囲を使って min-max 描画
+      - RSライン は下 30% の縦範囲を使って min-max 描画
+      - 仕切り線は出さず、線が「同パネルに重なって見えるが上下別帯を動く」状態にする
+        → 形の違いがはっきり読める
+    末尾 5 日部分は太く濃色で重ねて強調。
+    軸ガイド (20日前 / 5日前 / 今日) を縦薄線で表示。
+    弱気相場で株価停滞だが RS 新高値 = Blue Dot のシグナルが形のコントラストで見える。
+    """
+    price_asc = _asc_series_from_log(price_log, _SPARK_LOOKBACK)
+    rs_asc = _asc_series_from_log(rs_line, _SPARK_LOOKBACK)
+
+    if len(price_asc) < 2 and len(rs_asc) < 2:
+        return ("", "")
+
+    tooltip = _build_chart_tooltip(price_asc, rs_asc, has_blue_dot)
+
+    # Y軸ラベルのため左右に余白を確保
+    pad_left = 36  # 株価 (円, 緑) ラベル分
+    pad_right = 36  # RS変化率 (%, 青) ラベル分
+    pad_y_top = 14    # 凡例分
+    pad_y_bottom = 14  # 日付ラベル分
+    inner_w = width - pad_left - pad_right
+    inner_h = height - pad_y_top - pad_y_bottom
+    pad_x = pad_left  # 描画原点 (x)
+
+    # 上下分割: 株価 70%, ギャップ, RS 30%
+    panel_gap = 4
+    price_panel_h = (inner_h - panel_gap) * 0.7
+    rs_panel_h = (inner_h - panel_gap) * 0.3
+    price_panel_top = pad_y_top
+    rs_panel_top = pad_y_top + price_panel_h + panel_gap
+
+    # 株価と RS で長さが違うことがあるので、長い方の長さを基準に等間隔 x を作る
+    n = max(len(price_asc), len(rs_asc))
+    if n < 2:
+        return ("", "")
+    step = inner_w / max(n - 1, 1)
+
+    def _xs_for(series: List[float]) -> List[float]:
+        # 末尾揃え: 右端 = 今日, 左へさかのぼる
+        return [pad_x + inner_w - step * (len(series) - 1 - i) for i in range(len(series))]
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" width="{width}" height="{height}" style="display:block;">'
+    ]
+
+    # 背景枠
+    parts.append(
+        f'<rect x="0" y="0" width="{width}" height="{height}" fill="#fafafa" stroke="#e0e0e0"/>'
+    )
+
+    # 仕切り線は出さない。上下オフセットだけで「同パネル内で別帯を動く」状態にする
+    # (IBD MarketSmith 風: 線が重なって見えるが、上下に分かれているので形の違いが読める)
+
+    # 軸ガイド: 20日前/5日前/今日 の縦線 (両パネルにまたがる)
+    x_today = pad_x + inner_w
+    x_t5 = pad_x + inner_w - step * (_SPARK_RECENT - 1)
+    x_t20 = pad_x
+    for gx in (x_t20, x_t5, x_today):
+        parts.append(
+            f'<line x1="{gx:.1f}" y1="{pad_y_top}" x2="{gx:.1f}" y2="{pad_y_top + inner_h}" '
+            f'stroke="#e0e0e0" stroke-width="0.5"/>'
+        )
+
+    # 日付ラベル (price_log の日付を参照)。データが少ない場合は実在する最古日を使う
+    try:
+        today_label = price_log[0][0].strftime("%m/%d") if price_log else ""
+        t5_idx = min(_SPARK_RECENT - 1, len(price_log) - 1) if price_log else -1
+        t20_idx = len(price_log) - 1 if price_log else -1
+        t5_label = price_log[t5_idx][0].strftime("%m/%d") if t5_idx >= 0 else ""
+        t20_label = price_log[t20_idx][0].strftime("%m/%d") if t20_idx >= 0 else ""
+    except Exception:
+        today_label = t5_label = t20_label = ""
+    label_y = height - 2
+    parts.append(
+        f'<text x="{x_t20:.1f}" y="{label_y}" font-size="9" fill="#888" text-anchor="start">{t20_label}</text>'
+    )
+    parts.append(
+        f'<text x="{x_t5:.1f}" y="{label_y}" font-size="9" fill="#888" text-anchor="middle">{t5_label}</text>'
+    )
+    parts.append(
+        f'<text x="{x_today:.1f}" y="{label_y}" font-size="9" fill="#888" text-anchor="end">{today_label}</text>'
+    )
+
+    # 凡例 (上端)
+    parts.append(
+        '<text x="' + str(pad_x) + '" y="10" font-size="9" fill="#666">'
+        '<tspan fill="#2e7d32">━ 株価 (円)</tspan>'
+        '<tspan dx="6" fill="#1976d2" font-style="italic">┄ RSライン (対TOPIX, 期間変化率)</tspan>'
+        '</text>'
+    )
+
+    # 上下別パネル: それぞれが独自の min-max でフル高さを使う。
+    # 株価と RS が同じ動きでも上下別エリアに描かれるので、形の対比が見やすい。
+
+    # 株価パネル
+    price_slope_full = compute_slope_per_day(price_asc) if len(price_asc) >= 2 else None
+    price_slope_recent = (
+        compute_slope_per_day(price_asc[-_SPARK_RECENT:])
+        if len(price_asc) >= _SPARK_RECENT
+        else None
+    )
+    price_dir_full = _slope_direction(price_slope_full)
+    price_dir_recent = _slope_direction(price_slope_recent)
+
+    # 対数軸: +X% の動きが価格レンジに関係なく同じ縦距離になる (IBD準拠)
+    log_price_asc = to_log_scale(price_asc) if len(price_asc) >= 2 else []
+    if log_price_asc:
+        ys_price = normalize_minmax(log_price_asc, price_panel_h)
+        ys_price = [y + price_panel_top for y in ys_price]
+        xs_price = _xs_for(price_asc)
+        full_points = list(zip(xs_price, ys_price))
+        # 20日全体 (薄)
+        parts.append(_svg_polyline(full_points, _PRICE_FADED[price_dir_full], 1.5))
+        # 末尾5日 (濃)
+        if len(full_points) >= _SPARK_RECENT:
+            recent_points = full_points[-_SPARK_RECENT:]
+            parts.append(_svg_polyline(recent_points, _PRICE_COLORS[price_dir_recent], 2.2))
+        # 末尾マーカー
+        parts.append(_svg_circle(full_points[-1][0], full_points[-1][1], 2.5, _PRICE_COLORS[price_dir_recent]))
+
+        # 左軸 (株価): max を上端、min を下端、現在値を末尾の y 位置に
+        p_max = max(price_asc)
+        p_min = min(price_asc)
+        p_now = price_asc[-1]
+        label_x = pad_left - 2
+        parts.append(
+            f'<text x="{label_x}" y="{price_panel_top + 3:.1f}" font-size="8" '
+            f'fill="#2e7d32" text-anchor="end">{_format_price_axis(p_max)}</text>'
+        )
+        parts.append(
+            f'<text x="{label_x}" y="{price_panel_top + price_panel_h - 1:.1f}" font-size="8" '
+            f'fill="#2e7d32" text-anchor="end">{_format_price_axis(p_min)}</text>'
+        )
+        # 現在値: 末尾点の真横に強調 (濃緑、太字風)
+        now_y = full_points[-1][1]
+        parts.append(
+            f'<text x="{label_x}" y="{now_y + 3:.1f}" font-size="9" '
+            f'fill="#2e7d32" font-weight="bold" text-anchor="end">{_format_price_axis(p_now)}</text>'
+        )
+
+    # RSパネル
+    rs_slope_full = compute_slope_per_day(rs_asc) if len(rs_asc) >= 2 else None
+    rs_slope_recent = (
+        compute_slope_per_day(rs_asc[-_SPARK_RECENT:])
+        if len(rs_asc) >= _SPARK_RECENT
+        else None
+    )
+    rs_dir_full = _slope_direction(rs_slope_full)
+    rs_dir_recent = _slope_direction(rs_slope_recent)
+
+    if len(rs_asc) >= 2:
+        ys_rs = normalize_minmax(rs_asc, rs_panel_h)
+        ys_rs = [y + rs_panel_top for y in ys_rs]
+        xs_rs = _xs_for(rs_asc)
+        full_points = list(zip(xs_rs, ys_rs))
+        # 20日全体 (薄, 点線)
+        parts.append(_svg_polyline(full_points, _RS_FADED[rs_dir_full], 1.0, dasharray="2,2"))
+        # 末尾5日 (濃, 点線)
+        if len(full_points) >= _SPARK_RECENT:
+            recent_points = full_points[-_SPARK_RECENT:]
+            parts.append(
+                _svg_polyline(recent_points, _RS_COLORS[rs_dir_recent], 1.5, dasharray="2,1")
+            )
+        # 末尾マーカー: Blue Dot or 通常
+        if has_blue_dot:
+            parts.append(_svg_circle(full_points[-1][0], full_points[-1][1], 4.0, _BLUE_DOT))
+        else:
+            parts.append(_svg_circle(full_points[-1][0], full_points[-1][1], 2.0, _RS_COLORS[rs_dir_recent]))
+
+        # 右軸 (RS): 初日 (rs_asc[0]) を 0% 基準とした期間内の変化率を表示
+        rs_base = rs_asc[0]
+        if rs_base > 0:
+            rs_pct_max = (max(rs_asc) - rs_base) / rs_base * 100
+            rs_pct_min = (min(rs_asc) - rs_base) / rs_base * 100
+            rs_pct_now = (rs_asc[-1] - rs_base) / rs_base * 100
+            label_x = pad_left + inner_w + 2
+            parts.append(
+                f'<text x="{label_x}" y="{rs_panel_top + 3:.1f}" font-size="8" '
+                f'fill="#1976d2" text-anchor="start">{_format_pct_axis(rs_pct_max)}</text>'
+            )
+            parts.append(
+                f'<text x="{label_x}" y="{rs_panel_top + rs_panel_h - 1:.1f}" font-size="8" '
+                f'fill="#1976d2" text-anchor="start">{_format_pct_axis(rs_pct_min)}</text>'
+            )
+            # 現在値: 末尾点の真横に強調
+            now_y = full_points[-1][1]
+            parts.append(
+                f'<text x="{label_x}" y="{now_y + 3:.1f}" font-size="9" '
+                f'fill="#1976d2" font-weight="bold" text-anchor="start">{_format_pct_axis(rs_pct_now)}</text>'
+            )
+
+    parts.append("</svg>")
+    return ("".join(parts), tooltip)
+
+
+def build_stock_chart_payload(
+    stock: Dict[str, Any],
+    market_db: Optional[Dict[str, Any]],
+    mode: str = "mini",
+) -> Dict[str, Any]:
+    """stock + market_db からチャート用 svg + tooltip + blue_dot 情報を組み立てる。
+
+    mode: "mini" (portfolio 用) or "full" (detail 用)
+    market_db が None の場合は RS ラインが空で描画される (株価のみ)。
+    """
+    from make_stock_db import compute_rs_line, compute_rs_line_new_high  # 遅延 import
+
+    price_log = (stock or {}).get("price_log") or []
+    rs_line: List = []
+    has_blue_dot = False
+    if market_db is not None and stock:
+        try:
+            rs_line = compute_rs_line(stock, market_db)
+            has_blue_dot = compute_rs_line_new_high(
+                stock, market_db, lookback=_SPARK_RS_NEW_HIGH_LOOKBACK, rs_line=rs_line
+            )
+        except Exception:  # noqa: BLE001
+            rs_line = []
+            has_blue_dot = False
+
+    if mode == "full":
+        svg, tooltip = build_price_rs_chart_full(price_log, rs_line, has_blue_dot)
+    else:
+        svg, tooltip = build_price_rs_chart_mini(price_log, rs_line, has_blue_dot)
+    return {"svg": svg, "tooltip": tooltip, "blue_dot": has_blue_dot}
 
 
 def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2193,7 +2193,7 @@ def build_price_rs_chart_full(
         # 末尾マーカー
         parts.append(_svg_circle(full_points[-1][0], full_points[-1][1], 2.5, _PRICE_COLORS[price_dir_recent]))
 
-        # 左軸 (株価): max を上端、min を下端、現在値を末尾の y 位置に
+        # 左軸 (株価): max を上端、min を下端の軸外に配置
         p_max = max(price_asc)
         p_min = min(price_asc)
         p_now = price_asc[-1]
@@ -2206,10 +2206,11 @@ def build_price_rs_chart_full(
             f'<text x="{label_x}" y="{price_panel_top + price_panel_h - 1:.1f}" font-size="8" '
             f'fill="#2e7d32" text-anchor="end">{_format_price_axis(p_min)}</text>'
         )
-        # 現在値: 末尾点の真横に強調 (濃緑、太字風)
+        # 現在値: 末尾点の左隣、グラフ内部に配置 (軸外 max/min と重ならない)
+        now_x = full_points[-1][0]
         now_y = full_points[-1][1]
         parts.append(
-            f'<text x="{label_x}" y="{now_y + 3:.1f}" font-size="9" '
+            f'<text x="{now_x - 4:.1f}" y="{now_y + 3:.1f}" font-size="9" '
             f'fill="#2e7d32" font-weight="bold" text-anchor="end">{_format_price_axis(p_now)}</text>'
         )
 
@@ -2257,11 +2258,14 @@ def build_price_rs_chart_full(
                 f'<text x="{label_x}" y="{rs_panel_top + rs_panel_h - 1:.1f}" font-size="8" '
                 f'fill="#1976d2" text-anchor="start">{_format_pct_axis(rs_pct_min)}</text>'
             )
-            # 現在値: 末尾点の真横に強調
+            # 現在値: 末尾点の左隣、グラフ内部に配置 (軸外 max/min と重ならない)
+            now_x = full_points[-1][0]
             now_y = full_points[-1][1]
+            # Blue Dot 時は青丸(r=4)があるので余白を多めに
+            offset = 8 if has_blue_dot else 4
             parts.append(
-                f'<text x="{label_x}" y="{now_y + 3:.1f}" font-size="9" '
-                f'fill="#1976d2" font-weight="bold" text-anchor="start">{_format_pct_axis(rs_pct_now)}</text>'
+                f'<text x="{now_x - offset:.1f}" y="{now_y + 3:.1f}" font-size="9" '
+                f'fill="#1976d2" font-weight="bold" text-anchor="end">{_format_pct_axis(rs_pct_now)}</text>'
             )
 
     parts.append("</svg>")

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2133,11 +2133,14 @@ def build_price_rs_chart_full(
             f'stroke="#e0e0e0" stroke-width="0.5"/>'
         )
 
-    # 日付ラベル (price_log の日付を参照)。データが少ない場合は実在する最古日を使う
+    # 日付ラベル (price_log の日付を参照)。チャート本体は price_log[:_SPARK_LOOKBACK]
+    # 相当しか描画しないので、左端ラベルも表示窓内の最古日 (= 描画範囲の左端)
+    # に合わせる必要がある。price_log が _SPARK_LOOKBACK を超える場合に
+    # 「全履歴の最古日」が出る回帰を防ぐ。
     try:
         today_label = price_log[0][0].strftime("%m/%d") if price_log else ""
         t5_idx = min(_SPARK_RECENT - 1, len(price_log) - 1) if price_log else -1
-        t20_idx = len(price_log) - 1 if price_log else -1
+        t20_idx = min(_SPARK_LOOKBACK - 1, len(price_log) - 1) if price_log else -1
         t5_label = price_log[t5_idx][0].strftime("%m/%d") if t5_idx >= 0 else ""
         t20_label = price_log[t20_idx][0].strftime("%m/%d") if t20_idx >= 0 else ""
     except Exception:

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -93,10 +93,21 @@ def stock_detail(code_s: str):
         if not portfolio_fallback_mode else []
     )
 
+    # issue #227: 株価 + RSライン 統合チャート (フル版)
+    # market_db のロード失敗時は RS 無しの株価のみで描画 (500 にしない)
+    try:
+        from make_market_db import get_market_db  # 遅延 import
+        from webapp.helpers import build_stock_chart_payload
+        _market_db = get_market_db()
+        price_rs_chart = build_stock_chart_payload(stock, _market_db, mode="full")
+    except Exception:  # noqa: BLE001
+        price_rs_chart = {"svg": "", "tooltip": "", "blue_dot": False}
+
     return render_template(
         "detail.html",
         record=record,
         stock=stock,
+        price_rs_chart=price_rs_chart,
         disclosures=disclosures,
         disclosures_has_recent=disclosures_has_recent,
         indicator_snaps=indicator_snaps,

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -95,10 +95,15 @@ def stock_detail(code_s: str):
 
     # issue #227: 株価 + RSライン 統合チャート (フル版)
     # market_db のロード失敗時は RS 無しの株価のみで描画 (500 にしない)
+    from webapp.helpers import build_stock_chart_payload  # 遅延 import
+    _market_db = None
     try:
-        from make_market_db import get_market_db  # 遅延 import
-        from webapp.helpers import build_stock_chart_payload
+        from make_market_db import get_market_db  # 遅延 import (循環回避)
         _market_db = get_market_db()
+    except Exception:  # noqa: BLE001
+        _market_db = None  # 株価のみのフォールバック描画に進む
+    try:
+        # market_db が None でも build_stock_chart_payload は株価だけで SVG を返す
         price_rs_chart = build_stock_chart_payload(stock, _market_db, mode="full")
     except Exception:  # noqa: BLE001
         price_rs_chart = {"svg": "", "tooltip": "", "blue_dot": False}

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -97,17 +97,19 @@
         <span style="color:#a07000;font-size:0.85em;">portfolio_shelve 未移行モード</span>
       </div>
       {% endif %}
+    </div>{# /.meta #}
+  </div>{# /.left #}
+  {# issue #227: 株価 + RSライン 統合チャート (フル版)。
+     .stock-header の flex 子要素として .left の兄弟に置くことで、
+     justify-content: space-between により右上スペースに自動配置される。 #}
+  {% if price_rs_chart and price_rs_chart.svg %}
+  <div class="right" style="flex:0 0 auto;">
+    <div title="{{ price_rs_chart.tooltip }}" style="cursor:help;">
+      {{ price_rs_chart.svg|safe }}
     </div>
-    {# issue #227: 株価 + RSライン 統合チャート (フル版) #}
-    {% if price_rs_chart and price_rs_chart.svg %}
-    <div class="right" style="margin-left:1em;">
-      <div title="{{ price_rs_chart.tooltip }}" style="cursor:help;">
-        {{ price_rs_chart.svg|safe }}
-      </div>
-    </div>
-    {% endif %}
   </div>
-</div>
+  {% endif %}
+</div>{# /.stock-header #}
 
 {# ===== 適時開示 ===== #}
 {% if disclosures %}

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -98,6 +98,14 @@
       </div>
       {% endif %}
     </div>
+    {# issue #227: 株価 + RSライン 統合チャート (フル版) #}
+    {% if price_rs_chart and price_rs_chart.svg %}
+    <div class="right" style="margin-left:1em;">
+      <div title="{{ price_rs_chart.tooltip }}" style="cursor:help;">
+        {{ price_rs_chart.svg|safe }}
+      </div>
+    </div>
+    {% endif %}
   </div>
 </div>
 

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -158,10 +158,9 @@
       <th>更新日</th>
       <th>ステージ</th>
       <th>RS</th>
-      <th>RSライン(20,5)</th>
+      <th title="株価(実線, 緑/赤) + RSライン(点線, 青/オレンジ) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸">株価/RS(20,5)</th>
       <th>トレンド</th>
       <th>タグ</th>
-      <th>株価向き(20,5)</th>
       <th>買い集め</th>
       <th>時価総額</th>
     </tr>
@@ -224,18 +223,20 @@
           {% if not fallback_mode %}class="editable" data-code="{{ row.code_s }}" data-field="stage" data-touch-update="1"{% endif %}
           style="{{ row.styles.stage or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.stage or "—" }}</td>
       <td style="{{ row.styles.rs or '' }}">{{ row.rs }}</td>
-      <td style="color:#bbb;">—</td>
+      {# issue #227: 株価 + RSライン 3点ミニチャート (旧 RSライン/株価向き 2列を統合) #}
+      <td title="{{ row.price_rs_chart.tooltip }}" style="padding:0 2px;line-height:0;">
+        {% if row.price_rs_chart.svg %}{{ row.price_rs_chart.svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
+      </td>
       <td title="{{ row.trend_template_tooltip }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.trend_template or '' }}">{{ row.trend_template }}</td>
       <td title="{{ row.tags }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
-      <td style="color:#bbb;">—</td>
       <td style="{{ row.styles.buy_collection or '' }}">{{ row.buy_collection }}</td>
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 #}
-      <td colspan="{% if delete_mode_allowed %}24{% else %}23{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
+      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 / issue #227 で旧 RSライン+株価向き 2列を1列に統合 → 1 減 #}
+      <td colspan="{% if delete_mode_allowed %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2336,3 +2336,123 @@ class TestPriceRsSparkline:
         # RS の % 表記が右軸に出る (初日比で +X% or -X%)
         assert "%" in svg
         assert "#1976d2" in svg
+
+    # --- codex review 対応: 5日基準のずれ / 短期履歴ガイドはみ出し ---
+
+    def test_total_change_5day_matches_six_point_window(self):
+        """_format_total_change(values, 5) は「5営業日前→今日」の変化を返す。
+
+        既存の (20,5) 指標 (offset=5) と一致するよう、6点窓 (tail[0]→tail[-1]) で算出する。
+        従来は 5点窓 = 4営業日変化になっていた回帰の防止。
+        """
+        # 7 点: 末尾から 6 本目 (index=1) → 今日 (index=6) で +6.0%
+        values = [100.0, 100.0, 101.0, 102.0, 103.0, 104.0, 106.0]
+        result = helpers._format_total_change(values, 5)
+        assert result == "+6.0%"
+
+    def test_total_change_20day_uses_21_point_window_when_available(self):
+        """_format_total_change(values, 20) は 20営業日変化として 21点窓を取る。
+
+        20点しか無い場合は全 20点で計算する (= 19営業日変化, 既存実装維持)。
+        """
+        # 21 点ちょうど: index=0 → index=20 で +20.0%
+        values = [100.0 + i for i in range(21)]
+        result = helpers._format_total_change(values, 20)
+        assert result == "+20.0%"
+
+    def test_mini_chart_t5_point_uses_5_business_days_ago(self):
+        """mini チャートの t-5 点は 5営業日前 (= asc[-6]) を参照する。
+
+        従来は asc[-5] (= 4営業日前) を取っていた回帰の防止。
+        中間 y 座標が「5営業日前の値」に対応していることを確認する。
+        """
+        # 7 点入力 (新しい順): t-0=106, t-1=104, ... , t-5=100, t-6=99
+        # asc は古い順 = [99, 100, 101, 102, 103, 104, 106]
+        # t5 = asc[-6] = 100 (= 5営業日前)。 asc[-5]=101 (= 4営業日前) ではない。
+        price_log = self._make_log([106, 104, 103, 102, 101, 100, 99])
+        rs_line = self._make_log([1.06, 1.04, 1.03, 1.02, 1.01, 1.00, 0.99])
+        svg, _ = helpers.build_price_rs_chart_mini(price_log, rs_line, has_blue_dot=False)
+        # polyline が描画されている = 3点取得が成功
+        assert "polyline" in svg
+        # 中間点の y 座標を検証: log(99)=4.595, log(100)=4.605, log(101)=4.615, log(106)=4.663
+        # 5営業日前=100 を採用すれば log 空間で「下から 2 番目」相当 (asc-internal 0-1 で 0.147)
+        # 4営業日前=101 を採用すれば 0.293
+        # mini パネルは 60% inner_h = (24-6)*0.6 = 10.8 高さ
+        # 違いは小さいので、ここでは t-5 点で計算した値と直接比較する
+        import math
+        log_price = [math.log(v) for v in [99, 100, 101, 102, 103, 104, 106]]
+        t5_expected = log_price[-6]  # = log(100)
+        t5_wrong = log_price[-5]     # = log(101)
+        # 正規化後の y を再現
+        lo, hi = min(log_price), max(log_price)
+        # mini の panel: inner_h = 24-6 = 18, price_panel_h = (18-1)*0.6 = 10.2
+        panel_h = (18 - 1) * 0.6
+        pad_y = 3
+        y_t5_expected = pad_y + panel_h * (hi - t5_expected) / (hi - lo)
+        y_t5_wrong = pad_y + panel_h * (hi - t5_wrong) / (hi - lo)
+        # SVG に「中間点」の y 座標が含まれることを polyline points から抽出
+        # points="X1,Y1 X2,Y2 X3,Y3" の真ん中 Y2 が y_t5_expected に近いことを確認
+        import re
+        m = re.search(r'<polyline points="([^"]+)" fill="none"\s+stroke="#[0-9a-f]+" stroke-width="1.5"', svg)
+        assert m is not None, f"price polyline not found: {svg[:300]}"
+        pts = m.group(1).split()
+        assert len(pts) == 3
+        _, y2_str = pts[1].split(",")
+        y2 = float(y2_str)
+        # 正解側 (5営業日前=100) との差は小さく、誤り側 (4営業日前=101) より近い
+        assert abs(y2 - y_t5_expected) < abs(y2 - y_t5_wrong), (
+            f"中間点 y={y2} が 5営業日前 (期待 {y_t5_expected:.2f}) ではなく "
+            f"4営業日前 ({y_t5_wrong:.2f}) に近い"
+        )
+
+    def test_full_chart_t5_guide_omitted_for_short_history(self):
+        """短期履歴 (2 本) の銘柄でも 5日ガイドが viewBox 外に飛び出さない。
+
+        従来は x_t5 = pad_x - 3*inner_w 等 SVG 左外側に出てレイアウトを壊していた。
+        本数が _SPARK_RECENT+1 に満たない場合は 5日ガイドを省略し、
+        本体チャートだけは描画する。
+        """
+        from datetime import date as _d, timedelta
+        base = _d(2026, 5, 15)
+        # たった 2 点 (新しい順)
+        price_log = [(base, 100), (base - timedelta(days=1), 95)]
+        rs_line = [(base, 1.0), (base - timedelta(days=1), 0.95)]
+        svg, _ = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=False)
+        # 本体ポリラインは描画されている
+        assert "<polyline" in svg
+        # ガイド線の x1 がすべて pad_x (= 36, 左端) 以上、x_today (= 36+inner_w) 以下に収まる
+        import re
+        # viewBox 0 0 400 120 / pad_left=36 / pad_right=36 / inner_w = 400-72 = 328
+        pad_left = 36
+        inner_w = 400 - 72
+        x_today = pad_left + inner_w  # = 364
+        guides = re.findall(r'<line x1="([-0-9.]+)" y1="[0-9.]+" x2="[-0-9.]+" y2="[0-9.]+"\s+stroke="#e0e0e0"', svg)
+        assert len(guides) >= 2  # 少なくとも t20 と today のガイド
+        for gx in guides:
+            x = float(gx)
+            assert pad_left - 0.5 <= x <= x_today + 0.5, f"ガイド線が viewBox 外: x={x}"
+
+    def test_full_chart_t5_label_omitted_for_short_history(self):
+        """短期履歴 (3本) で 5日ラベルも省略される (t20 と重なる位置に出ない)。"""
+        from datetime import date as _d, timedelta
+        base = _d(2026, 5, 15)
+        # 3 本 = 2 営業日変化
+        price_log = [(base - timedelta(days=i), 100 + i) for i in range(3)]
+        rs_line = [(base - timedelta(days=i), 1.0 + i * 0.01) for i in range(3)]
+        svg, _ = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=False)
+        # 5/15 (today) ラベルは出る
+        assert "05/15" in svg
+        # 左端 = price_log[2] = 5/13
+        assert "05/13" in svg
+
+    def test_full_chart_t5_guide_present_for_normal_history(self):
+        """通常 20 本データでは 5日ガイド (t5) が描画される。"""
+        price_log = self._make_log(list(range(120, 100, -1)))  # 20点
+        rs_line = self._make_log([1.20 - i * 0.01 for i in range(20)])
+        svg, _ = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=False)
+        # ガイド線 3 本 (t20, t5, today) 描画されること
+        import re
+        guides = re.findall(r'stroke="#e0e0e0" stroke-width="0.5"', svg)
+        assert len(guides) == 3
+        # t-5 営業日前のラベル: 5/15 - 5 = 5/10
+        assert "05/10" in svg

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2272,6 +2272,26 @@ class TestPriceRsSparkline:
         # 当日 = 5/15 ラベルが出る
         assert "05/15" in svg
 
+    def test_full_chart_t20_label_matches_displayed_window(self):
+        """price_log が _SPARK_LOOKBACK (20) を超える場合、左端ラベルは
+        '表示窓内の最古日 (20日前)' であって '全履歴の最古日' ではない。
+        (codex review 対応: 履歴が長い銘柄で左端ラベルがチャート期間とずれる回帰防止)
+        """
+        from datetime import date as _d, timedelta
+        # 30営業日分の price_log (新しい順)。base_date=5/15
+        base = _d(2026, 5, 15)
+        price_log = [(base - timedelta(days=i), 100 + i) for i in range(30)]
+        rs_line = [(base - timedelta(days=i), 1.0 + i * 0.01) for i in range(30)]
+        svg, _ = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=False)
+        # 当日 = 5/15
+        assert "05/15" in svg
+        # 表示左端 = price_log[19] = 5/15 - 19日 = 4/26
+        t20_date = (base - timedelta(days=19)).strftime("%m/%d")
+        assert t20_date in svg
+        # 全履歴最古 = price_log[29] = 5/15 - 29日 = 4/16 は出ないこと (回帰防止)
+        t30_date = (base - timedelta(days=29)).strftime("%m/%d")
+        assert t30_date not in svg
+
     def test_full_chart_blue_dot_renders_blue_circle(self):
         price_log = self._make_log(list(range(120, 100, -1)))
         rs_line = self._make_log([1.20 - i * 0.01 for i in range(20)])

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2114,3 +2114,185 @@ class TestMarkdownToHtml:
     def test_url_still_linkified(self):
         result = helpers._markdown_to_html("see https://example.com")
         assert '<a href="https://example.com" target="_blank">' in result
+
+
+class TestPriceRsSparkline:
+    """株価 + RSライン 統合スパークライン (issue #227)"""
+
+    # --- compute_slope_per_day ---
+
+    def test_slope_positive_linear_series(self):
+        # 等差 100 → 110: 傾き 1/日, 末尾110で正規化 → ≒ 0.91%/日
+        values = list(range(100, 111))  # 11点
+        slope = helpers.compute_slope_per_day(values)
+        assert slope is not None
+        assert 0.85 < slope < 0.95
+
+    def test_slope_negative_linear_series(self):
+        values = list(range(110, 99, -1))  # 110→100
+        slope = helpers.compute_slope_per_day(values)
+        assert slope is not None
+        assert slope < 0
+
+    def test_slope_constant_series_is_zero(self):
+        slope = helpers.compute_slope_per_day([100, 100, 100, 100])
+        assert slope == 0.0
+
+    def test_slope_too_few_points_returns_none(self):
+        assert helpers.compute_slope_per_day([100]) is None
+        assert helpers.compute_slope_per_day([]) is None
+
+    # --- normalize_minmax ---
+
+    def test_normalize_range_is_within_height(self):
+        ys = helpers.normalize_minmax([1.0, 2.0, 3.0, 4.0], height=20)
+        assert min(ys) == 0.0
+        assert max(ys) == 20.0
+        # 昇順入力 → SVG y は降順 (top = 0 が最大値)
+        assert ys[0] > ys[-1]
+
+    def test_normalize_constant_series_centers(self):
+        ys = helpers.normalize_minmax([5.0, 5.0, 5.0], height=20)
+        assert ys == [10.0, 10.0, 10.0]
+
+    def test_normalize_empty_returns_empty(self):
+        assert helpers.normalize_minmax([], height=20) == []
+
+    # --- to_log_scale ---
+
+    def test_log_scale_returns_natural_log(self):
+        import math
+        result = helpers.to_log_scale([100, 200, 400])
+        assert abs(result[0] - math.log(100)) < 1e-9
+        assert abs(result[1] - math.log(200)) < 1e-9
+        assert abs(result[2] - math.log(400)) < 1e-9
+        # 100→200 と 200→400 (どちらも +100%) は log 空間で同じ距離になる
+        assert abs((result[1] - result[0]) - (result[2] - result[1])) < 1e-9
+
+    def test_log_scale_empty_or_nonpositive_returns_empty(self):
+        assert helpers.to_log_scale([]) == []
+        assert helpers.to_log_scale([100, 0, 200]) == []
+        assert helpers.to_log_scale([-1, 100]) == []
+
+    # --- to_base_index ---
+
+    def test_base_index_first_is_one(self):
+        result = helpers.to_base_index([100, 110, 105, 120])
+        assert result[0] == 1.0
+        assert result[1] == 1.1
+        assert abs(result[2] - 1.05) < 1e-9
+        assert result[3] == 1.2
+
+    def test_base_index_empty_or_zero_returns_empty(self):
+        assert helpers.to_base_index([]) == []
+        assert helpers.to_base_index([0, 10, 20]) == []
+        assert helpers.to_base_index([-5, 10]) == []
+
+    # --- normalize_shared_y ---
+
+    def test_shared_y_aligns_start_points(self):
+        # 株価: +20% 上昇, RS: +5% 上昇 → 同じ起点から終点が大きく乖離
+        price = [100.0, 110.0, 120.0]
+        rs = [1.0, 1.025, 1.05]
+        ys = helpers.normalize_shared_y([price, rs], height=20)
+        # 起点 (index=0) は両者とも先頭=1.0 に揃うので、共通スケール上で同じ y 座標
+        assert ys[0][0] == ys[1][0]
+        # 終点は乖離する (株価が 1.20、RSが 1.05)
+        assert ys[0][-1] != ys[1][-1]
+        # 株価の方が大きく上昇 → SVG y が小さい (上に伸びる)
+        assert ys[0][-1] < ys[1][-1]
+
+    def test_shared_y_constant_series_returns_center(self):
+        ys = helpers.normalize_shared_y([[100, 100, 100], [1.0, 1.0, 1.0]], height=20)
+        assert ys[0] == [10.0, 10.0, 10.0]
+        assert ys[1] == [10.0, 10.0, 10.0]
+
+    def test_shared_y_empty_input_returns_empty_each(self):
+        ys = helpers.normalize_shared_y([[], []], height=20)
+        assert ys == [[], []]
+
+    # --- build_price_rs_chart_mini ---
+
+    def _make_log(self, values, base_date=None):
+        """新しい順の (date, value) タプル列を組み立てる (テスト用)"""
+        from datetime import date as _d, timedelta
+        if base_date is None:
+            base_date = _d(2026, 5, 15)
+        return [(base_date - timedelta(days=i), v) for i, v in enumerate(values)]
+
+    def test_mini_chart_returns_svg_for_sufficient_data(self):
+        price_log = self._make_log([110, 108, 106, 104, 102, 100])  # 新しい順
+        rs_line = self._make_log([1.10, 1.08, 1.06, 1.04, 1.02, 1.00])
+        svg, tooltip = helpers.build_price_rs_chart_mini(price_log, rs_line, has_blue_dot=False)
+        assert "<svg" in svg
+        assert "</svg>" in svg
+        assert "polyline" in svg
+        assert "株価:" in tooltip
+        assert "RSライン:" in tooltip
+
+    def test_mini_chart_insufficient_data_returns_dash(self):
+        svg, _ = helpers.build_price_rs_chart_mini([], [], has_blue_dot=False)
+        assert svg == "—"
+
+    def test_mini_chart_blue_dot_uses_larger_circle(self):
+        price_log = self._make_log([110, 108, 106, 104, 102, 100])
+        rs_line = self._make_log([1.10, 1.08, 1.06, 1.04, 1.02, 1.00])
+        svg_with, _ = helpers.build_price_rs_chart_mini(price_log, rs_line, has_blue_dot=True)
+        svg_without, _ = helpers.build_price_rs_chart_mini(price_log, rs_line, has_blue_dot=False)
+        # Blue Dot は #1976d2 (青) の大きい circle
+        assert '#1976d2' in svg_with
+        assert 'r="2.5"' in svg_with
+        assert 'r="2.5"' not in svg_without
+
+    def test_mini_chart_tooltip_includes_blue_dot_when_present(self):
+        price_log = self._make_log([110, 108, 106, 104, 102, 100])
+        rs_line = self._make_log([1.10, 1.08, 1.06, 1.04, 1.02, 1.00])
+        _, tooltip = helpers.build_price_rs_chart_mini(price_log, rs_line, has_blue_dot=True)
+        assert "新高値" in tooltip
+        _, tooltip2 = helpers.build_price_rs_chart_mini(price_log, rs_line, has_blue_dot=False)
+        assert "新高値" not in tooltip2
+
+    # --- build_price_rs_chart_full ---
+
+    def test_full_chart_renders_two_polylines(self):
+        price_log = self._make_log(list(range(120, 100, -1)))  # 20点 (新しい順 = 降順)
+        rs_line = self._make_log([1.20 - i * 0.01 for i in range(20)])
+        svg, tooltip = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=False)
+        assert "<svg" in svg
+        # 株価実線 + 末尾5日重ね描き + RS点線 + 末尾5日重ね描き = polyline は 4 本以上
+        assert svg.count("<polyline") >= 4
+        assert "stroke-dasharray" in svg  # RSライン点線
+        assert "株価:" in tooltip
+        assert "RSライン:" in tooltip
+
+    def test_full_chart_includes_date_labels(self):
+        price_log = self._make_log(list(range(120, 100, -1)))
+        rs_line = self._make_log([1.20 - i * 0.01 for i in range(20)])
+        svg, _ = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=False)
+        # 当日 = 5/15 ラベルが出る
+        assert "05/15" in svg
+
+    def test_full_chart_blue_dot_renders_blue_circle(self):
+        price_log = self._make_log(list(range(120, 100, -1)))
+        rs_line = self._make_log([1.20 - i * 0.01 for i in range(20)])
+        svg, _ = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=True)
+        # Blue Dot は r=4 の青円
+        assert 'r="4.0"' in svg and '#1976d2' in svg
+
+    def test_full_chart_empty_input_returns_empty(self):
+        svg, tooltip = helpers.build_price_rs_chart_full([], [], has_blue_dot=False)
+        assert svg == ""
+        assert tooltip == ""
+
+    def test_full_chart_renders_axis_labels(self):
+        """Y軸ラベル: 株価=絶対値 (緑), RS=初日比変化率% (青) を表示する"""
+        price_log = self._make_log(list(range(120, 100, -1)))  # 20点: 101..120
+        # rs_line も初日比で見やすい値に
+        rs_line = self._make_log([1.20 - i * 0.01 for i in range(20)])  # 1.01..1.20
+        svg, _ = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=False)
+        # 株価最大値 120 (緑 #2e7d32) が左軸に出る
+        assert "120" in svg
+        assert "#2e7d32" in svg
+        # RS の % 表記が右軸に出る (初日比で +X% or -X%)
+        assert "%" in svg
+        assert "#1976d2" in svg

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2272,6 +2272,26 @@ class TestPriceRsSparkline:
         # 当日 = 5/15 ラベルが出る
         assert "05/15" in svg
 
+    def test_build_payload_with_none_market_db_returns_price_only_chart(self):
+        """build_stock_chart_payload は market_db=None でも株価のみで SVG を返す。
+
+        codex review 対応: detail ルートで market_db 取得失敗時に
+        フォールバックとして「価格のみチャート」を出すための保証。
+        """
+        from datetime import date as _d, timedelta
+        base = _d(2026, 5, 15)
+        stock = {
+            "price_log": [(base - timedelta(days=i), 100 + i) for i in range(20)],
+        }
+        payload = helpers.build_stock_chart_payload(stock, market_db=None, mode="full")
+        assert payload["svg"]  # 空文字でない
+        assert "<svg" in payload["svg"]
+        assert payload["blue_dot"] is False
+        # RS データが無いので、tooltip の RSライン 行は "—" になる
+        assert "RSライン" in payload["tooltip"]
+        # 株価分は正しく出る
+        assert "株価:" in payload["tooltip"]
+
     def test_full_chart_t20_label_matches_displayed_window(self):
         """price_log が _SPARK_LOOKBACK (20) を超える場合、左端ラベルは
         '表示窓内の最古日 (20日前)' であって '全履歴の最古日' ではない。


### PR DESCRIPTION
## Summary
- portfolio の旧「RSライン(20,5)」「株価向き(20,5)」 \`—\` 固定状態を解消
- IBD MarketSmith 風の **上下オフセット2軸チャート** で 株価 + RSライン (株価/TOPIX 比率) を統合
- 詳細ページにフル版 (400×120, 軸ラベル付き)、portfolio に3点ミニ版 (80×24)
- **Blue Dot** (RS新高値) でオニール式リーダー候補シグナルを視覚化

Closes #227

## 仕様
### 詳細ページ フルチャート
- 上 70% = 株価パネル (実線、対数軸、緑/赤、末尾5日太線)
- 下 30% = RSライン パネル (点線、線形、青/オレンジ、末尾5日太線)
- 仕切り線なし → 両線が「同パネル内で別帯を動く」見え方
- 左軸 (緑): 株価絶対値 max/min/**現在値 (太字)**
- 右軸 (青): RS初日比変化率% max/min/**現在値 (太字)**
- 横軸: 20日前/5日前/今日 の縦ガイド + 日付ラベル
- Blue Dot 時は RS末尾を青4px丸で強調
- tooltip: 株価/RS の **20日合計 + 5日合計** 騰落率

### portfolio ミニチャート
- 3点 (t-20, t-5, t-0) ポリライン、80×24px SVG
- 旧2列を1列に統合 (\`colspan\` -1)
- 同じ配色ルール

## 実装ポイント
- データソースは既存の \`compute_rs_line()\` \`compute_rs_line_new_high()\` を流用 (\`scripts/make_stock_db.py\`)
- \`market_db\` は portfolio ループ前 / detail ルート開始時に **1回だけロード**
- \`make_stock_db\` の重依存は webapp 起動時に巻き添えにしないよう **関数内 lazy import**
- 共通スケール(\`normalize_shared_y\`)も実装したが現状未使用 (将来用)
- Blue Dot lookback=18: 銘柄の price_log が約19本/TOPIX重なりで rs_line もほぼ19本に揃うため、過去18営業日比較で「最高」判定

## Test plan
- [x] \`pytest tests/test_webapp_helpers.py::TestPriceRsSparkline -v\` 23件 pass
  - 線形回帰 / 正規化 / 対数変換 / SVG生成 / Blue Dot / Y軸ラベル
- [x] 関連スイート 278+ passed (pre-existing failure 1件は無関係)
- [x] ブラウザ手動 E2E
  - 詳細ページ: /stock/3687 (Blue Dot 付き), /stock/5803 (急変動)
  - portfolio: 329銘柄全件描画、19件で Blue Dot 検出
  - tooltip 表示確認
- [ ] レビュアー側で銘柄違いを軽くチェック (極端な急騰急落で対数軸の効果が見えるか)

## スコープ外 (将来 issue 化候補)
- price_log を 60-90日 (3ヶ月) に拡張
- 出来高棒グラフ重ね
- 移動平均線 (5日/20日)
- 52週高値/安値ライン
- 傾きでのソート
- インタラクティブな拡大表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)