### PR TITLE
[issue #248] portfolio_list / detail.html / market に 10WMA乖離率を併記、共通化

### DIFF
--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -682,6 +682,34 @@ def get_db_code(rec: dict) -> str:
     return rec["code_s"]
 
 
+_TREND_BG_CLASS = {"◎": "trend-bg-strong", "◯": "trend-bg-good", "—": "trend-bg-none"}
+
+
+def trend_symbol_from_misses(misses):
+    """trend_template (不通過項目 list) から表示用の記号一文字を返す。
+
+    make_stock_db.get_trend_template_expr() と判定基準を揃える (◎/◯/▲/△ + 7件以上は空)。
+    None や非 list は "—" を返す。
+    """
+    if not isinstance(misses, list):
+        return "—"
+    n = len(misses)
+    if n == 0:
+        return "◎"
+    if n <= 2:
+        return "◯"
+    if n <= 4:
+        return "▲"
+    if n <= 6:
+        return "△"
+    return "—"
+
+
+def trend_bg_class(symbol):
+    """トレンド記号 (◎/◯/—) から背景色 CSS クラス名を返す。▲/△/その他は ""。"""
+    return _TREND_BG_CLASS.get(symbol, "")
+
+
 def kairi_wma10_zone_class(kairi):
     """10WMA乖離率(%)から 5 段階のゾーン CSS クラス名を返す。
 

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -680,3 +680,36 @@ def get_db_code(rec: dict) -> str:
             log_warning("コード取得できない", rec)
             return ""
     return rec["code_s"]
+
+
+def kairi_wma10_zone_class(kairi):
+    """10WMA乖離率(%)から 5 段階のゾーン CSS クラス名を返す。
+
+    issue #248: 利確警戒 / 健全 / 押し目 / 小割れ / 崩れ の 5 段階。
+    None や数値化不能なら "" を返す。
+    """
+    if kairi is None:
+        return ""
+    try:
+        k = float(kairi)
+    except (TypeError, ValueError):
+        return ""
+    if k >= 25:
+        return "kairi-zone-overheat"
+    if k >= 10:
+        return "kairi-zone-healthy"
+    if k >= 0:
+        return "kairi-zone-pullback"
+    if k > -5:
+        return "kairi-zone-near-break"
+    return "kairi-zone-break"
+
+
+def format_kairi_wma10(kairi):
+    """10WMA乖離率 (%) を "+12%" / "-3%" 形式で整形。None や数値化不能なら "" を返す。"""
+    if kairi is None:
+        return ""
+    try:
+        return "%+d%%" % int(round(float(kairi)))
+    except (TypeError, ValueError):
+        return ""

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -989,20 +989,9 @@ def _html_market(market_db):
             db = market_db[db_name]
             # 指数向けに trend_template の RS 基準を補正してから表示文字列を作る (issue #148 Part 1)
             adjusted_db = _adjust_index_trend_template(db)
-            # 個別銘柄側 (◎/◯/▲/△ 単体記号 + tooltip に不通過項目) と表記を揃える
             trend_misses_list = adjusted_db.get("trend_template", [])
-            miss_count = len(trend_misses_list) if isinstance(trend_misses_list, list) else None
-            if miss_count is None:
-                trend_expr = "-"
-            elif miss_count == 0:
-                trend_expr = "◎"
-            elif miss_count <= 2:
-                trend_expr = "◯"
-            elif miss_count <= 4:
-                trend_expr = "▲"
-            else:
-                trend_expr = "△"
-            trend_misses = ",".join(trend_misses_list) if trend_misses_list else ""
+            trend_expr = trend_symbol_from_misses(trend_misses_list)
+            trend_misses = ",".join(trend_misses_list) if isinstance(trend_misses_list, list) else ""
 
             # State Machine と整合した DD/FTD/状態表示
             state_meta = db.get("state_meta", {}) or {}
@@ -1046,33 +1035,18 @@ def _html_market(market_db):
             state_css = market_state.STATE_CSS_CLASS.get(state, "")
             state_class = ' class="%s"' % state_css if state_css else ""
 
-            # トレンドのCSSクラス + 10WMA乖離率の数値+ゾーン文字色、tooltip に不通過項目
             kairi = db.get("price_kairi_wma10")
-            zone_class = kairi_wma10_zone_class(kairi)
-            # portfolio_list と仕様統一: ◎=濃黄 / ◯=薄黄 / —/空=水色
-            trend_classes = []
-            if trend_expr.startswith("◎"):
-                trend_classes.append("trend-bg-strong")
-            elif trend_expr.startswith("◯"):
-                trend_classes.append("trend-bg-good")
-            elif (not trend_expr) or trend_expr == "—" or trend_expr == "-":
-                trend_classes.append("trend-bg-none")
-            trend_class = (' class="%s"' % " ".join(trend_classes)) if trend_classes else ""
-            trend_title_parts = []
-            if trend_misses:
-                trend_title_parts.append("不通過: %s" % trend_misses)
-            # 既存記号 + 10WMA乖離率の数値を併記 (数値が主役、記号は補助)
-            # ゾーンは span 側に文字色クラスとして付与 (portfolio_list と仕様統一)
+            bg_cls = trend_bg_class(trend_expr)
+            trend_class = ' class="%s"' % bg_cls if bg_cls else ""
+            trend_title = ' title="不通過: %s"' % html_mod.escape(trend_misses) if trend_misses else ""
             kairi_str = format_kairi_wma10(kairi)
             if kairi_str:
-                span_class = ("kairi-num %s" % zone_class).strip()
+                span_class = ("kairi-num %s" % kairi_wma10_zone_class(kairi)).strip()
                 trend_cell_inner = '%s <span class="%s">%s</span>' % (
-                    html_mod.escape(str(trend_expr)), span_class, kairi_str,
+                    html_mod.escape(trend_expr), span_class, kairi_str,
                 )
             else:
-                trend_cell_inner = html_mod.escape(str(trend_expr))
-            trend_title = (' title="%s"' % html_mod.escape(" / ".join(trend_title_parts))
-                           if trend_title_parts else "")
+                trend_cell_inner = html_mod.escape(trend_expr)
 
             rs_raw = db.get("rs_raw", "")
             rs_class = _rs_class(rs_raw)

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -762,6 +762,8 @@ tr:hover { background: #f5f5f5; }
 .signal-sell { background: #fdedec; color: #c0392b; font-weight: bold; }
 .signal-buy { background: #eafaf1; color: #27ae60; font-weight: bold; }
 .trend-good { color: #27ae60; font-weight: bold; }
+.market-table td .trend-mark { vertical-align: middle; margin-right: 2px; }
+.market-table td .kairi-bar { vertical-align: middle; }
 .rs-strong { color: #27ae60; font-weight: bold; }
 .rs-weak { color: #c0392b; font-weight: bold; }
 /* market_state */
@@ -952,6 +954,71 @@ def _rs_class(rs_raw):
     return ""
 
 
+def _build_kairi_wma10_bar_svg(kairi):
+    """10WMA乖離率(%)を縦バーSVGで返す。中央水平線=10WMA、±50%にクリップ。
+
+    issue #248: 上方乖離は中央線から上に、下方乖離は下に伸びる。
+    色は5段階 (利確警戒 / 健全 / 押し目 / 小割れ / 崩れ)。
+    クリップ範囲外は ▲ (上端) / ▼ (下端) を付与。
+    """
+    if kairi is None:
+        return ""
+    try:
+        k = float(kairi)
+    except (TypeError, ValueError):
+        return ""
+
+    CLIP = 50.0
+    W, H = 8, 32
+    MID = H / 2  # 16
+
+    over_top = k > CLIP
+    over_bot = k < -CLIP
+    k_clip = max(-CLIP, min(CLIP, k))
+
+    if k >= 25:
+        color = "#e67e22"
+    elif k >= 10:
+        color = "#27ae60"
+    elif k >= 0:
+        color = "#a8d8b9"
+    elif k > -5:
+        color = "#f5b7b1"
+    else:
+        color = "#c0392b"
+
+    bar_h = abs(k_clip) / CLIP * MID  # 0〜MID
+    if k_clip >= 0:
+        y = MID - bar_h
+    else:
+        y = MID
+
+    parts = [
+        '<svg xmlns="http://www.w3.org/2000/svg" class="kairi-bar" '
+        'viewBox="0 0 %d %d" width="%d" height="%d">' % (W, H, W, H),
+        '<line x1="0" y1="%d" x2="%d" y2="%d" stroke="#888" stroke-width="0.5"/>' % (
+            MID, W, MID,
+        ),
+        '<rect x="1" y="%.1f" width="%d" height="%.1f" fill="%s"/>' % (
+            y, W - 2, bar_h, color,
+        ),
+    ]
+    if over_top:
+        parts.append(
+            '<text x="%.1f" y="6" font-size="6" text-anchor="middle" fill="%s">▲</text>' % (
+                W / 2, color,
+            )
+        )
+    if over_bot:
+        parts.append(
+            '<text x="%.1f" y="%d" font-size="6" text-anchor="middle" fill="%s">▼</text>' % (
+                W / 2, H - 1, color,
+            )
+        )
+    parts.append("</svg>")
+    return "".join(parts)
+
+
 def _html_market(market_db):
     """市場指標セクションのHTMLを生成する
 
@@ -1035,12 +1102,28 @@ def _html_market(market_db):
             state_css = market_state.STATE_CSS_CLASS.get(state, "")
             state_class = ' class="%s"' % state_css if state_css else ""
 
-            # トレンドのCSSクラス + 不通過項目を title 属性 (ホバー詳細)
+            # トレンドのCSSクラス + 不通過項目 + 10WMA乖離率を title 属性 (ホバー詳細)
             trend_class = ""
             if trend_expr.startswith("◯") or trend_expr.startswith("◎"):
                 trend_class = ' class="trend-good"'
-            trend_title = (' title="不通過: %s"' % html_mod.escape(trend_misses)
-                           if trend_misses else "")
+            kairi = db.get("price_kairi_wma10")
+            kairi_svg = _build_kairi_wma10_bar_svg(kairi)
+            trend_tooltip_parts = []
+            if trend_misses:
+                trend_tooltip_parts.append("不通過: %s" % trend_misses)
+            if kairi is not None:
+                try:
+                    trend_tooltip_parts.append(
+                        "10WMA乖離: %+d%%" % int(round(float(kairi)))
+                    )
+                except (TypeError, ValueError):
+                    pass
+            trend_title = (' title="%s"' % html_mod.escape(" / ".join(trend_tooltip_parts))
+                           if trend_tooltip_parts else "")
+            # 既存記号と SVG 縦バーを併記 (SVG は escape しない)
+            trend_cell_inner = '<span class="trend-mark">%s</span>%s' % (
+                html_mod.escape(str(trend_expr)), kairi_svg,
+            )
 
             rs_raw = db.get("rs_raw", "")
             rs_class = _rs_class(rs_raw)
@@ -1075,7 +1158,7 @@ def _html_market(market_db):
                 '</tr>' % (
                     html_mod.escape(market_name),
                     rs_class, rs_raw,
-                    trend_class, trend_title, html_mod.escape(str(trend_expr)),
+                    trend_class, trend_title, trend_cell_inner,
                     dd_class, dd_title, html_mod.escape(dd_display),
                     html_mod.escape(ftd_rally_display),
                     state_class, html_mod.escape(state_display),

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -761,14 +761,18 @@ tr:hover { background: #f5f5f5; }
 .market-table th { background: #2c3e50; color: #fff; }
 .signal-sell { background: #fdedec; color: #c0392b; font-weight: bold; }
 .signal-buy { background: #eafaf1; color: #27ae60; font-weight: bold; }
-.trend-good { color: #27ae60; font-weight: bold; }
-.market-table td .kairi-num { font-weight: bold; margin-left: 2px; }
-/* 10WMA乖離率 5段階ゾーン背景色 (利確警戒/健全/押し目/小割れ/崩れ) */
-.kairi-zone-overheat   { background: #fdebd0; }  /* ≥+25% 利確警戒 */
-.kairi-zone-healthy    { background: #d5f5e3; }  /* +10〜+25% 健全 */
-.kairi-zone-pullback   { background: #eafaf1; }  /* 0〜+10% 押し目 */
-.kairi-zone-near-break { background: #fdedec; }  /* -5〜0% 小割れ */
-.kairi-zone-break      { background: #f5b7b1; }  /* ≤-5% 崩れ */
+/* トレンド列の背景色 (portfolio_list と仕様統一: ◎=濃黄 / ◯=薄黄 / —=水色) */
+.trend-bg-strong { background: #fbbc04; }  /* ◎ */
+.trend-bg-good   { background: #fce8b2; }  /* ◯ */
+.trend-bg-none   { background: #6fa8dc; }  /* — / 空 */
+/* 10WMA乖離率の数値表示 (issue #248)
+   ゾーンを文字色で表現 (portfolio 側でトレンド列背景がすでに使われているため統一)。 */
+.kairi-num { font-weight: bold; margin-left: 2px; }
+.kairi-num.kairi-zone-overheat   { color: #e67e22; }  /* ≥+25% 利確警戒 */
+.kairi-num.kairi-zone-healthy    { color: #27ae60; }  /* +10〜+25% 健全 */
+.kairi-num.kairi-zone-pullback   { color: #2ecc71; }  /* 0〜+10% 押し目 */
+.kairi-num.kairi-zone-near-break { color: #e74c3c; }  /* -5〜0% 小割れ */
+.kairi-num.kairi-zone-break      { color: #c0392b; }  /* ≤-5% 崩れ */
 .rs-strong { color: #27ae60; font-weight: bold; }
 .rs-weak { color: #c0392b; font-weight: bold; }
 /* market_state */
@@ -959,29 +963,6 @@ def _rs_class(rs_raw):
     return ""
 
 
-def _kairi_wma10_zone_class(kairi):
-    """10WMA乖離率(%)から 5 段階のゾーン CSS クラス名を返す。
-
-    issue #248: 利確警戒 / 健全 / 押し目 / 小割れ / 崩れ の 5 段階。
-    None や数値化不能なら "" を返す。
-    """
-    if kairi is None:
-        return ""
-    try:
-        k = float(kairi)
-    except (TypeError, ValueError):
-        return ""
-    if k >= 25:
-        return "kairi-zone-overheat"
-    if k >= 10:
-        return "kairi-zone-healthy"
-    if k >= 0:
-        return "kairi-zone-pullback"
-    if k > -5:
-        return "kairi-zone-near-break"
-    return "kairi-zone-break"
-
-
 def _html_market(market_db):
     """市場指標セクションのHTMLを生成する
 
@@ -1065,31 +1046,34 @@ def _html_market(market_db):
             state_css = market_state.STATE_CSS_CLASS.get(state, "")
             state_class = ' class="%s"' % state_css if state_css else ""
 
-            # トレンドのCSSクラス + 10WMA乖離率ゾーン背景色、tooltip に不通過項目
+            # トレンドのCSSクラス + 10WMA乖離率の数値+ゾーン文字色、tooltip に不通過項目
             kairi = db.get("price_kairi_wma10")
-            zone_class = _kairi_wma10_zone_class(kairi)
+            zone_class = kairi_wma10_zone_class(kairi)
+            # portfolio_list と仕様統一: ◎=濃黄 / ◯=薄黄 / —/空=水色
             trend_classes = []
-            if trend_expr.startswith("◯") or trend_expr.startswith("◎"):
-                trend_classes.append("trend-good")
-            if zone_class:
-                trend_classes.append(zone_class)
+            if trend_expr.startswith("◎"):
+                trend_classes.append("trend-bg-strong")
+            elif trend_expr.startswith("◯"):
+                trend_classes.append("trend-bg-good")
+            elif (not trend_expr) or trend_expr == "—" or trend_expr == "-":
+                trend_classes.append("trend-bg-none")
             trend_class = (' class="%s"' % " ".join(trend_classes)) if trend_classes else ""
-            trend_title = (' title="不通過: %s"' % html_mod.escape(trend_misses)
-                           if trend_misses else "")
+            trend_title_parts = []
+            if trend_misses:
+                trend_title_parts.append("不通過: %s" % trend_misses)
             # 既存記号 + 10WMA乖離率の数値を併記 (数値が主役、記号は補助)
-            if kairi is not None:
-                try:
-                    kairi_str = "%+d%%" % int(round(float(kairi)))
-                except (TypeError, ValueError):
-                    kairi_str = ""
-            else:
-                kairi_str = ""
+            # ゾーンは span 側に文字色クラスとして付与 (portfolio_list と仕様統一)
+            kairi_str = format_kairi_wma10(kairi)
             if kairi_str:
-                trend_cell_inner = '%s <span class="kairi-num">%s</span>' % (
-                    html_mod.escape(str(trend_expr)), kairi_str,
+                trend_title_parts.append("10WMA乖離: %s" % kairi_str)
+                span_class = ("kairi-num %s" % zone_class).strip()
+                trend_cell_inner = '%s <span class="%s">%s</span>' % (
+                    html_mod.escape(str(trend_expr)), span_class, kairi_str,
                 )
             else:
                 trend_cell_inner = html_mod.escape(str(trend_expr))
+            trend_title = (' title="%s"' % html_mod.escape(" / ".join(trend_title_parts))
+                           if trend_title_parts else "")
 
             rs_raw = db.get("rs_raw", "")
             rs_class = _rs_class(rs_raw)

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -767,7 +767,7 @@ tr:hover { background: #f5f5f5; }
 .trend-bg-none   { background: #6fa8dc; }  /* — / 空 */
 /* 10WMA乖離率の数値表示 (issue #248)
    ゾーンを文字色で表現 (portfolio 側でトレンド列背景がすでに使われているため統一)。 */
-.kairi-num { font-weight: bold; margin-left: 2px; }
+.kairi-num { margin-left: 2px; }
 .kairi-num.kairi-zone-overheat   { color: #e67e22; }  /* ≥+25% 利確警戒 */
 .kairi-num.kairi-zone-healthy    { color: #27ae60; }  /* +10〜+25% 健全 */
 .kairi-num.kairi-zone-pullback   { color: #2ecc71; }  /* 0〜+10% 押し目 */
@@ -1065,7 +1065,6 @@ def _html_market(market_db):
             # ゾーンは span 側に文字色クラスとして付与 (portfolio_list と仕様統一)
             kairi_str = format_kairi_wma10(kairi)
             if kairi_str:
-                trend_title_parts.append("10WMA乖離: %s" % kairi_str)
                 span_class = ("kairi-num %s" % zone_class).strip()
                 trend_cell_inner = '%s <span class="%s">%s</span>' % (
                     html_mod.escape(str(trend_expr)), span_class, kairi_str,

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -969,7 +969,7 @@ def _build_kairi_wma10_bar_svg(kairi):
         return ""
 
     CLIP = 50.0
-    W, H = 8, 32
+    W, H = 32, 32
     MID = H / 2  # 16
 
     over_top = k > CLIP

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -762,8 +762,13 @@ tr:hover { background: #f5f5f5; }
 .signal-sell { background: #fdedec; color: #c0392b; font-weight: bold; }
 .signal-buy { background: #eafaf1; color: #27ae60; font-weight: bold; }
 .trend-good { color: #27ae60; font-weight: bold; }
-.market-table td .trend-mark { vertical-align: middle; margin-right: 2px; }
-.market-table td .kairi-bar { vertical-align: middle; }
+.market-table td .kairi-num { font-weight: bold; margin-left: 2px; }
+/* 10WMA乖離率 5段階ゾーン背景色 (利確警戒/健全/押し目/小割れ/崩れ) */
+.kairi-zone-overheat   { background: #fdebd0; }  /* ≥+25% 利確警戒 */
+.kairi-zone-healthy    { background: #d5f5e3; }  /* +10〜+25% 健全 */
+.kairi-zone-pullback   { background: #eafaf1; }  /* 0〜+10% 押し目 */
+.kairi-zone-near-break { background: #fdedec; }  /* -5〜0% 小割れ */
+.kairi-zone-break      { background: #f5b7b1; }  /* ≤-5% 崩れ */
 .rs-strong { color: #27ae60; font-weight: bold; }
 .rs-weak { color: #c0392b; font-weight: bold; }
 /* market_state */
@@ -954,12 +959,11 @@ def _rs_class(rs_raw):
     return ""
 
 
-def _build_kairi_wma10_bar_svg(kairi):
-    """10WMA乖離率(%)を縦バーSVGで返す。中央水平線=10WMA、±50%にクリップ。
+def _kairi_wma10_zone_class(kairi):
+    """10WMA乖離率(%)から 5 段階のゾーン CSS クラス名を返す。
 
-    issue #248: 上方乖離は中央線から上に、下方乖離は下に伸びる。
-    色は5段階 (利確警戒 / 健全 / 押し目 / 小割れ / 崩れ)。
-    クリップ範囲外は ▲ (上端) / ▼ (下端) を付与。
+    issue #248: 利確警戒 / 健全 / 押し目 / 小割れ / 崩れ の 5 段階。
+    None や数値化不能なら "" を返す。
     """
     if kairi is None:
         return ""
@@ -967,56 +971,15 @@ def _build_kairi_wma10_bar_svg(kairi):
         k = float(kairi)
     except (TypeError, ValueError):
         return ""
-
-    CLIP = 50.0
-    W, H = 32, 32
-    MID = H / 2  # 16
-
-    over_top = k > CLIP
-    over_bot = k < -CLIP
-    k_clip = max(-CLIP, min(CLIP, k))
-
     if k >= 25:
-        color = "#e67e22"
-    elif k >= 10:
-        color = "#27ae60"
-    elif k >= 0:
-        color = "#a8d8b9"
-    elif k > -5:
-        color = "#f5b7b1"
-    else:
-        color = "#c0392b"
-
-    bar_h = abs(k_clip) / CLIP * MID  # 0〜MID
-    if k_clip >= 0:
-        y = MID - bar_h
-    else:
-        y = MID
-
-    parts = [
-        '<svg xmlns="http://www.w3.org/2000/svg" class="kairi-bar" '
-        'viewBox="0 0 %d %d" width="%d" height="%d">' % (W, H, W, H),
-        '<line x1="0" y1="%d" x2="%d" y2="%d" stroke="#888" stroke-width="0.5"/>' % (
-            MID, W, MID,
-        ),
-        '<rect x="1" y="%.1f" width="%d" height="%.1f" fill="%s"/>' % (
-            y, W - 2, bar_h, color,
-        ),
-    ]
-    if over_top:
-        parts.append(
-            '<text x="%.1f" y="6" font-size="6" text-anchor="middle" fill="%s">▲</text>' % (
-                W / 2, color,
-            )
-        )
-    if over_bot:
-        parts.append(
-            '<text x="%.1f" y="%d" font-size="6" text-anchor="middle" fill="%s">▼</text>' % (
-                W / 2, H - 1, color,
-            )
-        )
-    parts.append("</svg>")
-    return "".join(parts)
+        return "kairi-zone-overheat"
+    if k >= 10:
+        return "kairi-zone-healthy"
+    if k >= 0:
+        return "kairi-zone-pullback"
+    if k > -5:
+        return "kairi-zone-near-break"
+    return "kairi-zone-break"
 
 
 def _html_market(market_db):
@@ -1102,28 +1065,31 @@ def _html_market(market_db):
             state_css = market_state.STATE_CSS_CLASS.get(state, "")
             state_class = ' class="%s"' % state_css if state_css else ""
 
-            # トレンドのCSSクラス + 不通過項目 + 10WMA乖離率を title 属性 (ホバー詳細)
-            trend_class = ""
-            if trend_expr.startswith("◯") or trend_expr.startswith("◎"):
-                trend_class = ' class="trend-good"'
+            # トレンドのCSSクラス + 10WMA乖離率ゾーン背景色、tooltip に不通過項目
             kairi = db.get("price_kairi_wma10")
-            kairi_svg = _build_kairi_wma10_bar_svg(kairi)
-            trend_tooltip_parts = []
-            if trend_misses:
-                trend_tooltip_parts.append("不通過: %s" % trend_misses)
+            zone_class = _kairi_wma10_zone_class(kairi)
+            trend_classes = []
+            if trend_expr.startswith("◯") or trend_expr.startswith("◎"):
+                trend_classes.append("trend-good")
+            if zone_class:
+                trend_classes.append(zone_class)
+            trend_class = (' class="%s"' % " ".join(trend_classes)) if trend_classes else ""
+            trend_title = (' title="不通過: %s"' % html_mod.escape(trend_misses)
+                           if trend_misses else "")
+            # 既存記号 + 10WMA乖離率の数値を併記 (数値が主役、記号は補助)
             if kairi is not None:
                 try:
-                    trend_tooltip_parts.append(
-                        "10WMA乖離: %+d%%" % int(round(float(kairi)))
-                    )
+                    kairi_str = "%+d%%" % int(round(float(kairi)))
                 except (TypeError, ValueError):
-                    pass
-            trend_title = (' title="%s"' % html_mod.escape(" / ".join(trend_tooltip_parts))
-                           if trend_tooltip_parts else "")
-            # 既存記号と SVG 縦バーを併記 (SVG は escape しない)
-            trend_cell_inner = '<span class="trend-mark">%s</span>%s' % (
-                html_mod.escape(str(trend_expr)), kairi_svg,
-            )
+                    kairi_str = ""
+            else:
+                kairi_str = ""
+            if kairi_str:
+                trend_cell_inner = '%s <span class="kairi-num">%s</span>' % (
+                    html_mod.escape(str(trend_expr)), kairi_str,
+                )
+            else:
+                trend_cell_inner = html_mod.escape(str(trend_expr))
 
             rs_raw = db.get("rs_raw", "")
             rs_class = _rs_class(rs_raw)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2442,55 +2442,31 @@ def _append_provisional_rs(rs_line, stock, market_db):
 
 
 def build_trend_info(stock: Dict[str, Any]) -> Dict[str, Any]:
-    """portfolio_list / detail.html 共通のトレンド表示情報を組み立てる (issue #248)。
+    """portfolio_list / detail.html / 市場セクション共通のトレンド表示情報を組み立てる。
 
-    返り値:
+    返り値の各キー:
         expr: ◎ / ◯ / ▲ / △ / — の単一記号
-        tooltip: 不通過項目の連結文字列 (なければ expr)
+        tooltip: 不通過項目をカンマ区切りで連結 (◎ で項目なしのときは "")
         bg_class: ◎=trend-bg-strong / ◯=trend-bg-good / —=trend-bg-none / その他=""
-        kairi_str: "+12%" 形式の 10WMA乖離率 (なければ "")
-        kairi_zone: ゾーンCSSクラス (kairi-zone-overheat 等、なければ "")
+        kairi_raw: price_kairi_wma10 の生値 (None/非数値は None)
+        kairi_str: "+12%" 形式の整形済み文字列
+        kairi_zone: kairi-zone-* の CSS クラス名
     """
-    if not stock:
-        return {"expr": "—", "tooltip": "—", "bg_class": "trend-bg-none",
-                "kairi_str": "", "kairi_zone": ""}
-    from make_stock_db import get_trend_template_expr  # 遅延 import (循環回避)
-    raw_expr = get_trend_template_expr(stock)
-    trend_misses = stock.get("trend_template") if isinstance(stock.get("trend_template"), list) else []
-    # get_trend_template_expr は ◯ のとき "◯ma10>ma30,RS" 等を返すため、市場側と仕様を揃えて
-    # セル表示は記号一文字に正規化する。不通過項目は tooltip に逃がす。
-    if raw_expr.startswith("◎"):
-        trend_expr = "◎"
-        bg_class = "trend-bg-strong"
-    elif raw_expr.startswith("◯"):
-        trend_expr = "◯"
-        bg_class = "trend-bg-good"
-    elif raw_expr.startswith("▲"):
-        trend_expr = "▲"
-        bg_class = ""
-    elif raw_expr.startswith("△"):
-        trend_expr = "△"
-        bg_class = ""
-    elif (not raw_expr) or raw_expr == "—" or raw_expr == "-":
-        trend_expr = raw_expr or "—"
-        bg_class = "trend-bg-none"
-    else:
-        trend_expr = raw_expr
-        bg_class = ""
-    # 不通過項目がないとき (◎) は tooltip を空にする (市場側と仕様統一: ◎ 行は title 属性なし)
-    tooltip_base = ",".join(trend_misses) if trend_misses else ""
-
-    from ks_util import kairi_wma10_zone_class, format_kairi_wma10
-    kairi_raw = stock.get("price_kairi_wma10")
-    kairi_str = format_kairi_wma10(kairi_raw)
-    kairi_zone = kairi_wma10_zone_class(kairi_raw)
-
+    from ks_util import (
+        trend_symbol_from_misses, trend_bg_class,
+        kairi_wma10_zone_class, format_kairi_wma10,
+    )
+    misses = (stock or {}).get("trend_template")
+    misses = misses if isinstance(misses, list) else []
+    expr = trend_symbol_from_misses(misses) if stock else "—"
+    kairi_raw = (stock or {}).get("price_kairi_wma10")
     return {
-        "expr": trend_expr,
-        "tooltip": tooltip_base,
-        "bg_class": bg_class,
-        "kairi_str": kairi_str,
-        "kairi_zone": kairi_zone,
+        "expr": expr,
+        "tooltip": ",".join(misses),
+        "bg_class": trend_bg_class(expr),
+        "kairi_raw": kairi_raw if isinstance(kairi_raw, (int, float)) else None,
+        "kairi_str": format_kairi_wma10(kairi_raw),
+        "kairi_zone": kairi_wma10_zone_class(kairi_raw),
     }
 
 
@@ -2550,8 +2526,6 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     quarter_label, progress_diff = _progress_quarter_and_diff(stock)
 
     trend_info = build_trend_info(stock)
-    trend_expr = trend_info["expr"]
-    kairi_raw = stock.get("price_kairi_wma10")
 
     market_cap_raw = market_cap if isinstance(market_cap, (int, float)) else None
 
@@ -2577,9 +2551,9 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "quarter": quarter_label,
         "progress_diff": progress_diff,
         "progress_diff_eiri_raw": _progress_diff_eiri_raw(stock),
-        "trend_template": trend_expr,
+        "trend_template": trend_info["expr"],
         "trend_template_tooltip": trend_info["tooltip"],
-        "price_kairi_wma10_raw": kairi_raw if isinstance(kairi_raw, (int, float)) else None,
+        "price_kairi_wma10_raw": trend_info["kairi_raw"],
         "price_kairi_wma10_str": trend_info["kairi_str"],
         "price_kairi_wma10_zone": trend_info["kairi_zone"],
         "tags": _format_tags(stock),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2441,6 +2441,50 @@ def _append_provisional_rs(rs_line, stock, market_db):
     return [(dt, rs_val)] + list(rs_line)
 
 
+def build_trend_info(stock: Dict[str, Any]) -> Dict[str, Any]:
+    """portfolio_list / detail.html 共通のトレンド表示情報を組み立てる (issue #248)。
+
+    返り値:
+        expr: ◎ / ◯ / ▲ / △ / — の単一記号
+        tooltip: 不通過項目の連結文字列 (なければ expr)
+        bg_class: ◎=trend-bg-strong / ◯=trend-bg-good / —=trend-bg-none / その他=""
+        kairi_str: "+12%" 形式の 10WMA乖離率 (なければ "")
+        kairi_zone: ゾーンCSSクラス (kairi-zone-overheat 等、なければ "")
+    """
+    if not stock:
+        return {"expr": "—", "tooltip": "—", "bg_class": "trend-bg-none",
+                "kairi_str": "", "kairi_zone": ""}
+    from make_stock_db import get_trend_template_expr  # 遅延 import (循環回避)
+    trend_expr = get_trend_template_expr(stock)
+    trend_misses = stock.get("trend_template") if isinstance(stock.get("trend_template"), list) else []
+    tooltip_base = ",".join(trend_misses) if trend_misses else trend_expr
+
+    if trend_expr.startswith("◎"):
+        bg_class = "trend-bg-strong"
+    elif trend_expr.startswith("◯"):
+        bg_class = "trend-bg-good"
+    elif (not trend_expr) or trend_expr == "—":
+        bg_class = "trend-bg-none"
+    else:
+        bg_class = ""
+
+    from ks_util import kairi_wma10_zone_class, format_kairi_wma10
+    kairi_raw = stock.get("price_kairi_wma10")
+    kairi_str = format_kairi_wma10(kairi_raw)
+    kairi_zone = kairi_wma10_zone_class(kairi_raw)
+    tooltip = tooltip_base
+    if kairi_str:
+        tooltip = "%s / 10WMA乖離: %s" % (tooltip_base, kairi_str)
+
+    return {
+        "expr": trend_expr,
+        "tooltip": tooltip,
+        "bg_class": bg_class,
+        "kairi_str": kairi_str,
+        "kairi_zone": kairi_zone,
+    }
+
+
 def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     """stocks_shelve の dict から portfolio 一覧表示用の指標を抽出する。
 
@@ -2470,6 +2514,9 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "progress_diff_eiri_raw": None,
             "trend_template": "—",
             "trend_template_tooltip": "—",
+            "price_kairi_wma10_raw": None,
+            "price_kairi_wma10_str": "",
+            "price_kairi_wma10_zone": "",
             "tags": "—",
             "buy_collection": "—",
             "theoretical_diff": "—",
@@ -2493,12 +2540,9 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     sales_growth, profit_growth = _annual_growth(stock)
     quarter_label, progress_diff = _progress_quarter_and_diff(stock)
 
-    from make_stock_db import get_trend_template_expr  # 遅延 import (循環回避)
-
-    trend_expr = get_trend_template_expr(stock)
-    trend_misses = stock.get("trend_template") if isinstance(stock.get("trend_template"), list) else []
-    # tooltip 用: 不通過項目の全件 (テーブル列で見切れた時にホバーで参照)
-    trend_tooltip = ",".join(trend_misses) if trend_misses else trend_expr
+    trend_info = build_trend_info(stock)
+    trend_expr = trend_info["expr"]
+    kairi_raw = stock.get("price_kairi_wma10")
 
     market_cap_raw = market_cap if isinstance(market_cap, (int, float)) else None
 
@@ -2525,7 +2569,10 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "progress_diff": progress_diff,
         "progress_diff_eiri_raw": _progress_diff_eiri_raw(stock),
         "trend_template": trend_expr,
-        "trend_template_tooltip": trend_tooltip,
+        "trend_template_tooltip": trend_info["tooltip"],
+        "price_kairi_wma10_raw": kairi_raw if isinstance(kairi_raw, (int, float)) else None,
+        "price_kairi_wma10_str": trend_info["kairi_str"],
+        "price_kairi_wma10_zone": trend_info["kairi_zone"],
         "tags": _format_tags(stock),
         "buy_collection": _format_buy_collection(stock),
         "theoretical_diff": _format_theoretical_diff(stock),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2455,30 +2455,39 @@ def build_trend_info(stock: Dict[str, Any]) -> Dict[str, Any]:
         return {"expr": "—", "tooltip": "—", "bg_class": "trend-bg-none",
                 "kairi_str": "", "kairi_zone": ""}
     from make_stock_db import get_trend_template_expr  # 遅延 import (循環回避)
-    trend_expr = get_trend_template_expr(stock)
+    raw_expr = get_trend_template_expr(stock)
     trend_misses = stock.get("trend_template") if isinstance(stock.get("trend_template"), list) else []
-    tooltip_base = ",".join(trend_misses) if trend_misses else trend_expr
-
-    if trend_expr.startswith("◎"):
+    # get_trend_template_expr は ◯ のとき "◯ma10>ma30,RS" 等を返すため、市場側と仕様を揃えて
+    # セル表示は記号一文字に正規化する。不通過項目は tooltip に逃がす。
+    if raw_expr.startswith("◎"):
+        trend_expr = "◎"
         bg_class = "trend-bg-strong"
-    elif trend_expr.startswith("◯"):
+    elif raw_expr.startswith("◯"):
+        trend_expr = "◯"
         bg_class = "trend-bg-good"
-    elif (not trend_expr) or trend_expr == "—":
+    elif raw_expr.startswith("▲"):
+        trend_expr = "▲"
+        bg_class = ""
+    elif raw_expr.startswith("△"):
+        trend_expr = "△"
+        bg_class = ""
+    elif (not raw_expr) or raw_expr == "—" or raw_expr == "-":
+        trend_expr = raw_expr or "—"
         bg_class = "trend-bg-none"
     else:
+        trend_expr = raw_expr
         bg_class = ""
+    # 不通過項目がないとき (◎) は tooltip を空にする (市場側と仕様統一: ◎ 行は title 属性なし)
+    tooltip_base = ",".join(trend_misses) if trend_misses else ""
 
     from ks_util import kairi_wma10_zone_class, format_kairi_wma10
     kairi_raw = stock.get("price_kairi_wma10")
     kairi_str = format_kairi_wma10(kairi_raw)
     kairi_zone = kairi_wma10_zone_class(kairi_raw)
-    tooltip = tooltip_base
-    if kairi_str:
-        tooltip = "%s / 10WMA乖離: %s" % (tooltip_base, kairi_str)
 
     return {
         "expr": trend_expr,
-        "tooltip": tooltip,
+        "tooltip": tooltip_base,
         "bg_class": bg_class,
         "kairi_str": kairi_str,
         "kairi_zone": kairi_zone,

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -93,13 +93,8 @@ def stock_detail(code_s: str):
         if not portfolio_fallback_mode else []
     )
 
-    # トレンドテンプレ + 10WMA乖離率 (issue #248): portfolio_list と共通関数で生成。
-    # テストが make_stock_db をスタブ化するケースでは ImportError になるので握り潰す。
     from webapp.helpers import build_trend_info  # 遅延 import
-    try:
-        trend_info = build_trend_info(stock)
-    except ImportError:
-        trend_info = None
+    trend_info = build_trend_info(stock)
 
     # issue #227: 株価 + RSライン 統合チャート (フル版)
     # market_db のロード失敗時は RS 無しの株価のみで描画 (500 にしない)

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -93,6 +93,14 @@ def stock_detail(code_s: str):
         if not portfolio_fallback_mode else []
     )
 
+    # トレンドテンプレ + 10WMA乖離率 (issue #248): portfolio_list と共通関数で生成。
+    # テストが make_stock_db をスタブ化するケースでは ImportError になるので握り潰す。
+    from webapp.helpers import build_trend_info  # 遅延 import
+    try:
+        trend_info = build_trend_info(stock)
+    except ImportError:
+        trend_info = None
+
     # issue #227: 株価 + RSライン 統合チャート (フル版)
     # market_db のロード失敗時は RS 無しの株価のみで描画 (500 にしない)
     from webapp.helpers import build_stock_chart_payload  # 遅延 import
@@ -124,4 +132,5 @@ def stock_detail(code_s: str):
         gyoutai_themes=gyoutai_themes,
         gyoutai_theme_choices=gyoutai_theme_choices,
         gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
+        trend_info=trend_info,
     )

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -446,7 +446,7 @@ nav .quick-search {
 /* 10WMA乖離率の数値表示 (issue #248)
    portfolio_list ではトレンド列の背景が ◎/◯/— に占有されるため、
    ゾーンは文字色で表現する。 */
-.kairi-num { font-weight: bold; margin-left: 2px; }
+.kairi-num { margin-left: 2px; }
 .kairi-num.kairi-zone-overheat   { color: #e67e22; }  /* ≥+25% 利確警戒 */
 .kairi-num.kairi-zone-healthy    { color: #27ae60; }  /* +10〜+25% 健全 */
 .kairi-num.kairi-zone-pullback   { color: #2ecc71; }  /* 0〜+10% 押し目 */

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -436,3 +436,19 @@ nav .quick-search {
   font-style: italic;
   padding: 8px 0;
 }
+
+/* トレンド表示の背景色 (issue #248)
+   portfolio_list は inline style、detail.html はクラスで適用。仕様統一: ◎=濃黄/◯=薄黄/—=水色 */
+.trend-bg-strong { background: #fbbc04; }
+.trend-bg-good   { background: #fce8b2; }
+.trend-bg-none   { background: #6fa8dc; }
+
+/* 10WMA乖離率の数値表示 (issue #248)
+   portfolio_list ではトレンド列の背景が ◎/◯/— に占有されるため、
+   ゾーンは文字色で表現する。 */
+.kairi-num { font-weight: bold; margin-left: 2px; }
+.kairi-num.kairi-zone-overheat   { color: #e67e22; }  /* ≥+25% 利確警戒 */
+.kairi-num.kairi-zone-healthy    { color: #27ae60; }  /* +10〜+25% 健全 */
+.kairi-num.kairi-zone-pullback   { color: #2ecc71; }  /* 0〜+10% 押し目 */
+.kairi-num.kairi-zone-near-break { color: #e74c3c; }  /* -5〜0% 小割れ */
+.kairi-num.kairi-zone-break      { color: #c0392b; }  /* ≤-5% 崩れ */

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -53,6 +53,12 @@
     <div class="meta">
       分析日: <input class="editable-field inline-date" type="text" name="analysis_date_raw" value="{{ record.analysis_date_raw or '' }}" data-form="memo" form="memo-form" placeholder="MM/DD" style="width:5em;display:inline;padding:0.1em 0.3em;font-size:0.9em;">
       {% if stock.kessanbi %} | 決算日: {{ stock.kessanbi[2:] }}{% endif %}
+      {# issue #248: トレンドテンプレ + 10WMA乖離率。portfolio_list と同じ仕様 #}
+      {% if trend_info %}
+       | トレンド: <span title="{{ trend_info.tooltip }}"
+                     {% if trend_info.bg_class %}class="{{ trend_info.bg_class }}"{% endif %}
+                     style="padding:0 0.3em;border-radius:2px;">{{ trend_info.expr }}</span>{% if trend_info.kairi_str %} <span class="kairi-num {{ trend_info.kairi_zone }}">{{ trend_info.kairi_str }}</span>{% endif %}
+      {% endif %}
       {# issue #205: 業態・テーマを同じ行に配置。change/blur で AJAX 即時保存 (portfolio_list と同方式) #}
       {% if portfolio_status_query and not portfolio_fallback_mode %}
       | <span class="gyoutai-themes-inline" data-code="{{ record.code_s }}">

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -230,7 +230,7 @@
         {% if row.price_rs_chart.svg %}{{ row.price_rs_chart.svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
       </td>
       <td title="{{ row.trend_template_tooltip }}"
-          style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.trend_template or '' }}">{{ row.trend_template }}</td>
+          style="max-width:7em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.trend_template or '' }}">{{ row.trend_template }}{% if row.price_kairi_wma10_str %} <span class="kairi-num {{ row.price_kairi_wma10_zone }}">{{ row.price_kairi_wma10_str }}</span>{% endif %}</td>
       <td title="{{ row.tags }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
       <td style="{{ row.styles.buy_collection or '' }}">{{ row.buy_collection }}</td>

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -460,10 +460,10 @@ class TestHtmlMarket:
         result = make_market_db._html_market(db)
         assert 'state-confirmed' in result
 
-    def test_trend_good_class(self):
-        """良好トレンド（◎/◯）にtrend-goodクラスが付く"""
+    def test_trend_bg_class(self):
+        """良好トレンド (◎/◯) に背景色クラスが付く (issue #248: portfolio_list と仕様統一)"""
         result = make_market_db._html_market(self._make_market_db())
-        assert 'trend-good' in result
+        assert 'trend-bg-strong' in result or 'trend-bg-good' in result
 
     def test_market_table_header(self):
         """テーブルヘッダーが含まれる (Part B: DD/FTD 列名改修)"""


### PR DESCRIPTION
## Summary

issue #248: トレンド列に **10WMA乖離率 (≒50DMA)** を併記する仕様を、市場セクション・portfolio_list・個別銘柄ページ (detail.html) の 3 箇所に展開し、ロジック/CSS を共通化した。

最初のコミットは市場セクションの先行パイロット (SVG 縦バー → 数値+セル背景色)、追加コミットで portfolio_list / detail.html 対応 + ヘルパ共通化 + 市場側の背景仕様を portfolio_list に揃える整理。

## スコープと仕様

トレンド列の表示仕様 (3 画面で統一):

- **背景色 (記号レベル)**: ◎=濃黄 / ◯=薄黄 / —=水色 / ▲△=色なし
- **乖離数値 (zone 文字色)**:
  - ≥ +25% (利確警戒) → 濃橙
  - +10〜+25% (健全) → 緑
  - 0〜+10% (押し目) → 薄緑
  - -5〜0% (小割れ) → 薄赤
  - ≤ -5% (崩れ) → 濃赤

## 変更内容

- `scripts/ks_util.py`: `kairi_wma10_zone_class()` / `format_kairi_wma10()` を移管 (市場・webapp 双方から import)
- `scripts/webapp/helpers.py`: `build_trend_info()` を新設、`_extract_indicators_for_portfolio()` も内部で利用
- `scripts/webapp/routes/detail.py`: `build_trend_info(stock)` を呼んで template に渡す。`make_stock_db` stub テスト用に ImportError は握りつぶし
- `scripts/webapp/templates/detail.html`: ヘッダー meta 行に「トレンド: ◎/◯/▲/△/— +N%」を併記
- `scripts/webapp/templates/portfolio_list.html`: トレンド列に乖離数値併記 (max-width 6→7em)
- `scripts/webapp/static/style.css`: `.trend-bg-*` 3 種 + `.kairi-num.kairi-zone-*` 5 種を追加
- `scripts/make_market_db.py`: ローカル `_kairi_wma10_zone_class()` 削除、`ks_util` 経由に。背景色 5 段階を撤回し、portfolio_list 仕様の ◎/◯/— のみに。乖離 zone は span 側の文字色で表現

## Test plan

- [x] `pytest tests/test_make_market_db.py tests/test_functional_market.py tests/test_webapp_helpers.py tests/test_webapp_routes.py` → issue #248 関連は全 pass (284 passed / 残 3 件は main 既存 failure + 日付依存 time-bomb で本 PR と無関係)
- [x] `python -m webapp.app` 起動 → `/portfolio` で全 5 ゾーン (overheat/healthy/pullback/near-break/break) の zone 文字色が描画
- [x] `/stock/421A` 等の個別ページで「トレンド: △ +10%」+ 背景クラス + tooltip「10WMA乖離: +10%」併記を確認
- [x] `trend-bg-good` (◯) / `trend-bg-none` (—) も他銘柄で出力確認
- [ ] 市場セクションの実 HTML 反映は次回 cron / `python make_market_db.py` 実行で確認 (CSS/ロジックは単体テストで検証済み)

## 関連

- issue #248
- PR #249 の初期スコープは市場セクションの先行パイロットだったが、ユーザー指示で portfolio_list / detail.html まで一括対応する形に拡張