### PR TITLE
[codex] テーマ持続強度を可視化

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -264,12 +264,13 @@ def build_theme_portfolio_links(portfolio_records, stock_map):
 
 def collect_theme_portfolio_links():
     """portfolio_shelve と stocks_shelve からテーマカード強調用データを作る。"""
-    try:
-        from db_shelve import PORTFOLIO_SHELVE, STOCKS_SHELVE, ShelveDB
-        import portfolio_shelve
+    import dbm
+    from db_shelve import PORTFOLIO_SHELVE, STOCKS_SHELVE, ShelveDB
+    import portfolio_shelve
 
-        if not _shelve_path_exists(PORTFOLIO_SHELVE) or not _shelve_path_exists(STOCKS_SHELVE):
-            return {}
+    if not _shelve_path_exists(PORTFOLIO_SHELVE) or not _shelve_path_exists(STOCKS_SHELVE):
+        return {}
+    try:
         records = (
             portfolio_shelve.list_records(status="1保")
             + portfolio_shelve.list_records(status="2準")
@@ -283,7 +284,7 @@ def collect_theme_portfolio_links():
                 if code_s:
                     stock_map[code_s] = db.get(code_s) or {}
         return build_theme_portfolio_links(records, stock_map)
-    except Exception as e:
+    except dbm.error as e:
         log_warning("[theme] portfolio links 作成失敗:", e)
         return {}
 

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -19,6 +19,8 @@ from ks_util import *
 URL_THEME_RANK_KABUTAN = "https://kabutan.jp/info/accessranking/3_2"
 from db_shelve import get_market_db as _get_market_shelve_db
 
+THEME_STRENGTH_WINDOW_DAYS = 40
+
 
 def parse_theme_html(html):
     # print ux_cmd_head(html, 10)
@@ -173,11 +175,125 @@ THEME_RANK_INTERVAL = 1  # 再取得までの日数
 INTERVAL_BACKUP = 3  # バックアップ日数
 
 
-def make_theme_data(prev_momentum_rank=None):
+def _theme_rank_history_date(cach_date):
+    """テーマランク履歴用の日付文字列を返す。"""
+    if cach_date:
+        return get_price_day(cach_date).isoformat()
+    return get_price_day(datetime.today()).isoformat()
+
+
+def update_theme_rank_history(history, date_str, theme_rank_list,
+                              window_days=THEME_STRENGTH_WINDOW_DAYS):
+    """Kabutan生順位履歴を同日置換で更新し、強度値を計算する。
+
+    Args:
+        history: [(date_str, [(theme_name, rank), ...]), ...]
+        date_str: 更新対象日 (YYYY-MM-DD)
+        theme_rank_list: Kabutan生順位のテーマ名リスト
+        window_days: 保持する営業日数
+    Returns:
+        tuple: (new_history, theme_strength, theme_strength_days)
+    """
+    rank_rows = [(theme, i + 1) for i, theme in enumerate(theme_rank_list[:30])]
+    new_history = []
+    replaced = False
+    for old_date, old_rows in history or []:
+        if old_date == date_str:
+            new_history.append((date_str, rank_rows))
+            replaced = True
+        else:
+            new_history.append((old_date, old_rows))
+    if not replaced:
+        new_history.append((date_str, rank_rows))
+    new_history = new_history[-window_days:]
+
+    theme_strength = {}
+    theme_strength_days = {}
+    for _, rows in new_history:
+        for theme, rank in rows:
+            pt = max(0, 31 - int(rank))
+            if pt <= 0:
+                continue
+            theme_strength[theme] = theme_strength.get(theme, 0) + pt
+            theme_strength_days[theme] = theme_strength_days.get(theme, 0) + 1
+
+    return new_history, theme_strength, theme_strength_days
+
+
+def _shelve_path_exists(path):
+    """ShelveDB を新規作成せず、既存DBファイルの有無だけ判定する。"""
+    suffixes = ("", ".dat", ".dir", ".bak", ".db")
+    return any(os.path.exists(path + suffix) for suffix in suffixes)
+
+
+def _split_theme_names(themes):
+    """stock_data['themes'] をテーマ名リストに正規化する。"""
+    if isinstance(themes, str):
+        return [t.strip() for t in themes.split(",") if t.strip()]
+    if isinstance(themes, (list, tuple)):
+        return [str(t).strip() for t in themes if str(t).strip()]
+    return []
+
+
+def build_theme_portfolio_links(portfolio_records, stock_map):
+    """保有/準保有銘柄をテーマ名から逆引きできる形にする。
+
+    Returns:
+        dict: {theme_name: {"hold": [(code_s, stock_name)], "semi": [...]}}
+    """
+    status_key = {"1保": "hold", "2準": "semi"}
+    links = {}
+    for rec in portfolio_records or []:
+        status = rec.get("status")
+        key = status_key.get(status)
+        if not key:
+            continue
+        code_s = rec.get("code_s")
+        stock = (stock_map or {}).get(code_s) or {}
+        stock_name = stock.get("stock_name") or code_s
+        item = (code_s, stock_name)
+        for theme in _split_theme_names(stock.get("themes", "")):
+            theme_links = links.setdefault(theme, {"hold": [], "semi": []})
+            if item not in theme_links[key]:
+                theme_links[key].append(item)
+    for theme_links in links.values():
+        theme_links["hold"].sort(key=lambda item: item[0])
+        theme_links["semi"].sort(key=lambda item: item[0])
+    return links
+
+
+def collect_theme_portfolio_links():
+    """portfolio_shelve と stocks_shelve からテーマカード強調用データを作る。"""
+    try:
+        from db_shelve import PORTFOLIO_SHELVE, STOCKS_SHELVE, ShelveDB
+        import portfolio_shelve
+
+        if not _shelve_path_exists(PORTFOLIO_SHELVE) or not _shelve_path_exists(STOCKS_SHELVE):
+            return {}
+        records = (
+            portfolio_shelve.list_records(status="1保")
+            + portfolio_shelve.list_records(status="2準")
+        )
+        if not records:
+            return {}
+        stock_map = {}
+        with ShelveDB(STOCKS_SHELVE) as db:
+            for rec in records:
+                code_s = rec.get("code_s")
+                if code_s:
+                    stock_map[code_s] = db.get(code_s) or {}
+        return build_theme_portfolio_links(records, stock_map)
+    except Exception as e:
+        log_warning("[theme] portfolio links 作成失敗:", e)
+        return {}
+
+
+def make_theme_data(prev_momentum_rank=None, theme_rank_history=None):
     """テーマランクデータを作成
 
     Args:
         prev_momentum_rank: 前日のモメンタム順位リスト（差分ラベル計算用）
+        theme_rank_history: Kabutan生順位履歴（強度計算用）
     """
     log_print("テーマランクデータを作成します")
     theme_rank_list, prev_theme_rank_list, cach_date, _ = get_theme_rank_list()
@@ -223,6 +339,13 @@ def make_theme_data(prev_momentum_rank=None):
     market_db["theme_rank"] = theme_rank2_list
     market_db["theme_rank_diff"] = theme_rank_diff
     market_db["access_date_theme_rank"] = cach_date
+    history_date = _theme_rank_history_date(cach_date)
+    history, strength, strength_days = update_theme_rank_history(
+        theme_rank_history, history_date, theme_rank_list,
+    )
+    market_db["theme_rank_history"] = history
+    market_db["theme_strength"] = strength
+    market_db["theme_strength_days"] = strength_days
     return market_db
 
 
@@ -555,8 +678,12 @@ def update_market_db():
         market_db["prev_theme_rank_save_date"] = today_cal
         log_print("前日モメンタム順位を退避: %s" % today_cal)
     prev_momentum_rank = market_db.get("prev_theme_rank", [])
-    theme_db = make_theme_data(prev_momentum_rank)
+    theme_db = make_theme_data(
+        prev_momentum_rank,
+        theme_rank_history=market_db.get("theme_rank_history", []),
+    )
     market_db.update(theme_db)
+    market_db["theme_portfolio_links"] = collect_theme_portfolio_links()
 
     # 各指数を更新 (まず DD/FTD 候補と当日価格を取得)
     index_makers = [
@@ -739,13 +866,16 @@ tr:hover { background: #f5f5f5; }
 .theme-grid { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 16px 0; }
 .theme-badge {
   display: inline-flex; flex-direction: column; align-items: center;
-  border: 1px solid #ddd; border-radius: 6px; padding: 6px 10px;
+  border: 1px solid #ddd; border-radius: 6px; padding: 6px 10px 0 10px;
   background: #fff; min-width: 110px; font-size: 0.85em;
+  overflow: hidden;
 }
 .theme-badge .rank { font-size: 0.75em; color: #333; }
 .theme-badge .name { font-weight: bold; text-align: center; color: #333; }
 .theme-badge .change { font-size: 0.8em; margin-top: 2px; color: #333; }
 .theme-badge .rate { font-size: 0.8em; margin-top: 2px; }
+.theme-badge .strength-track { width: calc(100% + 20px); height: 5px; margin-top: 5px; background: rgba(255,255,255,0.55); align-self: stretch; }
+.theme-badge .strength-bar { height: 100%; background: #1f4e79; }
 .theme-badge .change-up { color: #c0392b; }
 .theme-badge .change-down { color: #2980b9; }
 .rate-pos { color: #c0392b; }
@@ -756,6 +886,11 @@ tr:hover { background: #f5f5f5; }
 .theme-heat0  { background: #fff; }
 .theme-heat1  { background: #a5d6a7; border-color: #81c784; }
 .theme-heat2  { background: #66bb6a; border-color: #4caf50; }
+.theme-badge.theme-hold { border: 3px solid #d4af37; }
+.theme-badge.theme-semi { border: 2px solid #a8a8a8; }
+.theme-badge .portfolio-links { margin-top: 4px; font-size: 0.75em; color: #333; }
+.theme-badge .portfolio-links summary { cursor: pointer; list-style: none; }
+.theme-badge .portfolio-links summary::-webkit-details-marker { display: none; }
 
 /* 市場テーブル */
 /* table のデフォルト width:100% を解除し、列幅の合計だけのコンパクトな表にする */
@@ -832,6 +967,10 @@ def _html_theme_rank(market_db, theme_rank_data=None):
     theme_rank = market_db.get("theme_rank", [])
     theme_rank_diff = market_db.get("theme_rank_diff", {})
     theme_momentum = market_db.get("theme_momentum", {})
+    theme_strength = market_db.get("theme_strength", {})
+    theme_strength_days = market_db.get("theme_strength_days", {})
+    theme_portfolio_links = market_db.get("theme_portfolio_links", {})
+    max_strength = max(theme_strength.values()) if theme_strength else 0
 
     if not theme_rank:
         return ""
@@ -880,14 +1019,54 @@ def _html_theme_rank(market_db, theme_rank_data=None):
                 rate_class, avg_rate, count
             )
 
+        strength = int(theme_strength.get(theme, 0) or 0)
+        strength_days = int(theme_strength_days.get(theme, 0) or 0)
+        strength_width = (strength * 100.0 / max_strength) if max_strength else 0
+        strength_title = html_mod.escape(
+            "強度: %dpt / %d日中%d日Top30" % (
+                strength, THEME_STRENGTH_WINDOW_DAYS, strength_days,
+            ),
+            quote=True,
+        )
+        link_info = theme_portfolio_links.get(theme, {}) or {}
+        hold_items = link_info.get("hold", []) or []
+        semi_items = link_info.get("semi", []) or []
+        portfolio_class = " theme-hold" if hold_items else (
+            " theme-semi" if semi_items else ""
+        )
+        portfolio_html = ""
+        if hold_items or semi_items:
+            def _stock_label(item):
+                if isinstance(item, (list, tuple)) and len(item) >= 2:
+                    code_s, stock_name = item[0], item[1]
+                    label = "%s %s" % (code_s, stock_name) if stock_name else code_s
+                else:
+                    label = str(item)
+                return html_mod.escape(label)
+
+            code_parts = []
+            if hold_items:
+                code_parts.append("保 " + ", ".join(_stock_label(item) for item in hold_items))
+            if semi_items:
+                code_parts.append("準 " + ", ".join(_stock_label(item) for item in semi_items))
+            portfolio_html = (
+                '    <details class="portfolio-links"><summary>銘柄</summary>%s</details>\n'
+                % "<br>".join(code_parts)
+            )
         theme_escaped = html_mod.escape(theme)
         parts.append(
-            '  <div class="theme-badge %s">\n'
+            '  <div class="theme-badge %s%s">\n'
             '    <span class="rank">#%d</span>\n'
             '    <span class="name">%s</span>\n'
             '    <span class="change %s">%s</span>\n'
             '    %s\n'
-            '  </div>' % (heat_class, i + 1, theme_escaped, change_class, change_text, rate_html)
+            '%s'
+            '    <div class="strength-track" title="%s"><div class="strength-bar" style="width:%.1f%%"></div></div>\n'
+            '  </div>' % (
+                heat_class, portfolio_class, i + 1, theme_escaped, change_class,
+                change_text, rate_html, portfolio_html, strength_title,
+                strength_width,
+            )
         )
 
     parts.append('</div>')

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -6,6 +6,7 @@
 
 import re
 import html as html_mod
+import json
 from datetime import datetime, timedelta
 import csv
 import os
@@ -867,15 +868,15 @@ tr:hover { background: #f5f5f5; }
 .theme-grid { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 16px 0; }
 .theme-badge {
   display: inline-flex; flex-direction: column; align-items: center;
-  border: 1px solid #ddd; border-radius: 6px; padding: 6px 10px 0 10px;
-  background: #fff; min-width: 110px; font-size: 0.85em;
+  border: 1px solid #ddd; border-radius: 6px; padding: 6px 6px 0 6px;
+  background: #fff; width: 108px; box-sizing: border-box; font-size: 0.8em;
   overflow: hidden;
 }
 .theme-badge .rank { font-size: 0.75em; color: #333; }
-.theme-badge .name { font-weight: bold; text-align: center; color: #333; }
+.theme-badge .name { font-weight: bold; text-align: center; color: #333; font-size: 0.95em; line-height: 1.2; word-break: break-all; overflow-wrap: anywhere; }
 .theme-badge .change { font-size: 0.8em; margin-top: 2px; color: #333; }
 .theme-badge .rate { font-size: 0.8em; margin-top: 2px; }
-.theme-badge .strength-track { width: calc(100% + 20px); height: 5px; margin-top: 5px; background: rgba(255,255,255,0.55); align-self: stretch; }
+.theme-badge .strength-track { width: 96px; height: 5px; margin-top: 5px; background: rgba(255,255,255,0.55); }
 .theme-badge .strength-bar { height: 100%; background: #1f4e79; }
 .theme-badge .change-up { color: #c0392b; }
 .theme-badge .change-down { color: #2980b9; }
@@ -889,9 +890,31 @@ tr:hover { background: #f5f5f5; }
 .theme-heat2  { background: #66bb6a; border-color: #4caf50; }
 .theme-badge.theme-hold { border: 3px solid #d4af37; }
 .theme-badge.theme-semi { border: 2px solid #a8a8a8; }
-.theme-badge .portfolio-links { margin-top: 4px; font-size: 0.75em; color: #333; }
-.theme-badge .portfolio-links summary { cursor: pointer; list-style: none; }
-.theme-badge .portfolio-links summary::-webkit-details-marker { display: none; }
+.theme-badge.theme-clickable { cursor: pointer; }
+.theme-modal-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 1000;
+  display: none; align-items: center; justify-content: center;
+}
+.theme-modal-content {
+  background: #fff; border-radius: 6px; padding: 1em 1.2em;
+  width: min(420px, 90vw); max-height: 80vh; overflow-y: auto;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+}
+.theme-modal-header {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 0.6em; padding-bottom: 0.4em; border-bottom: 1px solid #eee;
+}
+.theme-modal-header h3 { margin: 0; font-size: 1.05em; }
+.theme-modal-close {
+  background: none; border: none; font-size: 1.4em; cursor: pointer;
+  padding: 0 0.3em; line-height: 1; color: #888;
+}
+.theme-modal-section { margin-top: 0.6em; }
+.theme-modal-section h4 { margin: 0 0 0.3em 0; font-size: 0.9em; color: #555; }
+.theme-modal-section ul { list-style: none; padding: 0; margin: 0; }
+.theme-modal-section li { margin-bottom: 0.3em; font-size: 0.9em; list-style: none; }
+.theme-modal-section a { color: #1976d2; text-decoration: none; }
+.theme-modal-section a:hover { text-decoration: underline; }
 
 /* 市場テーブル */
 /* table のデフォルト width:100% を解除し、列幅の合計だけのコンパクトな表にする */
@@ -1032,45 +1055,102 @@ def _html_theme_rank(market_db, theme_rank_data=None):
         link_info = theme_portfolio_links.get(theme, {}) or {}
         hold_items = link_info.get("hold", []) or []
         semi_items = link_info.get("semi", []) or []
+        has_links = bool(hold_items or semi_items)
         portfolio_class = " theme-hold" if hold_items else (
             " theme-semi" if semi_items else ""
         )
-        portfolio_html = ""
-        if hold_items or semi_items:
-            def _stock_label(item):
-                if isinstance(item, (list, tuple)) and len(item) >= 2:
-                    code_s, stock_name = item[0], item[1]
-                    label = "%s %s" % (code_s, stock_name) if stock_name else code_s
-                else:
-                    label = str(item)
-                return html_mod.escape(label)
-
-            code_parts = []
-            if hold_items:
-                code_parts.append("保 " + ", ".join(_stock_label(item) for item in hold_items))
-            if semi_items:
-                code_parts.append("準 " + ", ".join(_stock_label(item) for item in semi_items))
-            portfolio_html = (
-                '    <details class="portfolio-links"><summary>銘柄</summary>%s</details>\n'
-                % "<br>".join(code_parts)
+        clickable_class = " theme-clickable" if has_links else ""
+        if has_links:
+            hold_json = html_mod.escape(
+                json.dumps(hold_items, ensure_ascii=False), quote=True,
             )
+            semi_json = html_mod.escape(
+                json.dumps(semi_items, ensure_ascii=False), quote=True,
+            )
+            theme_attr = html_mod.escape(theme, quote=True)
+            click_attrs = (
+                ' data-theme="%s" data-hold="%s" data-semi="%s"'
+                ' onclick="openThemeModal(this)"'
+            ) % (theme_attr, hold_json, semi_json)
+        else:
+            click_attrs = ""
         theme_escaped = html_mod.escape(theme)
         parts.append(
-            '  <div class="theme-badge %s%s">\n'
+            '  <div class="theme-badge %s%s%s"%s>\n'
             '    <span class="rank">#%d</span>\n'
             '    <span class="name">%s</span>\n'
             '    <span class="change %s">%s</span>\n'
             '    %s\n'
-            '%s'
             '    <div class="strength-track" title="%s"><div class="strength-bar" style="width:%.1f%%"></div></div>\n'
             '  </div>' % (
-                heat_class, portfolio_class, i + 1, theme_escaped, change_class,
-                change_text, rate_html, portfolio_html, strength_title,
+                heat_class, portfolio_class, clickable_class, click_attrs,
+                i + 1, theme_escaped, change_class,
+                change_text, rate_html, strength_title,
                 strength_width,
             )
         )
 
     parts.append('</div>')
+
+    # 保有/準保有銘柄ポップアップダイアログ
+    parts.append(
+        '<div id="theme-modal" class="theme-modal-overlay"'
+        ' onclick="closeThemeModalOnOverlay(event)">\n'
+        '  <div class="theme-modal-content">\n'
+        '    <div class="theme-modal-header">\n'
+        '      <h3 id="theme-modal-title"></h3>\n'
+        '      <button type="button" class="theme-modal-close"'
+        ' onclick="closeThemeModal()" aria-label="閉じる">×</button>\n'
+        '    </div>\n'
+        '    <div id="theme-modal-body"></div>\n'
+        '  </div>\n'
+        '</div>\n'
+        '<script>\n'
+        'function openThemeModal(card) {\n'
+        '  var theme = card.dataset.theme || "";\n'
+        '  var hold = [];\n'
+        '  var semi = [];\n'
+        '  try { hold = JSON.parse(card.dataset.hold || "[]"); } catch (e) {}\n'
+        '  try { semi = JSON.parse(card.dataset.semi || "[]"); } catch (e) {}\n'
+        '  document.getElementById("theme-modal-title").textContent = theme;\n'
+        '  var body = document.getElementById("theme-modal-body");\n'
+        '  body.innerHTML = "";\n'
+        '  function section(label, items) {\n'
+        '    if (!items.length) return;\n'
+        '    var div = document.createElement("div");\n'
+        '    div.className = "theme-modal-section";\n'
+        '    var h4 = document.createElement("h4");\n'
+        '    h4.textContent = label;\n'
+        '    div.appendChild(h4);\n'
+        '    var ul = document.createElement("ul");\n'
+        '    items.forEach(function(item) {\n'
+        '      var li = document.createElement("li");\n'
+        '      var a = document.createElement("a");\n'
+        '      a.href = "/detail/" + encodeURIComponent(item[0]);\n'
+        '      a.target = "_blank";\n'
+        '      a.rel = "noopener";\n'
+        '      a.textContent = item[0] + (item[1] ? " " + item[1] : "");\n'
+        '      li.appendChild(a);\n'
+        '      ul.appendChild(li);\n'
+        '    });\n'
+        '    div.appendChild(ul);\n'
+        '    body.appendChild(div);\n'
+        '  }\n'
+        '  section("保有", hold);\n'
+        '  section("準保有", semi);\n'
+        '  document.getElementById("theme-modal").style.display = "flex";\n'
+        '}\n'
+        'function closeThemeModal() {\n'
+        '  document.getElementById("theme-modal").style.display = "none";\n'
+        '}\n'
+        'function closeThemeModalOnOverlay(e) {\n'
+        '  if (e.target.id === "theme-modal") closeThemeModal();\n'
+        '}\n'
+        'document.addEventListener("keydown", function(e) {\n'
+        '  if (e.key === "Escape") closeThemeModal();\n'
+        '});\n'
+        '</script>'
+    )
 
     # Kabutanランキング履歴
     if theme_rank_data:

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -346,13 +346,22 @@ class TestHtmlThemeRank:
         assert 'style="width:50.0%"' in result
         assert '強度: 100pt / 40日中4日Top30' in result
 
-    def test_portfolio_border_and_codes(self):
-        """保有/準保有テーマに枠線クラスと銘柄コード・銘柄名が付く"""
+    def test_portfolio_border_and_modal_data(self):
+        """保有/準保有テーマに枠線・クリック属性・モーダル用JSON銘柄データが付く"""
         result = make_market_db._html_theme_rank(self._make_market_db())
+        # 枠線クラスは維持
         assert "theme-hold" in result
         assert "theme-semi" in result
-        assert "保 3496 アズーム" in result
-        assert "準 6324 ハーモニック" in result
+        # クリック可能カードとonclickハンドラ
+        assert "theme-clickable" in result
+        assert 'onclick="openThemeModal(this)"' in result
+        # data-* 属性に銘柄情報がJSONで埋め込まれる
+        assert 'data-theme="AI"' in result
+        assert "3496" in result and "アズーム" in result
+        assert "6324" in result and "ハーモニック" in result
+        # モーダル雛形が出力される
+        assert 'id="theme-modal"' in result
+        assert "function openThemeModal" in result
 
     def test_rank_history(self):
         """Kabutanランキング履歴が含まれる"""

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -289,6 +289,18 @@ class TestHtmlThemeRank:
                 "半導体": (-0.3, 5),
                 "防衛": (0.0, 8),
             },
+            "theme_strength": {
+                "AI": 100,
+                "半導体": 50,
+            },
+            "theme_strength_days": {
+                "AI": 4,
+                "半導体": 2,
+            },
+            "theme_portfolio_links": {
+                "AI": {"hold": [("3496", "アズーム")], "semi": []},
+                "半導体": {"hold": [], "semi": [("6324", "ハーモニック")]},
+            },
             "access_date_theme_rank": datetime(2026, 3, 15),
         }
 
@@ -324,6 +336,22 @@ class TestHtmlThemeRank:
         """テーマランクが空の場合は空文字列"""
         result = make_market_db._html_theme_rank({"theme_rank": []})
         assert result == ""
+
+    def test_strength_bar(self):
+        """テーマ持続強度バーとhover詳細が付く"""
+        result = make_market_db._html_theme_rank(self._make_market_db())
+        assert 'class="strength-track"' in result
+        assert 'class="strength-bar" style="width:100.0%"' in result
+        assert 'style="width:50.0%"' in result
+        assert '強度: 100pt / 40日中4日Top30' in result
+
+    def test_portfolio_border_and_codes(self):
+        """保有/準保有テーマに枠線クラスと銘柄コード・銘柄名が付く"""
+        result = make_market_db._html_theme_rank(self._make_market_db())
+        assert "theme-hold" in result
+        assert "theme-semi" in result
+        assert "保 3496 アズーム" in result
+        assert "準 6324 ハーモニック" in result
 
     def test_rank_history(self):
         """Kabutanランキング履歴が含まれる"""
@@ -1282,6 +1310,8 @@ class TestMakeThemeDataDiff:
         assert "theme_rank" in result
         assert "theme_rank_diff" in result
         assert "access_date_theme_rank" in result
+        assert "theme_rank_history" in result
+        assert "theme_strength" in result
 
     def test_all_themes_have_diff(self):
         """theme_rankの全テーマにtheme_rank_diffのエントリがある"""
@@ -1290,6 +1320,67 @@ class TestMakeThemeDataDiff:
             result = make_market_db.make_theme_data(prev_momentum)
         for theme in result["theme_rank"]:
             assert theme in result["theme_rank_diff"]
+
+
+class TestThemeRankHistory:
+    """テーマ持続強度の履歴計算テスト"""
+
+    def test_append_and_strength(self):
+        """Kabutan生順位から強度とTop30日数を計算する"""
+        history, strength, days = make_market_db.update_theme_rank_history(
+            [], "2026-03-18", ["AI", "半導体", "防衛"],
+        )
+        assert history == [
+            ("2026-03-18", [("AI", 1), ("半導体", 2), ("防衛", 3)])
+        ]
+        assert strength["AI"] == 30
+        assert strength["半導体"] == 29
+        assert days["AI"] == 1
+
+    def test_same_day_replaces(self):
+        """同日再実行はappendではなく置換する"""
+        history = [("2026-03-18", [("AI", 1), ("半導体", 2)])]
+        history, strength, days = make_market_db.update_theme_rank_history(
+            history, "2026-03-18", ["DX"],
+        )
+        assert history == [("2026-03-18", [("DX", 1)])]
+        assert strength == {"DX": 30}
+        assert days == {"DX": 1}
+
+    def test_window_keeps_latest_40_days(self):
+        """履歴は40営業日分だけ保持する"""
+        history = [
+            ("2026-03-%02d" % i, [("AI", 1)])
+            for i in range(1, 41)
+        ]
+        history, strength, _ = make_market_db.update_theme_rank_history(
+            history, "2026-04-01", ["AI"],
+        )
+        assert len(history) == make_market_db.THEME_STRENGTH_WINDOW_DAYS
+        assert history[0][0] == "2026-03-02"
+        assert history[-1][0] == "2026-04-01"
+        assert strength["AI"] == 30 * make_market_db.THEME_STRENGTH_WINDOW_DAYS
+
+
+class TestThemePortfolioLinks:
+    """テーマカードの保有/準保有リンク作成テスト"""
+
+    def test_build_links_exact_theme_match(self):
+        records = [
+            {"code_s": "3496", "status": "1保"},
+            {"code_s": "6324", "status": "2準"},
+            {"code_s": "7203", "status": "3監"},
+        ]
+        stock_map = {
+            "3496": {"stock_name": "アズーム", "themes": "AI,半導体"},
+            "6324": {"stock_name": "ハーモニック", "themes": "半導体,ロボット"},
+            "7203": {"stock_name": "トヨタ", "themes": "自動車"},
+        }
+        result = make_market_db.build_theme_portfolio_links(records, stock_map)
+        assert result["AI"]["hold"] == [("3496", "アズーム")]
+        assert result["半導体"]["hold"] == [("3496", "アズーム")]
+        assert result["半導体"]["semi"] == [("6324", "ハーモニック")]
+        assert "自動車" not in result
 
 
 # ==================================================

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -1,6 +1,7 @@
 """make_market_db.py の計算関数テスト"""
 
 import pytest
+import dbm
 import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -1381,6 +1382,19 @@ class TestThemePortfolioLinks:
         assert result["半導体"]["hold"] == [("3496", "アズーム")]
         assert result["半導体"]["semi"] == [("6324", "ハーモニック")]
         assert "自動車" not in result
+
+    def test_collect_links_dbm_error_returns_empty(self):
+        """DBアクセス系エラーは警告だけ出して空dictにする"""
+        with patch.object(make_market_db, "_shelve_path_exists", return_value=True), \
+                patch("portfolio_shelve.list_records", side_effect=dbm.error[0]("boom")):
+            assert make_market_db.collect_theme_portfolio_links() == {}
+
+    def test_collect_links_logic_error_is_not_swallowed(self):
+        """API変更などの論理エラーは握り潰さず失敗させる"""
+        with patch.object(make_market_db, "_shelve_path_exists", return_value=True), \
+                patch("portfolio_shelve.list_records", side_effect=AttributeError("boom")):
+            with pytest.raises(AttributeError):
+                make_market_db.collect_theme_portfolio_links()
 
 
 # ==================================================


### PR DESCRIPTION
## 概要

issue #182 の Phase 1-3 対応です。

- Kabutan 生順位のテーマランク履歴を 40 営業日分 `market_db` に保持
- 履歴から `theme_strength` / `theme_strength_days` を計算
- `/market` のテーマカード下端に持続強度バーを追加
- 保有銘柄テーマは金枠、準保有銘柄テーマは銀枠で強調
- カード内 details に `コード 銘柄名` を表示

## 補足

当初 issue 文面は 60 営業日でしたが、テーマ回転への追随性を優先して 40 営業日にしています。履歴長は `THEME_STRENGTH_WINDOW_DAYS` で定数化済みです。

## 確認

- `.venv/bin/python -m pytest tests/test_make_market_db.py tests/test_functional_market.py -q`
- 結果: `131 passed, 1 warning`
- Playwright で生成 HTML のテーマカードを確認
  - 強度バー表示
  - 金/銀枠
  - details 展開
  - カード重なりなし

Closes #182