### PR TITLE
portfolio: 色体系を意味ベースに整理 (赤=注目 / 緑追加 / ステージ・進捗率の塗り分け)

### DIFF
--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -716,29 +716,6 @@ def trend_bg_class(symbol):
     return _TREND_BG_CLASS.get(symbol, "")
 
 
-def kairi_wma10_zone_class(kairi):
-    """10WMA乖離率(%)から 5 段階のゾーン CSS クラス名を返す。
-
-    issue #248: 利確警戒 / 健全 / 押し目 / 小割れ / 崩れ の 5 段階。
-    None や数値化不能なら "" を返す。
-    """
-    if kairi is None:
-        return ""
-    try:
-        k = float(kairi)
-    except (TypeError, ValueError):
-        return ""
-    if k >= 25:
-        return "kairi-zone-overheat"
-    if k >= 10:
-        return "kairi-zone-healthy"
-    if k >= 0:
-        return "kairi-zone-pullback"
-    if k > -5:
-        return "kairi-zone-near-break"
-    return "kairi-zone-break"
-
-
 def format_kairi_wma10(kairi):
     """10WMA乖離率 (%) を "+12%" / "-3%" 形式で整形。None や数値化不能なら "" を返す。"""
     if kairi is None:

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -728,7 +728,10 @@ def format_kairi_wma10(kairi):
 
 # overheat 閾値と色は kairi_wma10_zone_class() の `kairi-zone-overheat` 境界と一致させる
 _KAIRI_GAUGE_RANGE = 25.0
-# マーカー縦線色: |kairi| < 10% 黒 (中立) / < 20% 淡色 / ≥ 20% 濃色
+# マーカー縦線色: |kairi| < faint 黒 (中立) / < strong 淡色 / ≥ strong 濃色
+# 個別銘柄の既定は (range=25, faint=10, strong=20)。市場用は (15, 5, 10) に縮める。
+_KAIRI_GAUGE_FAINT_THRESHOLD = 10.0
+_KAIRI_GAUGE_STRONG_THRESHOLD = 20.0
 _KAIRI_GAUGE_NEUTRAL_COLOR = "#000"
 _KAIRI_GAUGE_POS_FAINT = "#9be29b"
 _KAIRI_GAUGE_POS_STRONG = "#2e7d32"
@@ -736,20 +739,25 @@ _KAIRI_GAUGE_NEG_FAINT = "#f4c7c3"
 _KAIRI_GAUGE_NEG_STRONG = "#c62828"
 
 
-def _kairi_gauge_marker_color(kairi_pct: float) -> str:
+def _kairi_gauge_marker_color(kairi_pct: float,
+                              faint_threshold: float = _KAIRI_GAUGE_FAINT_THRESHOLD,
+                              strong_threshold: float = _KAIRI_GAUGE_STRONG_THRESHOLD) -> str:
     """10WMA乖離率の符号と大きさからマーカー縦線色を返す。"""
     abs_k = abs(kairi_pct)
-    if abs_k < 10.0:
+    if abs_k < faint_threshold:
         return _KAIRI_GAUGE_NEUTRAL_COLOR
     if kairi_pct > 0:
-        return _KAIRI_GAUGE_POS_FAINT if abs_k < 20.0 else _KAIRI_GAUGE_POS_STRONG
-    return _KAIRI_GAUGE_NEG_FAINT if abs_k < 20.0 else _KAIRI_GAUGE_NEG_STRONG
+        return _KAIRI_GAUGE_POS_FAINT if abs_k < strong_threshold else _KAIRI_GAUGE_POS_STRONG
+    return _KAIRI_GAUGE_NEG_FAINT if abs_k < strong_threshold else _KAIRI_GAUGE_NEG_STRONG
 
 
-def kairi_gauge_svg(kairi, symbol):
-    """10WMA乖離率を -25%〜+25% の縦線マーカーで描画する SVG を返す。
+def kairi_gauge_svg(kairi, symbol,
+                    range_pct: float = _KAIRI_GAUGE_RANGE,
+                    faint_threshold: float = _KAIRI_GAUGE_FAINT_THRESHOLD,
+                    strong_threshold: float = _KAIRI_GAUGE_STRONG_THRESHOLD):
+    """10WMA乖離率を -range_pct〜+range_pct の縦線マーカーで描画する SVG を返す。
 
-    kairi >= +25 はクランプ + overheat 色のマーカー。
+    kairi >= +range_pct はクランプ + strong 色のマーカー。
     kairi が None で symbol も空なら "" を返す。
     """
     width = 40
@@ -757,7 +765,7 @@ def kairi_gauge_svg(kairi, symbol):
     if kairi is None and not symbol:
         return ""
 
-    px_per_pct = width / (_KAIRI_GAUGE_RANGE * 2)
+    px_per_pct = width / (range_pct * 2)
     parts = ['<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d" style="vertical-align:middle;">' % (width, height, width, height)]
 
     if kairi is not None:
@@ -766,11 +774,11 @@ def kairi_gauge_svg(kairi, symbol):
         except (TypeError, ValueError):
             k = None
         if k is not None:
-            k_clamped = max(-_KAIRI_GAUGE_RANGE, min(_KAIRI_GAUGE_RANGE, k))
-            mx = (k_clamped + _KAIRI_GAUGE_RANGE) * px_per_pct
+            k_clamped = max(-range_pct, min(range_pct, k))
+            mx = (k_clamped + range_pct) * px_per_pct
             # 端でクリップされてマーカーが半分の太さに見えないよう、両端は 1px 内側に寄せる
             mx = max(1.0, min(width - 1.0, mx))
-            marker_color = _kairi_gauge_marker_color(k)
+            marker_color = _kairi_gauge_marker_color(k, faint_threshold, strong_threshold)
             # 緑系 (株価プラス) は淡色で細く見えるため少し太くする
             is_green = marker_color in (_KAIRI_GAUGE_POS_FAINT, _KAIRI_GAUGE_POS_STRONG)
             marker_w = 3 if is_green else 2

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -794,8 +794,12 @@ def kairi_gauge_svg(kairi, symbol):
             # 端でクリップされてマーカーが半分の太さに見えないよう、両端は 1px 内側に寄せる
             mx = max(1.0, min(width - 1.0, mx))
             marker_color = _kairi_gauge_marker_color(k)
-            parts.append('<line x1="%g" y1="0" x2="%g" y2="%d" stroke="white" stroke-width="3"/>' % (mx, mx, height))
-            parts.append('<line x1="%g" y1="0" x2="%g" y2="%d" stroke="%s" stroke-width="2"/>' % (mx, mx, height, marker_color))
+            # 緑系 (株価プラス) は淡色で細く見えるため少し太くする
+            is_green = marker_color in (_KAIRI_GAUGE_POS_FAINT, _KAIRI_GAUGE_POS_STRONG)
+            marker_w = 3 if is_green else 2
+            halo_w = marker_w + 1
+            parts.append('<line x1="%g" y1="0" x2="%g" y2="%d" stroke="white" stroke-width="%d"/>' % (mx, mx, height, halo_w))
+            parts.append('<line x1="%g" y1="0" x2="%g" y2="%d" stroke="%s" stroke-width="%d"/>' % (mx, mx, height, marker_color, marker_w))
 
     if symbol:
         parts.append('<text x="50%%" y="50%%" text-anchor="middle" dominant-baseline="central" font-size="12" font-weight="bold" fill="#000" stroke="white" stroke-width="3" paint-order="stroke">%s</text>' % symbol)

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -751,7 +751,22 @@ def format_kairi_wma10(kairi):
 
 # overheat 閾値と色は kairi_wma10_zone_class() の `kairi-zone-overheat` 境界と一致させる
 _KAIRI_GAUGE_RANGE = 25.0
-_KAIRI_GAUGE_OVERHEAT_COLOR = "#e67e22"
+# マーカー縦線色: |kairi| < 10% 黒 (中立) / < 20% 淡色 / ≥ 20% 濃色
+_KAIRI_GAUGE_NEUTRAL_COLOR = "#000"
+_KAIRI_GAUGE_POS_FAINT = "#9be29b"
+_KAIRI_GAUGE_POS_STRONG = "#2e7d32"
+_KAIRI_GAUGE_NEG_FAINT = "#f4c7c3"
+_KAIRI_GAUGE_NEG_STRONG = "#c62828"
+
+
+def _kairi_gauge_marker_color(kairi_pct: float) -> str:
+    """10WMA乖離率の符号と大きさからマーカー縦線色を返す。"""
+    abs_k = abs(kairi_pct)
+    if abs_k < 10.0:
+        return _KAIRI_GAUGE_NEUTRAL_COLOR
+    if kairi_pct > 0:
+        return _KAIRI_GAUGE_POS_FAINT if abs_k < 20.0 else _KAIRI_GAUGE_POS_STRONG
+    return _KAIRI_GAUGE_NEG_FAINT if abs_k < 20.0 else _KAIRI_GAUGE_NEG_STRONG
 
 
 def kairi_gauge_svg(kairi, symbol):
@@ -778,7 +793,7 @@ def kairi_gauge_svg(kairi, symbol):
             mx = (k_clamped + _KAIRI_GAUGE_RANGE) * px_per_pct
             # 端でクリップされてマーカーが半分の太さに見えないよう、両端は 1px 内側に寄せる
             mx = max(1.0, min(width - 1.0, mx))
-            marker_color = _KAIRI_GAUGE_OVERHEAT_COLOR if k >= _KAIRI_GAUGE_RANGE else "#000"
+            marker_color = _kairi_gauge_marker_color(k)
             parts.append('<line x1="%g" y1="0" x2="%g" y2="%d" stroke="white" stroke-width="3"/>' % (mx, mx, height))
             parts.append('<line x1="%g" y1="0" x2="%g" y2="%d" stroke="%s" stroke-width="2"/>' % (mx, mx, height, marker_color))
 

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -759,25 +759,21 @@ tr:hover { background: #f5f5f5; }
 
 /* 市場テーブル */
 .market-table th { background: #2c3e50; color: #fff; }
+/* 列幅: 市場名と市場状態は可変、それ以外は固定 (需給バランスを広げ、FTDを狭める) */
+.market-table th.col-rs,    .market-table td.col-rs    { width: 60px; text-align: center; }
+.market-table th.col-trend, .market-table td.col-trend { width: 50px; text-align: center; padding: 0; }
+.market-table th.col-dd,    .market-table td.col-dd    { width: 80px; text-align: center; }
+.market-table th.col-ftd,   .market-table td.col-ftd   { width: 80px; text-align: center; }
+.market-table th.col-spr,   .market-table td.col-spr   { width: 140px; }
 .signal-sell { background: #fdedec; color: #c0392b; font-weight: bold; }
 .signal-buy { background: #eafaf1; color: #27ae60; font-weight: bold; }
 /* トレンド列の背景色 (portfolio_list と仕様統一: ◎=濃黄 / ◯=薄黄 / —=水色) */
 .trend-bg-strong { background: #fbbc04; }  /* ◎ */
 .trend-bg-good   { background: #fce8b2; }  /* ◯ */
 .trend-bg-none   { background: #6fa8dc; }  /* — / 空 */
-/* 10WMA乖離率の数値表示 (issue #248)
-   ゾーンを文字色で表現 (portfolio 側でトレンド列背景がすでに使われているため統一)。 */
-.kairi-num { margin-left: 2px; }
-.kairi-num.kairi-zone-overheat   { color: #e67e22; }  /* ≥+25% 利確警戒 */
-.kairi-num.kairi-zone-healthy    { color: #27ae60; }  /* +10〜+25% 健全 */
-.kairi-num.kairi-zone-pullback   { color: #2ecc71; }  /* 0〜+10% 押し目 */
-.kairi-num.kairi-zone-near-break { color: #e74c3c; }  /* -5〜0% 小割れ */
-.kairi-num.kairi-zone-break      { color: #c0392b; }  /* ≤-5% 崩れ */
-.rs-strong { color: #27ae60; font-weight: bold; }
-.rs-weak { color: #c0392b; font-weight: bold; }
 /* 需給バランスセル (issue #247): SPR/rv の横バー 2 本縦積み */
 .spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; }
-.spr-gauge-cell svg { display: block; }
+.spr-gauge-cell svg { display: block; width: 100%; height: auto; }
 /* market_state */
 .state-confirmed { background: #eafaf1; color: #27ae60; font-weight: bold; }
 .state-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
@@ -953,16 +949,25 @@ def _adjust_index_trend_template(db):
     return adjusted
 
 
-def _rs_class(rs_raw):
-    """rs_raw 値からCSSクラス名を返す。
-    >1.0=rs-strong (緑) / <1.0=rs-weak (赤) / =1.0 もしくは未取得 = クラスなし
+def _rs_style(rs_raw):
+    """rs_raw 値から inline style 属性を返す (portfolio パレット準拠)。
+
+    - >= 1.2: 濃黄 (#fbbc04)
+    - 1.1〜1.2: 薄黄 (#fce8b2)
+    - 0.9〜1.1: 色なし (中立)
+    - 0.8〜0.9: 水色 (#6fa8dc 薄警告)
+    - <= 0.8: 青 (#4285f4 警告) + 白文字
     """
     if not rs_raw:
         return ""
-    if rs_raw > 1.0:
-        return ' class="rs-strong"'
-    if rs_raw < 1.0:
-        return ' class="rs-weak"'
+    if rs_raw >= 1.2:
+        return ' style="background:#fbbc04"'
+    if rs_raw >= 1.1:
+        return ' style="background:#fce8b2"'
+    if rs_raw <= 0.8:
+        return ' style="background:#4285f4;color:#fff"'
+    if rs_raw <= 0.9:
+        return ' style="background:#6fa8dc"'
     return ""
 
 
@@ -1162,11 +1167,11 @@ def _html_market(market_db):
                 dd_display = "%d / %d" % (dd_count, dd_threshold)
             dd_dates = ", ".join([d[0][3:] for d in dd_with_close if d and len(d) >= 1])
             dd_title = ' title="%s"' % html_mod.escape(dd_dates) if dd_dates else ""
-            dd_class = ""
+            dd_extra_cls = ""
             if dd_count >= market_state.DD_THRESHOLD_TO_CORRECTION:
-                dd_class = ' class="dd-correction"'
+                dd_extra_cls = " dd-correction"
             elif dd_count >= market_state.DD_THRESHOLD_TO_PRESSURE:
-                dd_class = ' class="dd-pressure"'
+                dd_extra_cls = " dd-pressure"
 
             # FTD/ラリー列: correction中はラリー Day N、それ以外は直近FTD日
             if state == market_state.MARKET_IN_CORRECTION:
@@ -1186,23 +1191,23 @@ def _html_market(market_db):
             else:
                 state_display = state_label
             state_css = market_state.STATE_CSS_CLASS.get(state, "")
-            state_class = ' class="%s"' % state_css if state_css else ""
 
-            kairi = db.get("price_kairi_wma10")
+            # トレンド列: portfolio と同仕様で 10WMA乖離率の縦バー + 中央記号 + 詳細tooltip
+            kairi_raw = db.get("price_kairi_wma10")
+            kairi_for_gauge = kairi_raw if isinstance(kairi_raw, (int, float)) else None
             bg_cls = trend_bg_class(trend_expr)
-            trend_class = ' class="%s"' % bg_cls if bg_cls else ""
-            trend_title = ' title="不通過: %s"' % html_mod.escape(trend_misses) if trend_misses else ""
-            kairi_str = format_kairi_wma10(kairi)
-            if kairi_str:
-                span_class = ("kairi-num %s" % kairi_wma10_zone_class(kairi)).strip()
-                trend_cell_inner = '%s <span class="%s">%s</span>' % (
-                    html_mod.escape(trend_expr), span_class, kairi_str,
-                )
-            else:
-                trend_cell_inner = html_mod.escape(trend_expr)
+            trend_extra_cls = " %s" % bg_cls if bg_cls else ""
+            # tooltip: 不通過 (◯のみ) + 10WMA乖離率
+            kairi_str = format_kairi_wma10(kairi_for_gauge) or "—"
+            tooltip_lines = []
+            if trend_expr == "◯" and trend_misses:
+                tooltip_lines.append("不通過: " + trend_misses)
+            tooltip_lines.append("10WMA乖離: " + kairi_str)
+            trend_title = ' title="%s"' % html_mod.escape("\n".join(tooltip_lines))
+            trend_cell_inner = kairi_gauge_svg(kairi_for_gauge, trend_expr)
 
             rs_raw = db.get("rs_raw", "")
-            rs_class = _rs_class(rs_raw)
+            rs_style = _rs_style(rs_raw)
 
             # 売り圧力レシオ + 買い集め評価 (週,日) → 需給バランスセル (issue #247)
             # 個別銘柄は price.get_spr_expr で評価しているが、指数は sell_pressure_ratio が空のため
@@ -1232,22 +1237,23 @@ def _html_market(market_db):
             )
             gauge_title_attr = ' title="%s"' % html_mod.escape(gauge_tooltip) if gauge_tooltip else ""
 
+            state_attr = ' class="%s"' % state_css if state_css else ""
             rows_html.append(
                 '<tr>\n'
                 '  <td><strong><a href="%s" target="_blank" rel="noopener">%s</a></strong></td>\n'
+                '  <td class="col-rs"%s>%s</td>\n'
+                '  <td class="col-trend%s"%s>%s</td>\n'
+                '  <td class="col-dd%s"%s>%s</td>\n'
+                '  <td class="col-ftd">%s</td>\n'
                 '  <td%s>%s</td>\n'
-                '  <td%s%s>%s</td>\n'
-                '  <td%s%s>%s</td>\n'
-                '  <td>%s</td>\n'
-                '  <td%s>%s</td>\n'
-                '  <td class="spr-gauge-cell"%s>%s</td>\n'
+                '  <td class="col-spr spr-gauge-cell"%s>%s</td>\n'
                 '</tr>' % (
                     html_mod.escape(chart_url), html_mod.escape(market_name),
-                    rs_class, rs_raw,
-                    trend_class, trend_title, trend_cell_inner,
-                    dd_class, dd_title, html_mod.escape(dd_display),
+                    rs_style, rs_raw,
+                    trend_extra_cls, trend_title, trend_cell_inner,
+                    dd_extra_cls, dd_title, html_mod.escape(dd_display),
                     html_mod.escape(ftd_rally_display),
-                    state_class, html_mod.escape(state_display),
+                    state_attr, html_mod.escape(state_display),
                     gauge_title_attr, gauge_svg,
                 )
             )
@@ -1261,9 +1267,9 @@ def _html_market(market_db):
         '<h2>市場</h2>\n'
         '<table class="market-table">\n'
         '<thead><tr>\n'
-        '  <th>市場名</th><th>RS</th><th>トレンド</th>\n'
-        '  <th>DD</th><th>FTD/ラリー</th>\n'
-        '  <th>市場状態</th><th>需給バランス</th>\n'
+        '  <th>市場名</th><th class="col-rs">RS</th><th class="col-trend">トレンド</th>\n'
+        '  <th class="col-dd">DD</th><th class="col-ftd">FTD/ラリー</th>\n'
+        '  <th>市場状態</th><th class="col-spr">需給バランス</th>\n'
         '</tr></thead>\n'
         '<tbody>'
     )

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -758,8 +758,11 @@ tr:hover { background: #f5f5f5; }
 .theme-heat2  { background: #66bb6a; border-color: #4caf50; }
 
 /* 市場テーブル */
+/* table のデフォルト width:100% を解除し、列幅の合計だけのコンパクトな表にする */
+.market-table { width: auto; }
 .market-table th { background: #2c3e50; color: #fff; }
-/* 列幅: 市場名と市場状態は可変、それ以外は固定 (需給バランスを広げ、FTDを狭める) */
+/* 列幅: 市場名と市場状態は内容に合わせ最小幅、それ以外は固定 (需給バランスを広げ、FTDを狭める) */
+.market-table th, .market-table td { white-space: nowrap; }
 .market-table th.col-rs,    .market-table td.col-rs    { width: 60px; text-align: center; }
 .market-table th.col-trend, .market-table td.col-trend { width: 50px; text-align: center; padding: 0; }
 .market-table th.col-dd,    .market-table td.col-dd    { width: 80px; text-align: center; }
@@ -1204,7 +1207,11 @@ def _html_market(market_db):
                 tooltip_lines.append("不通過: " + trend_misses)
             tooltip_lines.append("10WMA乖離: " + kairi_str)
             trend_title = ' title="%s"' % html_mod.escape("\n".join(tooltip_lines))
-            trend_cell_inner = kairi_gauge_svg(kairi_for_gauge, trend_expr)
+            # 市場指数は個別銘柄より日次ボラが小さいので、ゲージのレンジと濃淡閾値を縮める
+            trend_cell_inner = kairi_gauge_svg(
+                kairi_for_gauge, trend_expr,
+                range_pct=15.0, faint_threshold=5.0, strong_threshold=10.0,
+            )
 
             rs_raw = db.get("rs_raw", "")
             rs_style = _rs_style(rs_raw)
@@ -1237,7 +1244,8 @@ def _html_market(market_db):
             )
             gauge_title_attr = ' title="%s"' % html_mod.escape(gauge_tooltip) if gauge_tooltip else ""
 
-            state_attr = ' class="%s"' % state_css if state_css else ""
+            state_class = "col-state" + (" " + state_css if state_css else "")
+            state_attr = ' class="%s"' % state_class
             rows_html.append(
                 '<tr>\n'
                 '  <td><strong><a href="%s" target="_blank" rel="noopener">%s</a></strong></td>\n'
@@ -1269,7 +1277,7 @@ def _html_market(market_db):
         '<thead><tr>\n'
         '  <th>市場名</th><th class="col-rs">RS</th><th class="col-trend">トレンド</th>\n'
         '  <th class="col-dd">DD</th><th class="col-ftd">FTD/ラリー</th>\n'
-        '  <th>市場状態</th><th class="col-spr">需給バランス</th>\n'
+        '  <th class="col-state">市場状態</th><th class="col-spr">需給バランス</th>\n'
         '</tr></thead>\n'
         '<tbody>'
     )

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -980,7 +980,7 @@ _SPR_GAUGE_GREEN_COLORS = {
     "E": "#f8fef8",
 }
 _SPR_GAUGE_GREEN_DEFAULT = _SPR_GAUGE_GREEN_COLORS["C"]
-_SPR_GAUGE_RED_FIXED = "#f4d4d4"
+_SPR_GAUGE_RED_FIXED = "#f4c7c3"  # パレットの「薄赤 (株価マイナス)」と統一
 
 
 def _to_finite_number(v):

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1852,7 +1852,35 @@ _RS_COLORS = {"up": "#1976d2", "down": "#ef6c00", "flat": "#999"}
 _RS_FADED = {"up": "#90caf9", "down": "#ffcc80", "flat": "#ccc"}
 _BLUE_DOT = "#1976d2"
 
+# portfolio ミニチャート: 20日株価騰落率による線色 (|r20| < 10% 灰 / < 20% 淡 / ≥ 20% 濃)
+_MINI_LINE_NEUTRAL = "#999"
+_MINI_LINE_POS_FAINT = "#9be29b"
+_MINI_LINE_POS_STRONG = "#2e7d32"
+_MINI_LINE_NEG_FAINT = "#f4c7c3"
+_MINI_LINE_NEG_STRONG = "#c62828"
+
 _FLAT_THRESHOLD_PERCENT_PER_DAY = 0.05  # 傾き |x| < 0.05%/日 は flat 扱い
+
+
+def _mini_line_color_by_return(price_asc: List[float]) -> str:
+    """portfolio ミニチャート用に 20日株価騰落率の符号と大きさで線色を決める。
+
+    |r20| < 10% は灰 (中立)、10-20% は淡色、≥ 20% は濃色。
+    データ不足 (2点未満 or 始値<=0) は灰。
+    """
+    if len(price_asc) < 2:
+        return _MINI_LINE_NEUTRAL
+    p0 = price_asc[0]
+    p1 = price_asc[-1]
+    if not isinstance(p0, (int, float)) or not isinstance(p1, (int, float)) or p0 <= 0:
+        return _MINI_LINE_NEUTRAL
+    r20_pct = (p1 / p0 - 1.0) * 100.0
+    abs_r = abs(r20_pct)
+    if abs_r < 10.0:
+        return _MINI_LINE_NEUTRAL
+    if r20_pct > 0:
+        return _MINI_LINE_POS_FAINT if abs_r < 20.0 else _MINI_LINE_POS_STRONG
+    return _MINI_LINE_NEG_FAINT if abs_r < 20.0 else _MINI_LINE_NEG_STRONG
 
 
 def compute_slope_per_day(values: List[float]) -> Optional[float]:
@@ -2101,8 +2129,8 @@ def build_price_rs_chart_mini(
     # x 座標は等間隔 3 点
     xs = [pad_x, pad_x + inner_w / 2, pad_x + inner_w]
 
-    rs_slope_full = compute_slope_per_day(rs_asc) if len(rs_asc) >= 2 else None
-    rs_dir = _slope_direction(rs_slope_full)
+    # 線色は 20日株価騰落率ベース (|r20| < 10% 灰 / < 20% 淡 / ≥ 20% 濃)
+    line_color = _mini_line_color_by_return(price_asc)
 
     parts = [f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" width="{width}" height="{height}">']
 
@@ -2110,12 +2138,12 @@ def build_price_rs_chart_mini(
     ys = normalize_minmax(rs_pts_raw, inner_h)
     ys = [y + pad_y for y in ys]
     points = list(zip(xs, ys))
-    parts.append(_svg_polyline(points, _RS_COLORS[rs_dir], 1.5))
-    # 末尾点: Blue Dot or 通常マーカー
+    parts.append(_svg_polyline(points, line_color, 1.5))
+    # 末尾点: Blue Dot or 通常マーカー (通常マーカーは線色連動)
     if has_blue_dot:
         parts.append(_svg_circle(points[-1][0], points[-1][1], 2.5, _BLUE_DOT))
     else:
-        parts.append(_svg_circle(points[-1][0], points[-1][1], 1.6, _RS_COLORS[rs_dir]))
+        parts.append(_svg_circle(points[-1][0], points[-1][1], 1.6, line_color))
 
     parts.append("</svg>")
     return ("".join(parts), tooltip)
@@ -2601,14 +2629,18 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
 # ==================================================
 
 PORTFOLIO_COLORS = {
-    "薄黄": "#fce8b2",   # 良 (PER低い、配当>3、RS≧70 等)
+    # ポジティブ系
+    "薄黄": "#fce8b2",   # 良 (PER割安、配当>3、RS≧70 等)
     "濃黄": "#fbbc04",   # 強良 (順位<300、配当≧5、RS>80 等)
-    "薄赤": "#f4c7c3",   # 警告 (ステージ2S、3Q連続向上タグ)
-    "青":   "#4285f4",   # 警告シグナル (警/売)
-    "赤":   "#ea4335",   # 強警告シグナル (ポ/ブ/最)
+    "赤":   "#ea4335",   # 注目
+    "緑":   "#d4f4d4",   # 株価的にプラス (需給、MA乖離率)
+    # ネガティブ系
+    "青":   "#4285f4",   # 警告 (強)
+    "水色": "#6fa8dc",   # 薄警告 (青の弱い版)
+    "薄赤": "#f4c7c3",   # 株価的にマイナス (需給、MA乖離率)
+    # 中立 (データ状態)
     "薄灰": "#cccccc",   # データ古い (14日以上)
     "濃灰": "#999999",   # データ古い (1ヶ月以上)
-    "水色": "#6fa8dc",   # データなし/低スコア (買い集めDD以下、トレンド空)
 }
 
 def _parse_research_update_md(md_str: Optional[str], today: date) -> Optional[date]:
@@ -2685,12 +2717,19 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
         elif div_raw > 3:
             styles["dividend"] = bg("薄黄")
 
-    # --- 進捗率乖離 (ルール 9, 10): <C3>タグ 薄赤 / 営利乖離≧20 濃黄
+    # --- 進捗率乖離: <C3>タグ 赤(注目) / 営利乖離≧20 濃黄 / 両該当は左右分割
     quarity = row.get("gyoseki_quarity_expr") or ""
     eiri_raw = row.get("progress_diff_eiri_raw")
-    if "<C3>" in quarity:
-        styles["progress_diff"] = bg("薄赤")
-    elif isinstance(eiri_raw, (int, float)) and eiri_raw >= 20:
+    has_c3 = "<C3>" in quarity
+    hit_eiri = isinstance(eiri_raw, (int, float)) and eiri_raw >= 20
+    if has_c3 and hit_eiri:
+        styles["progress_diff"] = (
+            f"background:linear-gradient(to right,"
+            f"{PORTFOLIO_COLORS['赤']} 50%,{PORTFOLIO_COLORS['濃黄']} 50%)"
+        )
+    elif has_c3:
+        styles["progress_diff"] = bg_with_white("赤")
+    elif hit_eiri:
         styles["progress_diff"] = bg("濃黄")
 
     # --- 決算日 (ルール 22, 23): 更新日±1ヶ月+3Q 濃黄 / ±1ヶ月のみ 薄黄
@@ -2717,10 +2756,23 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
         elif diff_days >= 14:
             styles["last_research_update"] = bg("薄灰")
 
-    # --- ステージ (ルール 13): "2S" 含む → 薄赤
+    # --- ステージ: 2S=濃黄 / 3S=水色 / 4S=青、2つ併存は左右分割 (強い順に左)
     stage = (row.get("memo") or {}).get("stage") or ""
-    if "2S" in stage:
-        styles["stage"] = bg("薄赤")
+    stage_color_map = {"4S": "青", "3S": "水色", "2S": "濃黄"}
+    stage_hits = [s for s in ("4S", "3S", "2S") if s in stage]
+    if len(stage_hits) >= 2:
+        left, right = stage_hits[0], stage_hits[1]
+        styles["stage"] = (
+            f"background:linear-gradient(to right,"
+            f"{PORTFOLIO_COLORS[stage_color_map[left]]} 50%,"
+            f"{PORTFOLIO_COLORS[stage_color_map[right]]} 50%)"
+        )
+    elif stage_hits:
+        single = stage_hits[0]
+        if single == "4S":
+            styles["stage"] = bg_with_white("青")
+        else:
+            styles["stage"] = bg(stage_color_map[single])
 
     # --- RS (ルール 27, 28): > 80 濃黄 / >= 70 薄黄
     rs_raw = row.get("rs_raw")

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2131,6 +2131,9 @@ def build_price_rs_chart_mini(
 
     # 線色は 20日株価騰落率ベース (|r20| < 10% 灰 / < 20% 淡 / ≥ 20% 濃)
     line_color = _mini_line_color_by_return(price_asc)
+    # 緑系 (株価プラス) は淡色で細く見えるため少し太くする
+    is_green = line_color in (_MINI_LINE_POS_FAINT, _MINI_LINE_POS_STRONG)
+    line_w = 2.0 if is_green else 1.5
 
     parts = [f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" width="{width}" height="{height}">']
 
@@ -2138,7 +2141,7 @@ def build_price_rs_chart_mini(
     ys = normalize_minmax(rs_pts_raw, inner_h)
     ys = [y + pad_y for y in ys]
     points = list(zip(xs, ys))
-    parts.append(_svg_polyline(points, line_color, 1.5))
+    parts.append(_svg_polyline(points, line_color, line_w))
     # 末尾点: Blue Dot or 通常マーカー (通常マーカーは線色連動)
     if has_blue_dot:
         parts.append(_svg_circle(points[-1][0], points[-1][1], 2.5, _BLUE_DOT))

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -443,16 +443,6 @@ nav .quick-search {
 .trend-bg-good   { background: #fce8b2; }
 .trend-bg-none   { background: #6fa8dc; }
 
-/* 10WMA乖離率の数値表示 (issue #248)
-   portfolio_list ではトレンド列の背景が ◎/◯/— に占有されるため、
-   ゾーンは文字色で表現する。 */
-.kairi-num { margin-left: 2px; }
-.kairi-num.kairi-zone-overheat   { color: #e67e22; }  /* ≥+25% 利確警戒 */
-.kairi-num.kairi-zone-healthy    { color: #27ae60; }  /* +10〜+25% 健全 */
-.kairi-num.kairi-zone-pullback   { color: #2ecc71; }  /* 0〜+10% 押し目 */
-.kairi-num.kairi-zone-near-break { color: #e74c3c; }  /* -5〜0% 小割れ */
-.kairi-num.kairi-zone-break      { color: #c0392b; }  /* ≤-5% 崩れ */
-
 /* 需給バランスセル (issue #247): SPR/rv の横バー 2 本縦積み */
 .spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; width: 80px; }
 .spr-gauge-cell svg { display: block; width: 80px; height: auto; }

--- a/tests/test_ks_util.py
+++ b/tests/test_ks_util.py
@@ -376,23 +376,27 @@ class TestKairiGaugeSvg:
     """kairi_gauge_svg(): 10WMA乖離率の SVG バーゲージ生成 (issue portfolio-trend-gauge)"""
 
     @pytest.mark.parametrize(
-        "kairi, symbol, expect_svg, expect_marker, expect_overheat",
+        "kairi, symbol, expect_svg, expect_marker, expect_color",
         [
-            # 健全帯 +12: SVG + マーカーあり + 橙ではない
-            (12, "◎", True, True, False),
-            # 小割れ -3: SVG + マーカーあり + 橙ではない
-            (-3, "◯", True, True, False),
-            # +25 境界: マーカーは右端、橙
-            (25, "◎", True, True, True),
-            # 範囲外 +30: クランプ + 橙
-            (30, "◎", True, True, True),
+            # |kairi| < 10%: 中立 (黒)
+            (5, "◎", True, True, "#000"),
+            (-3, "◯", True, True, "#000"),
+            # プラス淡 (10〜20%): 淡緑
+            (12, "◎", True, True, "#9be29b"),
+            # プラス濃 (≥20%): 濃緑
+            (25, "◎", True, True, "#2e7d32"),
+            (30, "◎", True, True, "#2e7d32"),
+            # マイナス淡 (-10〜-20%): 淡薄赤
+            (-15, "◯", True, True, "#f4c7c3"),
+            # マイナス濃 (≤-20%): 濃薄赤
+            (-25, "◯", True, True, "#c62828"),
             # データ無し + 記号あり: SVG (記号のみ)、マーカーなし
-            (None, "—", True, False, False),
+            (None, "—", True, False, None),
             # データ無し + 記号も空: 空文字
-            (None, "", False, False, False),
+            (None, "", False, False, None),
         ],
     )
-    def test_gauge_shape(self, kairi, symbol, expect_svg, expect_marker, expect_overheat):
+    def test_gauge_shape(self, kairi, symbol, expect_svg, expect_marker, expect_color):
         svg = ks_util.kairi_gauge_svg(kairi, symbol)
         if not expect_svg:
             assert svg == ""
@@ -402,13 +406,11 @@ class TestKairiGaugeSvg:
         line_count = svg.count("<line")
         if expect_marker:
             assert line_count == 2
+            assert expect_color in svg
         else:
             assert line_count == 0
-        # overheat マーカー色は kairi >= +25 のみ
-        if expect_overheat:
-            assert "#e67e22" in svg
-        else:
-            assert "#e67e22" not in svg
+        # 廃止された overheat オレンジ色 (#e67e22) は出現しない
+        assert "#e67e22" not in svg
         # 記号が SVG に埋め込まれる
         if symbol:
             assert symbol in svg

--- a/tests/test_ks_util.py
+++ b/tests/test_ks_util.py
@@ -414,3 +414,25 @@ class TestKairiGaugeSvg:
         # 記号が SVG に埋め込まれる
         if symbol:
             assert symbol in svg
+
+    @pytest.mark.parametrize(
+        "kairi, expect_color",
+        [
+            # 縮小レンジ (range=15, faint=5, strong=10) での色境界
+            (4, "#000"),         # |k| < 5: 中立
+            (-4, "#000"),
+            (7, "#9be29b"),      # 5 <= k < 10: プラス淡
+            (-7, "#f4c7c3"),     # -10 < k <= -5: マイナス淡
+            (12, "#2e7d32"),     # k >= 10: プラス濃
+            (-12, "#c62828"),    # k <= -10: マイナス濃
+            (20, "#2e7d32"),     # range=15 を超える値もクランプして濃色
+        ],
+    )
+    def test_market_scale(self, kairi, expect_color):
+        """市場用 (range=15, faint=5, strong=10) の色境界が正しく切り替わる。"""
+        svg = ks_util.kairi_gauge_svg(
+            kairi, "◎",
+            range_pct=15.0, faint_threshold=5.0, strong_threshold=10.0,
+        )
+        assert svg.startswith("<svg")
+        assert expect_color in svg

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -712,9 +712,9 @@ class TestSprGaugeSvg:
         assert svg.startswith("<svg")
         # 各バー: 背景 rect 2枚 (左緑 + 右赤) × 2本 = 4枚
         assert svg.count('<rect') == 4
-        # ラベル未指定なので緑バーは C 相当 (#d4f4d4) ×2、赤バーは固定色 (#f4d4d4) ×2
+        # ラベル未指定なので緑バーは C 相当 (#d4f4d4) ×2、赤バーは固定色 (#f4c7c3) ×2
         assert svg.count('#d4f4d4') == 2
-        assert svg.count('#f4d4d4') == 2
+        assert svg.count('#f4c7c3') == 2
         # ティック (stroke-width=2) と ヒゲ (stroke-width=1) それぞれ 2 本ずつ
         assert svg.count('stroke-width="2"') == 2
         assert svg.count('stroke-width="1"') == 2
@@ -763,12 +763,12 @@ class TestSprGaugeSvg:
     ])
     def test_buy_collection_label_drives_green_bar_density(self, sprw, expected_green_20):
         """週評価 → 20日バー / 日評価 → 5日バー で緑バーの濃淡をコントロールする。
-        赤バーは固定色 (#f4d4d4)、ラベル欠損は C 相当にフォールバック。"""
+        赤バーは固定色 (#f4c7c3)、ラベル欠損は C 相当にフォールバック。"""
         svg = make_market_db.build_spr_gauge_svg(50, 2.0, 60, 3.0, sprw, None)
         # 緑バー (20日) は期待濃度
         assert expected_green_20 in svg
         # 赤バーは sprw / sprbg に関わらず固定色のみ (両バーぶん 2 回)
-        assert svg.count("#f4d4d4") == 2
+        assert svg.count("#f4c7c3") == 2
 
     def test_bar_title_includes_buy_collection_label(self):
         """バー単体 <title> に '買い集めX' が併記される (ホバー時に SVG <title> が勝つため)"""

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -466,11 +466,11 @@ class TestHtmlMarket:
         assert 'trend-bg-strong' in result or 'trend-bg-good' in result
 
     def test_market_table_header(self):
-        """テーブルヘッダーが含まれる (Part B: DD/FTD 列名改修)"""
+        """テーブルヘッダーが含まれる (Part B: DD/FTD 列名改修 + 列幅 class 追加)"""
         result = make_market_db._html_market(self._make_market_db())
         assert 'market-table' in result
-        assert '<th>DD</th>' in result
-        assert '<th>FTD/ラリー</th>' in result
+        assert '<th class="col-dd">DD</th>' in result
+        assert '<th class="col-ftd">FTD/ラリー</th>' in result
 
     # ===== Part B: 表示文言・列構成テスト =====
     def test_market_state_header_label(self):
@@ -653,26 +653,30 @@ class TestHtmlMarket:
         assert "NASDAQ" not in result
         assert "S&amp;P 500" not in result
 
-    def test_rs_strong_class_when_rs_raw_above_one(self):
-        """rs_raw > 1.0 で rs-strong クラスが付く (issue #148 Part 1)"""
-        result = make_market_db._html_market(self._make_market_db())
-        assert 'rs-strong' in result
-
-    def test_rs_weak_class_when_rs_raw_below_one(self):
-        """rs_raw < 1.0 で rs-weak クラスが付く (issue #148 Part 1)"""
+    def test_rs_bg_yellow_when_rs_raw_high(self):
+        """rs_raw >= 1.2 で濃黄背景 / 1.1〜1.2 で薄黄背景 (portfolio パレット準拠)"""
         db = self._make_market_db()
-        db["topix"]["rs_raw"] = 0.92
+        db["topix"]["rs_raw"] = 1.25
         result = make_market_db._html_market(db)
-        assert 'rs-weak' in result
+        assert 'background:#fbbc04' in result
 
-    def test_rs_no_class_when_rs_raw_equals_one(self):
-        """rs_raw == 1.0 ではクラス付かない (デフォルト灰)"""
+    def test_rs_bg_blue_when_rs_raw_low(self):
+        """rs_raw <= 0.8 で青背景+白文字 (警告)"""
+        db = self._make_market_db()
+        db["topix"]["rs_raw"] = 0.75
+        result = make_market_db._html_market(db)
+        assert 'background:#4285f4;color:#fff' in result
+
+    def test_rs_no_style_when_rs_raw_neutral(self):
+        """0.9 < rs < 1.1 では背景色付かない (中立)"""
         db = {
             "topix": dict(self._make_market_db()["topix"], rs_raw=1.0)
         }
         result = make_market_db._html_market(db)
-        assert 'rs-strong' not in result
-        assert 'rs-weak' not in result
+        assert 'background:#fbbc04' not in result
+        assert 'background:#fce8b2' not in result
+        assert 'background:#6fa8dc' not in result
+        assert 'background:#4285f4' not in result
 
     def test_index_rs_threshold_removes_RS_from_trend(self):
         """rs_raw > 1.05 なら trend_template の "RS" 未達が除外される (issue #148 Part 1)"""
@@ -835,23 +839,25 @@ class TestAdjustIndexTrendTemplate:
         assert original["trend_template"] == original_misses
 
 
-class TestRsClass:
-    """rs_raw 値からCSSクラスを返すテスト (issue #148 Part 1)"""
+class TestRsStyle:
+    """rs_raw 値から背景色 inline style を返すテスト (portfolio パレット準拠)"""
 
-    def test_strong_when_above_one(self):
-        assert make_market_db._rs_class(1.15) == ' class="rs-strong"'
-
-    def test_weak_when_below_one(self):
-        assert make_market_db._rs_class(0.92) == ' class="rs-weak"'
-
-    def test_no_class_when_equal_one(self):
-        assert make_market_db._rs_class(1.0) == ""
-
-    def test_no_class_when_zero(self):
-        assert make_market_db._rs_class(0) == ""
-
-    def test_no_class_when_empty_string(self):
-        assert make_market_db._rs_class("") == ""
+    @pytest.mark.parametrize("rs, expected", [
+        (1.25, ' style="background:#fbbc04"'),                  # >= 1.2 濃黄
+        (1.20, ' style="background:#fbbc04"'),                  # 境界
+        (1.15, ' style="background:#fce8b2"'),                  # >= 1.1 薄黄
+        (1.10, ' style="background:#fce8b2"'),                  # 境界
+        (1.00, ""),                                              # 中立
+        (0.95, ""),
+        (0.90, ' style="background:#6fa8dc"'),                  # <= 0.9 水色
+        (0.85, ' style="background:#6fa8dc"'),
+        (0.80, ' style="background:#4285f4;color:#fff"'),       # <= 0.8 青 + 白文字
+        (0.70, ' style="background:#4285f4;color:#fff"'),
+        (0, ""),                                                 # 未取得
+        ("", ""),                                                # 空文字
+    ])
+    def test_rs_style(self, rs, expected):
+        assert make_market_db._rs_style(rs) == expected
 
 
 class TestHtmlKessan:

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1481,9 +1481,11 @@ class TestComputeCellStyles:
             ({"progress_diff_eiri_raw": 20, "gyoseki_quarity_expr": ""}, "progress_diff",
              f"background:{C['濃黄']}"),
             ({"progress_diff_eiri_raw": 19, "gyoseki_quarity_expr": ""}, "progress_diff", None),
-            # ステージ ("2S" を含む → 薄赤)
-            ({"memo": {"stage": "2S(3T)"}}, "stage", f"background:{C['薄赤']}"),
-            ({"memo": {"stage": "3S"}}, "stage", None),
+            # ステージ (2S=濃黄 単色 / 3S=水色 単色 / 4S=青 単色 + 白文字)
+            ({"memo": {"stage": "2S(3T)"}}, "stage", f"background:{C['濃黄']}"),
+            ({"memo": {"stage": "3S"}}, "stage", f"background:{C['水色']}"),
+            ({"memo": {"stage": "4S"}}, "stage", f"background:{C['青']};color:#fff"),
+            ({"memo": {"stage": ""}}, "stage", None),
             # 時価総額 (カテゴリ "中"/"大" → 薄黄、それ以外なし)
             ({"market_cap_category": "中"}, "market_cap", f"background:{C['薄黄']}"),
             ({"market_cap_category": "大"}, "market_cap", f"background:{C['薄黄']}"),
@@ -1563,15 +1565,50 @@ class TestComputeCellStyles:
         else:
             assert styles["tags"] == expected
 
-    # ----- 進捗率乖離: <C3>タグ優先 -----
-    def test_progress_diff_c3_priority_over_eiri(self):
-        """<C3> タグは薄赤で営利>=20 の濃黄より優先 (タグありなしで両方確認)"""
-        # <C3> あり: 営利の値に関わらず薄赤
+    # ----- 進捗率乖離: <C3>=赤(注目) 単独 / eiri≧20 = 濃黄 単独 / 両該当=左右分割 -----
+    def test_progress_diff_c3_only(self):
+        """<C3> タグのみで eiri 不該当: 赤 (注目) 単色 + 白文字"""
+        styles = helpers.compute_cell_styles(
+            {"progress_diff_eiri_raw": 10, "gyoseki_quarity_expr": "[A]20%<C3>"},
+            today=TODAY,
+        )
+        assert styles["progress_diff"] == f"background:{C['赤']};color:#fff"
+
+    def test_progress_diff_c3_and_eiri_split(self):
+        """<C3> + eiri≧20 両該当: 左半分=赤 / 右半分=濃黄 の linear-gradient"""
         styles = helpers.compute_cell_styles(
             {"progress_diff_eiri_raw": 30, "gyoseki_quarity_expr": "[A]20%<C3>"},
             today=TODAY,
         )
-        assert styles["progress_diff"] == f"background:{C['薄赤']}"
+        assert styles["progress_diff"] == (
+            f"background:linear-gradient(to right,"
+            f"{C['赤']} 50%,{C['濃黄']} 50%)"
+        )
+
+    # ----- ステージ: 2 つ併存は強い順に左 -----
+    @pytest.mark.parametrize(
+        "stage, expected",
+        [
+            # 2S + 3S → 左 2S(濃黄) / 右 3S(水色) (注: 強い=数字大の S なので 3S が左)
+            ("2S/3S", (
+                f"background:linear-gradient(to right,"
+                f"{C['水色']} 50%,{C['濃黄']} 50%)"
+            )),
+            # 3S + 4S → 左 4S(青) / 右 3S(水色)
+            ("3S/4S", (
+                f"background:linear-gradient(to right,"
+                f"{C['青']} 50%,{C['水色']} 50%)"
+            )),
+            # 2S + 4S → 左 4S(青) / 右 2S(濃黄)
+            ("2S/4S", (
+                f"background:linear-gradient(to right,"
+                f"{C['青']} 50%,{C['濃黄']} 50%)"
+            )),
+        ],
+    )
+    def test_stage_split_two_marks(self, stage, expected):
+        styles = helpers.compute_cell_styles({"memo": {"stage": stage}}, today=TODAY)
+        assert styles["stage"] == expected
 
     # ----- 決算日 ±1ヶ月 + 3Q → 濃黄、それ以外 → 薄黄/色なし -----
     @pytest.mark.parametrize(
@@ -2312,22 +2349,28 @@ class TestBuildTrendInfoGauge:
     """build_trend_info() の kairi_gauge_svg と tooltip 結合を検証する (issue portfolio-trend-gauge)"""
 
     @pytest.mark.parametrize(
-        "kairi, misses, expect_marker, expect_overheat_marker, expect_unpass_tooltip",
+        "kairi, misses, expect_marker, expect_marker_color, expect_unpass_tooltip",
         [
-            # 健全帯 +12: マーカー有り / 橙ではない / 不通過0件なので「不通過:」行なし (◎扱い)
-            (12, [], True, False, False),
-            # 小割れ -3: マーカー有り / 不通過1件あるので「不通過:」行あり (◯扱い)
-            (-3, ["RS"], True, False, True),
-            # +25 ちょうど: overheat 境界、橙マーカー
-            (25, [], True, True, False),
-            # 範囲外 +30: クランプ + 橙マーカー
-            (30, [], True, True, False),
+            # |kairi| < 10%: 中立 (黒)、不通過0件なので「不通過:」行なし (◎扱い)
+            (5, [], True, "#000", False),
+            # 健全帯 +12: 淡緑 (#9be29b)、不通過1件あるので「不通過:」行あり (◯扱い)
+            (12, ["RS"], True, "#9be29b", True),
+            # 小割れ -3: 中立 (黒)、不通過1件あるので「不通過:」行あり
+            (-3, ["RS"], True, "#000", True),
+            # +25 ちょうど: 濃緑 (#2e7d32)
+            (25, [], True, "#2e7d32", False),
+            # 範囲外 +30: クランプ + 濃緑
+            (30, [], True, "#2e7d32", False),
+            # マイナス -15: 淡薄赤 (#f4c7c3)
+            (-15, ["RS"], True, "#f4c7c3", True),
+            # マイナス -25: 濃薄赤 (#c62828)
+            (-25, ["RS"], True, "#c62828", True),
             # データ無し: kairi=None、マーカーなし、記号のみ
-            (None, [], False, False, False),
+            (None, [], False, None, False),
         ],
     )
     def test_gauge_svg_and_tooltip(
-        self, kairi, misses, expect_marker, expect_overheat_marker, expect_unpass_tooltip,
+        self, kairi, misses, expect_marker, expect_marker_color, expect_unpass_tooltip,
     ):
         stock = {"price_kairi_wma10": kairi, "trend_template": misses}
         info = helpers.build_trend_info(stock)
@@ -2341,13 +2384,11 @@ class TestBuildTrendInfoGauge:
         line_count = svg.count("<line")
         if expect_marker:
             assert line_count == 2
+            assert expect_marker_color in svg
         else:
             assert line_count == 0
-        # overheat マーカー色 (kairi >= +25 のみ橙)
-        if expect_overheat_marker:
-            assert "#e67e22" in svg
-        else:
-            assert "#e67e22" not in svg
+        # 廃止された overheat オレンジ色 (#e67e22) は出現しない
+        assert "#e67e22" not in svg
         # tooltip は常に「10WMA乖離: ...」行を含む
         assert "10WMA乖離:" in info["tooltip"]
         # 不通過項目は ◯ のときのみ含まれる
@@ -2378,9 +2419,9 @@ class TestBuildSprGaugeForStock:
         # セル全体 tooltip にも (フォールバック用) 同等情報
         assert "SPR 48 ±2.4 (20日)" in gauge["tooltip"]
         assert "買い集め 週B 日A" in gauge["tooltip"]
-        # 緑バーは週B 相当の中濃緑 (#9be29b)、赤バーは固定色のまま
+        # 緑バーは週B 相当の中濃緑 (#9be29b)、赤バーは薄赤 (#f4c7c3) で統一
         assert "#9be29b" in gauge["svg"]
-        assert "#f4d4d4" in gauge["svg"]
+        assert "#f4c7c3" in gauge["svg"]
 
     def test_missing_data_returns_em_dash(self):
         """sprs/vols 欠損: svg は '—'、tooltip は空"""

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -660,8 +660,8 @@ class TestUpdateMemoAjax:
         assert resp.status_code == 200
         body = resp.get_json()
         assert "styles" in body
-        # ステージ "2S" は薄赤色付け対象 (ルール 13)
-        assert body["styles"].get("stage") == "background:#f4c7c3"
+        # ステージ "2S" 単独は濃黄 (新意味体系: 2S=濃黄 / 3S=水色 / 4S=青)
+        assert body["styles"].get("stage") == "background:#fbbc04"
         # display フィールドに保存後の表示値が入っている
         assert body["display"]["stage"] == "2S"
         assert body["display"]["last_research_update"] == "5/10"


### PR DESCRIPTION
## Summary

WebApp /portfolio ページの色定義を「色 → 意味」の対応関係で再整理し、ステージ列と進捗率乖離列の塗り分けロジックを拡張。

### パレット意味体系の確定
- **ポジティブ系**: 薄黄 / 濃黄 / **赤(注目)** / **緑(株価プラス, 新規 #d4f4d4)**
- **ネガティブ系**: 青(警告) / **水色(薄警告 = 青の弱い版)** / **薄赤(株価マイナス)**
- **中立**: 薄灰 / 濃灰

旧定義からの主な変更:
- 赤 #ea4335: 強警告シグナル → **注目** (ポジティブ系へ移動)
- 水色 #6fa8dc: データなし/低スコア → **薄警告**
- 薄赤 #f4c7c3: 警告(ステージ2S等) → **株価マイナス (需給/MA乖離率)**
- 緑 #d4f4d4: 新規追加 (需給ゲージ C 基準色と統一)

### 列ロジックの変更
- **進捗率乖離列**: `<C3>` = 赤(注目) / `eiri≧20` = 濃黄 / 両該当は左右分割 (linear-gradient 50/50)
- **ステージ列**: `2S` = 濃黄 / `3S` = 水色 / `4S` = 青(白文字)、2つ併存は強い順に左右分割
- **RS列ミニチャート**: 線色を 20日株価騰落率 (`price[-1]/price[0]-1`) ベースで決定
  - `|r20|<10%` = `#999` 灰、`<20%` = 淡色 (`#9be29b`/`#f4c7c3`)、`≥20%` = 濃色 (`#2e7d32`/`#c62828`)
- **10WMA乖離率バー** (`kairi_gauge_svg`): マーカー縦線色を同じ段階分けに統一 (overheat オレンジ `#e67e22` 廃止)
- **需給ゲージ赤バー**: `#f4d4d4` → `#f4c7c3` でパレットの薄赤と統一

### 残作業 (別タスク)
- `doc/PORTFOLIO_COLOR_RULES.md` の凡例・29ルール表を新意味体系に合わせて更新

## Test plan
- [x] `pytest tests/ -m \"not local_db and not live_html\"` 全 1484 件 PASS
- [x] /portfolio をブラウザで開いて目視確認
  - ステージ列: 単色 (2S=濃黄 / 3S=水色 / 4S=青+白文字) と 2 つ併存分割 (2S~3S / 3S~4S / 4S~1S) の表示確認
  - 進捗率乖離列: `<C3>` 赤背景、両該当時の左右分割の表示確認
  - RS線色: 5段階 (#999/#9be29b/#2e7d32/#f4c7c3/#c62828) すべて出現を確認
  - 10WMA乖離率バー: 4段階 (#000/#9be29b/#2e7d32/#f4c7c3) すべて出現を確認