### PR TITLE
portfolio: トレンド列の乖離率テキストを縦線バーゲージSVGに置換

### DIFF
--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -747,3 +747,43 @@ def format_kairi_wma10(kairi):
         return "%+d%%" % int(round(float(kairi)))
     except (TypeError, ValueError):
         return ""
+
+
+# overheat 閾値と色は kairi_wma10_zone_class() の `kairi-zone-overheat` 境界と一致させる
+_KAIRI_GAUGE_RANGE = 25.0
+_KAIRI_GAUGE_OVERHEAT_COLOR = "#e67e22"
+
+
+def kairi_gauge_svg(kairi, symbol):
+    """10WMA乖離率を -25%〜+25% の縦線マーカーで描画する SVG を返す。
+
+    kairi >= +25 はクランプ + overheat 色のマーカー。
+    kairi が None で symbol も空なら "" を返す。
+    """
+    width = 40
+    height = 28
+    if kairi is None and not symbol:
+        return ""
+
+    px_per_pct = width / (_KAIRI_GAUGE_RANGE * 2)
+    parts = ['<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d" style="vertical-align:middle;">' % (width, height, width, height)]
+
+    if kairi is not None:
+        try:
+            k = float(kairi)
+        except (TypeError, ValueError):
+            k = None
+        if k is not None:
+            k_clamped = max(-_KAIRI_GAUGE_RANGE, min(_KAIRI_GAUGE_RANGE, k))
+            mx = (k_clamped + _KAIRI_GAUGE_RANGE) * px_per_pct
+            # 端でクリップされてマーカーが半分の太さに見えないよう、両端は 1px 内側に寄せる
+            mx = max(1.0, min(width - 1.0, mx))
+            marker_color = _KAIRI_GAUGE_OVERHEAT_COLOR if k >= _KAIRI_GAUGE_RANGE else "#000"
+            parts.append('<line x1="%g" y1="0" x2="%g" y2="%d" stroke="white" stroke-width="3"/>' % (mx, mx, height))
+            parts.append('<line x1="%g" y1="0" x2="%g" y2="%d" stroke="%s" stroke-width="2"/>' % (mx, mx, height, marker_color))
+
+    if symbol:
+        parts.append('<text x="50%%" y="50%%" text-anchor="middle" dominant-baseline="central" font-size="12" font-weight="bold" fill="#000" stroke="white" stroke-width="3" paint-order="stroke">%s</text>' % symbol)
+
+    parts.append('</svg>')
+    return "".join(parts)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2474,15 +2474,11 @@ def build_trend_info(stock: Dict[str, Any]) -> Dict[str, Any]:
 
     返り値の各キー:
         expr: ◎ / ◯ / ▲ / △ / — の単一記号
-        tooltip: 不通過項目をカンマ区切りで連結 (◯ のときのみ、それ以外は "")
-        bg_class: ◎=trend-bg-strong / ◯=trend-bg-good / —=trend-bg-none / その他=""
-        kairi_raw: price_kairi_wma10 の生値 (None/非数値は None)
-        kairi_str: "+12%" 形式の整形済み文字列
-        kairi_zone: kairi-zone-* の CSS クラス名
+        tooltip: 不通過項目 (◯のときのみ) + 10WMA乖離率を改行で結合した文字列
+        kairi_gauge_svg: -25%〜+25% のバーゲージ + 中央記号オーバーレイ SVG
     """
     from ks_util import (
-        trend_symbol_from_misses, trend_bg_class,
-        kairi_wma10_zone_class, format_kairi_wma10,
+        trend_symbol_from_misses, format_kairi_wma10, kairi_gauge_svg,
     )
     # trend_template が未生成 / 欠損している銘柄を「◎ (完全通過)」と誤表示しないよう、
     # 非 list を [] に変換せず、未評価として trend_symbol_from_misses に渡して "—" を返す。
@@ -2491,14 +2487,17 @@ def build_trend_info(stock: Dict[str, Any]) -> Dict[str, Any]:
     # 不通過項目の tooltip は ◯ (1-2件不通過) のときだけ意味があるので、それ以外は空にする。
     # ◎=全通過で項目なし、▲/△=不通過項目が多くノイズ、—=未評価。
     tooltip_src = misses if (expr == "◯" and isinstance(misses, list)) else []
-    kairi_raw = (stock or {}).get("price_kairi_wma10")
+    raw = (stock or {}).get("price_kairi_wma10")
+    kairi_raw = raw if isinstance(raw, (int, float)) else None
+    kairi_str = format_kairi_wma10(kairi_raw) or "—"
+    tooltip_lines = []
+    if tooltip_src:
+        tooltip_lines.append("不通過: " + ",".join(tooltip_src))
+    tooltip_lines.append("10WMA乖離: " + kairi_str)
     return {
         "expr": expr,
-        "tooltip": ",".join(tooltip_src),
-        "bg_class": trend_bg_class(expr),
-        "kairi_raw": kairi_raw if isinstance(kairi_raw, (int, float)) else None,
-        "kairi_str": format_kairi_wma10(kairi_raw),
-        "kairi_zone": kairi_wma10_zone_class(kairi_raw),
+        "tooltip": "\n".join(tooltip_lines),
+        "kairi_gauge_svg": kairi_gauge_svg(kairi_raw, expr),
     }
 
 
@@ -2531,9 +2530,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "progress_diff_eiri_raw": None,
             "trend_template": "—",
             "trend_template_tooltip": "—",
-            "price_kairi_wma10_raw": None,
-            "price_kairi_wma10_str": "",
-            "price_kairi_wma10_zone": "",
+            "kairi_gauge_svg": "",
             "tags": "—",
             "spr_gauge": {"svg": "—", "tooltip": ""},
             "theoretical_diff": "—",
@@ -2585,9 +2582,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "progress_diff_eiri_raw": _progress_diff_eiri_raw(stock),
         "trend_template": trend_info["expr"],
         "trend_template_tooltip": trend_info["tooltip"],
-        "price_kairi_wma10_raw": trend_info["kairi_raw"],
-        "price_kairi_wma10_str": trend_info["kairi_str"],
-        "price_kairi_wma10_zone": trend_info["kairi_zone"],
+        "kairi_gauge_svg": trend_info["kairi_gauge_svg"],
         "tags": _format_tags(stock),
         "spr_gauge": _build_spr_gauge_for_stock(stock),
         "theoretical_diff": _format_theoretical_diff(stock),

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -454,5 +454,5 @@ nav .quick-search {
 .kairi-num.kairi-zone-break      { color: #c0392b; }  /* ≤-5% 崩れ */
 
 /* 需給バランスセル (issue #247): SPR/rv の横バー 2 本縦積み */
-.spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; }
-.spr-gauge-cell svg { display: block; }
+.spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; width: 80px; }
+.spr-gauge-cell svg { display: block; width: 80px; height: auto; }

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -229,8 +229,9 @@
       <td title="{{ row.price_rs_chart.tooltip }}" style="padding:0 2px;line-height:0;">
         {% if row.price_rs_chart.svg %}{{ row.price_rs_chart.svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
       </td>
-      <td title="{{ row.trend_template_tooltip }}"
-          style="max-width:7em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.trend_template or '' }}">{{ row.trend_template }}{% if row.price_kairi_wma10_str %} <span class="kairi-num {{ row.price_kairi_wma10_zone }}">{{ row.price_kairi_wma10_str }}</span>{% endif %}</td>
+      <td title="{{ row.trend_template_tooltip }}" style="width:40px;padding:0;line-height:0;text-align:center;{{ row.styles.trend_template or '' }}">
+        {% if row.kairi_gauge_svg %}{{ row.kairi_gauge_svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
+      </td>
       <td title="{{ row.tags }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
       <td class="spr-gauge-cell" title="{{ row.spr_gauge.tooltip }}">{{ row.spr_gauge.svg|safe }}</td>

--- a/tests/test_ks_util.py
+++ b/tests/test_ks_util.py
@@ -370,3 +370,45 @@ class TestFileWriteAtomic:
             "並行 read で空 or 部分内容が観測された: lengths sample=%s"
             % observed_lengths[:10]
         )
+
+
+class TestKairiGaugeSvg:
+    """kairi_gauge_svg(): 10WMA乖離率の SVG バーゲージ生成 (issue portfolio-trend-gauge)"""
+
+    @pytest.mark.parametrize(
+        "kairi, symbol, expect_svg, expect_marker, expect_overheat",
+        [
+            # 健全帯 +12: SVG + マーカーあり + 橙ではない
+            (12, "◎", True, True, False),
+            # 小割れ -3: SVG + マーカーあり + 橙ではない
+            (-3, "◯", True, True, False),
+            # +25 境界: マーカーは右端、橙
+            (25, "◎", True, True, True),
+            # 範囲外 +30: クランプ + 橙
+            (30, "◎", True, True, True),
+            # データ無し + 記号あり: SVG (記号のみ)、マーカーなし
+            (None, "—", True, False, False),
+            # データ無し + 記号も空: 空文字
+            (None, "", False, False, False),
+        ],
+    )
+    def test_gauge_shape(self, kairi, symbol, expect_svg, expect_marker, expect_overheat):
+        svg = ks_util.kairi_gauge_svg(kairi, symbol)
+        if not expect_svg:
+            assert svg == ""
+            return
+        assert svg.startswith("<svg")
+        # マーカー (現在値) の有無: マーカー有りなら 2 本 (白縁 + 本体)、無しなら 0 本
+        line_count = svg.count("<line")
+        if expect_marker:
+            assert line_count == 2
+        else:
+            assert line_count == 0
+        # overheat マーカー色は kairi >= +25 のみ
+        if expect_overheat:
+            assert "#e67e22" in svg
+        else:
+            assert "#e67e22" not in svg
+        # 記号が SVG に埋め込まれる
+        if symbol:
+            assert symbol in svg

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2308,6 +2308,55 @@ class TestBuildTrendInfoMissing:
         assert info["expr"] == expected_expr
 
 
+class TestBuildTrendInfoGauge:
+    """build_trend_info() の kairi_gauge_svg と tooltip 結合を検証する (issue portfolio-trend-gauge)"""
+
+    @pytest.mark.parametrize(
+        "kairi, misses, expect_marker, expect_overheat_marker, expect_unpass_tooltip",
+        [
+            # 健全帯 +12: マーカー有り / 橙ではない / 不通過0件なので「不通過:」行なし (◎扱い)
+            (12, [], True, False, False),
+            # 小割れ -3: マーカー有り / 不通過1件あるので「不通過:」行あり (◯扱い)
+            (-3, ["RS"], True, False, True),
+            # +25 ちょうど: overheat 境界、橙マーカー
+            (25, [], True, True, False),
+            # 範囲外 +30: クランプ + 橙マーカー
+            (30, [], True, True, False),
+            # データ無し: kairi=None、マーカーなし、記号のみ
+            (None, [], False, False, False),
+        ],
+    )
+    def test_gauge_svg_and_tooltip(
+        self, kairi, misses, expect_marker, expect_overheat_marker, expect_unpass_tooltip,
+    ):
+        stock = {"price_kairi_wma10": kairi, "trend_template": misses}
+        info = helpers.build_trend_info(stock)
+        svg = info["kairi_gauge_svg"]
+        # 必ず SVG が返る (kairi=None でも記号のみ表示)
+        assert svg.startswith("<svg")
+        # 記号は <text> として含まれる
+        assert "<text" in svg
+        # マーカー (現在値) の有無
+        # SVG line 内訳: マーカー有りなら 2 本 (白縁 + 本体)、無しなら 0 本
+        line_count = svg.count("<line")
+        if expect_marker:
+            assert line_count == 2
+        else:
+            assert line_count == 0
+        # overheat マーカー色 (kairi >= +25 のみ橙)
+        if expect_overheat_marker:
+            assert "#e67e22" in svg
+        else:
+            assert "#e67e22" not in svg
+        # tooltip は常に「10WMA乖離: ...」行を含む
+        assert "10WMA乖離:" in info["tooltip"]
+        # 不通過項目は ◯ のときのみ含まれる
+        if expect_unpass_tooltip:
+            assert "不通過:" in info["tooltip"]
+        else:
+            assert "不通過:" not in info["tooltip"]
+
+
 class TestBuildSprGaugeForStock:
     """個別銘柄 (price 形式の sell_pressure_ratio / stddev_volatility) から
     需給バランスゲージを組み立てるテスト (issue #247 portfolio_list 展開)"""


### PR DESCRIPTION
## Summary
- トレンド列の `+12%` 数値テキスト表記を、-25%〜+25% レンジの縦線バーゲージ SVG に置換
- 各銘柄の 10WMA 位置がビジュアルに比較可能に。kairi >= +25 は overheat 色 (#e67e22) で警告
- tooltip は「不通過: X\n10WMA乖離: Y」の改行併記形式に統合 (◯のときのみ不通過併記)
- 合わせて需給バランス列を 80% 幅に圧縮 (横余白削減)
- 既存セル背景色ルール (◎=濃黄 / ◯=薄黄 / —=水色) は維持

## Test plan
- [x] `pytest tests/ -m "not local_db and not live_html"` 1472 passed
- [x] WebApp /portfolio をブラウザで確認、複数銘柄でマーカー位置が異なることを目視
- [x] tooltip に「不通過: ...」と「10WMA乖離: +12%」が改行併記される
- [x] kairi >= +25 銘柄 (4970/9880/5985/6965) で右端橙マーカー表示
- [x] kairi=None 銘柄 (6701/6479) で記号のみ中央表示
- [x] 既存セル背景色 (◎=濃黄 / ◯=薄黄 / —=水色) が維持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)