### PR TITLE
決算日セクションを /market から /disclosure に移設 + タブ名「決算・開示」へ (#213)

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -467,11 +467,9 @@ def get_market_html_parts() -> Dict[str, str]:
       - "available": bool 相当の "1" or "" （ファイル存在判定）
       - "css": <style> タグの中身
       - "header": <h1> の HTML
-      - "body_without_kessan": <body> 内のコンテンツのうち、
-         <h2>決算日</h2> 以下のブロック（次の <h2> 直前まで、または
-         <details><summary>▶ 済の決算を表示...</summary> 含む）を除去したもの。
-         <h1> は除外し、決算セクションのあった位置にプレースホルダ
-         "<!--KESSAN_PLACEHOLDER-->" を挿入。
+      - "body": <body> 内のコンテンツのうち、<h2>決算日</h2> 以下のブロック
+         （次の <h2> 直前まで）を除去したもの。<h1>/footer も除外。
+         issue #213: 決算日セクションは /disclosure に移設したため、市場ページでは抑制する。
       - "footer": <footer> タグ
 
     ファイル未存在時は {"available": ""} を返す。
@@ -533,10 +531,6 @@ def get_market_html_parts() -> Dict[str, str]:
                     break
             to_remove.append(sibling)
             sibling = next_sib
-        # プレースホルダを h2決算日 の位置に挿入
-        placeholder = soup.new_tag("div", id="kessan-placeholder-mark")
-        placeholder.string = "__KESSAN_PLACEHOLDER__"
-        kessan_h2.insert_before(placeholder)
         for el in to_remove:
             el.extract()
 
@@ -556,7 +550,7 @@ def get_market_html_parts() -> Dict[str, str]:
         "available": "1",
         "css": css or "",
         "header": header_html,
-        "body_without_kessan": body_html,
+        "body": body_html,
         "footer": footer_html,
     }
 

--- a/scripts/webapp/routes/disclosure.py
+++ b/scripts/webapp/routes/disclosure.py
@@ -1,19 +1,100 @@
 """
-適宜開示ページ ルート。
+決算・開示ページ ルート。
 
-GET /disclosure : 適宜開示ページ (disclosure_data.html を取り込み表示)
+GET  /disclosure                     : 決算日カード + 適宜開示 (disclosure_data.html) ページ
+GET  /api/kessan_comment/<code_s>    : 指定銘柄・決算日のコメントを JSON で返す
+POST /api/kessan_comment/<code_s>    : 決算コメントを保存 (新規 or 上書き)
 """
 
-from flask import Blueprint, render_template
+from typing import Any, Dict
 
-from webapp.helpers import get_disclosure_html_parts
+from flask import Blueprint, jsonify, render_template, request
+
+from webapp.helpers import (
+    get_disclosure_html_parts,
+    get_kessan_comment,
+    get_market_kessan_data,
+    save_kessan_comment,
+)
+from research_shelve import (
+    KESSAN_REACTION_PERIODS,
+    VALID_EXPECTATIONS,
+    normalize_kessan_post_price_changes,
+)
 
 
 disclosure_bp = Blueprint("disclosure", __name__)
 
 
+# API レスポンスに含める決算コメントエントリのキー集合
+# 旧 post_price_change は API 契約上含めない（_serialize_kessan_entry_for_api で除外）
+_API_ENTRY_KEYS = (
+    "kessanbi",
+    "quarter",
+    "pre_expectation",
+    "pre_outlook",
+    "post_comment",
+    "kessan_matagi",
+    "held_before_kessan",
+    "held_after_kessan",
+)
+
+
+def _serialize_kessan_entry_for_api(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """決算コメントエントリを API 用に整形する。
+
+    新スキーマ (post_price_changes) のみを返し、旧 post_price_change キーは含めない。
+    旧形式のみのデータを受け取った場合は post_price_changes に正規化して返す。
+    """
+    result: Dict[str, Any] = {}
+    for key in _API_ENTRY_KEYS:
+        if key in entry:
+            result[key] = entry[key]
+    result["post_price_changes"] = normalize_kessan_post_price_changes(entry)
+    return result
+
+
 @disclosure_bp.route("/disclosure", methods=["GET"])
 def disclosure_page():
-    """適宜開示ページ。静的 disclosure_data.html を取り込んで表示する。"""
+    """決算・開示ページ。決算日カード + 静的 disclosure_data.html を取り込んで表示する。"""
     disclosure_parts = get_disclosure_html_parts()
-    return render_template("disclosure.html", disclosure_parts=disclosure_parts)
+    kessan_data = get_market_kessan_data()
+    expectation_options = sorted(VALID_EXPECTATIONS, key=lambda x: ("", "◎", "○", "▲", "△", "×").index(x))
+    return render_template(
+        "disclosure.html",
+        disclosure_parts=disclosure_parts,
+        kessan_data=kessan_data,
+        expectation_options=expectation_options,
+    )
+
+
+@disclosure_bp.route("/api/kessan_comment/<code_s>", methods=["GET"])
+def get_kessan_comment_api(code_s: str):
+    """指定銘柄・決算日のコメントを JSON で返す。未登録時は空エントリ。"""
+    kessanbi = request.args.get("kessanbi", "").strip()
+    if not kessanbi:
+        return jsonify({"error": "kessanbi required"}), 400
+    entry = get_kessan_comment(code_s, kessanbi)
+    if entry is None:
+        entry = {
+            "kessanbi": kessanbi,
+            "quarter": 0,
+            "pre_expectation": "",
+            "pre_outlook": "",
+            "post_price_changes": {key: "" for key, _ in KESSAN_REACTION_PERIODS},
+            "post_comment": "",
+            "kessan_matagi": False,
+        }
+        return jsonify(entry)
+    return jsonify(_serialize_kessan_entry_for_api(entry))
+
+
+@disclosure_bp.route("/api/kessan_comment/<code_s>", methods=["POST"])
+def post_kessan_comment_api(code_s: str):
+    """決算コメントを保存。成功時は保存後エントリを返す。"""
+    form = request.form if request.form else (request.get_json(silent=True) or {})
+    try:
+        entry = save_kessan_comment(code_s, form)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    return jsonify(_serialize_kessan_entry_for_api(entry))

--- a/scripts/webapp/routes/market.py
+++ b/scripts/webapp/routes/market.py
@@ -1,9 +1,7 @@
 """
-市場データ・決算カレンダー ルート。
+市場データ ルート。
 
-GET  /market                         : 市場データページ (market_data.html を取り込み + 動的決算セクション)
-GET  /api/kessan_comment/<code_s>    : 指定銘柄・決算日のコメントを JSON で返す
-POST /api/kessan_comment/<code_s>    : 決算コメントを保存 (新規 or 上書き)
+GET  /market                         : 市場データページ (market_data.html を取り込み + テーマニュース)
 POST /market/theme_news/run          : theme-news skill を非同期起動 (issue #165)
 GET  /market/theme_news/status       : theme-news 実行状況を JSON で返す (issue #165)
 """
@@ -15,20 +13,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from flask import Blueprint, jsonify, render_template, request
+from flask import Blueprint, jsonify, render_template
 
 from ks_util import get_price_day, log_print, log_warning
-from webapp.helpers import (
-    get_kessan_comment,
-    get_market_html_parts,
-    get_market_kessan_data,
-    save_kessan_comment,
-)
-from research_shelve import (
-    KESSAN_REACTION_PERIODS,
-    VALID_EXPECTATIONS,
-    normalize_kessan_post_price_changes,
-)
+from webapp.helpers import get_market_html_parts
 
 market_bp = Blueprint("market", __name__)
 
@@ -124,49 +112,16 @@ def _load_theme_news_for_display() -> Dict[str, Any]:
     return {"current": fallback, "is_today": False, "running": running}
 
 
-# API レスポンスに含める決算コメントエントリのキー集合
-# 旧 post_price_change は API 契約上含めない（_serialize_kessan_entry_for_api で除外）
-_API_ENTRY_KEYS = (
-    "kessanbi",
-    "quarter",
-    "pre_expectation",
-    "pre_outlook",
-    "post_comment",
-    "kessan_matagi",
-    "held_before_kessan",
-    "held_after_kessan",
-)
-
-
-def _serialize_kessan_entry_for_api(entry: Dict[str, Any]) -> Dict[str, Any]:
-    """決算コメントエントリを API 用に整形する。
-
-    新スキーマ (post_price_changes) のみを返し、旧 post_price_change キーは含めない。
-    旧形式のみのデータを受け取った場合は post_price_changes に正規化して返す。
-    """
-    result: Dict[str, Any] = {}
-    for key in _API_ENTRY_KEYS:
-        if key in entry:
-            result[key] = entry[key]
-    result["post_price_changes"] = normalize_kessan_post_price_changes(entry)
-    return result
-
-
 @market_bp.route("/market", methods=["GET"])
 def market_page():
-    """市場データページ。静的 market_data.html を取り込み、決算セクションを動的版に差し替える。"""
+    """市場データページ。静的 market_data.html (決算日セクション除く) と theme-news を表示する。"""
     market_parts = get_market_html_parts()
-    kessan_data = get_market_kessan_data()
     theme_news = _load_theme_news_for_display()
-
-    expectation_options = sorted(VALID_EXPECTATIONS, key=lambda x: ("", "◎", "○", "▲", "△", "×").index(x))
 
     return render_template(
         "market.html",
         market_parts=market_parts,
-        kessan_data=kessan_data,
         theme_news=theme_news,
-        expectation_options=expectation_options,
     )
 
 
@@ -243,33 +198,3 @@ def theme_news_status():
     })
 
 
-@market_bp.route("/api/kessan_comment/<code_s>", methods=["GET"])
-def get_kessan_comment_api(code_s: str):
-    """指定銘柄・決算日のコメントを JSON で返す。未登録時は空エントリ。"""
-    kessanbi = request.args.get("kessanbi", "").strip()
-    if not kessanbi:
-        return jsonify({"error": "kessanbi required"}), 400
-    entry = get_kessan_comment(code_s, kessanbi)
-    if entry is None:
-        entry = {
-            "kessanbi": kessanbi,
-            "quarter": 0,
-            "pre_expectation": "",
-            "pre_outlook": "",
-            "post_price_changes": {key: "" for key, _ in KESSAN_REACTION_PERIODS},
-            "post_comment": "",
-            "kessan_matagi": False,
-        }
-        return jsonify(entry)
-    return jsonify(_serialize_kessan_entry_for_api(entry))
-
-
-@market_bp.route("/api/kessan_comment/<code_s>", methods=["POST"])
-def post_kessan_comment_api(code_s: str):
-    """決算コメントを保存。成功時は保存後エントリを返す。"""
-    form = request.form if request.form else (request.get_json(silent=True) or {})
-    try:
-        entry = save_kessan_comment(code_s, form)
-    except ValueError as e:
-        return jsonify({"error": str(e)}), 400
-    return jsonify(_serialize_kessan_entry_for_api(entry))

--- a/scripts/webapp/templates/base.html
+++ b/scripts/webapp/templates/base.html
@@ -15,7 +15,7 @@
     <li><a href="/" class="brand">Shintakane Research</a></li>
     <li><a href="/market" class="nav-link">市場データ</a></li>
     <li><a href="/portfolio" class="nav-link">保有銘柄</a></li>
-    <li><a href="/disclosure" class="nav-link">適宜開示</a></li>
+    <li><a href="/disclosure" class="nav-link">決算・開示</a></li>
   </ul>
   <ul>
     <li class="quick-search">

--- a/scripts/webapp/templates/disclosure.html
+++ b/scripts/webapp/templates/disclosure.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}適宜開示 - Shintakane Research{% endblock %}
+{% import "_macros.html" as macros %}
+{% block title %}決算・開示 - Shintakane Research{% endblock %}
 {% block content %}
 
 {% if disclosure_parts.available %}
@@ -8,13 +9,155 @@
 {{ disclosure_parts.css | safe }}
 </style>
 {{ disclosure_parts.header | safe }}
-{{ disclosure_parts.body | safe }}
-{{ disclosure_parts.footer | safe }}
 {% else %}
 <div style="padding:12px;margin:12px 0;background:#fef3e6;border:1px solid #f5c37c;border-radius:6px;">
-  適宜開示データ (<code>disclosure_data.html</code>) が未生成です。<br>
-  <small>scripts/make_market_db.py を実行すると生成されます。</small>
+  決算・開示データ (<code>disclosure_data.html</code>) が未生成です。<br>
+  <small>scripts/make_market_db.py を実行すると生成されます。決算カレンダーは以下の通り利用できます。</small>
 </div>
+{% endif %}
+
+{# 動的決算セクション (市場ページから移設) #}
+<h2>決算日</h2>
+<div id="kessan-section">
+  {% macro render_kessan_editor(s, is_past) -%}
+    <div class="kessan-editor" style="display:none;" data-loaded="0">
+      <div class="kessan-editor-row">
+        <label>期待度:</label>
+        <select class="kessan-field kessan-pre-expectation">
+          {% for opt in expectation_options %}
+            <option value="{{ opt }}">{{ opt or '—' }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="kessan-editor-row">
+        <label>事前見通し:</label>
+        <textarea class="kessan-field kessan-pre-outlook" rows="2" placeholder="決算前の見通し"></textarea>
+      </div>
+      {% if is_past %}
+      <div class="kessan-editor-row">
+        <label>株価変動率:</label>
+        <span class="kessan-field-display kessan-post-price-change">
+          <span class="kessan-pc-1d">{{ s.post_price_changes['1d'] or '-' }}</span>
+          /
+          <span class="kessan-pc-5d">{{ s.post_price_changes['5d'] or '-' }}</span>
+        </span>
+      </div>
+      <div class="kessan-editor-row">
+        <label>反応コメ:</label>
+        <textarea class="kessan-field kessan-post-comment" rows="2" placeholder="決算後の反応・コメント"></textarea>
+      </div>
+      <div class="kessan-editor-row">
+        <label>決算またぎ:</label>
+        <input type="checkbox" class="kessan-field kessan-matagi">
+      </div>
+      {% endif %}
+    </div>
+  {%- endmacro %}
+
+  {% macro render_stock_li(s, is_past) -%}
+    {% set li_class = 'kessan-4q' if (s.quarter|string) == '4' else '' %}
+    {% set possess_class = ' is-possess' if s.is_possess else '' %}
+    <li class="{{ li_class }} kessan-stock{% if s.has_comment %} has-comment{% endif %}{{ possess_class }}"
+        data-code="{{ s.code_s }}"
+        data-kessanbi="{{ s.kessanbi }}"
+        data-quarter="{{ s.quarter }}"
+        data-is-past="{{ '1' if is_past else '0' }}"
+        onclick="handleKessanRowClick(event, this)"
+        title="クリックでコメント編集">
+      {% if s.is_possess %}<span class="kessan-possess-mark" title="保有銘柄">☆</span>{% endif %}
+      {% if s.kessan_matagi %}<span class="kessan-matagi-mark" title="決算またぎ保有">◆</span>{% endif %}
+      <a href="https://kabutan.jp/stock/chart?code={{ s.code_s }}" target="_blank">{{ s.code_s }}</a>
+      <a href="/stock/{{ s.code_s }}">{% if s.stock_name %}{{ macros.stock_name_with_prev(s) }}{% else %}-{% endif %}</a>
+      {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}
+      {% if s.pre_expectation %}<span class="kessan-expectation-badge exp-{{ s.pre_expectation }}">{{ s.pre_expectation }}</span>{% endif %}
+      {% if is_past and (s.post_price_changes['pts'] or s.post_price_changes['1d'] or s.post_price_changes['5d']) %}
+        {% set pcp = s.post_price_changes['pts'] %}
+        {% set pc1 = s.post_price_changes['1d'] %}
+        {% set pc5 = s.post_price_changes['5d'] %}
+        <span class="kessan-price-change">
+          {% if pcp %}<span class="kessan-pts-label">PTS</span><span class="{% if pcp.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pcp }}%</span>{% endif %}
+          {% if pc1 or pc5 %}
+            {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
+            /
+            {% if pc5 %}<span class="{% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% else %}<span>-</span>{% endif %}
+          {% endif %}
+        </span>
+      {% endif %}
+      {% if s.pre_outlook or s.post_comment %}
+      <div class="kessan-comment-view">
+        {% if s.pre_outlook %}<div class="kessan-pre-view"><span class="kessan-view-label">見通し:</span> {{ s.pre_outlook }}</div>{% endif %}
+        {% if is_past and s.post_comment %}<div class="kessan-post-view"><span class="kessan-view-label">反応:</span> {{ s.post_comment }}</div>{% endif %}
+      </div>
+      {% endif %}
+      {{ render_kessan_editor(s, is_past) }}
+    </li>
+  {%- endmacro %}
+
+  {# 直近1週間の過去決算: 常時表示 #}
+  {% if kessan_data.recent_past_entries %}
+  <div class="kessan-grid">
+    {% for kessanbi, stocks in kessan_data.recent_past_entries %}
+    <div class="kessan-card past">
+      <div class="card-date">{{ kessanbi[5:] }} (済)</div>
+      <ul class="stock-list">
+        {% for s in stocks %}{{ render_stock_li(s, true) }}{% endfor %}
+      </ul>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {# 当日決算 + 未来決算: 同じグリッドに横並び表示。
+     当日カードは中身は past 扱い (is_past=true) で反応コメ・株価変動率・
+     決算またぎを当日中に編集可能。見た目は通常 (past クラスなし、"(済)" ラベルなし)。
+     未来カードは future クラスで事前見通しのみ編集可。 #}
+  {% if kessan_data.today_entries or kessan_data.future_entries %}
+  <div class="kessan-grid">
+    {% for kessanbi, stocks in kessan_data.today_entries %}
+    <div class="kessan-card">
+      <div class="card-date">{{ kessanbi[5:] }}</div>
+      <ul class="stock-list">
+        {% for s in stocks %}{{ render_stock_li(s, true) }}{% endfor %}
+      </ul>
+    </div>
+    {% endfor %}
+    {% for kessanbi, stocks in kessan_data.future_entries %}
+    <div class="kessan-card future">
+      <div class="card-date">{{ kessanbi[5:] }}</div>
+      <ul class="stock-list">
+        {% for s in stocks %}{{ render_stock_li(s, false) }}{% endfor %}
+      </ul>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {# それ以前の過去決算: 折りたたみ #}
+  {% if kessan_data.older_past_entries %}
+  <details>
+    <summary style="cursor:pointer; color:#666; margin:8px 0;">▶ さらに前の決算を表示 ({{ kessan_data.older_past_entries|length }}件)</summary>
+    <div class="kessan-grid">
+      {% for kessanbi, stocks in kessan_data.older_past_entries %}
+      <div class="kessan-card past">
+        <div class="card-date">{{ kessanbi[5:] }} (済)</div>
+        <ul class="stock-list">
+          {% for s in stocks %}{{ render_stock_li(s, true) }}{% endfor %}
+        </ul>
+      </div>
+      {% endfor %}
+    </div>
+  </details>
+  {% endif %}
+
+  {% if not kessan_data.future_entries and not kessan_data.past_entries %}
+  <div style="color:#888;padding:12px;">決算予定の銘柄がありません（ポートフォリオ設定を確認してください）。</div>
+  {% endif %}
+</div>
+
+{# 適宜開示 (自動収集) #}
+{% if disclosure_parts.available %}
+{{ disclosure_parts.body | safe }}
+{{ disclosure_parts.footer | safe }}
 {% endif %}
 
 {% endblock %}

--- a/scripts/webapp/templates/market.html
+++ b/scripts/webapp/templates/market.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% import "_macros.html" as macros %}
 {% block title %}市場データ - Shintakane Research{% endblock %}
 {% block content %}
 
@@ -9,17 +8,12 @@
 {{ market_parts.css | safe }}
 </style>
 {{ market_parts.header | safe }}
+{{ market_parts.body | safe }}
 {% else %}
 <div style="padding:12px;margin:12px 0;background:#fef3e6;border:1px solid #f5c37c;border-radius:6px;">
   市場データ (<code>market_data.html</code>) が未生成です。<br>
-  <small>scripts/make_market_db.py を実行すると生成されます。決算カレンダーは以下の通り利用できます。</small>
+  <small>scripts/make_market_db.py を実行すると生成されます。</small>
 </div>
-{% endif %}
-
-{# 市場データ本文: 決算セクションはプレースホルダに置き換え済み (市場 → テーマランクの順) #}
-{% set body_parts = market_parts.get('body_without_kessan', '').split('<div id="kessan-placeholder-mark">__KESSAN_PLACEHOLDER__</div>') %}
-{% if body_parts[0] %}
-{{ body_parts[0] | safe }}
 {% endif %}
 
 {# issue #165: 市場 / テーマランクの後にテーマニュース調査を表示。手動実行ボタン付き #}
@@ -157,149 +151,6 @@
   {% if theme_news.running %}startPolling();{% endif %}
 })();
 </script>
-
-{# ここから動的決算セクション #}
-<h2>決算日</h2>
-<div id="kessan-section">
-  {% macro render_kessan_editor(s, is_past) -%}
-    <div class="kessan-editor" style="display:none;" data-loaded="0">
-      <div class="kessan-editor-row">
-        <label>期待度:</label>
-        <select class="kessan-field kessan-pre-expectation">
-          {% for opt in expectation_options %}
-            <option value="{{ opt }}">{{ opt or '—' }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="kessan-editor-row">
-        <label>事前見通し:</label>
-        <textarea class="kessan-field kessan-pre-outlook" rows="2" placeholder="決算前の見通し"></textarea>
-      </div>
-      {% if is_past %}
-      <div class="kessan-editor-row">
-        <label>株価変動率:</label>
-        <span class="kessan-field-display kessan-post-price-change">
-          <span class="kessan-pc-1d">{{ s.post_price_changes['1d'] or '-' }}</span>
-          /
-          <span class="kessan-pc-5d">{{ s.post_price_changes['5d'] or '-' }}</span>
-        </span>
-      </div>
-      <div class="kessan-editor-row">
-        <label>反応コメ:</label>
-        <textarea class="kessan-field kessan-post-comment" rows="2" placeholder="決算後の反応・コメント"></textarea>
-      </div>
-      <div class="kessan-editor-row">
-        <label>決算またぎ:</label>
-        <input type="checkbox" class="kessan-field kessan-matagi">
-      </div>
-      {% endif %}
-    </div>
-  {%- endmacro %}
-
-  {% macro render_stock_li(s, is_past) -%}
-    {% set li_class = 'kessan-4q' if (s.quarter|string) == '4' else '' %}
-    {% set possess_class = ' is-possess' if s.is_possess else '' %}
-    <li class="{{ li_class }} kessan-stock{% if s.has_comment %} has-comment{% endif %}{{ possess_class }}"
-        data-code="{{ s.code_s }}"
-        data-kessanbi="{{ s.kessanbi }}"
-        data-quarter="{{ s.quarter }}"
-        data-is-past="{{ '1' if is_past else '0' }}"
-        onclick="handleKessanRowClick(event, this)"
-        title="クリックでコメント編集">
-      {% if s.is_possess %}<span class="kessan-possess-mark" title="保有銘柄">☆</span>{% endif %}
-      {% if s.kessan_matagi %}<span class="kessan-matagi-mark" title="決算またぎ保有">◆</span>{% endif %}
-      <a href="https://kabutan.jp/stock/chart?code={{ s.code_s }}" target="_blank">{{ s.code_s }}</a>
-      <a href="/stock/{{ s.code_s }}">{% if s.stock_name %}{{ macros.stock_name_with_prev(s) }}{% else %}-{% endif %}</a>
-      {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}
-      {% if s.pre_expectation %}<span class="kessan-expectation-badge exp-{{ s.pre_expectation }}">{{ s.pre_expectation }}</span>{% endif %}
-      {% if is_past and (s.post_price_changes['pts'] or s.post_price_changes['1d'] or s.post_price_changes['5d']) %}
-        {% set pcp = s.post_price_changes['pts'] %}
-        {% set pc1 = s.post_price_changes['1d'] %}
-        {% set pc5 = s.post_price_changes['5d'] %}
-        <span class="kessan-price-change">
-          {% if pcp %}<span class="kessan-pts-label">PTS</span><span class="{% if pcp.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pcp }}%</span>{% endif %}
-          {% if pc1 or pc5 %}
-            {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-            /
-            {% if pc5 %}<span class="{% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% else %}<span>-</span>{% endif %}
-          {% endif %}
-        </span>
-      {% endif %}
-      {% if s.pre_outlook or s.post_comment %}
-      <div class="kessan-comment-view">
-        {% if s.pre_outlook %}<div class="kessan-pre-view"><span class="kessan-view-label">見通し:</span> {{ s.pre_outlook }}</div>{% endif %}
-        {% if is_past and s.post_comment %}<div class="kessan-post-view"><span class="kessan-view-label">反応:</span> {{ s.post_comment }}</div>{% endif %}
-      </div>
-      {% endif %}
-      {{ render_kessan_editor(s, is_past) }}
-    </li>
-  {%- endmacro %}
-
-  {# 直近1週間の過去決算: 常時表示 #}
-  {% if kessan_data.recent_past_entries %}
-  <div class="kessan-grid">
-    {% for kessanbi, stocks in kessan_data.recent_past_entries %}
-    <div class="kessan-card past">
-      <div class="card-date">{{ kessanbi[5:] }} (済)</div>
-      <ul class="stock-list">
-        {% for s in stocks %}{{ render_stock_li(s, true) }}{% endfor %}
-      </ul>
-    </div>
-    {% endfor %}
-  </div>
-  {% endif %}
-
-  {# 当日決算 + 未来決算: 同じグリッドに横並び表示。
-     当日カードは中身は past 扱い (is_past=true) で反応コメ・株価変動率・
-     決算またぎを当日中に編集可能。見た目は通常 (past クラスなし、"(済)" ラベルなし)。
-     未来カードは future クラスで事前見通しのみ編集可。 #}
-  {% if kessan_data.today_entries or kessan_data.future_entries %}
-  <div class="kessan-grid">
-    {% for kessanbi, stocks in kessan_data.today_entries %}
-    <div class="kessan-card">
-      <div class="card-date">{{ kessanbi[5:] }}</div>
-      <ul class="stock-list">
-        {% for s in stocks %}{{ render_stock_li(s, true) }}{% endfor %}
-      </ul>
-    </div>
-    {% endfor %}
-    {% for kessanbi, stocks in kessan_data.future_entries %}
-    <div class="kessan-card future">
-      <div class="card-date">{{ kessanbi[5:] }}</div>
-      <ul class="stock-list">
-        {% for s in stocks %}{{ render_stock_li(s, false) }}{% endfor %}
-      </ul>
-    </div>
-    {% endfor %}
-  </div>
-  {% endif %}
-
-  {# それ以前の過去決算: 折りたたみ #}
-  {% if kessan_data.older_past_entries %}
-  <details>
-    <summary style="cursor:pointer; color:#666; margin:8px 0;">▶ さらに前の決算を表示 ({{ kessan_data.older_past_entries|length }}件)</summary>
-    <div class="kessan-grid">
-      {% for kessanbi, stocks in kessan_data.older_past_entries %}
-      <div class="kessan-card past">
-        <div class="card-date">{{ kessanbi[5:] }} (済)</div>
-        <ul class="stock-list">
-          {% for s in stocks %}{{ render_stock_li(s, true) }}{% endfor %}
-        </ul>
-      </div>
-      {% endfor %}
-    </div>
-  </details>
-  {% endif %}
-
-  {% if not kessan_data.future_entries and not kessan_data.past_entries %}
-  <div style="color:#888;padding:12px;">決算予定の銘柄がありません（ポートフォリオ設定を確認してください）。</div>
-  {% endif %}
-</div>
-
-{# 決算以降の本文 (適時開示など) #}
-{% if body_parts|length > 1 and body_parts[1] %}
-{{ body_parts[1] | safe }}
-{% endif %}
 
 {% if market_parts.available %}
 {{ market_parts.footer | safe }}

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -788,15 +788,15 @@ class TestDisclosureRoute:
         assert "fin" in html
 
     def test_global_nav_has_disclosure_link(self, client):
-        """グローバルナビに /disclosure へのリンクがある"""
+        """グローバルナビに /disclosure へのリンクがある (タブ名は「決算・開示」)"""
         resp = client.get("/")
         html = resp.data.decode()
         assert 'href="/disclosure"' in html
-        assert "適宜開示" in html
+        assert "決算・開示" in html
 
 
-class TestMarketRouteKessanCard:
-    """GET /market の決算日カード表示テスト
+class TestDisclosureRouteKessanCard:
+    """GET /disclosure の決算日カード表示テスト (issue #213 で /market から移設)
 
     当日決算 (kessanbi == today) は中身は past 扱いで反応コメ枠を出すが、
     カードの見た目 ("(済)" ラベル / past クラス) は通常表示にする。
@@ -828,9 +828,9 @@ class TestMarketRouteKessanCard:
         today_md = _dt.today().strftime("%m/%d")
         yesterday_str = "2026/04/26"
 
-        from webapp.routes import market as _market_route
+        from webapp.routes import disclosure as _disc_route
         monkeypatch.setattr(
-            _market_route, "get_market_kessan_data",
+            _disc_route, "get_market_kessan_data",
             lambda: {
                 "base_day": _dt.today().date(),
                 "future_entries": [],
@@ -845,7 +845,7 @@ class TestMarketRouteKessanCard:
             },
         )
 
-        resp = client.get("/market")
+        resp = client.get("/disclosure")
         html = resp.data.decode()
         assert resp.status_code == 200
 
@@ -860,9 +860,9 @@ class TestMarketRouteKessanCard:
         from datetime import datetime as _dt
         today_str = _dt.today().strftime("%Y/%m/%d")
 
-        from webapp.routes import market as _market_route
+        from webapp.routes import disclosure as _disc_route
         monkeypatch.setattr(
-            _market_route, "get_market_kessan_data",
+            _disc_route, "get_market_kessan_data",
             lambda: {
                 "base_day": _dt.today().date(),
                 "future_entries": [],
@@ -875,7 +875,7 @@ class TestMarketRouteKessanCard:
             },
         )
 
-        resp = client.get("/market")
+        resp = client.get("/disclosure")
         html = resp.data.decode()
         # data-is-past="1" で past 扱い (反応コメ枠が出る)
         assert 'data-is-past="1"' in html


### PR DESCRIPTION
## Summary

- `/market` にあった決算日セクション（決算カレンダー + コメント編集UI）を `/disclosure` に移設し、`/market` は市況・指数・テーマランク・テーマニュース、`/disclosure` は決算スケジュール + 自動収集の適時開示、と役割分担を明確化
- ナビタブ名「適宜開示」→「**決算・開示**」へ変更（ページタイトルも追随）
- `/api/kessan_comment/<code_s>` GET/POST のパスは据え置き（フロント JS 不変）

Closes #213

## 変更内容

| ファイル | 内容 |
|---|---|
| `webapp/routes/disclosure.py` | 決算API + `get_market_kessan_data` 取り込みを移植 |
| `webapp/routes/market.py` | 決算API/serialize/kessan データを撤去 |
| `webapp/templates/disclosure.html` | 「決算日」見出し + macro + 3カードグリッドを移植。並び順 header → 決算日 → 適宜開示 body → footer |
| `webapp/templates/market.html` | 決算 macro/カードを撤去、`body_parts` split 撤廃 |
| `webapp/helpers.py` | `get_market_html_parts` のプレースホルダ挿入を撤去、戻り値キー `body_without_kessan` → `body` にリネーム（決算日 h2 抑制は継続） |
| `webapp/templates/base.html` | ナビタブを「決算・開示」へ |
| `tests/test_webapp_routes.py` | `TestMarketRouteKessanCard` → `TestDisclosureRouteKessanCard` に振り替え、ナビ assert をタブ名追随 |

## Test plan

- [x] `pytest tests/test_webapp_routes.py tests/test_webapp_helpers.py -v` → 310 passed
- [x] `/disclosure` 表示確認: 決算日カード描画 OK、その下に適宜開示テーブルが続く
- [x] `/market` 表示確認: 決算日セクションが消え、市場 → テーマランク → テーマニュースの順
- [x] `/api/kessan_comment/<code_s>` GET → 200 + 期待スキーマ（disclosure_bp 経由）
- [x] グローバルナビのタブ名が「決算・開示」になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)