### PR TITLE
issue #183: 銘柄名変更を research_shelve に追従させる (旧名併記表示)

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -110,9 +110,18 @@ stocks_shelve（日次更新の揮発性キャッシュ）とは別に、銘柄�
 
 `code_s` をキーに、3ブロックで構成:
 
-- **識別・評価**: 銘柄名、総合評価（S〜E）、企業概要、機関投資家コメント
+- **識別・評価**: 銘柄名、旧銘柄名（`stock_name_prev`, issue #183）、総合評価（S〜E）、企業概要、機関投資家コメント
 - **手動メモ**: OpenWork、ジムクレイマー、四季報コメント、メモ・総括
 - **スナップショット** (list): 決算タイミングごとの IR定量データ・クォリティ指標・理論株価乖離（`date_yy_m` 降順）
+
+### 銘柄名変更の追従（issue #183）
+
+`make_stock_db.py` の `_update_db_code()` で master を取得した直後、stocks_shelve の旧 `stock_name` と新値を比較し、差異があれば `research_shelve.sync_stock_name()` を呼んで旧名を `stock_name_prev` に退避する。
+
+- 排他制御: `sync_stock_name` 内部の flock 区間で read-modify-write を完結させ、UI 側の `upsert_research_record` と直列化。memo/rating などの手動資産が lost update で消えないことを保証
+- 平常時のオーバーヘッド: 文字列比較のみ。変更なしなら research_shelve への書き込みは発生しない
+- 表示: WebApp の各画面で「新名 (旧○○)」形式で併記 (`templates/_macros.html` の `stock_name_with_prev` マクロ)
+- 既存ズレ補正: `python sync_research_stock_names.py [--apply]` (dry-run デフォルト) で一括補正
 
 ### 決算スナップショットの自動追記
 

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -693,12 +693,45 @@ def update_db_rows(code_s_list, upd=UPD_INTERVAL, tables=None, sync=True):
         return stocks_db.export_to_dict()
 
 
+def _sync_research_stock_name(code_s, *, new_name):
+    """research_shelve の stock_name を排他更新する。
+
+    research_shelve.sync_stock_name に委譲し、lost update リスクを
+    research_shelve 側の flock 区間内に閉じ込める (issue #183)。
+    例外は warning に握る — stock_name 同期失敗で銘柄更新全体を止めない。
+    """
+    import research_shelve
+    try:
+        returned_old = research_shelve.sync_stock_name(code_s, new_name)
+    except Exception as e:
+        log_warning("[stock_name_sync] %s: 同期失敗: %s" % (code_s, e))
+        return
+    if returned_old:
+        log_print(
+            "[stock_name_sync] %s: %s → %s (research_shelve 旧名退避)"
+            % (code_s, returned_old, new_name)
+        )
+
+
 def _update_db_code(c_s, upd, tables, stocks, latest, force):
     """同期非同期共通のDB更新関数"""
     stock_data = {}
     if not tables or "master" in tables:
         if not has_stock_data(stocks, c_s, latest) or force:
-            stock_data.update(get_stock_master_data(stocks, c_s, upd))
+            # 旧名を取得 (master更新で上書きされる前の値)
+            try:
+                old_name = (stocks[c_s] or {}).get("stock_name", "") if c_s in stocks else ""
+            except (KeyError, TypeError):
+                old_name = ""
+            master_data = get_stock_master_data(stocks, c_s, upd)
+            stock_data.update(master_data)
+            new_name = (master_data or {}).get("stock_name", "")
+            if (
+                isinstance(new_name, str) and isinstance(old_name, str)
+                and new_name.strip() and old_name.strip()
+                and new_name.strip() != old_name.strip()
+            ):
+                _sync_research_stock_name(c_s, new_name=new_name.strip())
     if not tables or "price" in tables:
         if not has_price_data(stocks, c_s, latest) or force:
             stock_data.update(get_price_data(stocks, c_s, upd))

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -73,6 +73,7 @@ RECORD_FIELDS = frozenset(
     {
         "code_s",
         "stock_name",
+        "stock_name_prev",
         "overview",
         "overall_rating",
         "institutional_comment",
@@ -243,6 +244,7 @@ def create_research_record(
     code_s: str,
     stock_name: str,
     *,
+    stock_name_prev: Optional[str] = None,
     overview: str = "",
     overall_rating: str = "",
     institutional_comment: str = "",
@@ -269,6 +271,10 @@ def create_research_record(
     normalized_code = normalize_code_s(code_s)
     if not isinstance(stock_name, str):
         raise TypeError(f"stock_name must be str, got {type(stock_name).__name__}")
+    if stock_name_prev is not None and not isinstance(stock_name_prev, str):
+        raise TypeError(
+            f"stock_name_prev must be str or None, got {type(stock_name_prev).__name__}"
+        )
     validate_rating(overall_rating)
     if not isinstance(analysis_date_raw, str):
         raise TypeError(
@@ -286,6 +292,7 @@ def create_research_record(
     return {
         "code_s": normalized_code,
         "stock_name": stock_name,
+        "stock_name_prev": stock_name_prev,
         "overview": overview,
         "overall_rating": overall_rating,
         "institutional_comment": institutional_comment,
@@ -514,6 +521,8 @@ def get_research_record(
             entry["post_price_changes"] = normalize_kessan_post_price_changes(entry)
         if "corporate_url_override" not in record:
             record["corporate_url_override"] = ""
+        if "stock_name_prev" not in record:
+            record["stock_name_prev"] = None
     return record
 
 
@@ -542,6 +551,53 @@ def upsert_research_record(
         log_print("research_shelve: レコード更新", normalized)
     else:
         log_print("research_shelve: レコード追加", normalized)
+
+
+def sync_stock_name(
+    code_s: str,
+    new_name: str,
+    *,
+    db_path: Optional[str] = None,
+) -> Optional[str]:
+    """stock_name と stock_name_prev のみを排他的に書き換える。
+
+    flock 取得中に最新レコードを読み、stock_name が new_name と異なる場合のみ
+    更新し、旧名を stock_name_prev に保存する。他フィールド (memo/rating/snapshots 等)
+    は書き戻し直前の最新値を使うため、flock 区間中に他プロセスが介入しなければ
+    lost update は起きない。flock は UI 側 upsert_research_record と共通なので
+    その間はシリアライズされる。
+
+    Args:
+        code_s: 銘柄コード (正規化される)
+        new_name: 新しい銘柄名 (前後空白は strip)
+        db_path: テスト用パス上書き
+
+    Returns:
+        str | None: 同期した旧名 (実際に更新が走ったとき)、未更新時は None。
+        record が未登録の場合も None。
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    new_name_s = (new_name or "").strip()
+    if not new_name_s:
+        return None
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            if normalized not in db:
+                return None
+            record = db[normalized]
+            current = (record.get("stock_name") or "").strip()
+            if current == new_name_s:
+                return None
+            old_name = current
+            record["stock_name_prev"] = current or None
+            record["stock_name"] = new_name_s
+            db[normalized] = record
+    log_print(
+        "research_shelve: stock_name 同期", normalized, old_name, "→", new_name_s
+    )
+    return old_name
 
 
 def delete_research_record(

--- a/scripts/sync_research_stock_names.py
+++ b/scripts/sync_research_stock_names.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""research_shelve の stock_name を stocks_shelve の最新値に追従させる (issue #183)。
+
+research_shelve の全銘柄を走査し、stocks_shelve に存在しかつ stock_name が
+異なるものを検出する。dry-run がデフォルトで、`--apply` を付けたときだけ
+research_shelve.sync_stock_name 経由で旧名退避+新名上書きを実行する。
+
+通常の make_stock_db 実行で TTL ベース (7日) に自動同期されるが、過去に
+ズレてしまった既存銘柄を一括補正したいときに使う。
+"""
+
+import argparse
+
+import make_stock_db
+import research_shelve
+from ks_util import log_print, log_warning
+
+
+def collect_diffs():
+    """research_shelve と stocks_shelve の stock_name 差分を一覧で返す。
+
+    Returns:
+        list[tuple[str, str, str]]: (code_s, 旧名, 新名) のリスト
+    """
+    try:
+        research_records = research_shelve.list_research_records()
+    except Exception as e:
+        log_warning("research_shelve 読み込み失敗: %s" % e)
+        return []
+    stocks = make_stock_db.load_stock_db()
+    diffs = []
+    for rec in research_records:
+        code_s = rec.get("code_s", "")
+        if not code_s:
+            continue
+        stock = stocks.get(code_s) or {}
+        new_name = (stock.get("stock_name") or "").strip()
+        old_name = (rec.get("stock_name") or "").strip()
+        if not new_name or not old_name:
+            continue
+        if new_name == old_name:
+            continue
+        diffs.append((code_s, old_name, new_name))
+    return diffs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="research_shelve.stock_name を stocks_shelve に追従させる (dry-run default)"
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="実書き込みを行う (デフォルトはdry-run)",
+    )
+    args = parser.parse_args()
+
+    diffs = collect_diffs()
+    if not diffs:
+        log_print("差分なし")
+        return
+
+    log_print("差分 %d 件:" % len(diffs))
+    for code_s, old, new in diffs:
+        log_print("  %s: %s → %s" % (code_s, old, new))
+
+    if not args.apply:
+        log_print("(dry-run) --apply で実書き込み")
+        return
+
+    # 実書き込みは research_shelve.sync_stock_name に委譲 (flock 区間内で R-M-W)。
+    applied = 0
+    for code_s, _old, new in diffs:
+        try:
+            returned_old = research_shelve.sync_stock_name(code_s, new)
+        except Exception as e:
+            log_warning("[sync] %s: 同期失敗: %s" % (code_s, e))
+            continue
+        if returned_old is None:
+            log_print("[sync] %s: 既に最新 (no-op)" % code_s)
+        else:
+            log_print("[sync] %s: %s → %s" % (code_s, returned_old, new))
+            applied += 1
+    log_print("%d 件を更新しました (対象 %d 件中)" % (applied, len(diffs)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1184,6 +1184,7 @@ def get_market_kessan_data() -> Dict[str, Any]:
         merged[merged_key] = {
             "code_s": code_s,
             "stock_name": v.get("stock_name", ""),
+            "stock_name_prev": None,  # stocks_shelve 由来は旧名情報を持たない
             "kessanbi": kessanbi,
             "quarter": v.get("kessan_quarter", 0) or 0,
             "pre_expectation": "",
@@ -1221,9 +1222,13 @@ def get_market_kessan_data() -> Dict[str, Any]:
             quarter = entry.get("quarter", 0) or 0
             cur = merged.get(merged_key)
             stock_name = (cur or {}).get("stock_name") or rec.get("stock_name", "")
+            # research_shelve 側の旧名 (issue #183)。stocks_shelve 由来の cur に
+            # 上書きされた場合でも rec の prev を併記表示できるよう保持する。
+            stock_name_prev = (cur or {}).get("stock_name_prev") or rec.get("stock_name_prev")
             cand = {
                 "code_s": code_s,
                 "stock_name": stock_name,
+                "stock_name_prev": stock_name_prev,
                 "kessanbi": kessanbi,
                 "quarter": quarter if quarter else (cur or {}).get("quarter", 0),
                 "pre_expectation": entry.get("pre_expectation", "") or "",
@@ -1452,6 +1457,27 @@ def _bulk_resolve_stock_names(code_list: List[str]) -> Dict[str, str]:
     return result
 
 
+def _bulk_resolve_stock_name_prevs(code_list: List[str]) -> Dict[str, Optional[str]]:
+    """複数 code_s 分の旧銘柄名 (research_shelve.stock_name_prev) をバルク取得する (issue #183)。
+
+    旧名がないか research_shelve に未登録の銘柄は None。
+    """
+    from db_shelve import RESEARCH_SHELVE  # 遅延 import (循環回避)
+
+    result: Dict[str, Optional[str]] = {c: None for c in code_list if c}
+    if not result:
+        return result
+
+    with ShelveDB(RESEARCH_SHELVE) as db:
+        for c in list(result.keys()):
+            rec = db.get(normalize_code_s(c))
+            if rec:
+                prev = rec.get("stock_name_prev")
+                if isinstance(prev, str) and prev:
+                    result[c] = prev
+    return result
+
+
 # issue #178: status 内部値 → URL クエリ / 表示ラベルの対応表 (helpers 内部利用のみ)。
 # routes/portfolio.py の同名定数とは独立に保持し、循環 import を避ける。
 _PORTFOLIO_STATUS_QUERY = {
@@ -1505,6 +1531,7 @@ def list_portfolio_with_indicators(
     code_list = [r.get("code_s", "") for r in records]
     stock_map = _bulk_get_stock_data(code_list)
     name_map = _bulk_resolve_stock_names(code_list)
+    name_prev_map = _bulk_resolve_stock_name_prevs(code_list)  # issue #183
     today = date.today()  # 全 row 共通の基準日 (issue #177)
 
     # issue #227: 株価 + RSライン 統合チャート用に market_db を1回だけロード。
@@ -1520,6 +1547,7 @@ def list_portfolio_with_indicators(
         code_s = rec.get("code_s", "")
         row = dict(rec)
         row["stock_name"] = name_map.get(code_s, "") or rec.get("stock_name", "")  # 旧データ互換
+        row["stock_name_prev"] = name_prev_map.get(code_s)  # issue #183
         stock = stock_map.get(code_s, {})
         row.update(_extract_indicators_for_portfolio(stock))
         # issue #227: 3点ミニチャート (svg + tooltip)

--- a/scripts/webapp/templates/_macros.html
+++ b/scripts/webapp/templates/_macros.html
@@ -1,0 +1,9 @@
+{# 共通テンプレートマクロ #}
+
+{# 銘柄名と旧名 (issue #183)
+   record は dict like で stock_name / stock_name_prev を持つ。
+   旧名があれば「新名 (旧○○)」形式で出す。
+#}
+{% macro stock_name_with_prev(record) -%}
+{{ record.stock_name or '' }}{% if record.stock_name_prev %} (旧{{ record.stock_name_prev }}){% endif %}
+{%- endmacro %}

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}[{{ record.code_s }}] {{ record.stock_name or '' }} - 銘柄詳細 | Shintakane Research{% endblock %}
+{% import "_macros.html" as macros %}
+{% block title %}[{{ record.code_s }}] {{ macros.stock_name_with_prev(record) }} - 銘柄詳細 | Shintakane Research{% endblock %}
 
 {% block content %}
 {% with messages = get_flashed_messages(with_categories=true) %}
@@ -17,7 +18,7 @@
       <span class="rating-badge rating-{{ record.overall_rating }}">{{ record.overall_rating }}</span>
       {% endif %}
       <small style="color:#888;font-size:0.5em;">{{ record.code_s }}</small>
-      {{ record.stock_name or '' }}
+      {{ macros.stock_name_with_prev(record) }}
       {% if portfolio_status_query %}
         {% if portfolio_fallback_mode %}
         {# フォールバック中は書き込み不可なので静的バッジ #}
@@ -384,7 +385,7 @@
   <div class="portfolio-modal-content" role="dialog" aria-labelledby="portfolio-modal-title">
     <div class="portfolio-modal-header">
       <strong id="portfolio-modal-title">
-        {{ record.code_s }} {{ record.stock_name or '' }}
+        {{ record.code_s }} {{ macros.stock_name_with_prev(record) }}
       </strong>
       <button type="button" class="portfolio-modal-close" onclick="closePortfolioModal()" aria-label="閉じる">×</button>
     </div>

--- a/scripts/webapp/templates/market.html
+++ b/scripts/webapp/templates/market.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_macros.html" as macros %}
 {% block title %}市場データ - Shintakane Research{% endblock %}
 {% block content %}
 
@@ -72,7 +73,7 @@
       {% if s.is_possess %}<span class="kessan-possess-mark" title="保有銘柄">☆</span>{% endif %}
       {% if s.kessan_matagi %}<span class="kessan-matagi-mark" title="決算またぎ保有">◆</span>{% endif %}
       <a href="https://kabutan.jp/stock/chart?code={{ s.code_s }}" target="_blank">{{ s.code_s }}</a>
-      <a href="/stock/{{ s.code_s }}">{{ s.stock_name or '-' }}</a>
+      <a href="/stock/{{ s.code_s }}">{% if s.stock_name %}{{ macros.stock_name_with_prev(s) }}{% else %}-{% endif %}</a>
       {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}
       {% if s.pre_expectation %}<span class="kessan-expectation-badge exp-{{ s.pre_expectation }}">{{ s.pre_expectation }}</span>{% endif %}
       {% if is_past and (s.post_price_changes['pts'] or s.post_price_changes['1d'] or s.post_price_changes['5d']) %}

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_macros.html" as macros %}
 {% block title %}保有銘柄 | Shintakane Research{% endblock %}
 
 {% block content %}
@@ -187,7 +188,7 @@
       <td><a href="https://kabutan.jp/stock/chart?code={{ row.code_s }}" target="_blank" rel="noopener noreferrer">{{ row.code_s }}</a></td>
       <td title="{{ row.stock_name }}"
           style="max-width:10em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
-        <a href="/stock/{{ row.code_s }}">{{ row.stock_name }}</a>
+        <a href="/stock/{{ row.code_s }}">{{ macros.stock_name_with_prev(row) }}</a>
       </td>
       <td><span class="status-badge status-{{ row.status_query }}">{{ row.status_label }}</span></td>
       <td class="gyoutai-themes-cell" data-code="{{ row.code_s }}"

--- a/scripts/webapp/templates/search.html
+++ b/scripts/webapp/templates/search.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_macros.html" as macros %}
 {% block title %}検索 | Shintakane Research{% endblock %}
 
 {% block content %}
@@ -63,7 +64,7 @@
         <span class="rating-badge rating-{{ rec.overall_rating }}">{{ rec.overall_rating }}</span>
         {% else %}-{% endif %}
       </td>
-      <td><a href="/stock/{{ rec.code_s }}">{{ rec.stock_name or '-' }}</a></td>
+      <td><a href="/stock/{{ rec.code_s }}">{% if rec.stock_name %}{{ macros.stock_name_with_prev(rec) }}{% else %}-{% endif %}</a></td>
       <td>{{ (rec.snapshots or [])|length }}</td>
       <td>{{ (rec.overview or '')[:40] }}{% if (rec.overview or '')|length > 40 %}...{% endif %}</td>
     </tr>

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -1013,3 +1013,47 @@ class TestMakeSignalRsLine:
         }
         _, tags = make_stock_db.make_signal(stock, market_db=market_db)
         assert "R高" in tags
+
+
+# ==================================================
+# 銘柄名変更追従 (issue #183)
+# ==================================================
+class TestSyncResearchStockName:
+    """_sync_research_stock_name の呼び出し制御テスト"""
+
+    def test_calls_sync_api_with_new_name(self, monkeypatch):
+        """名前変更時に research_shelve.sync_stock_name が呼ばれる"""
+        import research_shelve
+        called = {}
+
+        def fake_sync(code_s, new_name, **kwargs):
+            called["code_s"] = code_s
+            called["new_name"] = new_name
+            return "旧名"
+
+        monkeypatch.setattr(research_shelve, "sync_stock_name", fake_sync)
+        make_stock_db._sync_research_stock_name("1436", new_name="新名")
+        assert called["code_s"] == "1436"
+        assert called["new_name"] == "新名"
+
+    def test_handles_api_exception(self, monkeypatch):
+        """API が例外を投げても呼び出し側で握って戻る"""
+        import research_shelve
+
+        def fake_sync(code_s, new_name, **kwargs):
+            raise RuntimeError("DB lock failed")
+
+        monkeypatch.setattr(research_shelve, "sync_stock_name", fake_sync)
+        # 例外を吐かずに正常終了すること
+        make_stock_db._sync_research_stock_name("1436", new_name="新名")
+
+    def test_silent_when_sync_api_returns_none(self, monkeypatch):
+        """API が None を返した場合 (no-op or 未登録) はログのみで戻る"""
+        import research_shelve
+
+        def fake_sync(code_s, new_name, **kwargs):
+            return None  # 未登録 or 同名 no-op
+
+        monkeypatch.setattr(research_shelve, "sync_stock_name", fake_sync)
+        # 例外を吐かずに正常終了
+        make_stock_db._sync_research_stock_name("1436", new_name="新名")

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -938,3 +938,91 @@ class TestCorporateUrlOverride:
     def test_record_fields_includes_corporate_url_override(self):
         """RECORD_FIELDS に corporate_url_override が含まれる"""
         assert "corporate_url_override" in rs.RECORD_FIELDS
+
+
+# ==================================================
+# 銘柄名変更追従 (issue #183)
+# ==================================================
+class TestStockNamePrev:
+    """stock_name_prev フィールドと sync_stock_name API のテスト"""
+
+    def test_create_research_record_default_stock_name_prev_none(self):
+        """stock_name_prev はデフォルト None"""
+        rec = rs.create_research_record("3496", "アズーム")
+        assert rec["stock_name_prev"] is None
+
+    def test_create_research_record_with_stock_name_prev(self):
+        """stock_name_prev を明示的に渡せる"""
+        rec = rs.create_research_record(
+            "1436", "グリーンエナジー&カンパニー", stock_name_prev="フィット"
+        )
+        assert rec["stock_name_prev"] == "フィット"
+
+    def test_get_research_record_backfills_stock_name_prev(self, db_path):
+        """旧形式 (stock_name_prev 無) のレコードは読込時に None で補完される"""
+        rec = rs.create_research_record("3496", "アズーム")
+        del rec["stock_name_prev"]  # 旧形式を模倣
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["stock_name_prev"] is None
+
+    def test_record_fields_includes_stock_name_prev(self):
+        """RECORD_FIELDS に stock_name_prev が含まれる"""
+        assert "stock_name_prev" in rs.RECORD_FIELDS
+
+    def test_sync_stock_name_updates_and_saves_prev(self, db_path):
+        """新名と異なる場合: 新名で更新+旧名が prev に退避、戻り値は旧名"""
+        rec = rs.create_research_record("1436", "フィット")
+        rs.upsert_research_record(rec, db_path=db_path)
+        returned = rs.sync_stock_name(
+            "1436", "グリーンエナジー&カンパニー", db_path=db_path
+        )
+        assert returned == "フィット"
+        loaded = rs.get_research_record("1436", db_path=db_path)
+        assert loaded["stock_name"] == "グリーンエナジー&カンパニー"
+        assert loaded["stock_name_prev"] == "フィット"
+
+    def test_sync_stock_name_noop_when_same(self, db_path):
+        """同名なら何もせず戻り値 None"""
+        rec = rs.create_research_record("1436", "フィット")
+        rs.upsert_research_record(rec, db_path=db_path)
+        returned = rs.sync_stock_name("1436", "フィット", db_path=db_path)
+        assert returned is None
+        loaded = rs.get_research_record("1436", db_path=db_path)
+        assert loaded["stock_name"] == "フィット"
+        assert loaded["stock_name_prev"] is None  # 旧名退避が起きていない
+
+    def test_sync_stock_name_noop_when_record_missing(self, db_path):
+        """未登録銘柄は何もせず戻り値 None"""
+        returned = rs.sync_stock_name("9999", "未登録銘柄", db_path=db_path)
+        assert returned is None
+        # 登録もされていない
+        assert rs.get_research_record("9999", db_path=db_path) is None
+
+    def test_sync_stock_name_preserves_other_fields(self, db_path):
+        """memo/rating/snapshots など他フィールドが保持される (lost update protection)"""
+        snap = rs.create_snapshot("26.1", ir_quant="[A]26%,21%")
+        rec = rs.create_research_record(
+            "1436",
+            "フィット",
+            overall_rating="S",
+            memo="重要なメモ",
+            openwork="3.72",
+            snapshots=[snap],
+        )
+        rs.upsert_research_record(rec, db_path=db_path)
+        rs.sync_stock_name("1436", "グリーンエナジー&カンパニー", db_path=db_path)
+        loaded = rs.get_research_record("1436", db_path=db_path)
+        # 他フィールドが消えていない
+        assert loaded["overall_rating"] == "S"
+        assert loaded["memo"] == "重要なメモ"
+        assert loaded["openwork"] == "3.72"
+        assert len(loaded["snapshots"]) == 1
+        assert loaded["snapshots"][0]["ir_quant"] == "[A]26%,21%"
+
+    def test_sync_stock_name_strips_whitespace(self, db_path):
+        """前後空白で同名扱いとなる (no-op)"""
+        rec = rs.create_research_record("1436", "フィット")
+        rs.upsert_research_record(rec, db_path=db_path)
+        returned = rs.sync_stock_name("1436", "  フィット  ", db_path=db_path)
+        assert returned is None

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -134,6 +134,26 @@ class TestDetailRoute:
         assert resp.status_code == 404
 
 
+class TestDetailStockNamePrev:
+    """issue #183: stock_name_prev の併記表示"""
+
+    def test_detail_displays_stock_name_prev(self, client, db_path):
+        """stock_name_prev が入っていれば「新名 (旧○○)」併記される"""
+        # 既存テストデータの 3496 に旧名を入れる
+        rs.sync_stock_name("3496", "アズームニューネーム", db_path=db_path)
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "アズームニューネーム" in html
+        assert "(旧アズーム)" in html
+
+    def test_detail_no_paren_when_stock_name_prev_none(self, client, db_path):
+        """stock_name_prev が None なら旧名併記なし (デフォルト状態)"""
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "アズーム" in html
+        assert "(旧" not in html
+
+
 class TestDetailPortfolioModal:
     """issue #195: 詳細ページにポートフォリオステータス変更モーダルを描画する。
 


### PR DESCRIPTION
Closes #183

## 概要

stocks_shelve の `stock_name` は Kabutan から7日TTLで再取得され社名変更に自動追従するが、research_shelve は初回登録時にコピーしたまま固定で、旧社名のままズレ続ける問題があった。research_shelve に追従させつつ、ユーザー記憶補助のため旧名を併記表示する。

## 主な変更

### データモデル

- research_shelve レコードに `stock_name_prev: str | None` を追加 (デフォルト None)
- `get_research_record` で欠損は None で補完 (後方互換)

### 同期ロジック (Lost Update Protection)

新規 API **`research_shelve.sync_stock_name(code_s, new_name)`**:

- `flock` 区間内で「読み → 比較 → 更新」を完結
- UI 側 `upsert_research_record` と直列化されるため、memo/rating など手動編集資産の lost update を防ぐ
- `stock_name` と `stock_name_prev` の2フィールドのみ排他的に書き換える

`make_stock_db._update_db_code` 内で master 取得直後に旧名と新名を比較し、差異があれば `_sync_research_stock_name` → `sync_stock_name` に委譲。例外は warning に握って銘柄更新全体を止めない。

### 表示 (WebApp)

- `templates/_macros.html` に `stock_name_with_prev` マクロを切り出し
- detail / search / market / portfolio_list で「新名 (旧○○)」併記
- `helpers.py` の market 合成 dict と portfolio 行 dict に `stock_name_prev` を流す
- portfolio 用 `_bulk_resolve_stock_name_prevs` を新規追加

### 既存ズレ補正ワンショット

`scripts/sync_research_stock_names.py` を新設:

- research_shelve 全銘柄を走査し stocks_shelve と差異を検出
- dry-run デフォルト、`--apply` で `sync_stock_name` 経由で一括補正
- `log_print` 使用 (CLAUDE.md 規約準拠)

### ドキュメント

- `doc/ARCHITECTURE.md` の research_shelve 章に「銘柄名変更の追従」セクションを追加

## 設計上のポイント

### Codex プランレビューの初回指摘 (両方反映済)

1. ❌ **Lost Update リスク**: `get → 変更 → upsert` の R-M-W で UI側 memo 編集と競合すると memo が消える
   → ✅ `sync_stock_name` API を新設、flock 区間内で R-M-W を完結
2. ❌ **規約違反**: スクリプトで `print()` 使用
   → ✅ `log_print` に修正

### スコープ外 (本PRで触らない)

- **stock_name の手動更新 UI/CLI**: 現状、独自表記での手動上書きには対応していない。`sync_stock_name` API を直接呼べば書き換え可能だが、次回 master 更新で stocks_shelve の値に戻されるため、「Kabutan の表記とは違う独自表記を恒久的に維持したい」要件とは原理的に両立しない。必要になった時点で別 issue で UI/CLI 追加を検討
- 旧名を消す UI (DB 直編集で対応)
- 改名履歴の完全保持 (直近1件のみ。A→B→C の A は B→C のタイミングで失う)

## 検証結果

### テスト (14件追加 + 関連回帰)

- `tests/test_research_shelve.py`: 9件追加 (後方互換4件 + sync_stock_name 5件、**lost update protection 含む**)
- `tests/test_make_stock_db.py`: 3件追加 (呼び出し制御 + 例外ハンドリング)
- `tests/test_webapp_routes.py`: 2件追加 (併記表示 + None時の非表示)
- 関連回帰テスト: **498 passed, 1 failed**
  - 失敗1件 (`test_today_card_appears_between_recent_past_and_future`) は日付固定の時間依存テストで、**main でも同じく失敗** = 本PRとは無関係

### 既存DB dry-run 実行結果

```
差分 279 件:
  1436: フィット → グリーンエナジー&カンパニー   ← issue記載の例 ✓
  9044: 南海電気鉄道 → ＮＡＮＫＡＩ
  8704: トレイダーズHD → トレイダーズホールディングス
  ...
```

差分のほとんどは社名変更ではなく**表記揺れ** (HD→ホールディングス、半角→全角、英記号→全角英記号など)。Kabutan の表記が時期で変わったものを stocks_shelve が拾い、research_shelve は移行時CSVの表記で固まっていたため。`--apply` するかは運用判断 (本PRには含めない)。

## Test plan

- [x] 新規 14件テストパス
- [x] 関連回帰テスト全パス (1件失敗は別件)
- [x] `python sync_research_stock_names.py` (dry-run) で 279件の差分検出を確認
- [ ] WebApp 起動 → detail/search/market/portfolio で「(旧○○)」併記表示を目視確認 (マージ後)
- [ ] `python make_stock_db.py update <変更銘柄>` で実銘柄の同期動作確認 (マージ後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)