### PR TITLE
市場ステート遷移の FTD/ラリー判定を復活

### DIFF
--- a/scripts/market_state.py
+++ b/scripts/market_state.py
@@ -271,6 +271,12 @@ def derive_state(prev_state, valid_dd_count, ftd_today, below_10ma=False):
 def append_state_history(history, today_date, new_state, trigger):
     """state_history に1件追加。直近 STATE_HISTORY_MAX 件のみ保持。
 
+    1日に複数回呼ばれる場合 (cron + 手動再実行など) の保護:
+      - 既存と new_state が同じで、既存 trigger が遷移系 (= "stay"/"init" 以外) なら、
+        既存エントリの trigger を保持して上書きしない。新規 trigger が "stay" でも
+        元の遷移情報 (例: "dd>=4") が失われないようにする
+      - state が異なる場合は新規 entry で置換 (= 同日内の遷移を反映)
+
     Args:
         history: 既存の履歴 [(date, state, trigger), ...] (新しいが先頭)
         today_date: str
@@ -282,7 +288,14 @@ def append_state_history(history, today_date, new_state, trigger):
     """
     if not isinstance(history, list):
         history = []
-    # 同じ日の既存エントリは置き換え (1日複数回計算される場合)
+    # 同日エントリを探す
+    existing = next((h for h in history if h[0] == today_date), None)
+    if existing is not None:
+        existing_state, existing_trigger = existing[1], existing[2]
+        # 同日かつ state 同じで、既存が遷移系 trigger なら trigger を保持
+        if existing_state == new_state and existing_trigger not in ("stay", "init"):
+            trigger = existing_trigger
+    # 既存エントリを除外して先頭に追加
     history = [h for h in history if h[0] != today_date]
     history.insert(0, (today_date, new_state, trigger))
     return history[:STATE_HISTORY_MAX]

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -495,6 +495,19 @@ def _calc_daily_indicators(daily_price_list):
     dic["followthrough_days"] = followthrough_day
     # daily_history (新しい日が先頭) を State Machine の DD 失効判定で使う
     dic["daily_history"] = [d[0] for d in daily_price_list[:count_day + 1]]
+    # 当日 OHLV をトップレベルキーに詰める。make_market_db._update_index_market_state
+    # が new_index_db["price"|"low"|"high"|"volume"] を参照して FTD/ラリー判定を行うため、
+    # kabutan/yfinance 両系統で確実にセットしておく (issue: state遷移FTD不動作)。
+    # daily_price_list[0] = 当日 (新しい順、8要素タプル「日付,始値,高値,安値,終値,前日比,前日比%,売買高」)。
+    try:
+        head = daily_price_list[0]
+        dic["price"] = int(float(head[4].replace(",", "")))   # 終値
+        dic["low"] = int(float(head[3].replace(",", "")))
+        dic["high"] = int(float(head[2].replace(",", "")))
+        dic["volume"] = int(float(head[7].replace(",", "")))
+    except (ValueError, IndexError, AttributeError, TypeError):
+        # raw データが想定外なら明示的に None を残す (state machine 側が安全に短絡する)
+        pass
     log_debug("ディストリビューション:", distribution_day)
     log_debug("フォロースルー候補:", followthrough_day)
 

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -1004,6 +1004,88 @@ class TestHtmlDisclosure:
         assert 'disc-row-gyoseki' in result
 
 
+class TestUpdateIndexMarketStateFTD:
+    """_update_index_market_state の FTD 判定統合テスト。
+
+    issue (state遷移FTD不動作): _calc_daily_indicators が
+    new_index_db["price"|"low"|"volume"] を返さなかったため、ラリー追跡が一度も
+    起動せず FTD が成立しないバグの回帰防止。
+    """
+
+    def _build_meta(self, prev_state, rally_start_date=None, rally_start_low=None,
+                    prev_volume=0, dd_list=None):
+        return {
+            "rally_attempt_start_date": rally_start_date,
+            "rally_attempt_start_low": rally_start_low,
+            "distribution_days_with_close": dd_list or [],
+            "last_ftd_date": None,
+            "prev_volume": prev_volume,
+        }
+
+    def test_rally_day1_starts_when_correction_and_close_up(self):
+        """前日 correction + 当日終値 > 前日終値 で rally Day 1 が確定する。
+
+        当日 OHLV (price/low/volume) が new_index_db に詰まっていることが前提。
+        欠落するとラリー追跡が永遠に起動しない (本タスクの主バグ)。
+        """
+        import market_state
+        prev_index_db = {
+            "market_state": market_state.MARKET_IN_CORRECTION,
+            "state_meta": self._build_meta(market_state.MARKET_IN_CORRECTION,
+                                            prev_volume=1000),
+            "state_history": [("26/05/20", market_state.MARKET_IN_CORRECTION, "dd>=6")],
+        }
+        # 当日: 大幅反発、出来高増、low/high あり
+        new_index_db = {
+            "price": 61684,
+            "low": 60282,
+            "high": 62043,
+            "volume": 2504900,
+            "daily_history": ["26/05/21", "26/05/20", "26/05/19"],
+            "distribution_days_with_close": [],
+            "price_log": [
+                (datetime(2026, 5, 21).date(), 61684),
+                (datetime(2026, 5, 20).date(), 59804),
+            ],
+            "price_kairi_wma10": -2.0,
+        }
+        make_market_db._update_index_market_state(prev_index_db, new_index_db)
+        sm = new_index_db["state_meta"]
+        assert sm["rally_attempt_start_date"] == "26/05/21", (
+            f"ラリー Day 1 が記録されていない: {sm}"
+        )
+        assert sm["rally_attempt_start_low"] == 60282
+        # まだ Day 1 なので FTD は成立しない (Day 4 以降が条件)
+        assert sm["last_ftd_date"] is None
+        assert new_index_db["market_state"] == market_state.MARKET_IN_CORRECTION
+
+    def test_no_rally_when_close_not_up(self):
+        """前日 correction でも当日終値が前日以下ならラリー Day 1 にならない。"""
+        import market_state
+        prev_index_db = {
+            "market_state": market_state.MARKET_IN_CORRECTION,
+            "state_meta": self._build_meta(market_state.MARKET_IN_CORRECTION,
+                                            prev_volume=1000),
+            "state_history": [],
+        }
+        new_index_db = {
+            "price": 59500,  # 前日 59804 より下
+            "low": 59000,
+            "high": 60000,
+            "volume": 2000000,
+            "daily_history": ["26/05/21", "26/05/20"],
+            "distribution_days_with_close": [],
+            "price_log": [
+                (datetime(2026, 5, 21).date(), 59500),
+                (datetime(2026, 5, 20).date(), 59804),
+            ],
+            "price_kairi_wma10": -3.0,
+        }
+        make_market_db._update_index_market_state(prev_index_db, new_index_db)
+        sm = new_index_db["state_meta"]
+        assert sm["rally_attempt_start_date"] is None
+
+
 class TestCreateMarketHtml:
     """create_market_html() 統合テスト"""
 

--- a/tests/test_market_state.py
+++ b/tests/test_market_state.py
@@ -405,6 +405,25 @@ class TestAppendStateHistory:
         h = ms.append_state_history(None, "26/04/30", ms.CONFIRMED_UPTREND, "init")
         assert h == [("26/04/30", ms.CONFIRMED_UPTREND, "init")]
 
+    def test_preserves_transition_trigger_on_same_day_stay_overwrite(self):
+        """同日 2 回呼ばれた時、後から "stay" で上書きすると遷移系 trigger が失われる
+        バグへの回帰防止。state が同じで既存が遷移系なら trigger を保持する。
+
+        シナリオ: 当日 cron で under_pressure → confirmed_uptrend に遷移して "dd<4_recover"
+        が記録される。同日に make_market_db が再実行されると、prev_state が既に
+        confirmed になっているため derive_state は "stay" を返すが、append_state_history
+        はそれを無視して既存 "dd<4_recover" を維持する。
+        """
+        h = [("26/05/14", ms.CONFIRMED_UPTREND, "dd<4_recover")]
+        h2 = ms.append_state_history(h, "26/05/14", ms.CONFIRMED_UPTREND, "stay")
+        assert h2[0] == ("26/05/14", ms.CONFIRMED_UPTREND, "dd<4_recover")
+
+    def test_replaces_when_state_changes_on_same_day(self):
+        """同日でも state が変わった場合は新規 entry で置換 (遷移を記録する)。"""
+        h = [("26/05/14", ms.CONFIRMED_UPTREND, "stay")]
+        h2 = ms.append_state_history(h, "26/05/14", ms.UPTREND_UNDER_PRESSURE, "dd>=4")
+        assert h2[0] == ("26/05/14", ms.UPTREND_UNDER_PRESSURE, "dd>=4")
+
 
 # ==================================================
 # to_direction_signal

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -443,8 +443,27 @@ class TestCalcDailyIndicators:
             "distribution_days", "distribution_days_with_close", "followthrough_days",
             "daily_history", "direction_signal",
             "spr_20", "spr_5", "spr_buygagher", "rv_20", "rv_5",
+            # state machine の FTD/ラリー判定が当日 OHLV をトップレベルキーから読むため必須
+            "price", "low", "high", "volume",
         ):
             assert key in result
+
+    def test_top_level_ohlv_matches_latest_row(self):
+        """当日 OHLV (price/low/high/volume) が daily_price_list[0] と一致する。
+
+        make_market_db._update_index_market_state が new_index_db["price"|"low"|
+        "high"|"volume"] を参照して FTD/ラリー判定を行うため、ここで欠落すると
+        state machine の上方向遷移 (correction → confirmed) が常時不発になる。
+        """
+        rows = self._make_price_list(25)
+        result = price._calc_daily_indicators(rows)
+        # daily_price_list[0] = 当日 (新しい順) なので最後に追加された n=24 のデータ
+        # _make_price_list で reverse 済なので rows[0] が最新 (=close 1120)
+        head = rows[0]
+        assert result["price"] == int(head[4].replace(",", ""))
+        assert result["low"] == int(head[3].replace(",", ""))
+        assert result["high"] == int(head[2].replace(",", ""))
+        assert result["volume"] == int(head[7].replace(",", ""))
 
     def test_empty_input_returns_empty(self):
         result = price._calc_daily_indicators([])


### PR DESCRIPTION
## Summary
過去ずっと **FTD (Follow-Through Day) が成立せず、market_in_correction から confirmed_uptrend への上方向遷移が機能していなかった** ことが判明したので修正。

### 主バグ: 当日 OHLV がトップレベル key に詰められていない
\`_calc_daily_indicators\` は SPR/RV/DD候補などの計算結果のみ返し、当日の \`price\` / \`low\` / \`high\` / \`volume\` をトップレベル key として詰めていなかった。

しかし \`make_market_db._update_index_market_state\` は \`new_index_db["price"|"low"|"volume"]\` から読む実装だったため、

- kabutan 経路 (TOPIX/Nikkei/Mothers): すべて None → 0
- yfinance 経路 (NASDAQ/SP500): \`price\` のみ別途詰めていたが \`low/high/volume\` は欠落

結果:
- ラリー Day 1 確定の \`today.close > prev.close\` が常時 \`0 > prev\` で False
- FTD 出来高増チェック \`today.volume > prev.volume\` が常時 \`0 > 0\` で False
- → **ラリー追跡が一度も起動せず、過去全ての指数で \`last_ftd_date: None\`**
- → 一度 correction に入ると、FTD で復帰できないので **片道切符** で居座る

### 副次バグ: trigger='stay' 上書き問題
同日に \`make_market_db\` が複数回呼ばれると、最初の処理で記録した遷移系 trigger (例 \`"dd>=4"\`) を後続呼び出しの \`"stay"\` が上書き → state_history から「いつどの理由で遷移したか」の情報が失われていた。

### トレンド/需給バランス列への影響
- **trend_template**: 週足 raw を直接読むので影響なし ✅
- **spr_*/rv_***: 日足 raw を直接読むので影響なし ✅
- **price_kairi_wma10**: 週足計算で独立にセット ✅
- 影響を受けるのは **state machine 経由の FTD/ラリー判定のみ**

## Changes
- \`scripts/price.py:_calc_daily_indicators\`: 当日 OHLV を \`dic["price"|"low"|"high"|"volume"]\` に詰める (kabutan/yfinance 両系統で共通効果)
- \`scripts/market_state.py:append_state_history\`: 同日 state 同一かつ既存 trigger が遷移系なら保持
- テスト追加 3 本

## 移行注意
本修正後の初回 cron では \`prev_volume\` がまだ state_meta に 0 として残るため、FTD 出来高チェックは短絡される。**次々回 cron** (2 営業日後) から完全に正常動作する想定。過去 DB の遡及修復は行わない (今後の動作で前向きに修復される)。

## Test plan
- [x] \`pytest tests/test_price.py tests/test_market_state.py tests/test_make_market_db.py\` → 301 passed