### PR TITLE
issue #216 / #220 / #221: WebApp モーダル系の運用改善 3 件

### DIFF
--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -198,6 +198,36 @@ def now_iso() -> str:
     return datetime.now(JST).isoformat()
 
 
+_ACTION_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _parse_action_date_to_iso(action_date: str) -> str:
+    """YYYY-MM-DD を JST 12:00 の ISO 8601 文字列に変換する。
+
+    issue #220: UI 側 <input type="date"> から受け取る日付を action_log の
+    timestamp として保存する。00:00 だと JST 表示時に前日扱いになる縁起問題を
+    避けるため固定 12:00 を当てる。
+
+    未来日 (`datetime.now(JST).date()` 基準) は ValueError。
+    `ks_util.get_price_day()` の業務日は使わない (17:00 前に前日を返すため、
+    実カレンダーの今日入力を誤って弾いてしまう)。
+    """
+    if not isinstance(action_date, str) or not _ACTION_DATE_RE.match(action_date):
+        raise ValueError(
+            f"action_date は YYYY-MM-DD 形式で指定してください: {action_date!r}"
+        )
+    try:
+        parsed = datetime.strptime(action_date, "%Y-%m-%d").date()
+    except ValueError as e:
+        raise ValueError(f"action_date のパースに失敗: {action_date!r} ({e})") from e
+    today = datetime.now(JST).date()
+    if parsed > today:
+        raise ValueError(
+            f"action_date に未来日は指定できません: {action_date} (今日={today.isoformat()})"
+        )
+    return datetime(parsed.year, parsed.month, parsed.day, 12, 0, 0, tzinfo=JST).isoformat()
+
+
 # ===========================================
 # キー組立
 # ===========================================
@@ -510,6 +540,7 @@ def add_to_watch(
     *,
     memo: Optional[Dict[str, str]] = None,
     reason: str = "",
+    action_date: Optional[str] = None,
     db_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """銘柄を 3監 として登録、または除外済みレコードをユニバース復活させる。
@@ -522,11 +553,14 @@ def add_to_watch(
       memo / status は既存値を保持。「ユニバース除外」ログを reason="復活" で記録
       (復活時は reason 引数は無視される)
     - 既存レコードあり & excluded=False → ValueError (重複登録防止)
+    - action_date (YYYY-MM-DD) を指定すると、action_log の timestamp を
+      その日の JST 12:00 に固定する (issue #220)。未指定なら現在時刻
 
     Returns: 追加または復活したレコード
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
+    action_ts = _parse_action_date_to_iso(action_date) if action_date else None
     path = _resolve_db_path(db_path)
     with _flock(db_path):
         with ShelveDB(path) as db:
@@ -554,6 +588,7 @@ def add_to_watch(
                 normalized,
                 "ユニバース除外",
                 reason="復活",
+                timestamp=action_ts,
                 db_path=db_path,
             )
             log_print("portfolio_shelve: ユニバース復活", normalized)
@@ -564,6 +599,7 @@ def add_to_watch(
                 status_from=None,
                 status_to="3監",
                 reason=reason,
+                timestamp=action_ts,
                 db_path=db_path,
             )
             log_print("portfolio_shelve: 3監 追加", normalized)
@@ -614,6 +650,7 @@ def transition_status(
     new_status: str,
     *,
     reason: str = "",
+    action_date: Optional[str] = None,
     db_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """既存レコードのステータスを変更する。
@@ -622,6 +659,8 @@ def transition_status(
     - それ以外の遷移は action_type=ステータス変更
     - 遷移バリデーション (ALLOWED_TRANSITIONS) を満たさなければ ValueError
     - レコードが存在しない場合は KeyError
+    - action_date (YYYY-MM-DD) を指定すると、action_log の timestamp を
+      その日の JST 12:00 に固定する (issue #220)。未指定なら現在時刻
 
     Returns: 更新後のレコード
     """
@@ -630,6 +669,8 @@ def transition_status(
     validate_status(new_status)
     if not isinstance(reason, str):
         raise TypeError(f"reason must be str, got {type(reason).__name__}")
+
+    action_ts = _parse_action_date_to_iso(action_date) if action_date else None
 
     path = _resolve_db_path(db_path)
     with _flock(db_path):
@@ -661,6 +702,7 @@ def transition_status(
             status_from=old_status,
             status_to=new_status,
             reason=reason,
+            timestamp=action_ts,
             db_path=db_path,
         )
     log_print(

--- a/scripts/webapp/__init__.py
+++ b/scripts/webapp/__init__.py
@@ -6,8 +6,11 @@ research_shelve のデータをブラウザで閲覧・編集するためのWeb�
 
 import os
 import sys
+from datetime import datetime, timezone, timedelta
 
 from flask import Flask
+
+_JST = timezone(timedelta(hours=9))
 
 # scripts/ を sys.path に追加して research_shelve 等をインポート可能にする
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -35,5 +38,11 @@ def create_app() -> Flask:
     app.register_blueprint(market_bp)
     app.register_blueprint(disclosure_bp)
     app.register_blueprint(portfolio_bp)
+
+    @app.context_processor
+    def _inject_today_jst():
+        # issue #220: action_date input の value/max に使う実カレンダー上の JST 当日。
+        # ks_util.get_price_day() は業務日 (17:00 前は前日) のため使わない。
+        return {"today_jst": datetime.now(_JST).date().strftime("%Y-%m-%d")}
 
     return app

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -253,6 +253,7 @@ def transition(code_s: str):
 
     new_status = (request.form.get("new_status") or "").strip()
     reason = (request.form.get("reason") or "").strip()
+    action_date = (request.form.get("action_date") or "").strip() or None
 
     try:
         ps.validate_code_s(code_s)
@@ -265,7 +266,7 @@ def transition(code_s: str):
         return _redirect_with_return_query(code_s=code_s)
 
     try:
-        ps.transition_status(code_s, new_status, reason=reason)
+        ps.transition_status(code_s, new_status, reason=reason, action_date=action_date)
     except KeyError as e:
         flash(f"レコード未登録: {e}", "error")
         return _redirect_with_return_query(code_s=code_s)
@@ -411,6 +412,8 @@ def add():
     # issue #195: 詳細モーダルから理由を受け取れるように引数化。
     # 未送信フォーム (portfolio ダッシュボード追加) では空文字 → 従来の "WebApp 追加" にフォールバック。
     reason = (request.form.get("reason") or "").strip() or "WebApp 追加"
+    # issue #220: アクション日付 (YYYY-MM-DD)。未指定なら現在時刻。
+    action_date = (request.form.get("action_date") or "").strip() or None
     if not code_s:
         flash("銘柄コードが空です", "error")
         return _redirect_with_return_query(default_status_query="watch")
@@ -436,7 +439,7 @@ def add():
             return _redirect_with_return_query(default_status_query="watch")
 
     try:
-        ps.add_to_watch(normalized, reason=reason)
+        ps.add_to_watch(normalized, reason=reason, action_date=action_date)
     except ValueError as e:
         flash(str(e), "error")
         return _redirect_with_return_query(default_status_query="watch", code_s=normalized)

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -237,7 +237,10 @@ def bulk_exclude():
         flash(f"{len(success)} 件をユニバースから除外しました ({', '.join(success)})", "info")
     if failures:
         flash("除外できなかったコードがあります: " + " / ".join(failures), "error")
-    return _redirect_with_return_query()
+    # issue #221: 詳細モーダルからの単一除外 (return_to=detail + return_code_s) は
+    # 同じ詳細ページに戻す。除外後は未登録扱いで表示されるため、操作結果が画面に反映される。
+    return_code = (request.form.get("return_code_s") or "").strip()
+    return _redirect_with_return_query(code_s=return_code or None)
 
 
 @portfolio_bp.route("/portfolio/<code_s>/transition", methods=["POST"])

--- a/scripts/webapp/routes/search.py
+++ b/scripts/webapp/routes/search.py
@@ -6,6 +6,7 @@ GET / : 銘柄コード/名前/評価でフィルタし一覧表示
 
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 
+from research_shelve import CODE_S_PATTERN
 from webapp.helpers import search_records, add_stock
 
 search_bp = Blueprint("search", __name__)
@@ -45,6 +46,15 @@ def index():
     if (q or code_s) and len(records) == 1:
         return redirect(url_for("detail.stock_detail", code_s=records[0]["code_s"]))
 
+    # issue #216: q がコード形式 (4桁数字 or 3桁数字+大文字) で 0 件ヒット時のみ
+    # 「この銘柄を追加」フォームを出す。銘柄名検索や不正フォーマットでは出さない。
+    q_normalized = q.upper()
+    can_add = (
+        bool(q)
+        and not records
+        and bool(CODE_S_PATTERN.match(q_normalized))
+    )
+
     return render_template(
         "search.html",
         records=records,
@@ -52,6 +62,8 @@ def index():
         filter_keyword=keyword or "",
         filter_code_s=code_s,
         filter_q=q,
+        can_add=can_add,
+        q_normalized=q_normalized,
     )
 
 

--- a/scripts/webapp/templates/base.html
+++ b/scripts/webapp/templates/base.html
@@ -23,23 +23,7 @@
         <input id="nav-code" type="text" name="q" placeholder="コード/銘柄名" aria-label="コード/銘柄名検索"
                style="width:9em;padding:0.3em 0.5em;margin:0;font-size:0.9em;height:auto;">
         <button type="submit" class="outline" style="padding:0.3em 0.7em;margin:0;font-size:0.9em;">Go</button>
-        <button type="button" class="outline" style="padding:0.3em 0.7em;margin:0;font-size:0.9em;white-space:nowrap;" onclick="navAddStock()">+ 追加</button>
       </form>
-      <form id="nav-add-form" method="post" action="/stock/add" style="display:none;">
-        <input type="hidden" name="add_code_s" id="nav-add-code">
-      </form>
-      <script>
-      function navAddStock() {
-        var code = document.getElementById('nav-code').value.trim();
-        if (!code) { alert('銘柄コードを入力してください'); return; }
-        if (!/^[0-9A-Za-z]{4}$/.test(code)) {
-          alert('追加は4桁の銘柄コード (例: 3496, 135A) を入力してください');
-          return;
-        }
-        document.getElementById('nav-add-code').value = code;
-        document.getElementById('nav-add-form').submit();
-      }
-      </script>
     </li>
   </ul>
 </nav>

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -403,17 +403,31 @@
         </select>
       </label>
       <label style="display:block;margin-bottom:0.6em;">
+        アクション日付:
+        <input type="date" name="action_date" value="{{ today_jst }}" max="{{ today_jst }}" required
+               class="portfolio-action-date" style="margin-left:0.4em;">
+      </label>
+      <label style="display:block;margin-bottom:0.6em;">
         理由 (任意):
         <textarea name="reason" rows="2" style="width:100%;margin-top:0.2em;" placeholder="例: 業績下振れ"></textarea>
       </label>
       <div class="portfolio-modal-actions">
         <button type="button" class="secondary" onclick="closePortfolioModal()">キャンセル</button>
         <button type="submit">変更する</button>
+        {% if portfolio_status_query in ("semi", "watch") %}
+        {# issue #221: 2準/3監 のみユニバース除外可能 (1保 は exclude_from_universe 側で拒否) #}
+        <button type="button" class="portfolio-exclude-button"
+                onclick="excludeFromUniverse('{{ record.code_s }}')">ユニバースから除外</button>
+        {% endif %}
       </div>
       {% else %}
       <p style="color:#888;">許可された遷移先がありません。</p>
       <div class="portfolio-modal-actions">
         <button type="button" class="secondary" onclick="closePortfolioModal()">閉じる</button>
+        {% if portfolio_status_query in ("semi", "watch") %}
+        <button type="button" class="portfolio-exclude-button"
+                onclick="excludeFromUniverse('{{ record.code_s }}')">ユニバースから除外</button>
+        {% endif %}
       </div>
       {% endif %}
     </form>
@@ -423,6 +437,11 @@
       <input type="hidden" name="code_s" value="{{ record.code_s }}">
       <input type="hidden" name="return_to" value="detail">
       <p style="margin:0 0 0.6em 0;">この銘柄は未登録です。監視に追加します。</p>
+      <label style="display:block;margin-bottom:0.6em;">
+        アクション日付:
+        <input type="date" name="action_date" value="{{ today_jst }}" max="{{ today_jst }}" required
+               class="portfolio-action-date" style="margin-left:0.4em;">
+      </label>
       <label style="display:block;margin-bottom:0.6em;">
         理由 (任意):
         <textarea name="reason" rows="2" style="width:100%;margin-top:0.2em;" placeholder="例: 高値ブレイク候補"></textarea>
@@ -493,6 +512,14 @@
 .gyoutai-input-detail.saving { background: #fff8c4; }
 .gyoutai-input-detail.error { background: #fce4e4; border-color: #d33; }
 .gyoutai-input-detail:focus { outline: 1px solid #4285f4; }
+
+/* issue #221: ユニバース除外ボタン (危険操作なので赤系で識別) */
+.portfolio-exclude-button {
+  background: #c0392b;
+  color: #fff;
+  border: 1px solid #c0392b;
+}
+.portfolio-exclude-button:hover { background: #a93226; border-color: #a93226; }
 </style>
 
 <script>
@@ -511,6 +538,52 @@ document.addEventListener('keydown', function(e) {
     if (m && m.style.display !== 'none') closePortfolioModal();
   }
 });
+
+// issue #221: ユニバース除外。モーダル内 reason textarea の値を一緒に POST する。
+function excludeFromUniverse(codeS) {
+  if (!confirm('ユニバースから除外しますか？')) return;
+  var modal = document.getElementById('portfolio-modal');
+  var reasonEl = modal ? modal.querySelector('textarea[name="reason"]') : null;
+  var reason = reasonEl ? reasonEl.value : '';
+  var form = document.createElement('form');
+  form.method = 'POST';
+  form.action = '/portfolio/bulk-exclude';
+  // DOM API で hidden を組み立てる (innerHTML 連結は reason 経由で XSS の余地ができるため使わない)
+  var codeInput = document.createElement('input');
+  codeInput.type = 'hidden';
+  codeInput.name = 'codes';
+  codeInput.value = codeS;
+  var reasonInput = document.createElement('input');
+  reasonInput.type = 'hidden';
+  reasonInput.name = 'reason';
+  reasonInput.value = reason;
+  form.appendChild(codeInput);
+  form.appendChild(reasonInput);
+  document.body.appendChild(form);
+  form.submit();
+}
+
+// issue #220: action_date input がある portfolio モーダルのフォーム submit 時、
+// 未来日が入っていたら alert で送信中止。サーバ側でも同じ判定を行う二重防御。
+(function() {
+  var modal = document.getElementById('portfolio-modal');
+  if (!modal) return;
+  modal.querySelectorAll('form').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+      var inp = form.querySelector('input.portfolio-action-date');
+      if (!inp || !inp.value) return;
+      var today = new Date();
+      var yyyy = today.getFullYear();
+      var mm = String(today.getMonth() + 1).padStart(2, '0');
+      var dd = String(today.getDate()).padStart(2, '0');
+      var todayStr = yyyy + '-' + mm + '-' + dd;
+      if (inp.value > todayStr) {
+        e.preventDefault();
+        alert('アクション日付に未来日は指定できません (今日まで): ' + inp.value);
+      }
+    });
+  });
+})();
 
 // issue #205: 業態・テーマの change/blur で AJAX 即時保存 (portfolio_list.html と同方式)
 (function() {

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -540,6 +540,7 @@ document.addEventListener('keydown', function(e) {
 });
 
 // issue #221: ユニバース除外。モーダル内 reason textarea の値を一緒に POST する。
+// 詳細からの除外 = 単一銘柄なので、return_to=detail を付けて bulk_exclude 側に詳細復帰を伝える。
 function excludeFromUniverse(codeS) {
   if (!confirm('ユニバースから除外しますか？')) return;
   var modal = document.getElementById('portfolio-modal');
@@ -549,22 +550,25 @@ function excludeFromUniverse(codeS) {
   form.method = 'POST';
   form.action = '/portfolio/bulk-exclude';
   // DOM API で hidden を組み立てる (innerHTML 連結は reason 経由で XSS の余地ができるため使わない)
-  var codeInput = document.createElement('input');
-  codeInput.type = 'hidden';
-  codeInput.name = 'codes';
-  codeInput.value = codeS;
-  var reasonInput = document.createElement('input');
-  reasonInput.type = 'hidden';
-  reasonInput.name = 'reason';
-  reasonInput.value = reason;
-  form.appendChild(codeInput);
-  form.appendChild(reasonInput);
+  function addHidden(name, value) {
+    var inp = document.createElement('input');
+    inp.type = 'hidden';
+    inp.name = name;
+    inp.value = value;
+    form.appendChild(inp);
+  }
+  addHidden('codes', codeS);
+  addHidden('reason', reason);
+  addHidden('return_to', 'detail');
+  addHidden('return_code_s', codeS);
   document.body.appendChild(form);
   form.submit();
 }
 
 // issue #220: action_date input がある portfolio モーダルのフォーム submit 時、
 // 未来日が入っていたら alert で送信中止。サーバ側でも同じ判定を行う二重防御。
+// クライアント端末の TZ が JST 以外でも基準ズレが起きないよう、サーバから注入された
+// today_jst (= max 属性の値) と直接文字列比較する。
 (function() {
   var modal = document.getElementById('portfolio-modal');
   if (!modal) return;
@@ -572,12 +576,8 @@ function excludeFromUniverse(codeS) {
     form.addEventListener('submit', function(e) {
       var inp = form.querySelector('input.portfolio-action-date');
       if (!inp || !inp.value) return;
-      var today = new Date();
-      var yyyy = today.getFullYear();
-      var mm = String(today.getMonth() + 1).padStart(2, '0');
-      var dd = String(today.getDate()).padStart(2, '0');
-      var todayStr = yyyy + '-' + mm + '-' + dd;
-      if (inp.value > todayStr) {
+      var todayStr = inp.max || '';
+      if (todayStr && inp.value > todayStr) {
         e.preventDefault();
         alert('アクション日付に未来日は指定できません (今日まで): ' + inp.value);
       }

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -287,7 +287,7 @@
             <strong style="font-size:0.85em;color:#666;">操作</strong>
             <div style="display:flex;flex-direction:column;gap:0.5em;margin-top:0.3em;font-size:0.85em;">
               {% if row.transitions %}
-              <form action="/portfolio/{{ row.code_s }}/transition" method="POST" style="display:flex;flex-direction:column;gap:0.3em;margin:0;">
+              <form action="/portfolio/{{ row.code_s }}/transition" method="POST" class="portfolio-transition-form" style="display:flex;flex-direction:column;gap:0.3em;margin:0;">
                 <input type="hidden" name="return_query" value="{{ return_query }}">
                 <label style="font-size:0.85em;color:#666;">ステータス変更</label>
                 <select name="new_status" style="padding:0.3em;font-size:0.85em;margin:0;">
@@ -295,6 +295,8 @@
                   <option value="{{ value }}">{{ label }}</option>
                   {% endfor %}
                 </select>
+                <input type="date" name="action_date" value="{{ today_jst }}" max="{{ today_jst }}" required
+                       class="portfolio-action-date" style="font-size:0.85em;padding:0.3em;margin:0;">
                 <textarea name="reason" placeholder="理由 (任意)" rows="2" style="font-size:0.85em;padding:0.3em;margin:0;"></textarea>
                 <button type="submit" style="padding:0.3em 0.6em;font-size:0.85em;margin:0;">変更</button>
               </form>
@@ -723,6 +725,25 @@ document.querySelectorAll('table details').forEach(function(d) {
       .catch(function(err) { alert('除外失敗: ' + err); });
   });
   refresh();
+})();
+
+// issue #220: ステータス変更フォームの action_date 未来日チェック (二重防御)。
+(function() {
+  document.querySelectorAll('form.portfolio-transition-form').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+      var inp = form.querySelector('input.portfolio-action-date');
+      if (!inp || !inp.value) return;
+      var today = new Date();
+      var yyyy = today.getFullYear();
+      var mm = String(today.getMonth() + 1).padStart(2, '0');
+      var dd = String(today.getDate()).padStart(2, '0');
+      var todayStr = yyyy + '-' + mm + '-' + dd;
+      if (inp.value > todayStr) {
+        e.preventDefault();
+        alert('アクション日付に未来日は指定できません (今日まで): ' + inp.value);
+      }
+    });
+  });
 })();
 </script>
 

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -728,17 +728,15 @@ document.querySelectorAll('table details').forEach(function(d) {
 })();
 
 // issue #220: ステータス変更フォームの action_date 未来日チェック (二重防御)。
+// クライアント端末の TZ が JST 以外でも基準ズレが起きないよう、サーバから注入された
+// today_jst (= max 属性の値) と直接文字列比較する。
 (function() {
   document.querySelectorAll('form.portfolio-transition-form').forEach(function(form) {
     form.addEventListener('submit', function(e) {
       var inp = form.querySelector('input.portfolio-action-date');
       if (!inp || !inp.value) return;
-      var today = new Date();
-      var yyyy = today.getFullYear();
-      var mm = String(today.getMonth() + 1).padStart(2, '0');
-      var dd = String(today.getDate()).padStart(2, '0');
-      var todayStr = yyyy + '-' + mm + '-' + dd;
-      if (inp.value > todayStr) {
+      var todayStr = inp.max || '';
+      if (todayStr && inp.value > todayStr) {
         e.preventDefault();
         alert('アクション日付に未来日は指定できません (今日まで): ' + inp.value);
       }

--- a/scripts/webapp/templates/search.html
+++ b/scripts/webapp/templates/search.html
@@ -73,5 +73,11 @@
 </div>
 {% else %}
 <p>該当する銘柄がありません。</p>
+{% if can_add %}
+<form method="post" action="/stock/add" style="margin-top:1em;">
+  <input type="hidden" name="add_code_s" value="{{ q_normalized }}">
+  <button type="submit">この銘柄 ({{ q_normalized }}) を ResearchDB に追加</button>
+</form>
+{% endif %}
 {% endif %}
 {% endblock %}

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -193,6 +193,56 @@ class TestTransitionStatus:
         logs = ps.list_action_logs("4377", db_path=db_path)
         assert len(logs) == 1  # 初回登録だけ、ステータス変更ログは出ない
 
+    def test_transition_with_past_action_date(self, db_path):
+        """issue #220: action_date 指定で action_log の timestamp が JST 12:00 で固定される"""
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.transition_status(
+            "4377", "2準",
+            reason="3日前に売却",
+            action_date="2026-05-10",
+            db_path=db_path,
+        )
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert logs[1]["timestamp"] == "2026-05-10T12:00:00+09:00"
+
+    def test_transition_with_future_action_date_raises(self, db_path):
+        """issue #220: 未来日は ValueError"""
+        ps.add_to_watch("4377", db_path=db_path)
+        with pytest.raises(ValueError, match="未来日"):
+            ps.transition_status(
+                "4377", "2準",
+                action_date="2099-12-31",
+                db_path=db_path,
+            )
+
+    def test_transition_with_invalid_action_date_format_raises(self, db_path):
+        """issue #220: YYYY-MM-DD 以外のフォーマットは ValueError"""
+        ps.add_to_watch("4377", db_path=db_path)
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            ps.transition_status(
+                "4377", "2準",
+                action_date="2026/05/10",
+                db_path=db_path,
+            )
+        with pytest.raises(ValueError):
+            ps.transition_status(
+                "4377", "2準",
+                action_date="2026-13-99",
+                db_path=db_path,
+            )
+
+    def test_add_to_watch_with_past_action_date(self, db_path):
+        """issue #220: add_to_watch でも action_date が初回登録ログに反映される"""
+        ps.add_to_watch(
+            "4377",
+            reason="昨日メモった銘柄",
+            action_date="2026-05-10",
+            db_path=db_path,
+        )
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == 1
+        assert logs[0]["timestamp"] == "2026-05-10T12:00:00+09:00"
+
 
 # ==================================================
 # 高レベル操作: delete_record

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -259,6 +259,32 @@ class TestTransitionPost:
         # 9999 は登録されていない
         assert ps.get_record("9999", db_path=portfolio_db_path) is None
 
+    def test_transition_with_action_date_form_param(self, client, portfolio_db_path):
+        """issue #220: form の action_date が action_log の timestamp に伝搬する"""
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={
+                "new_status": "2準",
+                "reason": "昨日売却",
+                "action_date": "2026-05-10",
+            },
+        )
+        assert resp.status_code == 302
+        logs = ps.list_action_logs(code_s="3496", db_path=portfolio_db_path)
+        latest = logs[-1]
+        assert latest["timestamp"] == "2026-05-10T12:00:00+09:00"
+        assert latest["action_type"] == "売却"
+
+    def test_transition_future_action_date_flashes_error(self, client, portfolio_db_path):
+        """issue #220: 未来日は flash error でステータス変更されない"""
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "2準", "action_date": "2099-12-31"},
+        )
+        assert resp.status_code == 302
+        rec = ps.get_record("3496", db_path=portfolio_db_path)
+        assert rec["status"] == "1保"  # 変更されていない
+
 
 class TestBulkExclude:
     """POST /portfolio/bulk-exclude (issue #186)"""

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -375,6 +375,29 @@ class TestBulkExclude:
         # /portfolio に戻る (status= 等のフィルタクエリは付かない)
         assert loc.endswith("/portfolio")
 
+    def test_bulk_exclude_from_detail_returns_to_detail(self, client, portfolio_db_path):
+        """issue #221: 詳細モーダルからの単一除外 (return_to=detail + return_code_s) は
+        同じ銘柄の詳細ページに戻す"""
+        resp = client.post(
+            "/portfolio/bulk-exclude",
+            data={
+                "codes": "6324",
+                "return_to": "detail",
+                "return_code_s": "6324",
+            },
+        )
+        assert resp.status_code == 302
+        assert "/stock/6324" in resp.headers["Location"]
+
+    def test_bulk_exclude_without_return_code_falls_back(self, client, portfolio_db_path):
+        """return_to=detail でも return_code_s が無ければ通常の /portfolio に戻る"""
+        resp = client.post(
+            "/portfolio/bulk-exclude",
+            data={"codes": "6324", "return_to": "detail"},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/portfolio")
+
     def test_bulk_exclude_empty_codes_flash_error(self, client, portfolio_db_path):
         resp = client.post("/portfolio/bulk-exclude", data={})
         assert resp.status_code == 302

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -114,6 +114,62 @@ class TestSearchRoute:
         resp = client.get("/?q=テスト")  # "アズーム" の "テストメモ" と "空テスト" 両方にヒット
         assert resp.status_code == 200
 
+    def test_index_no_hit_with_code_q_shows_add_button(self, client):
+        """issue #216: ?q=未登録コード 0件時は追加フォームを表示"""
+        resp = client.get("/?q=9999")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "該当する銘柄がありません" in html
+        assert 'name="add_code_s"' in html
+        assert 'value="9999"' in html
+
+    def test_index_no_hit_with_keyword_q_hides_add_button(self, client):
+        """issue #216: 銘柄名検索でヒット0件でも追加フォームは出さない"""
+        resp = client.get("/?q=存在しない銘柄名")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "該当する銘柄がありません" in html
+        assert 'name="add_code_s"' not in html
+
+    def test_index_no_hit_with_invalid_code_hides_add_button(self, client):
+        """issue #216: 5桁などコード形式でない場合は追加フォーム非表示"""
+        resp = client.get("/?q=99999")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "該当する銘柄がありません" in html
+        assert 'name="add_code_s"' not in html
+
+    def test_index_no_hit_with_3digit_plus_letter_shows_add_button(self, client):
+        """issue #216: 215A 形式 (3桁+大文字) も追加対象"""
+        resp = client.get("/?q=215A")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'value="215A"' in html
+
+
+class TestStockAddRoute:
+    """POST /stock/add のテスト"""
+
+    def test_add_valid_code_redirects_to_detail(self, client, monkeypatch):
+        """issue #216: 検索0件ページからの追加 → 詳細ページへリダイレクト"""
+        # add_stock は stocks_shelve 参照するためスタブ化
+        monkeypatch.setattr(
+            "webapp.routes.search.add_stock",
+            lambda code: code.upper(),
+        )
+        resp = client.post("/stock/add", data={"add_code_s": "9999"})
+        assert resp.status_code == 302
+        assert "/stock/9999" in resp.headers["Location"]
+
+    def test_add_invalid_code_redirects_to_index(self, client, monkeypatch):
+        """不正コードは flash + index へ"""
+        def _raise(code):
+            raise ValueError("invalid code")
+        monkeypatch.setattr("webapp.routes.search.add_stock", _raise)
+        resp = client.post("/stock/add", data={"add_code_s": "bad"})
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/")
+
 
 class TestDetailRoute:
     """GET /stock/<code_s> のテスト"""
@@ -197,6 +253,57 @@ class TestDetailPortfolioModal:
         html = resp.data.decode()
         assert "portfolio-badge-button" in html
         assert "openPortfolioModal()" in html
+
+    def test_hold_status_no_exclude_button(self, portfolio_client):
+        """issue #221: 1保 銘柄の詳細では「ユニバース除外」ボタンが出ない"""
+        resp = portfolio_client.get("/stock/3496")  # 1保
+        html = resp.data.decode()
+        # JS 関数定義 / CSS クラス定義 / confirm() メッセージは常に含まれるので、
+        # ボタンの onclick="excludeFromUniverse(...)" 呼び出しが無いことで判定
+        assert 'onclick="excludeFromUniverse' not in html
+
+    def test_semi_status_shows_exclude_button(self, db_path, tmp_path, monkeypatch):
+        """issue #221: 2準 銘柄の詳細では「ユニバース除外」ボタンが出る"""
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+
+        rec = rs.create_research_record("3496", "アズーム", overall_rating="A")
+        rs.upsert_research_record(rec, db_path=db_path)
+        # 3監 → 2準 に遷移させる
+        ps.add_to_watch("3496", reason="テスト", db_path=portfolio_db)
+        ps.transition_status("3496", "2準", db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        client = app.test_client()
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "excludeFromUniverse('3496')" in html
+        assert "ユニバースから除外" in html
+
+    def test_watch_status_shows_exclude_button(self, db_path, tmp_path, monkeypatch):
+        """issue #221: 3監 銘柄の詳細では「ユニバース除外」ボタンが出る"""
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+
+        rec = rs.create_research_record("3496", "アズーム", overall_rating="A")
+        rs.upsert_research_record(rec, db_path=db_path)
+        ps.add_to_watch("3496", reason="テスト", db_path=portfolio_db)  # 3監 のまま
+
+        app = create_app()
+        app.config["TESTING"] = True
+        client = app.test_client()
+        resp = client.get("/stock/3496")
+        html = resp.data.decode()
+        assert "excludeFromUniverse('3496')" in html
 
     def test_excluded_record_treated_as_unregistered(self, db_path, tmp_path, monkeypatch):
         """除外済み (excluded=True) は未登録扱い: バッジ/transition モーダルは出さず、


### PR DESCRIPTION
## Summary

WebApp の UI/運用改善 3 件を 1 ブランチでまとめて対応。

- **#216**: ヘッダの「+ 追加」ボタンを廃止し、検索ヒット 0 件画面に移設 (q がコード形式 `4桁数字` or `3桁+大文字1` のときのみ表示)
- **#220**: 保有ステータス変更モーダル / 監視追加モーダルにアクション日付欄を追加し、過去日のアクションを正しく action_log の timestamp (JST 12:00) に記録できるようにした
- **#221**: 詳細ページのステータス変更モーダルから 2準 / 3監 のユニバース除外を可能化 (1保 は exclude_from_universe 側で reject)

主な変更:
- `scripts/portfolio_shelve.py`: `_parse_action_date_to_iso()` 追加、`transition_status()` / `add_to_watch()` に `action_date` 引数追加。「今日」基準は `datetime.now(JST).date()` (業務日 `get_price_day()` は 17:00 前に前日を返すため使わない)
- `scripts/webapp/__init__.py`: `today_jst` を context_processor で全テンプレに注入
- `scripts/webapp/routes/{portfolio,search}.py`: form パラメータ追加 / can_add フラグ算出
- `scripts/webapp/templates/{base,search,detail,portfolio_list}.html`: モーダル UI 更新
- テスト: 計 11 ケース追加 (169 pass、関連3ファイル)

## Test plan

- [x] `pytest tests/test_webapp_routes.py tests/test_portfolio_shelve.py tests/test_webapp_portfolio_routes.py -v` → 169 pass
- [x] 全体回帰 `pytest tests/ -m "not local_db and not live_html"` → 1441 pass (1 fail は本変更と無関係な main 由来の `TestMarketRouteKessanCard::test_today_card_appears_between_recent_past_and_future`)
- [x] E2E (実 webapp, Playwright)
  - #216: ヘッダから「+ 追加」消滅、`/?q=9999` で追加ボタン表示、`/?q=99999`・銘柄名検索で非表示
  - #220: 1保 (421A) / 2準 (4259) / 3監 (3687) の各モーダルと portfolio 一覧の全 26 件のフォームに action_date 欄 (value=max=今日, required)、未来日入力で alert + submit 中止
  - #221: 1保で除外ボタン非表示、2準/3監 で `excludeFromUniverse('<record.code_s>')` ボタン表示

## Notes

- Codex プランレビュー (gpt-5.3-codex) で 3 回イテレーション。指摘 (XSS / 業務日基準 / record.code_s 参照) はすべて反映済み
- exclude ボタンの JS は `innerHTML` 連結ではなく `createElement` で組み立て (reason 経由の XSS 防止)

Closes #216
Closes #220
Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)