### PR TITLE
issue #247: 市場セクションの売り圧力レシオ / ボラティリティを需給バランス横バーゲージで可視化

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -775,6 +775,9 @@ tr:hover { background: #f5f5f5; }
 .kairi-num.kairi-zone-break      { color: #c0392b; }  /* ≤-5% 崩れ */
 .rs-strong { color: #27ae60; font-weight: bold; }
 .rs-weak { color: #c0392b; font-weight: bold; }
+/* 需給バランスセル (issue #247): SPR/rv の横バー 2 本縦積み */
+.spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; }
+.spr-gauge-cell svg { display: block; }
 /* market_state */
 .state-confirmed { background: #eafaf1; color: #27ae60; font-weight: bold; }
 .state-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
@@ -963,6 +966,131 @@ def _rs_class(rs_raw):
     return ""
 
 
+_SPR_GAUGE_WIDTH = 100      # バー本体の幅 (= SPR 0〜100 のスケール)
+_SPR_GAUGE_BAR_H = 14       # 1 本のバーの高さ
+_SPR_GAUGE_BAR_GAP = 3      # 20日バーと5日バーの縦間隔
+
+
+def _to_finite_number(v):
+    """None / 数値化不能 / NaN を None に正規化する。それ以外は float を返す。"""
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN
+        return None
+    return f
+
+
+def _format_spr_rv_text(spr_f, rv_f, period_label=None):
+    """SPR / rv 値を tooltip 表示用の文字列に整形する (バー単体 / セル全体で共通)。
+
+    spr_f / rv_f は _to_finite_number 通過後の float | None を渡す。
+    period_label を渡すと末尾に " (20日)" のような期間表記が付く。
+    """
+    base = "SPR %d" % int(round(spr_f))
+    if rv_f is not None:
+        base += " ±%.1f" % rv_f
+    if period_label:
+        base += " (%s)" % period_label
+    return base
+
+
+def _build_spr_gauge_bar_svg(spr, rv, y, period_label):
+    """SPR/rv 1 本分のバー要素 (rect + ティック [+ ヒゲ]) を SVG 文字列で返す。
+
+    spr が欠損ならバー全体をスキップ ("" を返す)。rv 欠損ならヒゲ無しで描画。
+    spr は 0〜100 にクリップ、ヒゲ端も 0〜100 にクリップする。
+    period_label は "20日" / "5日" などの期間表示で、SVG <title> に埋め込み
+    バー単体のホバーで「SPR ±rv (20日)」が出るようにする。
+    """
+    spr_f = _to_finite_number(spr)
+    if spr_f is None:
+        return ""
+    spr_x = max(0.0, min(100.0, spr_f))
+    rv_f = _to_finite_number(rv)
+    bar_title = _format_spr_rv_text(spr_f, rv_f, period_label)
+    parts = ['<title>%s</title>' % html_mod.escape(bar_title)]
+    # 背景塗り分け: 左=薄緑 (買い余地)、右=薄赤 (売り圧)
+    parts.append(
+        '<rect x="0" y="%d" width="%g" height="%d" fill="#d4f4d4"/>' % (y, spr_x, _SPR_GAUGE_BAR_H)
+    )
+    parts.append(
+        '<rect x="%g" y="%d" width="%g" height="%d" fill="#f4d4d4"/>' % (
+            spr_x, y, _SPR_GAUGE_WIDTH - spr_x, _SPR_GAUGE_BAR_H,
+        )
+    )
+    # ヒゲ (± rv) を先に描いてからティックを最後に上載せ → 交差箇所でティックが消えない
+    if rv_f is not None:
+        whisker_lo = max(0.0, spr_x - rv_f)
+        whisker_hi = min(100.0, spr_x + rv_f)
+        whisker_y = y + _SPR_GAUGE_BAR_H / 2
+        parts.append(
+            '<line x1="%g" y1="%g" x2="%g" y2="%g" stroke="#555" stroke-width="1"/>' % (
+                whisker_lo, whisker_y, whisker_hi, whisker_y,
+            )
+        )
+    # 中央ティック (SPR 値の縦線): 太め
+    parts.append(
+        '<line x1="%g" y1="%d" x2="%g" y2="%d" stroke="#555" stroke-width="2"/>' % (
+            spr_x, y, spr_x, y + _SPR_GAUGE_BAR_H,
+        )
+    )
+    # 1 本のバーを <g> で包んで <title> をそのバー専用にする
+    return '<g>%s</g>' % "".join(parts)
+
+
+def _build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5):
+    """SPR/rv の横バーゲージ (2 本縦積み、上=20日 / 下=5日) を SVG 文字列で返す。
+
+    20日バー / 5日バーは独立に欠損判定する:
+      - spr_X が欠損 → 該当バーをスキップ (もう一方は描画)
+      - rv_X が欠損 → 該当バーはティック + 背景のみ (ヒゲ無し)
+      - spr_20 / spr_5 両方欠損 → "—" を返す
+    片側だけ欠損で両方非表示になる回帰を避けるため、内部で 2 本独立に判定する。
+    """
+    has_20 = _to_finite_number(spr_20) is not None
+    has_5 = _to_finite_number(spr_5) is not None
+    if not has_20 and not has_5:
+        return "—"
+    h = _SPR_GAUGE_BAR_H * 2 + _SPR_GAUGE_BAR_GAP
+    bars = [
+        _build_spr_gauge_bar_svg(spr_20, rv_20, 0, "20日"),
+        _build_spr_gauge_bar_svg(spr_5, rv_5, _SPR_GAUGE_BAR_H + _SPR_GAUGE_BAR_GAP, "5日"),
+    ]
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d">'
+        '%s</svg>'
+    ) % (_SPR_GAUGE_WIDTH, h, _SPR_GAUGE_WIDTH, h, "".join(bars))
+
+
+def _build_spr_gauge_tooltip(spr_20, rv_20, spr_5, rv_5, sprw_label, sprbg_label):
+    """需給バランスセルの title 属性文字列を組み立てる。
+
+    1 行目: SPR ± rv (20日/5日) — 片側欠損なら欠損側を省略
+    2 行目: 買い集め 週X 日Y — sprw_label / sprbg_label が None なら該当を省略、両方 None なら 2 行目自体を省略
+    """
+    def _fmt(spr, rv, label):
+        spr_f = _to_finite_number(spr)
+        if spr_f is None:
+            return None
+        return _format_spr_rv_text(spr_f, _to_finite_number(rv), label)
+    spr_parts = [s for s in (_fmt(spr_20, rv_20, "20日"), _fmt(spr_5, rv_5, "5日")) if s]
+    lines = []
+    if spr_parts:
+        lines.append(" / ".join(spr_parts))
+    bg_parts = []
+    if sprw_label:
+        bg_parts.append("週%s" % sprw_label)
+    if sprbg_label:
+        bg_parts.append("日%s" % sprbg_label)
+    if bg_parts:
+        lines.append("買い集め " + " ".join(bg_parts))
+    return "\n".join(lines)
+
+
 def _html_market(market_db):
     """市場指標セクションのHTMLを生成する
 
@@ -1053,22 +1181,31 @@ def _html_market(market_db):
             rs_raw = db.get("rs_raw", "")
             rs_class = _rs_class(rs_raw)
 
-            # 売り圧力レシオ + 買い集め評価 (週,日)
+            # 売り圧力レシオ + 買い集め評価 (週,日) → 需給バランスセル (issue #247)
             # 個別銘柄は price.get_spr_expr で評価しているが、指数は sell_pressure_ratio が空のため
             # spr_20 / spr_buygagher (日次) と sell_pressure_ratio_w (週次) から直接計算する。
             from price import step_func
             spr_levels = [-10, -5, 0, 5, 10]
             spr_labels = ["E", "D", "C", "B", "A"]
-            spr_parts = ["%d" % db.get("spr_20", 0), "%d" % db.get("spr_5", 0)]
-            # データ有無は None / 長さで判定 (0 は calc_ratio が返す有効値なので除外しない)
-            sprw = db.get("sell_pressure_ratio_w")
-            if isinstance(sprw, list) and len(sprw) >= 3:
-                spr_parts.append(step_func(sprw[2] - sprw[0], spr_levels, spr_labels))
             spr_20 = db.get("spr_20")
+            spr_5 = db.get("spr_5")
+            rv_20 = db.get("rv_20")
+            rv_5 = db.get("rv_5")
+            # 買い集め評価 (週次): sell_pressure_ratio_w[2] - [0] のステップ評価
+            sprw = db.get("sell_pressure_ratio_w")
+            sprw_label = None
+            if isinstance(sprw, list) and len(sprw) >= 3:
+                sprw_label = step_func(sprw[2] - sprw[0], spr_levels, spr_labels)
+            # 買い集め評価 (日次): spr_buygagher - spr_20 のステップ評価
             spr_bg = db.get("spr_buygagher")
+            sprbg_label = None
             if spr_20 is not None and spr_bg is not None:
-                spr_parts.append(step_func(spr_bg - spr_20, spr_levels, spr_labels))
-            spr_display = ", ".join(spr_parts)
+                sprbg_label = step_func(spr_bg - spr_20, spr_levels, spr_labels)
+            gauge_svg = _build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5)
+            gauge_tooltip = _build_spr_gauge_tooltip(
+                spr_20, rv_20, spr_5, rv_5, sprw_label, sprbg_label,
+            )
+            gauge_title_attr = ' title="%s"' % html_mod.escape(gauge_tooltip) if gauge_tooltip else ""
 
             rows_html.append(
                 '<tr>\n'
@@ -1078,8 +1215,7 @@ def _html_market(market_db):
                 '  <td%s%s>%s</td>\n'
                 '  <td>%s</td>\n'
                 '  <td%s>%s</td>\n'
-                '  <td>%s</td>\n'
-                '  <td>%.1f, %.1f</td>\n'
+                '  <td class="spr-gauge-cell"%s>%s</td>\n'
                 '</tr>' % (
                     html_mod.escape(chart_url), html_mod.escape(market_name),
                     rs_class, rs_raw,
@@ -1087,8 +1223,7 @@ def _html_market(market_db):
                     dd_class, dd_title, html_mod.escape(dd_display),
                     html_mod.escape(ftd_rally_display),
                     state_class, html_mod.escape(state_display),
-                    html_mod.escape(spr_display),
-                    db.get("rv_20", 0.0), db.get("rv_5", 0.0),
+                    gauge_title_attr, gauge_svg,
                 )
             )
         except KeyError:
@@ -1103,7 +1238,7 @@ def _html_market(market_db):
         '<thead><tr>\n'
         '  <th>市場名</th><th>RS</th><th>トレンド</th>\n'
         '  <th>DD</th><th>FTD/ラリー</th>\n'
-        '  <th>市場状態</th><th>売り圧力レシオ (20,5,買い集め週,日)</th><th>ボラティリティ (20,5)</th>\n'
+        '  <th>市場状態</th><th>需給バランス</th>\n'
         '</tr></thead>\n'
         '<tbody>'
     )

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -1042,7 +1042,7 @@ def _build_spr_gauge_bar_svg(spr, rv, y, period_label):
     return '<g>%s</g>' % "".join(parts)
 
 
-def _build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5):
+def build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5):
     """SPR/rv の横バーゲージ (2 本縦積み、上=20日 / 下=5日) を SVG 文字列で返す。
 
     20日バー / 5日バーは独立に欠損判定する:
@@ -1066,11 +1066,13 @@ def _build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5):
     ) % (_SPR_GAUGE_WIDTH, h, _SPR_GAUGE_WIDTH, h, "".join(bars))
 
 
-def _build_spr_gauge_tooltip(spr_20, rv_20, spr_5, rv_5, sprw_label, sprbg_label):
+def build_spr_gauge_tooltip(spr_20, rv_20, spr_5, rv_5, sprw_label=None, sprbg_label=None):
     """需給バランスセルの title 属性文字列を組み立てる。
 
     1 行目: SPR ± rv (20日/5日) — 片側欠損なら欠損側を省略
     2 行目: 買い集め 週X 日Y — sprw_label / sprbg_label が None なら該当を省略、両方 None なら 2 行目自体を省略
+    sprw_label / sprbg_label は呼び出し側で評価有無を決められる任意フィールド
+    (個別銘柄の portfolio 一覧では「買い集め」列が別途あるため省略する)。
     """
     def _fmt(spr, rv, label):
         spr_f = _to_finite_number(spr)
@@ -1201,8 +1203,8 @@ def _html_market(market_db):
             sprbg_label = None
             if spr_20 is not None and spr_bg is not None:
                 sprbg_label = step_func(spr_bg - spr_20, spr_levels, spr_labels)
-            gauge_svg = _build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5)
-            gauge_tooltip = _build_spr_gauge_tooltip(
+            gauge_svg = build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5)
+            gauge_tooltip = build_spr_gauge_tooltip(
                 spr_20, rv_20, spr_5, rv_5, sprw_label, sprbg_label,
             )
             gauge_title_attr = ' title="%s"' % html_mod.escape(gauge_tooltip) if gauge_tooltip else ""

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1663,6 +1663,29 @@ def _annual_growth(stock: Dict[str, Any]) -> tuple:
     return result[1], result[2]
 
 
+def _build_spr_gauge_for_stock(stock: Dict[str, Any]) -> Dict[str, str]:
+    """個別銘柄の sell_pressure_ratio / stddev_volatility から需給バランスゲージを組み立てる。
+
+    個別銘柄の price 指標は:
+      sell_pressure_ratio = [spr_20, spr_5, buygather]  (price.py 参照)
+      stddev_volatility   = [rv_20, rv_5]
+    市場指数 (make_market_db) の spr_20 / spr_5 / rv_20 / rv_5 と形式が違うため、
+    ここで取り出して build_spr_gauge_svg / build_spr_gauge_tooltip に渡す。
+    買い集め評価は portfolio 一覧では別列に出すので tooltip 側からは省略。
+    """
+    from make_market_db import build_spr_gauge_svg, build_spr_gauge_tooltip  # 遅延 import (循環回避)
+    sprs = stock.get("sell_pressure_ratio") or []
+    vols = stock.get("stddev_volatility") or []
+    spr_20 = sprs[0] if len(sprs) > 0 else None
+    spr_5 = sprs[1] if len(sprs) > 1 else None
+    rv_20 = vols[0] if len(vols) > 0 else None
+    rv_5 = vols[1] if len(vols) > 1 else None
+    return {
+        "svg": build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5),
+        "tooltip": build_spr_gauge_tooltip(spr_20, rv_20, spr_5, rv_5),
+    }
+
+
 def _format_buy_collection(stock: Dict[str, Any]) -> str:
     """買い集めの週/日アルファベット評価を "週,日" の形式で返す (例: "D,E")。
 
@@ -2508,6 +2531,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "price_kairi_wma10_zone": "",
             "tags": "—",
             "buy_collection": "—",
+            "spr_gauge": {"svg": "—", "tooltip": ""},
             "theoretical_diff": "—",
             "theoretical_diff_raw": None,
             "gyoseki_quarity_expr": "",
@@ -2562,6 +2586,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "price_kairi_wma10_zone": trend_info["kairi_zone"],
         "tags": _format_tags(stock),
         "buy_collection": _format_buy_collection(stock),
+        "spr_gauge": _build_spr_gauge_for_stock(stock),
         "theoretical_diff": _format_theoretical_diff(stock),
         "theoretical_diff_raw": _theoretical_diff_raw(stock),
         "gyoseki_quarity_expr": _gyoseki_quarity_expr_safe(stock),

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -452,3 +452,7 @@ nav .quick-search {
 .kairi-num.kairi-zone-pullback   { color: #2ecc71; }  /* 0〜+10% 押し目 */
 .kairi-num.kairi-zone-near-break { color: #e74c3c; }  /* -5〜0% 小割れ */
 .kairi-num.kairi-zone-break      { color: #c0392b; }  /* ≤-5% 崩れ */
+
+/* 需給バランスセル (issue #247): SPR/rv の横バー 2 本縦積み */
+.spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; }
+.spr-gauge-cell svg { display: block; }

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -163,6 +163,7 @@
       <th>トレンド</th>
       <th>タグ</th>
       <th>買い集め</th>
+      <th>需給バランス</th>
       <th>時価総額</th>
     </tr>
   </thead>
@@ -234,11 +235,12 @@
       <td title="{{ row.tags }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
       <td style="{{ row.styles.buy_collection or '' }}">{{ row.buy_collection }}</td>
+      <td class="spr-gauge-cell" title="{{ row.spr_gauge.tooltip }}">{{ row.spr_gauge.svg|safe }}</td>
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 / issue #227 で旧 RSライン+株価向き 2列を1列に統合 → 1 減 #}
-      <td colspan="{% if delete_mode_allowed %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
+      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 / issue #227 で旧 RSライン+株価向き 2列を1列に統合 → 1 減 / issue #247 で需給バランス列追加 +1 #}
+      <td colspan="{% if delete_mode_allowed %}24{% else %}23{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -704,11 +704,11 @@ class TestHtmlMarket:
 
 
 class TestSprGaugeSvg:
-    """_build_spr_gauge_svg の欠損フォールバック・クリップ挙動テスト (issue #247)"""
+    """build_spr_gauge_svg の欠損フォールバック・クリップ挙動テスト (issue #247)"""
 
     def test_both_bars_rendered_when_all_present(self):
         """4 引数すべて有効: rect 4枚 + ティック line 2本 + ヒゲ line 2本"""
-        svg = make_market_db._build_spr_gauge_svg(50, 2.0, 60, 3.0)
+        svg = make_market_db.build_spr_gauge_svg(50, 2.0, 60, 3.0)
         assert svg.startswith("<svg")
         # 各バー: 背景 rect 2枚 (左緑 + 右赤) × 2本 = 4枚
         assert svg.count('<rect') == 4
@@ -724,7 +724,7 @@ class TestSprGaugeSvg:
     ])
     def test_one_side_missing_renders_only_other(self, spr_20, spr_5, expected_label):
         """spr 片側欠損: 欠損していない方だけが描画される (両側非表示の回帰防止)"""
-        svg = make_market_db._build_spr_gauge_svg(spr_20, 2.0, spr_5, 3.0)
+        svg = make_market_db.build_spr_gauge_svg(spr_20, 2.0, spr_5, 3.0)
         assert svg.startswith("<svg")
         # 描画されたバー 1 本ぶん: 背景 rect 2枚 + ティック 1本 + ヒゲ 1本
         assert svg.count('<rect') == 2
@@ -735,12 +735,12 @@ class TestSprGaugeSvg:
 
     def test_em_dash_when_both_spr_missing(self):
         """spr_20 / spr_5 両方欠損 → "—" を返す (rv は無視)"""
-        svg = make_market_db._build_spr_gauge_svg(None, 2.0, None, 3.0)
+        svg = make_market_db.build_spr_gauge_svg(None, 2.0, None, 3.0)
         assert svg == "—"
 
     def test_no_whisker_when_rv_missing(self):
         """rv 欠損時: 該当バーはティック + 背景のみ (ヒゲ無し)"""
-        svg = make_market_db._build_spr_gauge_svg(50, None, 60, 3.0)
+        svg = make_market_db.build_spr_gauge_svg(50, None, 60, 3.0)
         assert svg.startswith("<svg")
         # ヒゲは 5 日ぶんだけ (rv_5=3.0), 20日バーはヒゲ無し → stroke-width=1 が 1 本
         assert svg.count('stroke-width="1"') == 1
@@ -749,24 +749,24 @@ class TestSprGaugeSvg:
 
     def test_spr_clipped_to_0_100(self):
         """SPR が範囲外 (120) でも 100 にクリップしてティック描画される"""
-        svg = make_market_db._build_spr_gauge_svg(120, 2.0, -10, 1.0)
+        svg = make_market_db.build_spr_gauge_svg(120, 2.0, -10, 1.0)
         # ティックの x 座標が 100 と 0 (それぞれ x1="100" / x1="0") に固定
         assert 'x1="100" y1="0"' in svg or 'x1="100"' in svg
         assert 'x1="0"' in svg
 
 
 class TestSprGaugeTooltip:
-    """_build_spr_gauge_tooltip の表示組み立てテスト (issue #247)"""
+    """build_spr_gauge_tooltip の表示組み立てテスト (issue #247)"""
 
     def test_full_tooltip(self):
-        text = make_market_db._build_spr_gauge_tooltip(49, 2.3, 46, 2.5, "D", "C")
+        text = make_market_db.build_spr_gauge_tooltip(49, 2.3, 46, 2.5, "D", "C")
         assert "SPR 49 ±2.3 (20日)" in text
         assert "SPR 46 ±2.5 (5日)" in text
         assert "買い集め 週D 日C" in text
 
     def test_omits_missing_spr_and_buygather(self):
         """spr 片側欠損 + 買い集め評価両欠損: 欠損部分が出ない"""
-        text = make_market_db._build_spr_gauge_tooltip(49, 2.3, None, None, None, None)
+        text = make_market_db.build_spr_gauge_tooltip(49, 2.3, None, None, None, None)
         assert "(20日)" in text
         assert "(5日)" not in text
         assert "買い集め" not in text

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -703,6 +703,75 @@ class TestHtmlMarket:
         assert 'RS' in result
 
 
+class TestSprGaugeSvg:
+    """_build_spr_gauge_svg の欠損フォールバック・クリップ挙動テスト (issue #247)"""
+
+    def test_both_bars_rendered_when_all_present(self):
+        """4 引数すべて有効: rect 4枚 + ティック line 2本 + ヒゲ line 2本"""
+        svg = make_market_db._build_spr_gauge_svg(50, 2.0, 60, 3.0)
+        assert svg.startswith("<svg")
+        # 各バー: 背景 rect 2枚 (左緑 + 右赤) × 2本 = 4枚
+        assert svg.count('<rect') == 4
+        assert svg.count('#d4f4d4') == 2
+        assert svg.count('#f4d4d4') == 2
+        # ティック (stroke-width=2) と ヒゲ (stroke-width=1) それぞれ 2 本ずつ
+        assert svg.count('stroke-width="2"') == 2
+        assert svg.count('stroke-width="1"') == 2
+
+    @pytest.mark.parametrize("spr_20,spr_5,expected_label", [
+        (50, None, "20日"),   # 5日欠損 → 20日のみ
+        (None, 60, "5日"),    # 20日欠損 → 5日のみ
+    ])
+    def test_one_side_missing_renders_only_other(self, spr_20, spr_5, expected_label):
+        """spr 片側欠損: 欠損していない方だけが描画される (両側非表示の回帰防止)"""
+        svg = make_market_db._build_spr_gauge_svg(spr_20, 2.0, spr_5, 3.0)
+        assert svg.startswith("<svg")
+        # 描画されたバー 1 本ぶん: 背景 rect 2枚 + ティック 1本 + ヒゲ 1本
+        assert svg.count('<rect') == 2
+        assert svg.count('stroke-width="2"') == 1
+        assert svg.count('stroke-width="1"') == 1
+        # 残ったバーの <title> に期待した期間ラベルが入っている
+        assert "(%s)" % expected_label in svg
+
+    def test_em_dash_when_both_spr_missing(self):
+        """spr_20 / spr_5 両方欠損 → "—" を返す (rv は無視)"""
+        svg = make_market_db._build_spr_gauge_svg(None, 2.0, None, 3.0)
+        assert svg == "—"
+
+    def test_no_whisker_when_rv_missing(self):
+        """rv 欠損時: 該当バーはティック + 背景のみ (ヒゲ無し)"""
+        svg = make_market_db._build_spr_gauge_svg(50, None, 60, 3.0)
+        assert svg.startswith("<svg")
+        # ヒゲは 5 日ぶんだけ (rv_5=3.0), 20日バーはヒゲ無し → stroke-width=1 が 1 本
+        assert svg.count('stroke-width="1"') == 1
+        # ティックは両バーぶん
+        assert svg.count('stroke-width="2"') == 2
+
+    def test_spr_clipped_to_0_100(self):
+        """SPR が範囲外 (120) でも 100 にクリップしてティック描画される"""
+        svg = make_market_db._build_spr_gauge_svg(120, 2.0, -10, 1.0)
+        # ティックの x 座標が 100 と 0 (それぞれ x1="100" / x1="0") に固定
+        assert 'x1="100" y1="0"' in svg or 'x1="100"' in svg
+        assert 'x1="0"' in svg
+
+
+class TestSprGaugeTooltip:
+    """_build_spr_gauge_tooltip の表示組み立てテスト (issue #247)"""
+
+    def test_full_tooltip(self):
+        text = make_market_db._build_spr_gauge_tooltip(49, 2.3, 46, 2.5, "D", "C")
+        assert "SPR 49 ±2.3 (20日)" in text
+        assert "SPR 46 ±2.5 (5日)" in text
+        assert "買い集め 週D 日C" in text
+
+    def test_omits_missing_spr_and_buygather(self):
+        """spr 片側欠損 + 買い集め評価両欠損: 欠損部分が出ない"""
+        text = make_market_db._build_spr_gauge_tooltip(49, 2.3, None, None, None, None)
+        assert "(20日)" in text
+        assert "(5日)" not in text
+        assert "買い集め" not in text
+
+
 class TestAdjustIndexTrendTemplate:
     """指数向け trend_template 補正のテスト (issue #148 Part 1)"""
 

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2328,3 +2328,27 @@ class TestBuildTrendInfoMissing:
     def test_missing_trend_returns_em_dash_not_circle(self, stock, expected_expr):
         info = helpers.build_trend_info(stock)
         assert info["expr"] == expected_expr
+
+
+class TestBuildSprGaugeForStock:
+    """個別銘柄 (price 形式の sell_pressure_ratio / stddev_volatility) から
+    需給バランスゲージを組み立てるテスト (issue #247 portfolio_list 展開)"""
+
+    def test_normal_renders_svg_and_tooltip(self):
+        """正常: sprs/vols が揃っている → svg は <svg> 開始、tooltip に SPR ±rv を含む"""
+        stock = {
+            "sell_pressure_ratio": [48, 45, 0],
+            "stddev_volatility": [2.4, 2.6],
+        }
+        gauge = helpers._build_spr_gauge_for_stock(stock)
+        assert gauge["svg"].startswith("<svg")
+        assert "SPR 48 ±2.4 (20日)" in gauge["tooltip"]
+        assert "SPR 45 ±2.6 (5日)" in gauge["tooltip"]
+        # 個別銘柄では「買い集め」列が別途あるため tooltip 2 行目は出さない
+        assert "買い集め" not in gauge["tooltip"]
+
+    def test_missing_data_returns_em_dash(self):
+        """sprs/vols 欠損: svg は '—'、tooltip は空"""
+        gauge = helpers._build_spr_gauge_for_stock({})
+        assert gauge["svg"] == "—"
+        assert gauge["tooltip"] == ""


### PR DESCRIPTION
## Summary

issue #247 対応。市場セクションの「売り圧力レシオ (20,5,買い集め週,日)」「ボラティリティ (20,5)」の 2 列を **需給バランス** 1 列に統合し、SPR ± rv を横バー 2 本 (上=20日 / 下=5日) で視覚化する。

- 横バー方式: x 軸 0〜100 全市場固定 → 5 行でティック位置が縦に揃って **銘柄間比較しやすい**
- 背景 2 色塗り分け: SPR ティックを境に **左=薄緑 (買い余地) / 右=薄赤 (売り圧)** → 優勢を面積として直感化
- バー単体 SVG `<title>` 付き → ホバー位置で 20日/5日 を即時判別 (`SPR 48 ±2.4 (20日)` / `SPR 45 ±2.6 (5日)`)
- セル全体 `td title` には総合 tooltip + 買い集め評価 (`SPR ... / SPR ... \n 買い集め 週D 日B`)

仕様変更経緯は #247 の追記コメント参照。当初の縦バー + 0〜100 グラデーション案から、ユーザーフィードバック「銘柄間比較しやすさ重視で横バー」「カラフルすぎるのでシンプル 2 色塗り分け」を反映して改訂済み。

## 実装ポイント

- `_build_spr_gauge_svg` / `_build_spr_gauge_bar_svg`: 横バー SVG 生成。20日 / 5日 を独立フォールバック判定 (片側欠損で両側非表示の回帰防止)、spr 欠損時はバーをスキップ、rv 欠損時はヒゲ無しで描画継続
- `_build_spr_gauge_tooltip` + `_format_spr_rv_text`: セル全体 title 属性とバー単体 `<title>` で SPR 表記フォーマットを共用
- 列ヘッダ: `売り圧力レシオ (20,5,買い集め週,日)` + `ボラティリティ (20,5)` → `需給バランス`

## Test plan

- [x] `pytest tests/test_make_market_db.py tests/test_functional_market.py -v` → 108 件 pass
- [x] 新規ユニットテスト 8 件 (SprGaugeSvg / SprGaugeTooltip): 正常 / spr 片側欠損 (両方向 parametrize) / 両 spr 欠損で `—` / rv 欠損でヒゲ無し / SPR 範囲外クリップ / tooltip 組み立て
- [x] `python make_market_db.py` で `market_data.html` 再生成 → 5 市場すべてに新ゲージ描画確認
- [ ] ブラウザで `/market` を開いて目視確認 (レイアウト崩れ / バー位置 / tooltip 動作)

🤖 Generated with [Claude Code](https://claude.com/claude-code)