### PR TITLE
トップページの銘柄一覧を非表示化 + What's new プレースホルダー追加 (#244)

### DIFF
--- a/scripts/webapp/routes/search.py
+++ b/scripts/webapp/routes/search.py
@@ -55,6 +55,10 @@ def index():
         and bool(CODE_S_PATTERN.match(q_normalized))
     )
 
+    # issue #244: クエリが何も無いトップアクセスでは銘柄一覧を出さず
+    # What's new プレースホルダーを描画する。一覧は検索クエリありのときだけ。
+    has_query = bool(q or code_s or rating or keyword)
+
     return render_template(
         "search.html",
         records=records,
@@ -64,6 +68,7 @@ def index():
         filter_q=q,
         can_add=can_add,
         q_normalized=q_normalized,
+        has_query=has_query,
     )
 
 

--- a/scripts/webapp/templates/search.html
+++ b/scripts/webapp/templates/search.html
@@ -41,6 +41,7 @@
 {% endif %}
 {% endwith %}
 
+{% if has_query %}
 <p style="font-size:0.85em;color:#666;">{{ records|length }} 件</p>
 
 {% if records %}
@@ -80,5 +81,13 @@
   <button type="submit">この銘柄 ({{ q_normalized }}) を ResearchDB に追加</button>
 </form>
 {% endif %}
+{% endif %}
+
+{% else %}
+{# issue #244: クエリなしトップアクセスは銘柄一覧ではなく What's new プレースホルダーを表示 #}
+<section id="whats-new" style="margin-top:1.5em;padding:1.2em 1.4em;background:#f6f8fa;border:1px solid #e1e5ea;border-radius:6px;">
+  <h3 style="margin-top:0;font-size:1.05em;color:#2c3e50;">📌 What's new — 今日の注目要素</h3>
+  <p style="color:#888;font-size:0.9em;margin-bottom:0;">準備中。市況・テーマ・保有銘柄など、その日にチェックすべき要素を後日ここに集約予定。</p>
+</section>
 {% endif %}
 {% endblock %}

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -75,10 +75,24 @@ class TestSearchRoute:
         resp = client.get("/")
         assert resp.status_code == 200
 
-    def test_index_shows_records(self, client):
+    def test_index_no_query_hides_records_and_shows_whats_new(self, client):
+        """issue #244: クエリなしトップでは銘柄一覧を出さず What's new プレースホルダーを表示"""
         resp = client.get("/")
-        assert "3496" in resp.data.decode()
-        assert "アズーム" in resp.data.decode()
+        html = resp.data.decode()
+        # 銘柄一覧テーブルは描画されない
+        assert "アズーム" not in html
+        assert '<table' not in html
+        # What's new プレースホルダーが存在する
+        assert 'id="whats-new"' in html
+        assert "What's new" in html
+
+    def test_index_with_keyword_shows_records(self, client):
+        """issue #244: 検索クエリ付き (keyword) では従来通り一覧を表示"""
+        resp = client.get("/?keyword=アズーム")
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert "3496" in html
+        assert "アズーム" in html
 
     def test_index_filter_by_rating(self, client):
         resp = client.get("/?rating=A")


### PR DESCRIPTION
## Summary

- `GET /` (検索クエリなし) では銘柄一覧テーブルを描画せず、What's new プレースホルダーだけを表示
- 検索クエリ (`q` / `code_s` / `rating` / `keyword` のいずれか) ありのときは従来通り一覧表示
- What's new の中身は次フェーズ。本 PR は「**一覧を消して What's new の場所を確保する**」までがスコープ

Closes #244

## 変更内容

| ファイル | 内容 |
|---|---|
| `scripts/webapp/routes/search.py` | `has_query = bool(q or code_s or rating or keyword)` をテンプレに渡す |
| `scripts/webapp/templates/search.html` | 件数表示 + 一覧テーブル + 0件案内を `{% if has_query %}` に閉じ込め、else 側に `<section id="whats-new">` (📌 What's new — 今日の注目要素 / 「準備中」文言) を追加 |
| `tests/test_webapp_routes.py` | 旧 `test_index_shows_records` を「クエリなしで一覧が消え What's new が出る」「`?keyword=` 付きで一覧表示」の 2 件に置き換え |

## Test plan

- [x] `pytest tests/test_webapp_routes.py tests/test_webapp_helpers.py -v` → 全 PASS (routes 76 / helpers 235)
- [x] ブラウザ実機: `GET /` で銘柄一覧テーブル消滅 + What's new セクション表示
- [x] ブラウザ実機: `GET /?keyword=test` で従来通り検索結果 (「0 件 / 該当する銘柄がありません。」) 表示
- [x] 既存 filter 系テスト (`?rating=S` / `?q=3496` / `?code_s=...`) はクエリありのため不変、全 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)