### PR TITLE
issue #236: stock_name_prev を手動エイリアスとして検索可能化 + 自動上書きから保護

### DIFF
--- a/scripts/oneshots/clear_stock_name_prev.py
+++ b/scripts/oneshots/clear_stock_name_prev.py
@@ -8,10 +8,11 @@ issue #183 (PR #235) で導入された自動退避により、既存 research_s
 本スクリプトは Step 2 の前提として 1 回だけ実行する想定。実行後は手動で
 入力された stock_name_prev のみが残り、Step 2 のロジックで保護される。
 
-research_shelve 規約 (research_shelve.py L15-17) に従い、直接 ShelveDB を
-開かず公開 API (list_research_records / upsert_research_record) を使う。
-upsert_research_record は内部で _flock を取るため webapp / 他バッチとの
-並行書き込みから保護される。
+research_shelve 規約 (research_shelve.py L15-17) に従い、公開 API のみを使う。
+列挙は list_research_records() (フィルタなし全件)、クリアは
+clear_stock_name_prev_field() を 1 件ずつ呼ぶ。後者は _flock 区間内で R-M-W を
+完結させるため、Web UI / 他バッチが同レコードの他フィールド (memo 等) を
+同時更新していても lost update を起こさない (codex P2 対応)。
 
 Usage:
     python scripts/oneshots/clear_stock_name_prev.py --dry-run   # 対象件数のみ表示
@@ -36,7 +37,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # 1. 読み取り: 既存 prev を持つレコードを列挙
+    # 1. 読み取り: 既存 prev を持つレコードを列挙 (代表値のスナップショット)
     all_records = rs.list_research_records()
     targets = [r for r in all_records if r.get("stock_name_prev")]
 
@@ -51,12 +52,13 @@ def main():
             log_print(f"  ... (他 {len(targets) - 20} 件)")
         return
 
-    # 2. 書き込み: 公開 API upsert_research_record で完全上書き
+    # 2. クリア: 公開 API で _flock 内 R-M-W を 1 件ずつ。
+    #    targets[i] のスナップショットは古い可能性があるが、code_s だけ使い、
+    #    実書き換えは clear_stock_name_prev_field 内で最新値を再読込してから行う。
     cleared = 0
     for r in targets:
-        r["stock_name_prev"] = None
-        rs.upsert_research_record(r)
-        cleared += 1
+        if rs.clear_stock_name_prev_field(r["code_s"]):
+            cleared += 1
 
     log_print(f"cleared {cleared} records (stock_name_prev を None にリセット)")
 

--- a/scripts/oneshots/clear_stock_name_prev.py
+++ b/scripts/oneshots/clear_stock_name_prev.py
@@ -1,0 +1,65 @@
+"""issue #236 Step 1: stock_name_prev クリーンアップ。
+
+issue #183 (PR #235) で導入された自動退避により、既存 research_shelve の
+`stock_name_prev` には旧名が大量に入っている。issue #236 Step 2 で導入する
+「prev が空でない限り sync が上書きしない」ルールを安全に適用するため、
+本スクリプトで既存の `stock_name_prev` を全て None にリセットする。
+
+本スクリプトは Step 2 の前提として 1 回だけ実行する想定。実行後は手動で
+入力された stock_name_prev のみが残り、Step 2 のロジックで保護される。
+
+research_shelve 規約 (research_shelve.py L15-17) に従い、直接 ShelveDB を
+開かず公開 API (list_research_records / upsert_research_record) を使う。
+upsert_research_record は内部で _flock を取るため webapp / 他バッチとの
+並行書き込みから保護される。
+
+Usage:
+    python scripts/oneshots/clear_stock_name_prev.py --dry-run   # 対象件数のみ表示
+    python scripts/oneshots/clear_stock_name_prev.py             # 実行
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import research_shelve as rs
+from ks_util import log_print
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="変更せず対象件数のみ表示",
+    )
+    args = parser.parse_args()
+
+    # 1. 読み取り: 既存 prev を持つレコードを列挙
+    all_records = rs.list_research_records()
+    targets = [r for r in all_records if r.get("stock_name_prev")]
+
+    if args.dry_run:
+        log_print(f"[dry-run] {len(targets)} 件が対象:")
+        for r in targets[:20]:
+            log_print(
+                f"  {r['code_s']} {r.get('stock_name')} "
+                f"(旧 {r['stock_name_prev']})"
+            )
+        if len(targets) > 20:
+            log_print(f"  ... (他 {len(targets) - 20} 件)")
+        return
+
+    # 2. 書き込み: 公開 API upsert_research_record で完全上書き
+    cleared = 0
+    for r in targets:
+        r["stock_name_prev"] = None
+        rs.upsert_research_record(r)
+        cleared += 1
+
+    log_print(f"cleared {cleared} records (stock_name_prev を None にリセット)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -604,6 +604,36 @@ def sync_stock_name(
     return old_name
 
 
+def clear_stock_name_prev_field(
+    code_s: str,
+    *,
+    db_path: Optional[str] = None,
+) -> bool:
+    """指定銘柄の stock_name_prev を None にリセットする (issue #236)。
+
+    one-shot クリーンアップスクリプトから呼ぶ想定。
+    _flock 区間内で read-modify-write を完結させ、Web UI / 他バッチが
+    同レコードの他フィールド (memo 等) を同時更新していても lost update を起こさない。
+
+    Returns:
+        bool: 実際にクリアした場合 True、レコード未登録 or 既に None なら False
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            if normalized not in db:
+                return False
+            record = db[normalized]
+            if not isinstance(record, dict) or not record.get("stock_name_prev"):
+                return False
+            record["stock_name_prev"] = None
+            db[normalized] = record
+    log_print("research_shelve: stock_name_prev クリア", normalized)
+    return True
+
+
 def delete_research_record(
     code_s: str,
     *,

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -591,7 +591,11 @@ def sync_stock_name(
             if current == new_name_s:
                 return None
             old_name = current
-            record["stock_name_prev"] = current or None
+            # issue #236: stock_name_prev は手動エイリアス (俗称/旧表記での検索) として
+            # 使えるため、既に値が入っている場合は自動上書きしない。空に戻したい場合は
+            # UI から明示的に空文字保存してもらう。
+            if not record.get("stock_name_prev"):
+                record["stock_name_prev"] = current or None
             record["stock_name"] = new_name_s
             db[normalized] = record
     log_print(
@@ -736,8 +740,10 @@ def upsert_snapshot(
 # ===========================================
 
 # keyword 部分一致の対象フィールド
+# issue #236: stock_name_prev も検索エイリアス (俗称/旧表記) として活用する
 KEYWORD_SEARCH_FIELDS = (
     "stock_name",
+    "stock_name_prev",
     "overview",
     "memo",
     "openwork",

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -291,6 +291,26 @@ def save_memo(code_s: str, form_data: dict) -> None:
         upsert_research_record(record)
 
 
+def save_stock_name_prev(code_s: str, value: str) -> None:
+    """detail ページの inline 編集から呼ばれる stock_name_prev 単体更新 (issue #236)。
+
+    - 空文字 (前後 strip 後) なら None にリセット (= 手動エイリアス解除、次回 sync_stock_name で
+      自動退避が再び有効になる)
+    - 未登録 code_s は KeyError
+    - 他フィールドは _flock 区間内で最新値を保持
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    cleaned = (value or "").strip() or None
+
+    with _flock():
+        record = get_research_record(normalized)
+        if record is None:
+            raise KeyError(f"research_shelve: {normalized} は未登録です")
+        record["stock_name_prev"] = cleaned
+        upsert_research_record(record)
+
+
 def save_shikiho(code_s: str, form_data: dict) -> None:
     """四季報フィールドを更新する。
 

--- a/scripts/webapp/routes/memo.py
+++ b/scripts/webapp/routes/memo.py
@@ -1,19 +1,21 @@
 """
 メモ保存ルート。
 
-POST /stock/<code_s>/memo           : 手動メモ保存
-POST /stock/<code_s>/shikiho        : 四季報保存
-POST /stock/<code_s>/ir_comment     : IR分析コメント一括保存
-POST /stock/<code_s>/corporate_url  : 会社HP URL 上書き保存/クリア (issue #208)
+POST /stock/<code_s>/memo             : 手動メモ保存
+POST /stock/<code_s>/shikiho          : 四季報保存
+POST /stock/<code_s>/ir_comment       : IR分析コメント一括保存
+POST /stock/<code_s>/corporate_url    : 会社HP URL 上書き保存/クリア (issue #208)
+POST /stock/<code_s>/stock_name_prev  : 旧名/エイリアス 保存/クリア (issue #236, AJAX)
 """
 
-from flask import Blueprint, flash, request, redirect, url_for
+from flask import Blueprint, flash, jsonify, request, redirect, url_for
 
 from webapp.helpers import (
     save_memo,
     save_shikiho,
     save_ir_comments,
     save_corporate_url_override,
+    save_stock_name_prev,
 )
 
 memo_bp = Blueprint("memo", __name__)
@@ -66,3 +68,20 @@ def post_corporate_url(code_s: str):
     except Exception as e:  # noqa: BLE001
         flash(f"会社HPリンクの保存に失敗しました ({code_s}): {e}", "error")
     return redirect(url_for("detail.stock_detail", code_s=code_s))
+
+
+@memo_bp.route("/stock/<code_s>/stock_name_prev", methods=["POST"])
+def post_stock_name_prev(code_s: str):
+    """旧名/エイリアスの手動編集 -> 204/JSON (issue #236, AJAX 想定)。
+
+    空文字保存で stock_name_prev を None にリセット (= 手動エイリアス解除)。
+    成功は 204 No Content、未登録は 404、不正値は 400 (いずれも JSON エラー本文)。
+    """
+    value = request.form.get("stock_name_prev", "")
+    try:
+        save_stock_name_prev(code_s, value)
+    except KeyError as e:
+        return jsonify({"ok": False, "error": str(e)}), 404
+    except (ValueError, TypeError) as e:
+        return jsonify({"ok": False, "error": str(e)}), 400
+    return ("", 204)

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -18,7 +18,23 @@
       <span class="rating-badge rating-{{ record.overall_rating }}">{{ record.overall_rating }}</span>
       {% endif %}
       <small style="color:#888;font-size:0.5em;">{{ record.code_s }}</small>
-      {{ macros.stock_name_with_prev(record) }}
+      {{ record.stock_name or '' }}
+      {# issue #236: stock_name_prev を inline 編集化。旧名 / エイリアス (俗称・旧表記) #}
+      {% if record.stock_name_prev %}
+      <span class="stock-name-prev-edit"
+            title="クリックで編集 (空欄で削除)"
+            data-code="{{ record.code_s }}"
+            data-current="{{ record.stock_name_prev }}"
+            onclick="editStockNamePrev(this)">
+        (旧{{ record.stock_name_prev }})
+      </span>
+      {% else %}
+      <button type="button" class="stock-name-prev-add"
+              title="旧名・俗称などのエイリアスを追加すると検索でヒットするようになります"
+              data-code="{{ record.code_s }}"
+              data-current=""
+              onclick="editStockNamePrev(this)">+ 旧名/エイリアス</button>
+      {% endif %}
       {% if portfolio_status_query %}
         {% if portfolio_fallback_mode %}
         {# フォールバック中は書き込み不可なので静的バッジ #}
@@ -85,6 +101,34 @@
         if (input === null) return;  // Cancel
         document.getElementById('corp-url-input-' + codeS).value = input;
         document.getElementById('corp-url-form-' + codeS).submit();
+      }
+
+      // issue #236: 旧名/エイリアスの prompt() 編集。空欄で保存すると None にリセット。
+      // data-code / data-current は HTML 属性経由で受け取る (editCorpUrl と同パターン)。
+      function editStockNamePrev(el) {
+        var codeS = el.dataset.code;
+        var currentValue = el.dataset.current || "";
+        var input = window.prompt(
+          "旧名・エイリアスを入力してください\n(検索で引っかけたい俗称や旧表記。空欄で削除)",
+          currentValue
+        );
+        if (input === null) return;  // Cancel
+        var fd = new FormData();
+        fd.append("stock_name_prev", input);
+        fetch("/stock/" + encodeURIComponent(codeS) + "/stock_name_prev", {
+          method: "POST",
+          headers: {"X-Requested-With": "XMLHttpRequest"},
+          body: fd,
+        }).then(function(r) {
+          if (!r.ok) {
+            return r.json().then(function(j) {
+              alert("保存失敗: " + (j.error || r.status));
+            });
+          }
+          window.location.reload();
+        }).catch(function(err) {
+          alert("通信エラー: " + err);
+        });
       }
       </script>
       {% if not portfolio_status_query and not portfolio_fallback_mode %}
@@ -457,6 +501,27 @@
 </div>
 
 <style>
+/* issue #236: 旧名/エイリアス inline 編集 */
+.stock-name-prev-edit {
+  font-size: 0.5em;
+  color: #888;
+  cursor: pointer;
+  margin-left: 0.3em;
+}
+.stock-name-prev-edit:hover { color: #4285f4; text-decoration: underline; }
+.stock-name-prev-add {
+  font-size: 0.5em;
+  padding: 0.15em 0.5em;
+  margin-left: 0.5em;
+  border: 1px dotted #aaa;
+  background: none;
+  color: #888;
+  cursor: pointer;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+.stock-name-prev-add:hover { color: #4285f4; border-color: #4285f4; }
+
 .portfolio-badge-button {
   border: none;
   cursor: pointer;

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -578,6 +578,23 @@ class TestListFilter:
         assert len(results) == 1
         assert results[0]["code_s"] == "9999"
 
+    # --- issue #236: stock_name_prev も検索対象 (エイリアス) ---
+    def test_filter_keyword_stock_name_prev(self, db_path):
+        rec = rs.create_research_record(
+            "1436", "グリーンエナジー&カンパニー", stock_name_prev="フィット"
+        )
+        rs.upsert_research_record(rec, db_path=db_path)
+        # 旧名でヒット
+        hits = rs.list_research_records(keyword="フィット", db_path=db_path)
+        assert [r["code_s"] for r in hits] == ["1436"]
+        # case-insensitive (英字エイリアスのケース)
+        rec2 = rs.create_research_record(
+            "9501", "東京電力ホールディングス", stock_name_prev="TEPCO"
+        )
+        rs.upsert_research_record(rec2, db_path=db_path)
+        hits2 = rs.list_research_records(keyword="tepco", db_path=db_path)
+        assert [r["code_s"] for r in hits2] == ["9501"]
+
     # --- ケース28: rating と keyword の AND ---
     def test_filter_rating_and_keyword(self, populated_db):
         results = rs.list_research_records(
@@ -952,3 +969,18 @@ class TestStockNamePrev:
         assert loaded["openwork"] == "3.72"
         assert len(loaded["snapshots"]) == 1
         assert loaded["snapshots"][0]["ir_quant"] == "[A]26%,21%"
+
+    def test_sync_stock_name_does_not_overwrite_existing_prev(self, db_path):
+        """issue #236: prev に手動エイリアスが入っていれば自動退避は skip、stock_name のみ更新"""
+        rec = rs.create_research_record(
+            "1436", "フィット", stock_name_prev="手動エイリアス"
+        )
+        rs.upsert_research_record(rec, db_path=db_path)
+        returned = rs.sync_stock_name(
+            "1436", "グリーンエナジー&カンパニー", db_path=db_path
+        )
+        assert returned == "フィット"  # 戻り値は旧 stock_name (現状実装維持)
+        loaded = rs.get_research_record("1436", db_path=db_path)
+        assert loaded["stock_name"] == "グリーンエナジー&カンパニー"
+        # prev は手動入力が保持されたまま、「フィット」で上書きされていない
+        assert loaded["stock_name_prev"] == "手動エイリアス"

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -984,3 +984,21 @@ class TestStockNamePrev:
         assert loaded["stock_name"] == "グリーンエナジー&カンパニー"
         # prev は手動入力が保持されたまま、「フィット」で上書きされていない
         assert loaded["stock_name_prev"] == "手動エイリアス"
+
+    def test_clear_stock_name_prev_field(self, db_path):
+        """issue #236: clear_stock_name_prev_field は _flock 内 R-M-W で prev のみクリア"""
+        rec = rs.create_research_record(
+            "1436", "フィット", overall_rating="A", memo="重要", stock_name_prev="旧名"
+        )
+        rs.upsert_research_record(rec, db_path=db_path)
+        # 値あり → True
+        assert rs.clear_stock_name_prev_field("1436", db_path=db_path) is True
+        loaded = rs.get_research_record("1436", db_path=db_path)
+        assert loaded["stock_name_prev"] is None
+        # 他フィールドは保持されている
+        assert loaded["overall_rating"] == "A"
+        assert loaded["memo"] == "重要"
+        # 既に None → False (no-op)
+        assert rs.clear_stock_name_prev_field("1436", db_path=db_path) is False
+        # 未登録 → False
+        assert rs.clear_stock_name_prev_field("9999", db_path=db_path) is False

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -661,6 +661,29 @@ class TestSaveMemo:
         assert len(rec["snapshots"]) == 2
 
 
+class TestSaveStockNamePrev:
+    """issue #236: save_stock_name_prev のテスト"""
+
+    @pytest.mark.parametrize(
+        "input_value, expected",
+        [
+            ("南海電鉄", "南海電鉄"),       # 通常文字列はそのまま保存
+            ("", None),                     # 空文字 → None リセット
+            ("   ", None),                  # 前後空白だけ → None リセット
+            ("  TEPCO  ", "TEPCO"),         # 前後空白を strip して保存
+        ],
+    )
+    def test_save_stock_name_prev_variants(self, populated_db, input_value, expected):
+        helpers.save_stock_name_prev("3496", input_value)
+        rec = helpers.get_research_detail("3496")
+        assert rec["stock_name_prev"] == expected
+
+    def test_save_stock_name_prev_unknown_code_raises(self, populated_db):
+        import pytest as _pytest
+        with _pytest.raises(KeyError):
+            helpers.save_stock_name_prev("9999", "any")
+
+
 class TestSaveShikiho:
     """save_shikiho のテスト"""
 

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -210,6 +210,36 @@ class TestDetailStockNamePrev:
         assert "(旧" not in html
 
 
+class TestStockNamePrevRoute:
+    """issue #236: stock_name_prev の手動編集 + エイリアス検索"""
+
+    def test_save_and_search_alias(self, client, db_path):
+        """POST で旧名/エイリアスを保存 → 検索でヒット → 単一ヒット時は detail へリダイレクト"""
+        resp = client.post(
+            "/stock/3496/stock_name_prev",
+            data={"stock_name_prev": "テストエイリアス"},
+        )
+        assert resp.status_code == 204
+        # research_shelve に反映確認
+        rec = rs.get_research_record("3496", db_path=db_path)
+        assert rec["stock_name_prev"] == "テストエイリアス"
+        # 検索でヒット → 単一ヒットなので /stock/3496 へリダイレクト
+        resp_search = client.get("/?q=テストエイリアス")
+        assert resp_search.status_code == 302
+        assert "/stock/3496" in resp_search.headers["Location"]
+
+    def test_clear_prev_with_empty_string(self, client, db_path):
+        """空文字保存で stock_name_prev を None にリセット"""
+        client.post("/stock/3496/stock_name_prev", data={"stock_name_prev": "tmp"})
+        rec = rs.get_research_record("3496", db_path=db_path)
+        assert rec["stock_name_prev"] == "tmp"
+        # 空文字で再保存 → None
+        resp = client.post("/stock/3496/stock_name_prev", data={"stock_name_prev": ""})
+        assert resp.status_code == 204
+        rec = rs.get_research_record("3496", db_path=db_path)
+        assert rec["stock_name_prev"] is None
+
+
 class TestDetailPortfolioModal:
     """issue #195: 詳細ページにポートフォリオステータス変更モーダルを描画する。
 


### PR DESCRIPTION
## ⚠️ マージ前に必須の運用手順 (codex P1 対応)

本 PR では `stock_name_prev` を全文検索の対象に追加します。issue #183 で
自動退避された半角→全角変換などの旧表記が残っているレコードがあると、検索結果に
意図しないノイズが混ざります。**他環境・レプリカ DB で本変更を適用する場合は、
コードマージの前後で以下のクリーンアップを必ず実行してください。**

```bash
source .venv/bin/activate

# 1. 差分を最新化 (Kabutan の最新名を research_shelve に反映)
python scripts/sync_research_stock_names.py            # まず dry-run で件数確認
python scripts/sync_research_stock_names.py --apply

# 2. stock_name_prev を一括クリア (本 PR で追加した oneshot)
python scripts/oneshots/clear_stock_name_prev.py --dry-run
python scripts/oneshots/clear_stock_name_prev.py

# 3. 以後、ユーザーが detail ページから手動入力した分だけ
#    stock_name_prev に残り、検索エイリアスとして使われる
```

**本リポジトリの本番 shelve では作業着手時に上記を実行済み**
(sync 279 件 + clear 279 件、PR コメントログ参照)。

---

## Summary

issue #183 (PR #235) で導入した `stock_name_prev` (旧銘柄名) を、ユーザーが
手動で編集できる「検索エイリアス」として活用できるようにする。俗称・旧表記で
検索引っかけたい要件に対応。

- 「南海電気鉄道」と入れて正式名「ＮＡＮＫＡＩ」がヒット
- 「フィット」と入れて「グリーンエナジー＆カンパニー」がヒット (#1436)

## 主な変更

### サーバ側
- **`sync_stock_name()`**: `if not record.get("stock_name_prev"):` 1 行追加で
  手動エイリアスを自動上書きから保護 (案 B 折衷「Skip-if-Locked Lite」)。
  prev が空でない限り sync は触らず、stock_name のみ更新する。
  「prev を空にする = 保護解除」というユーザー操作が自然に提供される。
- **`KEYWORD_SEARCH_FIELDS`**: `stock_name_prev` を追加。case-insensitive 部分一致
- **`save_stock_name_prev(code_s, value)`**: 空文字 → None リセット対応
- **`clear_stock_name_prev_field(code_s)`** (codex P2 対応): _flock 内 R-M-W で
  prev のみクリア。oneshot から呼ぶことで Web UI / 他バッチとの並行書き込みで
  他フィールドが消える lost update を防ぐ
- **POST `/stock/<code_s>/stock_name_prev`**: AJAX 204/400/404

### UI
- detail ページのヘッダで旧名/エイリアスを inline 編集化 (data-* + prompt() パターン、
  既存 `editCorpUrl` と同形)
  - 旧名あり: 「(旧○○)」クリックで編集 / 空文字保存で削除
  - 旧名なし: 「+ 旧名/エイリアス」点線ボタン

### 運用ワンショット
- **`scripts/oneshots/clear_stock_name_prev.py`**: 既存 `stock_name_prev` を一括
  クリアするスクリプト。`clear_stock_name_prev_field()` を 1 件ずつ呼び _flock 排他

## 設計上の判断

- **案 B 折衷 (Skip-if-Locked Lite)** 採用: フラグ追加なし、ロジック差分 1 行
- スキーマ拡張ゼロ (RECORD_FIELDS / create 引数 / get の None 補完 すべて据え置き)
- `_macros.html` の `stock_name_with_prev` マクロは search.html / portfolio_list.html 等で
  併記表示にそのまま使われるため変更なし。detail のヘッダだけ inline 編集化
- prompt() ベースの編集 (corporate_url と同パターン): 専用モーダル不要

## Test plan

- [x] `pytest tests/test_research_shelve.py tests/test_webapp_helpers.py tests/test_webapp_routes.py -v`
  - 新規 6 本 pass (research 3 / helpers 1 / routes 2) + 既存全 pass
- [x] 全体回帰 `pytest tests/ -m "not local_db and not live_html"` → 1430 pass
  (1 fail は無関係な既存 main 由来の `TestMarketRouteKessanCard`)
- [x] E2E (Playwright)
  - `/stock/1436` で「+ 旧名/エイリアス」表示
  - prompt → 「フィット」入力 → タイトルに「(旧フィット)」反映
  - `/?q=フィット` で 1436 が検索結果に出る (旧名ヒット動線)
  - 「(旧フィット)」クリック → 空文字保存 → ヘッダから消える
- [x] codex プランレビュー 3 ラウンドで重大指摘解消
- [x] codex PR レビュー: P2 (oneshot lost update) → public API 経由に修正、P1 (DB 移行依存) → PR 本文の運用手順明記

## スコープ外

- `stock_name_prev_locked` フラグ追加 (案 C 不採用)
- list[str] 拡張で複数エイリアス保持 (案 D 不採用)
- 検索結果リスト側での「旧名ヒット」明示ハイライト (既存 `stock_name_with_prev` マクロが
  「新名 (旧○○)」を表示しているので暗黙ハイライト)
- 改名履歴の複数件保持

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)