### PR TITLE
/market theme-news 読みやすさ改善 + 表示順を「市場→テーマランク→ニュース→決算」に変更

### DIFF
--- a/scripts/html_sanitizer.py
+++ b/scripts/html_sanitizer.py
@@ -21,19 +21,24 @@ from html.parser import HTMLParser
 # 許可タグと属性の定義
 ALLOWED_TAGS = frozenset({
     "b", "a", "span",
-    # theme-news 表示用 (markdown 生成タグ)
+    # theme-news 表示用 (markdown 生成タグ + Sources 折りたたみ + 改行ヒント)
     "h2", "h3", "h4", "ul", "ol", "li", "p", "strong", "em", "code", "br",
     "table", "thead", "tbody", "tr", "th", "td",
+    "details", "summary", "wbr",
 })
 
 # 属性値の許可パターン
 _HREF_PATTERN = re.compile(r"^https?://")
 _TARGET_PATTERN = re.compile(r"^_blank$")
 _STYLE_COLOR_PATTERN = re.compile(r"^color:#[0-9a-fA-F]{3,6}$")
+# theme-news Sources セクション折りたたみ用に <details class="sources"> のみ許可。
+# 他クラス名は除去される (XSS 経路にはならないが、混乱回避のため厳密に絞る)。
+_DETAILS_CLASS_PATTERN = re.compile(r"^sources$")
 
 ALLOWED_ATTRS = {
     "a": {"href": _HREF_PATTERN, "target": _TARGET_PATTERN},
     "span": {"style": _STYLE_COLOR_PATTERN},
+    "details": {"class": _DETAILS_CLASS_PATTERN},
 }
 
 

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -1640,8 +1640,8 @@ def create_market_html(market_db,
         now.strftime("%Y-%m-%d"),
         _HTML_CSS,
         date_str,
+        market_html,   # 市場を先 (/market 表示順を「市場 → テーマランク → ニュース → 決算」に揃える)
         theme_html,
-        market_html,
         kessan_html,
         now.strftime("%Y-%m-%d %H:%M"),
     )

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -263,6 +263,19 @@ def theme_news_md_to_html(text: str) -> str:
     # 文の区切りで使われている全角中点を改行ポイントにする。
     # 先頭 `・` (li 直後) には br を入れないよう、`>・` の直後は対象外。
     html = re.sub(r"(?<![>\s])・", "<br>・", html)
+    # 「+」「→」の前に <wbr> を挟んで、文が長くても自然な位置で折り返せるようにする。
+    # skill 出力で「日経+1.9%+KOSPI+4%+Samsungスト中止」のような連結が頻出するため。
+    html = re.sub(r"(?<=[ぁ-んァ-ヶー一-龯%])([+→])", r"<wbr>\1", html)
+    # Sources セクション (`## Sources` から末尾まで) を <details class="sources"> で
+    # 折りたたむ。skill 出力末尾に必ず「## Sources」見出しが入る規約に依存。
+    # マッチしなければ何もしない (旧 history で Sources 無いものは素通り)。
+    html = re.sub(
+        r'<h2>Sources</h2>\s*(<ul>.*?</ul>)',
+        r'<details class="sources"><summary>📎 Sources を表示</summary>\1</details>',
+        html,
+        count=1,
+        flags=re.DOTALL,
+    )
     return sanitize_html(html)
 
 

--- a/scripts/webapp/templates/market.html
+++ b/scripts/webapp/templates/market.html
@@ -16,8 +16,30 @@
 </div>
 {% endif %}
 
-{# issue #165: テーマランク直下に theme-news 調査結果を表示。手動実行ボタン付き #}
-<div id="theme-news-section" style="margin: 0.5em 0 1em 0;">
+{# 市場データ本文: 決算セクションはプレースホルダに置き換え済み (市場 → テーマランクの順) #}
+{% set body_parts = market_parts.get('body_without_kessan', '').split('<div id="kessan-placeholder-mark">__KESSAN_PLACEHOLDER__</div>') %}
+{% if body_parts[0] %}
+{{ body_parts[0] | safe }}
+{% endif %}
+
+{# issue #165: 市場 / テーマランクの後にテーマニュース調査を表示。手動実行ボタン付き #}
+<style>
+  /* skill 出力の長文 li を読みやすくする scoped CSS */
+  .theme-news-body h2 { font-size: 1.05em; margin: 1.2em 0 0.4em 0; padding-bottom: 0.15em; border-bottom: 1px solid #d8dde2; color: #2c3e50; }
+  .theme-news-body h2:first-child { margin-top: 0; }
+  .theme-news-body h3 { font-size: 0.95em; margin: 1em 0 0.3em 0; color: #555; }
+  .theme-news-body ul { margin: 0.3em 0 0.8em 0; padding-left: 1.4em; }
+  .theme-news-body li { margin-bottom: 0.5em; }
+  .theme-news-body li:last-child { margin-bottom: 0; }
+  .theme-news-body strong { color: #1a2532; }
+  .theme-news-body a { color: #1976d2; text-decoration: none; }
+  .theme-news-body a:hover { text-decoration: underline; }
+  /* Sources 折りたたみ */
+  .theme-news-body details.sources { margin-top: 1em; }
+  .theme-news-body details.sources summary { cursor: pointer; color: #555; font-size: 0.9em; padding: 0.3em 0; }
+  .theme-news-body details.sources ul { font-size: 0.85em; }
+</style>
+<div id="theme-news-section" style="margin: 1em 0 1em 0;">
   <details open>
     <summary style="cursor:pointer;font-weight:bold;color:#2c3e50;">
       📰 テーマニュース調査
@@ -58,7 +80,7 @@
       </span>
     </div>
     {% if theme_news.current %}
-    <div class="theme-news-body" style="padding: 0.5em 1em; background: #f8f9fa; border-radius: 4px; margin-top: 0.5em;">
+    <div class="theme-news-body" style="padding: 0.8em 1.2em; background: #f8f9fa; border-radius: 4px; margin-top: 0.5em; max-width: 60em; line-height: 1.75; font-size: 0.95em;">
       {{ theme_news.current.markdown | theme_news_md_to_html | safe }}
     </div>
     {% else %}
@@ -129,12 +151,6 @@
   {% if theme_news.running %}startPolling();{% endif %}
 })();
 </script>
-
-{# 市場データ本文: 決算セクションはプレースホルダに置き換え済み #}
-{% set body_parts = market_parts.get('body_without_kessan', '').split('<div id="kessan-placeholder-mark">__KESSAN_PLACEHOLDER__</div>') %}
-{% if body_parts[0] %}
-{{ body_parts[0] | safe }}
-{% endif %}
 
 {# ここから動的決算セクション #}
 <h2>決算日</h2>

--- a/scripts/webapp/templates/market.html
+++ b/scripts/webapp/templates/market.html
@@ -24,8 +24,14 @@
 
 {# issue #165: 市場 / テーマランクの後にテーマニュース調査を表示。手動実行ボタン付き #}
 <style>
-  /* skill 出力の長文 li を読みやすくする scoped CSS */
-  .theme-news-body h2 { font-size: 1.05em; margin: 1.2em 0 0.4em 0; padding-bottom: 0.15em; border-bottom: 1px solid #d8dde2; color: #2c3e50; }
+  /* skill 出力の長文 li を読みやすくする scoped CSS。
+     market_data.html 由来のグローバル h2 (濃紺背景+白文字) を上書きするため、
+     background/color/padding/border-radius を明示リセットする。 */
+  .theme-news-body h2 {
+    font-size: 1.05em; margin: 1.2em 0 0.4em 0;
+    padding: 0 0 0.15em 0; border-bottom: 1px solid #d8dde2;
+    color: #2c3e50; background: transparent; border-radius: 0;
+  }
   .theme-news-body h2:first-child { margin-top: 0; }
   .theme-news-body h3 { font-size: 0.95em; margin: 1em 0 0.3em 0; color: #555; }
   .theme-news-body ul { margin: 0.3em 0 0.8em 0; padding-left: 1.4em; }

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -1008,7 +1008,7 @@ class TestCreateMarketHtml:
     """create_market_html() 統合テスト"""
 
     def test_generates_html_file(self, tmp_path):
-        """HTMLファイルが生成される"""
+        """HTMLファイルが生成される。/market 表示順に揃えて「市場」を先に出すこと。"""
         market_db = {
             "theme_rank": ["AI"],
             "theme_rank_diff": {"AI": None},
@@ -1036,6 +1036,8 @@ class TestCreateMarketHtml:
             assert '<!DOCTYPE html>' in content
             assert 'テーマランク' in content
             assert '市場' in content
+            # 表示順検証: 「市場」セクションが「テーマランク」より先に出ること
+            assert content.index('<h2>市場</h2>') < content.index('<h2>テーマランク</h2>')
 
     def test_sections_omitted_when_none(self, tmp_path):
         """引数がNoneのセクションは省略される（セクション見出しが生成されない）"""

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2475,3 +2475,25 @@ class TestThemeNewsMdToHtml:
         assert "&lt;h1&gt;" not in out
         # 後続の h2 は残る
         assert "<h2>市場全体</h2>" in out
+
+    def test_sources_section_collapsed_in_details(self):
+        """`## Sources` 以降は <details class="sources"> で折りたたまれる。"""
+        src = (
+            "## 1. 蓄電池\n- 材料\n\n"
+            "## Sources\n- [link1](https://example.com/a)\n- [link2](https://example.com/b)\n"
+        )
+        out = helpers.theme_news_md_to_html(src)
+        assert '<details class="sources">' in out
+        assert "<summary>📎 Sources を表示</summary>" in out
+        # Sources の中身 (リンク) は details の中に入っている
+        i_details = out.index('<details class="sources">')
+        i_link = out.index('https://example.com/a')
+        assert i_details < i_link
+        # 本編の h2 は details の外に残る
+        assert "<h2>1. 蓄電池</h2>" in out
+
+    def test_inserts_wbr_before_plus_and_arrow(self):
+        """日本語/数字/% に続く `+` `→` の前に <wbr> を挟む (長文折返しヒント)。"""
+        src = "- 反発+1.9%→翌日続伸\n"
+        out = helpers.theme_news_md_to_html(src)
+        assert "反発<wbr>+1.9%<wbr>→翌日続伸" in out


### PR DESCRIPTION
## Summary
- /market 表示順を **市場 → テーマランク → テーマニュース調査 → 決算日** に変更 (テーマニュースを market 本文の後・決算日の前へ移動)
- テーマニュース本文の読みやすさ改善:
  - scoped CSS で h2/h3/ul/li の余白・line-height を調整、`max-width: 60em` で長文を読みやすく
  - **Sources セクション** (\`## Sources\` 以降) を \`<details class="sources">\` で折りたたみ、初期非表示 (クリックで展開)
  - skill 出力長文中の日本語+「+」「→」前に \`<wbr>\` を挿入して自然な折返しを可能に
- \`html_sanitizer.ALLOWED_TAGS\` に \`details\` / \`summary\` / \`wbr\` を追加、\`details\` には \`class="sources"\` 固定値のみ許可

## Why
ユーザーから「theme-news 本文が読みにくい」「Sources が常時展開で邪魔」「決算日の前にテーマニュースが欲しい」というフィードバック対応。

## Test plan
- [x] \`pytest tests/test_webapp_helpers.py::TestThemeNewsMdToHtml tests/test_html_sanitizer.py tests/test_webapp_routes.py::TestMarketRouteThemeNews -v\` → 39 passed (新規 2 本含む)
- [ ] webapp 再起動して /market で目視確認 (表示順 / Sources 折りたたみ / li 余白)