### PR TITLE
portfolio: 買い集め列を需給バランスに統合 (緑バー濃淡で表現)

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -970,6 +970,18 @@ _SPR_GAUGE_WIDTH = 100      # バー本体の幅 (= SPR 0〜100 のスケール)
 _SPR_GAUGE_BAR_H = 14       # 1 本のバーの高さ
 _SPR_GAUGE_BAR_GAP = 3      # 20日バーと5日バーの縦間隔
 
+# 買い集め評価 A〜E による緑バー (買い側) の背景色。C が現状色 (#d4f4d4)。
+# 赤バー (売り側) は濃淡を付けず固定色 (#f4d4d4)。
+_SPR_GAUGE_GREEN_COLORS = {
+    "A": "#5cc85c",
+    "B": "#9be29b",
+    "C": "#d4f4d4",
+    "D": "#ecfbec",
+    "E": "#f8fef8",
+}
+_SPR_GAUGE_GREEN_DEFAULT = _SPR_GAUGE_GREEN_COLORS["C"]
+_SPR_GAUGE_RED_FIXED = "#f4d4d4"
+
 
 def _to_finite_number(v):
     """None / 数値化不能 / NaN を None に正規化する。それ以外は float を返す。"""
@@ -998,13 +1010,15 @@ def _format_spr_rv_text(spr_f, rv_f, period_label=None):
     return base
 
 
-def _build_spr_gauge_bar_svg(spr, rv, y, period_label):
+def _build_spr_gauge_bar_svg(spr, rv, y, period_label, bg_label=None):
     """SPR/rv 1 本分のバー要素 (rect + ティック [+ ヒゲ]) を SVG 文字列で返す。
 
     spr が欠損ならバー全体をスキップ ("" を返す)。rv 欠損ならヒゲ無しで描画。
     spr は 0〜100 にクリップ、ヒゲ端も 0〜100 にクリップする。
     period_label は "20日" / "5日" などの期間表示で、SVG <title> に埋め込み
-    バー単体のホバーで「SPR ±rv (20日)」が出るようにする。
+    バー単体のホバーで「SPR ±rv (20日) 買い集めX」が出るようにする。
+    bg_label は買い集め評価 (A〜E)。指定があれば緑バーの濃淡を 5 段階で変える
+    (A=濃 / C=現状 / E=薄)。赤バーは固定色。None や未知ラベルは C 相当にフォールバック。
     """
     spr_f = _to_finite_number(spr)
     if spr_f is None:
@@ -1012,14 +1026,19 @@ def _build_spr_gauge_bar_svg(spr, rv, y, period_label):
     spr_x = max(0.0, min(100.0, spr_f))
     rv_f = _to_finite_number(rv)
     bar_title = _format_spr_rv_text(spr_f, rv_f, period_label)
+    if bg_label:
+        bar_title += " 買い集め%s" % bg_label
     parts = ['<title>%s</title>' % html_mod.escape(bar_title)]
-    # 背景塗り分け: 左=薄緑 (買い余地)、右=薄赤 (売り圧)
+    # 背景塗り分け: 左=緑 (買い余地、濃淡=買い集め評価) / 右=赤 (売り圧、固定色)
+    green = _SPR_GAUGE_GREEN_COLORS.get(bg_label, _SPR_GAUGE_GREEN_DEFAULT)
     parts.append(
-        '<rect x="0" y="%d" width="%g" height="%d" fill="#d4f4d4"/>' % (y, spr_x, _SPR_GAUGE_BAR_H)
+        '<rect x="0" y="%d" width="%g" height="%d" fill="%s"/>' % (
+            y, spr_x, _SPR_GAUGE_BAR_H, green,
+        )
     )
     parts.append(
-        '<rect x="%g" y="%d" width="%g" height="%d" fill="#f4d4d4"/>' % (
-            spr_x, y, _SPR_GAUGE_WIDTH - spr_x, _SPR_GAUGE_BAR_H,
+        '<rect x="%g" y="%d" width="%g" height="%d" fill="%s"/>' % (
+            spr_x, y, _SPR_GAUGE_WIDTH - spr_x, _SPR_GAUGE_BAR_H, _SPR_GAUGE_RED_FIXED,
         )
     )
     # ヒゲ (± rv) を先に描いてからティックを最後に上載せ → 交差箇所でティックが消えない
@@ -1042,7 +1061,7 @@ def _build_spr_gauge_bar_svg(spr, rv, y, period_label):
     return '<g>%s</g>' % "".join(parts)
 
 
-def build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5):
+def build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5, sprw_label=None, sprbg_label=None):
     """SPR/rv の横バーゲージ (2 本縦積み、上=20日 / 下=5日) を SVG 文字列で返す。
 
     20日バー / 5日バーは独立に欠損判定する:
@@ -1050,6 +1069,8 @@ def build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5):
       - rv_X が欠損 → 該当バーはティック + 背景のみ (ヒゲ無し)
       - spr_20 / spr_5 両方欠損 → "—" を返す
     片側だけ欠損で両方非表示になる回帰を避けるため、内部で 2 本独立に判定する。
+    sprw_label (週評価 A〜E) → 20日バーの色濃度、sprbg_label (日評価) → 5日バーの色濃度。
+    None や未知ラベルは C 相当 (現状色) にフォールバック。
     """
     has_20 = _to_finite_number(spr_20) is not None
     has_5 = _to_finite_number(spr_5) is not None
@@ -1057,8 +1078,8 @@ def build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5):
         return "—"
     h = _SPR_GAUGE_BAR_H * 2 + _SPR_GAUGE_BAR_GAP
     bars = [
-        _build_spr_gauge_bar_svg(spr_20, rv_20, 0, "20日"),
-        _build_spr_gauge_bar_svg(spr_5, rv_5, _SPR_GAUGE_BAR_H + _SPR_GAUGE_BAR_GAP, "5日"),
+        _build_spr_gauge_bar_svg(spr_20, rv_20, 0, "20日", sprw_label),
+        _build_spr_gauge_bar_svg(spr_5, rv_5, _SPR_GAUGE_BAR_H + _SPR_GAUGE_BAR_GAP, "5日", sprbg_label),
     ]
     return (
         '<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d">'
@@ -1203,7 +1224,9 @@ def _html_market(market_db):
             sprbg_label = None
             if spr_20 is not None and spr_bg is not None:
                 sprbg_label = step_func(spr_bg - spr_20, spr_levels, spr_labels)
-            gauge_svg = build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5)
+            gauge_svg = build_spr_gauge_svg(
+                spr_20, rv_20, spr_5, rv_5, sprw_label, sprbg_label,
+            )
             gauge_tooltip = build_spr_gauge_tooltip(
                 spr_20, rv_20, spr_5, rv_5, sprw_label, sprbg_label,
             )

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1663,6 +1663,31 @@ def _annual_growth(stock: Dict[str, Any]) -> tuple:
     return result[1], result[2]
 
 
+def _extract_buy_collection_labels(stock: Dict[str, Any]) -> tuple:
+    """個別銘柄の sell_pressure_ratio / sell_pressure_ratio_w から
+    買い集め評価 (週, 日) のアルファベットラベルを返す。
+
+    price.get_spr_expr の出力 (例 "47,32,D,E") からアルファベット部分のみ抽出。
+    片方/両方欠損は (None, None) や (週ラベル, None) で返す。
+    """
+    if not stock:
+        return (None, None)
+    sprs = stock.get("sell_pressure_ratio") or []
+    sprs_w = stock.get("sell_pressure_ratio_w") or []
+    if not sprs:
+        return (None, None)
+    try:
+        from price import get_spr_expr  # 遅延 import (循環回避)
+        full = get_spr_expr(sprs, sprs_w)
+    except Exception:
+        return (None, None)
+    parts = full.split(",")
+    letters = [p for p in parts if p and not p.lstrip("+-").isdigit()]
+    sprw = letters[0] if len(letters) > 0 else None
+    sprbg = letters[1] if len(letters) > 1 else None
+    return (sprw, sprbg)
+
+
 def _build_spr_gauge_for_stock(stock: Dict[str, Any]) -> Dict[str, str]:
     """個別銘柄の sell_pressure_ratio / stddev_volatility から需給バランスゲージを組み立てる。
 
@@ -1671,7 +1696,7 @@ def _build_spr_gauge_for_stock(stock: Dict[str, Any]) -> Dict[str, str]:
       stddev_volatility   = [rv_20, rv_5]
     市場指数 (make_market_db) の spr_20 / spr_5 / rv_20 / rv_5 と形式が違うため、
     ここで取り出して build_spr_gauge_svg / build_spr_gauge_tooltip に渡す。
-    買い集め評価は portfolio 一覧では別列に出すので tooltip 側からは省略。
+    買い集め評価 (週/日) はバー背景の濃淡と tooltip に併記する。
     """
     from make_market_db import build_spr_gauge_svg, build_spr_gauge_tooltip  # 遅延 import (循環回避)
     sprs = stock.get("sell_pressure_ratio") or []
@@ -1680,33 +1705,13 @@ def _build_spr_gauge_for_stock(stock: Dict[str, Any]) -> Dict[str, str]:
     spr_5 = sprs[1] if len(sprs) > 1 else None
     rv_20 = vols[0] if len(vols) > 0 else None
     rv_5 = vols[1] if len(vols) > 1 else None
+    sprw_label, sprbg_label = _extract_buy_collection_labels(stock)
     return {
-        "svg": build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5),
-        "tooltip": build_spr_gauge_tooltip(spr_20, rv_20, spr_5, rv_5),
+        "svg": build_spr_gauge_svg(spr_20, rv_20, spr_5, rv_5, sprw_label, sprbg_label),
+        "tooltip": build_spr_gauge_tooltip(
+            spr_20, rv_20, spr_5, rv_5, sprw_label, sprbg_label,
+        ),
     }
-
-
-def _format_buy_collection(stock: Dict[str, Any]) -> str:
-    """買い集めの週/日アルファベット評価を "週,日" の形式で返す (例: "D,E")。
-
-    code_rank.csv SRR 列の "47,32,D,E,-6" のうち最後 (50DMA乖離率を除く)
-    アルファベット 2 文字に相当する。price.get_spr_expr のロジックを再利用。
-    """
-    if not stock:
-        return "—"
-    sprs = stock.get("sell_pressure_ratio") or []
-    sprs_w = stock.get("sell_pressure_ratio_w") or []
-    if not sprs:
-        return "—"
-    try:
-        from price import get_spr_expr  # 遅延 import (循環回避)
-        full = get_spr_expr(sprs, sprs_w)
-    except Exception:
-        return "—"
-    # full は "47,32,D,E" や "47,32,D" 等。アルファベット部分のみ抽出
-    parts = full.split(",")
-    letters = [p for p in parts if p and not p.lstrip("+-").isdigit()]
-    return ",".join(letters) if letters else "—"
 
 
 def _progress_quarter_and_diff(stock: Dict[str, Any]) -> tuple:
@@ -2530,7 +2535,6 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "price_kairi_wma10_str": "",
             "price_kairi_wma10_zone": "",
             "tags": "—",
-            "buy_collection": "—",
             "spr_gauge": {"svg": "—", "tooltip": ""},
             "theoretical_diff": "—",
             "theoretical_diff_raw": None,
@@ -2585,7 +2589,6 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "price_kairi_wma10_str": trend_info["kairi_str"],
         "price_kairi_wma10_zone": trend_info["kairi_zone"],
         "tags": _format_tags(stock),
-        "buy_collection": _format_buy_collection(stock),
         "spr_gauge": _build_spr_gauge_for_stock(stock),
         "theoretical_diff": _format_theoretical_diff(stock),
         "theoretical_diff_raw": _theoretical_diff_raw(stock),
@@ -2613,10 +2616,6 @@ PORTFOLIO_COLORS = {
     "水色": "#6fa8dc",   # データなし/低スコア (買い集めDD以下、トレンド空)
 }
 
-# 買い集めスコア (A=5, B=4, ..., E=1)。スプシの CHOOSE(CODE-64,5,4,3,2,1) に対応
-_BUY_COLLECTION_SCORE = {"A": 5, "B": 4, "C": 3, "D": 2, "E": 1}
-
-
 def _parse_research_update_md(md_str: Optional[str], today: date) -> Optional[date]:
     """'4/27' を date オブジェクトにする。today より未来なら去年扱い。"""
     if not md_str or md_str == "—":
@@ -2629,20 +2628,6 @@ def _parse_research_update_md(md_str: Optional[str], today: date) -> Optional[da
         return candidate
     except (ValueError, AttributeError):
         return None
-
-
-def _buy_collection_score_sum(s: Optional[str]) -> Optional[int]:
-    """'C,C' → 各文字スコアの合計 (A=5..E=1)。フォーマット不正なら None。"""
-    if not s or "," not in s:
-        return None
-    parts = s.split(",")
-    if len(parts) < 2:
-        return None
-    left = parts[0].strip()
-    right = parts[1].strip()
-    if left not in _BUY_COLLECTION_SCORE or right not in _BUY_COLLECTION_SCORE:
-        return None
-    return _BUY_COLLECTION_SCORE[left] + _BUY_COLLECTION_SCORE[right]
 
 
 def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Dict[str, str]:
@@ -2767,14 +2752,6 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
         styles["tags"] = bg_with_white("青")
     elif "押" in tags:
         styles["tags"] = f"color:{PORTFOLIO_COLORS['青']}"
-
-    # --- 買い集め (ルール 20, 21): スコア合計 ≧ 8 濃黄 / ≦ 4 水色
-    score = _buy_collection_score_sum(row.get("buy_collection"))
-    if isinstance(score, int):
-        if score >= 8:
-            styles["buy_collection"] = bg("濃黄")
-        elif score <= 4:
-            styles["buy_collection"] = bg("水色")
 
     # --- 時価総額 (ルール 29, 30): カテゴリ "中" / "大" → 薄黄 (極小/小/特大は色なし)
     cat = row.get("market_cap_category")

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -162,8 +162,7 @@
       <th title="RSライン (対TOPIX, 青=上昇/オレンジ=下降) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸">RS(20,5)</th>
       <th>トレンド</th>
       <th>タグ</th>
-      <th>買い集め</th>
-      <th>需給バランス</th>
+      <th title="バー背景の濃淡で買い集め評価 (A=濃 / E=薄、左=緑 / 右=赤)">需給バランス</th>
       <th>時価総額</th>
     </tr>
   </thead>
@@ -234,13 +233,12 @@
           style="max-width:7em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.trend_template or '' }}">{{ row.trend_template }}{% if row.price_kairi_wma10_str %} <span class="kairi-num {{ row.price_kairi_wma10_zone }}">{{ row.price_kairi_wma10_str }}</span>{% endif %}</td>
       <td title="{{ row.tags }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
-      <td style="{{ row.styles.buy_collection or '' }}">{{ row.buy_collection }}</td>
       <td class="spr-gauge-cell" title="{{ row.spr_gauge.tooltip }}">{{ row.spr_gauge.svg|safe }}</td>
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 / issue #227 で旧 RSライン+株価向き 2列を1列に統合 → 1 減 / issue #247 で需給バランス列追加 +1 #}
-      <td colspan="{% if delete_mode_allowed %}24{% else %}23{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
+      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 / issue #227 で旧 RSライン+株価向き 2列を1列に統合 → 1 減 / 買い集め+需給バランスを需給バランス1列に統合 → 1 減 #}
+      <td colspan="{% if delete_mode_allowed %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -712,6 +712,7 @@ class TestSprGaugeSvg:
         assert svg.startswith("<svg")
         # 各バー: 背景 rect 2枚 (左緑 + 右赤) × 2本 = 4枚
         assert svg.count('<rect') == 4
+        # ラベル未指定なので緑バーは C 相当 (#d4f4d4) ×2、赤バーは固定色 (#f4d4d4) ×2
         assert svg.count('#d4f4d4') == 2
         assert svg.count('#f4d4d4') == 2
         # ティック (stroke-width=2) と ヒゲ (stroke-width=1) それぞれ 2 本ずつ
@@ -753,6 +754,32 @@ class TestSprGaugeSvg:
         # ティックの x 座標が 100 と 0 (それぞれ x1="100" / x1="0") に固定
         assert 'x1="100" y1="0"' in svg or 'x1="100"' in svg
         assert 'x1="0"' in svg
+
+    @pytest.mark.parametrize("sprw,expected_green_20", [
+        ("A", "#5cc85c"),     # 最濃
+        ("C", "#d4f4d4"),     # 現状色 (中間)
+        ("E", "#f8fef8"),     # 最薄
+        (None, "#d4f4d4"),    # ラベル欠損 → C 相当にフォールバック
+    ])
+    def test_buy_collection_label_drives_green_bar_density(self, sprw, expected_green_20):
+        """週評価 → 20日バー / 日評価 → 5日バー で緑バーの濃淡をコントロールする。
+        赤バーは固定色 (#f4d4d4)、ラベル欠損は C 相当にフォールバック。"""
+        svg = make_market_db.build_spr_gauge_svg(50, 2.0, 60, 3.0, sprw, None)
+        # 緑バー (20日) は期待濃度
+        assert expected_green_20 in svg
+        # 赤バーは sprw / sprbg に関わらず固定色のみ (両バーぶん 2 回)
+        assert svg.count("#f4d4d4") == 2
+
+    def test_bar_title_includes_buy_collection_label(self):
+        """バー単体 <title> に '買い集めX' が併記される (ホバー時に SVG <title> が勝つため)"""
+        svg = make_market_db.build_spr_gauge_svg(50, 2.0, 60, 3.0, "B", "A")
+        assert "SPR 50 ±2.0 (20日) 買い集めB" in svg
+        assert "SPR 60 ±3.0 (5日) 買い集めA" in svg
+
+    def test_bar_title_omits_buy_collection_when_label_missing(self):
+        """ラベル None のバーは <title> に買い集めを出さない"""
+        svg = make_market_db.build_spr_gauge_svg(50, 2.0, 60, 3.0, None, None)
+        assert "買い集め" not in svg
 
 
 class TestSprGaugeTooltip:

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1563,28 +1563,6 @@ class TestComputeCellStyles:
         else:
             assert styles["tags"] == expected
 
-    # ----- 買い集め (合計 >=8 濃黄 / <=4 水色 / 5-7 色なし) -----
-    # 手入力データで空白混入が多いため "A, B" のような空白付き入力が
-    # _buy_collection_score_sum 内部で strip されて正常評価されることも確認する。
-    @pytest.mark.parametrize(
-        "value, expected",
-        [
-            ("A,A", f"background:{C['濃黄']}"),   # 10 >=8
-            ("A,B", f"background:{C['濃黄']}"),   # 9 >=8 (境界)
-            ("A, B", f"background:{C['濃黄']}"), # 空白付き入力 (strip 処理の退行検知)
-            ("B,C", None),                         # 7 5-7範囲
-            ("D,D", f"background:{C['水色']}"),   # 4 <=4 (境界)
-            ("E,E", f"background:{C['水色']}"),   # 2 <=4
-            ("—", None),                           # 不正値
-        ],
-    )
-    def test_buy_collection_rule(self, value, expected):
-        styles = helpers.compute_cell_styles({"buy_collection": value}, today=TODAY)
-        if expected is None:
-            assert "buy_collection" not in styles
-        else:
-            assert styles["buy_collection"] == expected
-
     # ----- 進捗率乖離: <C3>タグ優先 -----
     def test_progress_diff_c3_priority_over_eiri(self):
         """<C3> タグは薄赤で営利>=20 の濃黄より優先 (タグありなしで両方確認)"""
@@ -2335,17 +2313,25 @@ class TestBuildSprGaugeForStock:
     需給バランスゲージを組み立てるテスト (issue #247 portfolio_list 展開)"""
 
     def test_normal_renders_svg_and_tooltip(self):
-        """正常: sprs/vols が揃っている → svg は <svg> 開始、tooltip に SPR ±rv を含む"""
+        """正常: sprs/vols が揃っている → svg は <svg> 開始、SVG 内 <title> + セル全体 tooltip に
+        買い集め評価が併記される (SVG <title> がホバー時に勝つため両方に出す)"""
+        # price.get_spr_expr で 週diff=10 → B / 日diff=12 → A になる入力
         stock = {
-            "sell_pressure_ratio": [48, 45, 0],
+            "sell_pressure_ratio": [48, 45, 60],
+            "sell_pressure_ratio_w": [40, 42, 50],
             "stddev_volatility": [2.4, 2.6],
         }
         gauge = helpers._build_spr_gauge_for_stock(stock)
         assert gauge["svg"].startswith("<svg")
+        # バー単体 <title> に SPR + 買い集め評価が併記される
+        assert "SPR 48 ±2.4 (20日) 買い集めB" in gauge["svg"]
+        assert "SPR 45 ±2.6 (5日) 買い集めA" in gauge["svg"]
+        # セル全体 tooltip にも (フォールバック用) 同等情報
         assert "SPR 48 ±2.4 (20日)" in gauge["tooltip"]
-        assert "SPR 45 ±2.6 (5日)" in gauge["tooltip"]
-        # 個別銘柄では「買い集め」列が別途あるため tooltip 2 行目は出さない
-        assert "買い集め" not in gauge["tooltip"]
+        assert "買い集め 週B 日A" in gauge["tooltip"]
+        # 緑バーは週B 相当の中濃緑 (#9be29b)、赤バーは固定色のまま
+        assert "#9be29b" in gauge["svg"]
+        assert "#f4d4d4" in gauge["svg"]
 
     def test_missing_data_returns_em_dash(self):
         """sprs/vols 欠損: svg は '—'、tooltip は空"""


### PR DESCRIPTION
## Summary

個別銘柄 portfolio 一覧の **「買い集め」列** を **「需給バランス」列** に統合。買い集めの週/日 A〜E 評価を需給バランスの **緑バー (買い側) の濃淡 5 段階** として表現する。列を 1 つ削減して情報密度を整理。

## 仕様

### 列構成

- `portfolio_list.html` から「買い集め」列を削除 (`<th>`/`<td>`、`colspan` 調整)
- 「需給バランス」列 1 列に集約

### 緑バー濃淡 (買い側のみ)

| 評価 | 緑バー色 |
|---|---|
| A | `#5cc85c` (濃) |
| B | `#9be29b` |
| C | `#d4f4d4` (現状色、ラベル欠損時のフォールバック) |
| D | `#ecfbec` |
| E | `#f8fef8` (ほぼ白) |

- 赤バー (売り側) は固定色 `#f4d4d4`、濃淡なし
- **週評価 → 20日バー / 日評価 → 5日バー** の対応

### tooltip

- バー単体 `<title>` に SPR + 買い集め評価を併記:
  - 20日バー: `SPR 48 ±2.4 (20日) 買い集めB`
  - 5日バー: `SPR 45 ±2.6 (5日) 買い集めA`
- SVG `<title>` がホバー時にセル `<td title>` より優先されるため、バー単体側で完結させる
- セル全体 `<td title>` も従来通り維持 (フォールバック用)

## 実装ポイント

- `make_market_db.py`: `_SPR_GAUGE_GREEN_COLORS` / `_SPR_GAUGE_RED_FIXED` 定数化。`build_spr_gauge_svg` / `_build_spr_gauge_bar_svg` に `bg_label` 引数追加 (None → C 相当にフォールバック)
- `webapp/helpers.py`: `_extract_buy_collection_labels` で週/日アルファベットを抽出して SVG/tooltip に渡す。`_format_buy_collection` / `_buy_collection_score_sum` / `_BUY_COLLECTION_SCORE` を削除
- `compute_cell_styles`: 買い集め単独セルへの色付けルール (≥8 濃黄 / ≤4 水色) を削除
- 市場セクション (`market.html`) 側も同 SVG ヘルパーを共用しているため、副次効果として同じ緑濃淡が反映される

## Test plan

- [x] `pytest tests/test_make_market_db.py tests/test_webapp_helpers.py tests/test_functional_market.py tests/test_webapp_routes.py tests/test_html_sanitizer.py -v` → 全 pass
- [x] 新規ユニットテスト:
  - 緑バー濃度: A/C/E/None フォールバック (parametrize 4件)
  - 赤バー固定色を維持
  - バー単体 `<title>` に「買い集めX」併記、ラベル欠損時は併記なし
- [x] ブラウザで `/portfolio` を目視確認: 緑バー濃淡が識別可能、ホバーで「買い集めX」表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)