### PR TITLE
市場セクションに買い集め評価 (週,日) を復活

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -1052,12 +1052,14 @@ def _html_market(market_db):
             spr_levels = [-10, -5, 0, 5, 10]
             spr_labels = ["E", "D", "C", "B", "A"]
             spr_parts = ["%d" % db.get("spr_20", 0), "%d" % db.get("spr_5", 0)]
-            sprw = db.get("sell_pressure_ratio_w") or []
-            if len(sprw) >= 3 and sprw[0]:
+            # データ有無は None / 長さで判定 (0 は calc_ratio が返す有効値なので除外しない)
+            sprw = db.get("sell_pressure_ratio_w")
+            if isinstance(sprw, list) and len(sprw) >= 3:
                 spr_parts.append(step_func(sprw[2] - sprw[0], spr_levels, spr_labels))
-            if db.get("spr_20") and db.get("spr_buygagher") is not None:
-                spr_parts.append(step_func(db.get("spr_buygagher", 0) - db.get("spr_20", 0),
-                                           spr_levels, spr_labels))
+            spr_20 = db.get("spr_20")
+            spr_bg = db.get("spr_buygagher")
+            if spr_20 is not None and spr_bg is not None:
+                spr_parts.append(step_func(spr_bg - spr_20, spr_levels, spr_labels))
             spr_display = ", ".join(spr_parts)
 
             rows_html.append(

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -1045,6 +1045,21 @@ def _html_market(market_db):
             rs_raw = db.get("rs_raw", "")
             rs_class = _rs_class(rs_raw)
 
+            # 売り圧力レシオ + 買い集め評価 (週,日)
+            # 個別銘柄は price.get_spr_expr で評価しているが、指数は sell_pressure_ratio が空のため
+            # spr_20 / spr_buygagher (日次) と sell_pressure_ratio_w (週次) から直接計算する。
+            from price import step_func
+            spr_levels = [-10, -5, 0, 5, 10]
+            spr_labels = ["E", "D", "C", "B", "A"]
+            spr_parts = ["%d" % db.get("spr_20", 0), "%d" % db.get("spr_5", 0)]
+            sprw = db.get("sell_pressure_ratio_w") or []
+            if len(sprw) >= 3 and sprw[0]:
+                spr_parts.append(step_func(sprw[2] - sprw[0], spr_levels, spr_labels))
+            if db.get("spr_20") and db.get("spr_buygagher") is not None:
+                spr_parts.append(step_func(db.get("spr_buygagher", 0) - db.get("spr_20", 0),
+                                           spr_levels, spr_labels))
+            spr_display = ", ".join(spr_parts)
+
             rows_html.append(
                 '<tr>\n'
                 '  <td><strong>%s</strong></td>\n'
@@ -1053,7 +1068,7 @@ def _html_market(market_db):
                 '  <td%s%s>%s</td>\n'
                 '  <td>%s</td>\n'
                 '  <td%s>%s</td>\n'
-                '  <td>%d, %d</td>\n'
+                '  <td>%s</td>\n'
                 '  <td>%.1f, %.1f</td>\n'
                 '</tr>' % (
                     html_mod.escape(market_name),
@@ -1062,7 +1077,7 @@ def _html_market(market_db):
                     dd_class, dd_title, html_mod.escape(dd_display),
                     html_mod.escape(ftd_rally_display),
                     state_class, html_mod.escape(state_display),
-                    db.get("spr_20", 0), db.get("spr_5", 0),
+                    html_mod.escape(spr_display),
                     db.get("rv_20", 0.0), db.get("rv_5", 0.0),
                 )
             )
@@ -1078,7 +1093,7 @@ def _html_market(market_db):
         '<thead><tr>\n'
         '  <th>市場名</th><th>RS</th><th>トレンド</th>\n'
         '  <th>DD</th><th>FTD/ラリー</th>\n'
-        '  <th>市場状態</th><th>売り圧力レシオ (20,5)</th><th>ボラティリティ (20,5)</th>\n'
+        '  <th>市場状態</th><th>売り圧力レシオ (20,5,買い集め週,日)</th><th>ボラティリティ (20,5)</th>\n'
         '</tr></thead>\n'
         '<tbody>'
     )


### PR DESCRIPTION
## Summary
- 市場セクションの売り圧力レシオ列に、個別銘柄と揃った買い集め A-E 評価 (週,日) を追加
- 表記例: `49, 46, D, C` (20日SPR, 5日SPR, 週次買い集め評価, 日次買い集め評価)
- issue #117 Part B (`1fe872f`) で「機能していなかった」として削除されたものを、
  現行の指数DBで実際に値を確認した上で復活

## 経緯
過去のコミット `1fe872f` のメッセージに「売り圧力レシオ列から買い集め指数 A-E 評価を削除 (機能していなかった)」とあったが、具体的な不具合の詳細は記録なし。
現行 DB を確認したところ、指数も `spr_20` / `spr_buygagher` (日次) と `sell_pressure_ratio_w` (週次) を持っており、計算結果は E〜C にきれいに分布して弁別力があった (例: TOPIX `D,C` / 日経225 `E,D` / S&P500 `D,E`)。
削除当時の「機能していなかった」根拠は現状あてはまらないと判断し、個別銘柄と表記を揃える形で復活させる。

## 実装メモ
- 個別銘柄は `price.get_spr_expr` を経由 (`sell_pressure_ratio` 3要素リスト前提) だが、指数では `sell_pressure_ratio` が空 (`None`) のため、個別フィールド `spr_buygagher - spr_20` (日) と `sell_pressure_ratio_w[2] - sell_pressure_ratio_w[0]` (週) から直接 A-E を出す
- データ欠損時 (週次値が0/空) は欠損部だけ表示を省略

## Test plan
- [x] `pytest tests/test_make_market_db.py -v` (98 passed)
- [x] 実 DB を読み込んだ `_html_market` 出力で各指数の評価値を確認
- [ ] ブラウザで市場セクションの表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)