### PR TITLE
[codex] portfolioステータスバッジ変更対応

### DIFF
--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -38,9 +38,67 @@
     border-radius: 3px; font-size: 0.85em; line-height: 1.3;
     white-space: nowrap;
   }
+  .status-badge-button {
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+    margin: 0;
+  }
+  .status-badge-button:hover { filter: brightness(0.95); }
   .status-badge.status-hold  { background: #d4ead4; color: #285028; }
   .status-badge.status-semi  { background: #fdf0c0; color: #856100; }
   .status-badge.status-watch { background: #e2e2e2; color: #555; }
+  .portfolio-modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .portfolio-modal-content {
+    background: #fff;
+    border-radius: 6px;
+    padding: 1em 1.2em;
+    width: min(420px, 90vw);
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  }
+  .portfolio-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.8em;
+    padding-bottom: 0.4em;
+    border-bottom: 1px solid #eee;
+  }
+  .portfolio-modal-close {
+    background: none;
+    border: none;
+    font-size: 1.4em;
+    cursor: pointer;
+    padding: 0 0.3em;
+    line-height: 1;
+    color: #888;
+  }
+  .portfolio-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5em;
+    margin-top: 0.5em;
+  }
+  .portfolio-modal-actions button {
+    margin: 0;
+    padding: 0.4em 1em;
+  }
+  .portfolio-exclude-button {
+    background: #c0392b;
+    color: #fff;
+    border: 1px solid #c0392b;
+  }
+  .portfolio-exclude-button:hover { background: #a93226; border-color: #a93226; }
   /* 一括削除アクションバー */
   #bulk-delete-bar {
     position: sticky; bottom: 0; z-index: 10;
@@ -190,7 +248,21 @@
           style="max-width:10em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
         <a href="/stock/{{ row.code_s }}">{{ macros.stock_name_with_prev(row) }}</a>
       </td>
-      <td><span class="status-badge status-{{ row.status_query }}">{{ row.status_label }}</span></td>
+      <td>
+        {% if fallback_mode %}
+        <span class="status-badge status-{{ row.status_query }}">{{ row.status_label }}</span>
+        {% else %}
+        <button type="button"
+                class="status-badge status-{{ row.status_query }} status-badge-button"
+                data-code="{{ row.code_s }}"
+                data-stock-name="{{ macros.stock_name_with_prev(row)|striptags }}"
+                data-status-label="{{ row.status_label }}"
+                data-status-query="{{ row.status_query }}"
+                data-transitions='{{ row.transitions|tojson|forceescape }}'
+                onclick="openPortfolioModalFromBadge(this)"
+                aria-label="保有ステータスを変更">{{ row.status_label }}</button>
+        {% endif %}
+      </td>
       <td class="gyoutai-themes-cell" data-code="{{ row.code_s }}"
           style="max-width:11em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
         {% set themes = row.memo.gyoutai_themes or [] %}
@@ -286,27 +358,6 @@
             </ul>
             {% endif %}
           </div>
-          <div style="flex:0 0 240px;">
-            <strong style="font-size:0.85em;color:#666;">操作</strong>
-            <div style="display:flex;flex-direction:column;gap:0.5em;margin-top:0.3em;font-size:0.85em;">
-              {% if row.transitions %}
-              <form action="/portfolio/{{ row.code_s }}/transition" method="POST" class="portfolio-transition-form" style="display:flex;flex-direction:column;gap:0.3em;margin:0;">
-                <input type="hidden" name="return_query" value="{{ return_query }}">
-                <label style="font-size:0.85em;color:#666;">ステータス変更</label>
-                <select name="new_status" style="padding:0.3em;font-size:0.85em;margin:0;">
-                  {% for label, value in row.transitions %}
-                  <option value="{{ value }}">{{ label }}</option>
-                  {% endfor %}
-                </select>
-                <input type="date" name="action_date" value="{{ today_jst }}" max="{{ today_jst }}" required
-                       class="portfolio-action-date" style="font-size:0.85em;padding:0.3em;margin:0;">
-                <textarea name="reason" placeholder="理由 (任意)" rows="2" style="font-size:0.85em;padding:0.3em;margin:0;"></textarea>
-                <button type="submit" style="padding:0.3em 0.6em;font-size:0.85em;margin:0;">変更</button>
-              </form>
-              {% endif %}
-              {# 削除はテーブル上部の「削除モード」 (issue #186) で一括処理する #}
-            </div>
-          </div>
         </div>
       </td>
     </tr>
@@ -320,6 +371,42 @@
   <option value="{{ choice }}">
   {% endfor %}
 </datalist>
+
+{% if not fallback_mode %}
+<div id="portfolio-modal" class="portfolio-modal-overlay" style="display:none;" onclick="closePortfolioModalOnOverlay(event)">
+  <div class="portfolio-modal-content" role="dialog" aria-labelledby="portfolio-modal-title">
+    <div class="portfolio-modal-header">
+      <strong id="portfolio-modal-title"></strong>
+      <button type="button" class="portfolio-modal-close" onclick="closePortfolioModal()" aria-label="閉じる">×</button>
+    </div>
+    <form method="POST" id="portfolio-modal-form" class="portfolio-modal-body">
+      <input type="hidden" name="return_query" value="{{ return_query }}">
+      <p style="margin:0 0 0.6em 0;">現在: <strong id="portfolio-modal-current"></strong></p>
+      <div id="portfolio-modal-transition-fields">
+        <label style="display:block;margin-bottom:0.6em;">
+          変更先:
+          <select name="new_status" required id="portfolio-modal-new-status" style="margin-left:0.4em;"></select>
+        </label>
+        <label style="display:block;margin-bottom:0.6em;">
+          アクション日付:
+          <input type="date" name="action_date" value="{{ today_jst }}" max="{{ today_jst }}" required
+                 class="portfolio-action-date" style="margin-left:0.4em;">
+        </label>
+        <label style="display:block;margin-bottom:0.6em;">
+          理由 (任意):
+          <textarea name="reason" rows="2" style="width:100%;margin-top:0.2em;" placeholder="例: 業績下振れ"></textarea>
+        </label>
+      </div>
+      <p id="portfolio-modal-no-transition" style="display:none;color:#888;">許可された遷移先がありません。</p>
+      <div class="portfolio-modal-actions">
+        <button type="button" class="secondary" onclick="closePortfolioModal()">キャンセル</button>
+        <button type="submit" id="portfolio-modal-submit">変更する</button>
+        <button type="button" class="portfolio-exclude-button" id="portfolio-modal-exclude">ユニバースから除外</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endif %}
 
 <style>
 .gyoutai-themes-cell { vertical-align: middle; }
@@ -356,6 +443,83 @@ document.querySelectorAll('table details').forEach(function(d) {
     if (summary) summary.textContent = d.open ? '▾' : '▸';
   });
 });
+
+{% if not fallback_mode %}
+// ========== 保有状態モーダル ==========
+function openPortfolioModalFromBadge(btn) {
+  var modal = document.getElementById('portfolio-modal');
+  if (!modal) return;
+  var code = btn.dataset.code || '';
+  var stockName = btn.dataset.stockName || '';
+  var statusLabel = btn.dataset.statusLabel || '';
+  var statusQuery = btn.dataset.statusQuery || '';
+  var transitions = [];
+  try {
+    transitions = JSON.parse(btn.dataset.transitions || '[]');
+  } catch (e) {
+    transitions = [];
+  }
+
+  document.getElementById('portfolio-modal-title').textContent = code + (stockName ? ' ' + stockName : '');
+  document.getElementById('portfolio-modal-current').textContent = statusLabel;
+
+  var form = document.getElementById('portfolio-modal-form');
+  form.action = '/portfolio/' + encodeURIComponent(code) + '/transition';
+  form.dataset.code = code;
+
+  var select = document.getElementById('portfolio-modal-new-status');
+  select.innerHTML = '';
+  transitions.forEach(function(pair) {
+    var opt = document.createElement('option');
+    opt.value = pair[1];
+    opt.textContent = pair[0];
+    select.appendChild(opt);
+  });
+
+  var hasTransitions = transitions.length > 0;
+  document.getElementById('portfolio-modal-transition-fields').style.display = hasTransitions ? '' : 'none';
+  document.getElementById('portfolio-modal-no-transition').style.display = hasTransitions ? 'none' : '';
+  document.getElementById('portfolio-modal-submit').style.display = hasTransitions ? '' : 'none';
+
+  var excludeBtn = document.getElementById('portfolio-modal-exclude');
+  excludeBtn.style.display = (statusQuery === 'semi' || statusQuery === 'watch') ? '' : 'none';
+  excludeBtn.onclick = function() { excludeFromUniverse(code); };
+
+  modal.style.display = 'flex';
+}
+function closePortfolioModal() {
+  var modal = document.getElementById('portfolio-modal');
+  if (modal) modal.style.display = 'none';
+}
+function closePortfolioModalOnOverlay(e) {
+  if (e.target.id === 'portfolio-modal') closePortfolioModal();
+}
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'Escape') closePortfolioModal();
+});
+
+function excludeFromUniverse(codeS) {
+  if (!confirm('ユニバースから除外しますか？')) return;
+  var modal = document.getElementById('portfolio-modal');
+  var reasonEl = modal ? modal.querySelector('textarea[name="reason"]') : null;
+  var reason = reasonEl ? reasonEl.value : '';
+  var form = document.createElement('form');
+  form.method = 'POST';
+  form.action = '/portfolio/bulk-exclude';
+  function addHidden(name, value) {
+    var inp = document.createElement('input');
+    inp.type = 'hidden';
+    inp.name = name;
+    inp.value = value;
+    form.appendChild(inp);
+  }
+  addHidden('codes', codeS);
+  addHidden('reason', reason);
+  addHidden('return_query', {{ return_query | tojson }});
+  document.body.appendChild(form);
+  form.submit();
+}
+{% endif %}
 
 // ========== inline 編集 (issue #177) ==========
 // .editable セルをクリック → input/textarea に置換 → blur で fetch POST → DOM 書き戻し
@@ -743,7 +907,7 @@ document.querySelectorAll('table details').forEach(function(d) {
 // クライアント端末の TZ が JST 以外でも基準ズレが起きないよう、サーバから注入された
 // today_jst (= max 属性の値) と直接文字列比較する。
 (function() {
-  document.querySelectorAll('form.portfolio-transition-form').forEach(function(form) {
+  document.querySelectorAll('#portfolio-modal-form').forEach(function(form) {
     form.addEventListener('submit', function(e) {
       var inp = form.querySelector('input.portfolio-action-date');
       if (!inp || !inp.value) return;

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -957,9 +957,27 @@ class TestDashboardFilter:
         """全件表示時 (?status=)、ステータス badge (保有/準保有/監視) が HTML に出る"""
         resp = client.get("/portfolio?status=")
         html = resp.data.decode()
-        assert 'class="status-badge status-hold"' in html
-        assert 'class="status-badge status-semi"' in html
-        assert 'class="status-badge status-watch"' in html
+        assert "status-badge status-hold status-badge-button" in html
+        assert "status-badge status-semi status-badge-button" in html
+        assert "status-badge status-watch status-badge-button" in html
+
+    def test_status_badge_opens_transition_modal(self, client):
+        """通常モードでは状態バッジクリックで detail と同仕様の遷移モーダルを使う"""
+        resp = client.get("/portfolio?status=")
+        html = resp.data.decode()
+        assert "openPortfolioModalFromBadge(this)" in html
+        assert 'id="portfolio-modal"' in html
+        assert 'id="portfolio-modal-new-status"' in html
+        assert 'name="action_date"' in html
+        assert 'name="reason"' in html
+        assert "ユニバースから除外" in html
+
+    def test_expanded_row_no_longer_has_transition_form(self, client):
+        """折りたたみ展開内の操作セクションからステータス変更フォームをなくす"""
+        resp = client.get("/portfolio?status=")
+        html = resp.data.decode()
+        assert "portfolio-transition-form" not in html
+        assert ">変更<" not in html
 
     def test_gyoutai_theme_filter_applies(
         self, client, portfolio_db_path


### PR DESCRIPTION
## 概要
- portfolio ダッシュボードのステータスバッジをクリック可能にし、detail ページと同様のステータス変更モーダルを開くようにしました。
- 折りたたみ展開内の操作セクションからステータス変更フォームと変更ボタンを削除しました。
- dashboard 側の新 UI と旧フォーム削除をテストで確認しています。

## 影響
- portfolio 一覧から、状態バッジクリックで変更先・アクション日付・理由を入力してステータス変更できます。
- 2準/3監 ではモーダルからユニバース除外も可能です。
- fallback モードでは従来通り書き込み UI は出しません。

## 検証
- `/Users/k_sohara/Library/CloudStorage/Dropbox/document/shintakane/.venv/bin/python -m pytest tests/test_webapp_portfolio_routes.py -q`
- 結果: `84 passed, 1 warning`