### PR TITLE
helpers: trend_template 欠損銘柄を ◎ と誤表示する回帰を修正

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2456,13 +2456,15 @@ def build_trend_info(stock: Dict[str, Any]) -> Dict[str, Any]:
         trend_symbol_from_misses, trend_bg_class,
         kairi_wma10_zone_class, format_kairi_wma10,
     )
+    # trend_template が未生成 / 欠損している銘柄を「◎ (完全通過)」と誤表示しないよう、
+    # 非 list を [] に変換せず、未評価として trend_symbol_from_misses に渡して "—" を返す。
     misses = (stock or {}).get("trend_template")
-    misses = misses if isinstance(misses, list) else []
     expr = trend_symbol_from_misses(misses) if stock else "—"
+    tooltip_src = misses if isinstance(misses, list) else []
     kairi_raw = (stock or {}).get("price_kairi_wma10")
     return {
         "expr": expr,
-        "tooltip": ",".join(misses),
+        "tooltip": ",".join(tooltip_src),
         "bg_class": trend_bg_class(expr),
         "kairi_raw": kairi_raw if isinstance(kairi_raw, (int, float)) else None,
         "kairi_str": format_kairi_wma10(kairi_raw),

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2308,3 +2308,23 @@ class TestPriceRsSparkline:
             assert 'r="4.0"' in svg
         else:
             assert 'r="4.0"' not in svg
+
+
+class TestBuildTrendInfoMissing:
+    """trend_template が欠損している銘柄を「完全通過 (◎)」と誤表示しないこと"""
+
+    @pytest.mark.parametrize("stock,expected_expr", [
+        # キー欠損 (DB に trend_template が無い既存銘柄)
+        ({"price": 1000}, "—"),
+        # 値が None (取得失敗で None が入っている)
+        ({"trend_template": None}, "—"),
+        # 旧フォーマットの文字列 "-" (移行残存)
+        ({"trend_template": "-"}, "—"),
+        # 正常: 空 list (= 不通過 0 件) は ◎ のまま
+        ({"trend_template": []}, "◎"),
+        # 正常: 1 件不通過は ◯
+        ({"trend_template": ["RS"]}, "◯"),
+    ])
+    def test_missing_trend_returns_em_dash_not_circle(self, stock, expected_expr):
+        info = helpers.build_trend_info(stock)
+        assert info["expr"] == expected_expr


### PR DESCRIPTION
## Summary
PR #249 (issue #248) で導入された `build_trend_info` で、`trend_template` が
未生成 / 欠損している銘柄を「◎ (完全通過)」と誤表示する回帰がありました。

## 原因
`scripts/webapp/helpers.py:2459-2461` で `misses` が非 list (None / "-" / キー欠損) のとき
`[]` に変換してから `trend_symbol_from_misses(misses)` に渡しており、
`trend_symbol_from_misses([])` は「不通過 0 件 = ◎」を返すため、欠損銘柄が
濃黄背景の良好トレンドとして portfolio/detail で表示されていた。

`trend_symbol_from_misses` 自体は **None / 非 list で "—" を返す仕様** なので、
呼び出し側で `[]` 化せず未評価のまま渡すように修正。tooltip 用の `",".join()` には
別途 `tooltip_src` (list 保証) を使う。

## Test plan
- [x] `TestBuildTrendInfoMissing` を 5 ケース parametrize で追加
  - キー欠損 / `None` / 旧 "-" → "—" になる
  - 正常 `[]` → ◎、`["RS"]` → ◯ も継続確認
- [x] `pytest tests/test_webapp_helpers.py::TestBuildTrendInfoMissing -v` → 5 passed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>