### PR TITLE
portfolio: 売上成長/利益成長/進捗率乖離 列に過去業績tooltipを追加 (#204)

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1874,6 +1874,66 @@ def _gyoseki_quarity_expr_safe(stock: Dict[str, Any]) -> str:
         return ""
 
 
+# issue #204: gyoseki_quarity_expr を [A]…/[Q]…/<C3> の各セグメントに分解する
+_GYOSEKI_EXPR_RE = re.compile(
+    r"\[A\](?P<annual>[-\d]+±\d+%,[-\d]+±\d+%)"
+    r"\[Q\](?P<quarter>[-\d]+±\d+%,[-\d]+±\d+%)"
+    r"(?P<c3><C3>)?"
+)
+
+
+def parse_gyoseki_quarity_expr(expr: str) -> Dict[str, Any]:
+    """gyoseki_quarity_expr を tooltip 生成用に分解する。
+
+    入力例: "[A]5±8%,2±6%[Q]-5±12%,1±8%<C3>"
+    返り値: {
+        "sales_5y": "5±8%", "profit_5y": "2±6%",     # [A] = 過去5年年度平均
+        "sales_4q": "-5±12%", "profit_4q": "1±8%",   # [Q] = 過去4Q平均
+        "has_c3": True,                              # 3Q連続利益率向上タグ
+    }
+    パース失敗時は全フィールドが None / has_c3 = False の dict を返す。
+    """
+    empty = {"sales_5y": None, "profit_5y": None, "sales_4q": None, "profit_4q": None, "has_c3": False}
+    if not expr:
+        return empty
+    m = _GYOSEKI_EXPR_RE.search(expr)
+    if not m:
+        return empty
+    sales_5y, profit_5y = m.group("annual").split(",", 1)
+    sales_4q, profit_4q = m.group("quarter").split(",", 1)
+    return {
+        "sales_5y": sales_5y,
+        "profit_5y": profit_5y,
+        "sales_4q": sales_4q,
+        "profit_4q": profit_4q,
+        "has_c3": bool(m.group("c3")),
+    }
+
+
+def build_gyoseki_tooltips(expr: str) -> Dict[str, str]:
+    """gyoseki_quarity_expr から 3 セル分の tooltip 文字列を生成する (issue #204)。
+
+    返り値キー: sales_growth / profit_growth / progress_diff
+    データが無いセルは空文字。Jinja2 側で空なら title 属性を出さない想定。
+    """
+    parsed = parse_gyoseki_quarity_expr(expr)
+    sales_tip = f"5年平均: {parsed['sales_5y']}" if parsed["sales_5y"] else ""
+    profit_tip = f"5年平均: {parsed['profit_5y']}" if parsed["profit_5y"] else ""
+
+    parts: List[str] = []
+    if parsed["sales_4q"] and parsed["profit_4q"]:
+        parts.append(f"4Q平均: 売上{parsed['sales_4q']} / 利益{parsed['profit_4q']}")
+    if parsed["has_c3"]:
+        parts.append("[3Q連続利益率向上]")
+    progress_tip = " ".join(parts)
+
+    return {
+        "sales_growth": sales_tip,
+        "profit_growth": profit_tip,
+        "progress_diff": progress_tip,
+    }
+
+
 # ==================================================
 # 株価 + RSライン 統合スパークライン (issue #227)
 # ==================================================
@@ -2600,6 +2660,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "theoretical_diff": "—",
             "theoretical_diff_raw": None,
             "gyoseki_quarity_expr": "",
+            "gyoseki_tooltips": {"sales_growth": "", "profit_growth": "", "progress_diff": ""},
             "gyoseki": {},
             "indicators_raw": {},
         }
@@ -2621,6 +2682,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     trend_info = build_trend_info(stock)
 
     market_cap_raw = market_cap if isinstance(market_cap, (int, float)) else None
+    gyoseki_quarity_expr = _gyoseki_quarity_expr_safe(stock)
 
     return {
         "rank": rank if isinstance(rank, int) else None,
@@ -2651,7 +2713,9 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "spr_gauge": _build_spr_gauge_for_stock(stock),
         "theoretical_diff": _format_theoretical_diff(stock),
         "theoretical_diff_raw": _theoretical_diff_raw(stock),
-        "gyoseki_quarity_expr": _gyoseki_quarity_expr_safe(stock),
+        "gyoseki_quarity_expr": gyoseki_quarity_expr,
+        # issue #204: 売上成長/利益成長/進捗率乖離 列の tooltip
+        "gyoseki_tooltips": build_gyoseki_tooltips(gyoseki_quarity_expr),
         "gyoseki": {
             "isKonki": stock.get("isKonki"),
         },

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -279,13 +279,16 @@
         {% endfor %}
       </td>
       <td style="{{ row.styles.rank or '' }}">{{ row.rank if row.rank is not none else "—" }}</td>
-      <td style="{{ row.styles.sales_growth or '' }}">{{ row.sales_growth }}</td>
-      <td style="{{ row.styles.profit_growth or '' }}">{{ row.profit_growth }}</td>
+      <td {% if row.gyoseki_tooltips.sales_growth %}title="{{ row.gyoseki_tooltips.sales_growth }}"{% endif %}
+          style="{{ row.styles.sales_growth or '' }}">{{ row.sales_growth }}</td>
+      <td {% if row.gyoseki_tooltips.profit_growth %}title="{{ row.gyoseki_tooltips.profit_growth }}"{% endif %}
+          style="{{ row.styles.profit_growth or '' }}">{{ row.profit_growth }}</td>
       <td style="{{ row.styles.per or '' }}">{{ row.per }}</td>
       <td style="{{ row.styles.theoretical_diff or '' }}">{{ row.theoretical_diff }}</td>
       <td style="{{ row.styles.dividend or '' }}">{{ row.dividend }}</td>
       <td>{{ row.quarter }}</td>
-      <td style="{{ row.styles.progress_diff or '' }}">{{ row.progress_diff }}</td>
+      <td {% if row.gyoseki_tooltips.progress_diff %}title="{{ row.gyoseki_tooltips.progress_diff }}"{% endif %}
+          style="{{ row.styles.progress_diff or '' }}">{{ row.progress_diff }}</td>
       <td data-style-field="kessanbi_md"
           style="{{ row.styles.kessanbi_md or '' }}">{{ row.kessanbi_md }}</td>
       <td title="クリックで編集 (M/D 形式)"

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2497,3 +2497,33 @@ class TestThemeNewsMdToHtml:
         src = "- 反発+1.9%→翌日続伸\n"
         out = helpers.theme_news_md_to_html(src)
         assert "反発<wbr>+1.9%<wbr>→翌日続伸" in out
+
+
+class TestBuildGyosekiTooltips:
+    """issue #204: gyoseki_quarity_expr から portfolio 列 tooltip を生成する。"""
+
+    @pytest.mark.parametrize("expr,expected", [
+        # 通常ケース (<C3>無し)
+        (
+            "[A]5±8%,2±6%[Q]-5±12%,1±8%",
+            {
+                "sales_growth": "5年平均: 5±8%",
+                "profit_growth": "5年平均: 2±6%",
+                "progress_diff": "4Q平均: 売上-5±12% / 利益1±8%",
+            },
+        ),
+        # <C3> タグ付き
+        (
+            "[A]5±8%,2±6%[Q]-5±12%,1±8%<C3>",
+            {
+                "sales_growth": "5年平均: 5±8%",
+                "profit_growth": "5年平均: 2±6%",
+                "progress_diff": "4Q平均: 売上-5±12% / 利益1±8% [3Q連続利益率向上]",
+            },
+        ),
+        # 空文字・パース失敗時は全空 (Jinja 側で title 属性が出ない想定)
+        ("", {"sales_growth": "", "profit_growth": "", "progress_diff": ""}),
+        ("invalid", {"sales_growth": "", "profit_growth": "", "progress_diff": ""}),
+    ])
+    def test_tooltip_format(self, expr, expected):
+        assert helpers.build_gyoseki_tooltips(expr) == expected


### PR DESCRIPTION
## Summary

ポートフォリオ一覧の **売上成長(%)** / **利益成長(%)** / **進捗率乖離** 列に、`gyoseki_quarity_expr` 由来の過去業績情報を tooltip (title 属性) として追加。

- 売上成長(%) tooltip: 「**5年平均: x±y%**」
- 利益成長(%) tooltip: 「**5年平均: x±y%**」
- 進捗率乖離 tooltip: 「**4Q平均: 売上x±y% / 利益a±b%**」
  - `<C3>` 銘柄は末尾に **`[3Q連続利益率向上]`** を追記
- `<C3>` 銘柄の既存赤背景はそのまま、tooltip は意味の補足として併用
- 表示文字列は別列追加せず tooltip に閉じ込めたため、テーブル幅は不変

Closes #204

## 変更内容

| ファイル | 内容 |
|---|---|
| `scripts/webapp/helpers.py` | `parse_gyoseki_quarity_expr` / `build_gyoseki_tooltips` を新規追加。`list_portfolio_with_indicators` の row dict に `gyoseki_tooltips` を embed |
| `scripts/webapp/templates/portfolio_list.html` | 売上成長/利益成長/進捗率乖離の td に `{% if row.gyoseki_tooltips.xxx %}title="..."{% endif %}` を追加 |
| `tests/test_webapp_helpers.py` | `TestBuildGyosekiTooltips` を parametrize 4 ケースで追加（通常 / `<C3>`付き / 空 / パース失敗）|

## Test plan

- [x] `pytest tests/test_webapp_helpers.py tests/test_webapp_routes.py -v` → 315 passed
- [x] ブラウザ実機: 28 銘柄全てで売上/利益/進捗率乖離の 3 tooltip が想定文字列で表示
- [x] `<C3>` 銘柄 (4417, 285A) の進捗率乖離セルで `[3Q連続利益率向上]` 追記を確認
- [x] `<C3>` 銘柄の既存赤背景 (`background:#ea4335;color:#fff`) は維持
- [x] tooltip が空のセル（理論的には `gyoseki_quarity_expr` パース失敗時）では title 属性が出ない (Jinja2 ガード)

🤖 Generated with [Claude Code](https://claude.com/claude-code)