### PR TITLE
[codex] Fear & Greedを市場DBに追加

### DIFF
--- a/scripts/fng.py
+++ b/scripts/fng.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""CNN Fear & Greed Index の取得・パース。"""
+
+from datetime import datetime
+
+import requests
+
+
+FNG_URL = "https://production.dataviz.cnn.io/index/fearandgreed/graphdata"
+FNG_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Referer": "https://edition.cnn.com/",
+    "Origin": "https://edition.cnn.com",
+}
+
+
+def _score_from_point(point):
+    """CNN履歴1点から score を取り出す。"""
+    if isinstance(point, dict):
+        for key in ("y", "score", "value"):
+            if key in point:
+                return float(point[key])
+    return float(point)
+
+
+def parse_fear_and_greed(payload, access_date=None):
+    """CNN Fear & Greed JSON から保存用 dict を作る。
+
+    Args:
+        payload: CNN API の JSON dict
+        access_date: 取得日時。Noneなら現在時刻
+    Returns:
+        dict: market_db["fear_and_greed"] に保存する値
+    """
+    fg = payload.get("fear_and_greed") or {}
+    hist = ((payload.get("fear_and_greed_historical") or {}).get("data") or [])
+    if len(hist) < 20:
+        raise ValueError("Fear & Greed historical data is too short")
+
+    score = float(fg["score"])
+    rating = str(fg.get("rating", "")).strip().lower()
+    score_5d_ago = _score_from_point(hist[-5])
+    score_20d_ago = _score_from_point(hist[-20])
+    return {
+        "score": score,
+        "rating": rating,
+        "score_5d_ago": score_5d_ago,
+        "score_20d_ago": score_20d_ago,
+        "access_date": access_date or datetime.now(),
+    }
+
+
+def fetch_fear_and_greed(timeout=10):
+    """CNN API から Fear & Greed Index を取得する。"""
+    resp = requests.get(FNG_URL, headers=FNG_HEADERS, timeout=timeout)
+    resp.raise_for_status()
+    return parse_fear_and_greed(resp.json(), access_date=datetime.now())

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -921,7 +921,10 @@ def _html_theme_rank(market_db, theme_rank_data=None):
     if theme_rank_data:
         theme_rank_list, prev_theme_rank_list, _, prev_day = theme_rank_data
         if theme_rank_list or prev_theme_rank_list:
-            parts.append('<h3>Kabutanランキング履歴</h3>')
+            parts.append(
+                '<h3><a href="https://kabutan.jp/info/accessranking/3_2"'
+                ' target="_blank" rel="noopener">Kabutanランキング履歴</a></h3>'
+            )
             parts.append('<div class="rank-history"><table>')
             access_date = market_db.get("access_date_theme_rank")
             def _rank_row(date_str, rank_list):
@@ -1031,7 +1034,8 @@ def _html_fear_and_greed(market_db):
 
     return (
         '<div class="fng-card" title="%s">\n'
-        '  <strong>Fear &amp; Greed</strong>\n'
+        '  <strong><a href="https://edition.cnn.com/markets/fear-and-greed"'
+        ' target="_blank" rel="noopener">Fear &amp; Greed</a></strong>\n'
         '  <span class="fng-score">%.1f</span>\n'
         '  <span class="fng-rating %s">%s</span>\n'
         '  <span>5営業日前比 <span class="%s">%s</span></span>\n'

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -12,6 +12,7 @@ import os
 
 import price
 import make_stock_db
+import fng
 
 from ks_util import *
 
@@ -381,6 +382,11 @@ def make_sp500_db():
     return _make_us_index_db("_GSPC", "^GSPC", "sp500")
 
 
+def make_fng_db():
+    """CNN Fear & Greed Index を取得する。"""
+    return {"fear_and_greed": fng.fetch_fear_and_greed()}
+
+
 _market_db_cache = None
 _market_db_lock = threading.Lock()
 
@@ -557,6 +563,14 @@ def update_market_db():
     prev_momentum_rank = market_db.get("prev_theme_rank", [])
     theme_db = make_theme_data(prev_momentum_rank)
     market_db.update(theme_db)
+
+    try:
+        market_db.update(make_fng_db())
+    except Exception as e:
+        log_warning(
+            "[market] Fear & Greed 取得失敗のため DB 更新をスキップ "
+            "(前回データを保持): %s" % e
+        )
 
     # 各指数を更新 (まず DD/FTD 候補と当日価格を取得)
     index_makers = [
@@ -784,6 +798,16 @@ tr:hover { background: #f5f5f5; }
 /* DD 進行度の警告色 */
 .dd-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
 .dd-correction { background: #fdedec; color: #c0392b; font-weight: bold; }
+.fng-card { display: inline-flex; align-items: center; gap: 12px; margin: 0 0 10px 0; padding: 8px 12px; border: 1px solid #ddd; border-radius: 6px; background: #fff; font-size: 0.9em; }
+.fng-score { font-size: 1.35em; font-weight: bold; }
+.fng-rating { padding: 2px 8px; border-radius: 999px; font-size: 0.85em; font-weight: bold; color: #fff; }
+.fng-rating-extreme-fear { background: #a93226; }
+.fng-rating-fear { background: #e67e22; }
+.fng-rating-neutral { background: #7f8c8d; }
+.fng-rating-greed { background: #27ae60; }
+.fng-rating-extreme-greed { background: #145a32; }
+.fng-delta-pos { color: #c0392b; }
+.fng-delta-neg { color: #2980b9; }
 
 /* 決算 */
 .kessan-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
@@ -972,6 +996,56 @@ def _rs_style(rs_raw):
     if rs_raw <= 0.9:
         return ' style="background:#6fa8dc"'
     return ""
+
+
+def _format_fng_delta(score, past_score):
+    """Fear & Greed の差分表示用テキストを返す。"""
+    try:
+        delta = float(score) - float(past_score)
+    except (TypeError, ValueError):
+        return "—", ""
+    cls = "fng-delta-pos" if delta >= 0 else "fng-delta-neg"
+    return "%+.1f" % delta, cls
+
+
+def _html_fear_and_greed(market_db):
+    """Fear & Greed Index のサマリーHTMLを生成する。"""
+    fng_db = market_db.get("fear_and_greed") or {}
+    if not fng_db:
+        return ""
+
+    try:
+        score = float(fng_db["score"])
+    except (KeyError, TypeError, ValueError):
+        return ""
+    rating = str(fng_db.get("rating", "")).strip().lower()
+    rating_label = rating.replace("_", " ").title() if rating else "Unknown"
+    rating_class = "fng-rating-" + rating.replace(" ", "-") if rating else "fng-rating-neutral"
+    delta_5, delta_5_class = _format_fng_delta(score, fng_db.get("score_5d_ago"))
+    delta_20, delta_20_class = _format_fng_delta(score, fng_db.get("score_20d_ago"))
+    access_date = fng_db.get("access_date")
+    access_text = ""
+    if hasattr(access_date, "strftime"):
+        access_text = " 更新: " + access_date.strftime("%Y-%m-%d %H:%M")
+
+    return (
+        '<div class="fng-card" title="%s">\n'
+        '  <strong>Fear &amp; Greed</strong>\n'
+        '  <span class="fng-score">%.1f</span>\n'
+        '  <span class="fng-rating %s">%s</span>\n'
+        '  <span>5営業日前比 <span class="%s">%s</span></span>\n'
+        '  <span>20営業日前比 <span class="%s">%s</span></span>\n'
+        '</div>\n'
+    ) % (
+        html_mod.escape(access_text.strip()),
+        score,
+        html_mod.escape(rating_class),
+        html_mod.escape(rating_label),
+        html_mod.escape(delta_5_class),
+        html_mod.escape(delta_5),
+        html_mod.escape(delta_20_class),
+        html_mod.escape(delta_20),
+    )
 
 
 _SPR_GAUGE_WIDTH = 100      # バー本体の幅 (= SPR 0〜100 のスケール)
@@ -1273,6 +1347,7 @@ def _html_market(market_db):
 
     header = (
         '<h2>市場</h2>\n'
+        '%s'
         '<table class="market-table">\n'
         '<thead><tr>\n'
         '  <th>市場名</th><th class="col-rs">RS</th><th class="col-trend">トレンド</th>\n'
@@ -1280,7 +1355,7 @@ def _html_market(market_db):
         '  <th class="col-state">市場状態</th><th class="col-spr">需給バランス</th>\n'
         '</tr></thead>\n'
         '<tbody>'
-    )
+    ) % _html_fear_and_greed(market_db)
     return header + '\n'.join(rows_html) + '\n</tbody></table>'
 
 

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -564,6 +564,7 @@ def update_market_db():
     theme_db = make_theme_data(prev_momentum_rank)
     market_db.update(theme_db)
 
+    market_db.setdefault("fear_and_greed", {})
     try:
         market_db.update(make_fng_db())
     except Exception as e:
@@ -1345,9 +1346,8 @@ def _html_market(market_db):
     if not rows_html:
         return ""
 
-    header = (
-        '<h2>市場</h2>\n'
-        '%s'
+    fng_html = _html_fear_and_greed(market_db)
+    header_static = (
         '<table class="market-table">\n'
         '<thead><tr>\n'
         '  <th>市場名</th><th class="col-rs">RS</th><th class="col-trend">トレンド</th>\n'
@@ -1355,7 +1355,8 @@ def _html_market(market_db):
         '  <th class="col-state">市場状態</th><th class="col-spr">需給バランス</th>\n'
         '</tr></thead>\n'
         '<tbody>'
-    ) % _html_fear_and_greed(market_db)
+    )
+    header = '<h2>市場</h2>\n' + fng_html + header_static
     return header + '\n'.join(rows_html) + '\n</tbody></table>'
 
 

--- a/tests/test_fng.py
+++ b/tests/test_fng.py
@@ -1,0 +1,74 @@
+"""CNN Fear & Greed Index パーサーのテスト。"""
+
+from datetime import datetime
+
+import pytest
+
+import fng
+
+
+def _payload(score=66.9, rating="greed", hist_len=25):
+    return {
+        "fear_and_greed": {
+            "score": score,
+            "rating": rating,
+        },
+        "fear_and_greed_historical": {
+            "data": [{"x": i, "y": float(i)} for i in range(hist_len)],
+        },
+    }
+
+
+def test_parse_current_score_and_rating():
+    result = fng.parse_fear_and_greed(
+        _payload(score=66.9, rating="Greed"),
+        access_date=datetime(2026, 5, 23, 12, 0),
+    )
+    assert result["score"] == 66.9
+    assert result["rating"] == "greed"
+    assert result["access_date"] == datetime(2026, 5, 23, 12, 0)
+
+
+def test_parse_5d_and_20d_scores_from_dict_points():
+    result = fng.parse_fear_and_greed(_payload(hist_len=25))
+    assert result["score_5d_ago"] == 20.0
+    assert result["score_20d_ago"] == 5.0
+
+
+def test_parse_history_numeric_points():
+    payload = _payload(hist_len=25)
+    payload["fear_and_greed_historical"]["data"] = [float(i) for i in range(25)]
+    result = fng.parse_fear_and_greed(payload)
+    assert result["score_5d_ago"] == 20.0
+    assert result["score_20d_ago"] == 5.0
+
+
+def test_parse_rejects_short_history():
+    with pytest.raises(ValueError):
+        fng.parse_fear_and_greed(_payload(hist_len=19))
+
+
+def test_fetch_uses_required_headers(monkeypatch):
+    captured = {}
+
+    class Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return _payload()
+
+    def fake_get(url, headers, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return Resp()
+
+    monkeypatch.setattr(fng.requests, "get", fake_get)
+    result = fng.fetch_fear_and_greed(timeout=3)
+    assert result["score"] == 66.9
+    assert captured["url"] == fng.FNG_URL
+    assert captured["headers"]["Referer"] == "https://edition.cnn.com/"
+    assert captured["headers"]["Origin"] == "https://edition.cnn.com"
+    assert "Mozilla/5.0" in captured["headers"]["User-Agent"]
+    assert captured["timeout"] == 3

--- a/tests/test_functional_market.py
+++ b/tests/test_functional_market.py
@@ -134,6 +134,16 @@ def market_env(tmp_path):
         make_market_db, "make_sp500_db",
         return_value={"sp500": index_data.copy()},
     ))
+    patches.append(patch.object(
+        make_market_db, "make_fng_db",
+        return_value={"fear_and_greed": {
+            "score": 66.9,
+            "rating": "greed",
+            "score_5d_ago": 58.2,
+            "score_20d_ago": 38.1,
+            "access_date": datetime(2026, 5, 23, 12, 0),
+        }},
+    ))
 
     # Google Drive、決算、適宜開示をモック
     patches.append(patch("googledrive.upload_csv"))
@@ -282,4 +292,3 @@ class TestUpdateMarketDbFlow:
         assert "↑" in content or "↓" in content, (
             "HTML内に差分ラベルが含まれていない"
         )
-

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -472,6 +472,24 @@ class TestHtmlMarket:
         assert '<th class="col-dd">DD</th>' in result
         assert '<th class="col-ftd">FTD/ラリー</th>' in result
 
+    def test_fear_and_greed_summary(self):
+        """Fear & Greed サマリーが市場テーブル前に表示される"""
+        db = self._make_market_db()
+        db["fear_and_greed"] = {
+            "score": 66.9,
+            "rating": "greed",
+            "score_5d_ago": 58.2,
+            "score_20d_ago": 38.1,
+            "access_date": datetime(2026, 5, 23, 12, 0),
+        }
+        result = make_market_db._html_market(db)
+        assert "Fear &amp; Greed" in result
+        assert "66.9" in result
+        assert "Greed" in result
+        assert "+8.7" in result
+        assert "+28.8" in result
+        assert "fng-rating-greed" in result
+
     # ===== Part B: 表示文言・列構成テスト =====
     def test_market_state_header_label(self):
         """列ヘッダが「市場状態」になっている"""
@@ -1447,13 +1465,18 @@ class TestUpdateMarketDbSkipsOnFetchFailure:
             patch.object(
                 make_market_db, "make_theme_data", return_value={"theme_rank": []}
             ),
+            patch.object(
+                make_market_db,
+                "make_fng_db",
+                return_value={"fear_and_greed": {"score": 50, "rating": "neutral"}},
+            ),
         )
 
     def test_前日DBが取得失敗時に保持される(self):
         """前日に正常取得した topix が、当日の取得失敗で上書きされない"""
         prev_topix = self._good_index_dict(rs=1.17)
         prev_db = {"topix": prev_topix, "theme_rank": []}
-        captured, p_get, p_save, p_theme = self._patch_common(prev_db)
+        captured, p_get, p_save, p_theme, p_fng = self._patch_common(prev_db)
 
         empty_maker = lambda: {"topix": {}}
         good_mothers = lambda: {"mothers": self._good_index_dict(rs=1.08)}
@@ -1461,7 +1484,7 @@ class TestUpdateMarketDbSkipsOnFetchFailure:
         good_nasdaq = lambda: {"nasdaq": self._good_index_dict(rs=1.17)}
         good_sp500 = lambda: {"sp500": self._good_index_dict(rs=1.11)}
 
-        with p_get, p_save, p_theme, \
+        with p_get, p_save, p_theme, p_fng, \
                 patch.object(make_market_db, "make_topix_db", side_effect=empty_maker), \
                 patch.object(make_market_db, "make_mothers_db", side_effect=good_mothers), \
                 patch.object(make_market_db, "make_nikkei_db", side_effect=good_nikkei), \
@@ -1478,14 +1501,14 @@ class TestUpdateMarketDbSkipsOnFetchFailure:
         """週足だけ部分的に成功 (rs_raw=0, price_log 無し) でも上書きされない"""
         prev_topix = self._good_index_dict(rs=1.17)
         prev_db = {"topix": prev_topix, "theme_rank": []}
-        captured, p_get, p_save, p_theme = self._patch_common(prev_db)
+        captured, p_get, p_save, p_theme, p_fng = self._patch_common(prev_db)
 
         partial_maker = lambda: {
             "topix": {"rs_raw": 0, "trend_template": "0/7", "pullback_20": 0}
         }
         good = lambda key, rs: (lambda: {key: self._good_index_dict(rs=rs)})
 
-        with p_get, p_save, p_theme, \
+        with p_get, p_save, p_theme, p_fng, \
                 patch.object(make_market_db, "make_topix_db", side_effect=partial_maker), \
                 patch.object(make_market_db, "make_mothers_db", side_effect=good("mothers", 1.08)), \
                 patch.object(make_market_db, "make_nikkei_db", side_effect=good("nikkei225", 1.29)), \
@@ -1499,12 +1522,12 @@ class TestUpdateMarketDbSkipsOnFetchFailure:
         """既存DBに topix が無い状態で取得失敗 → 空 dict をセットして
         下流の market_db['topix'] 参照が KeyError にならないようにする"""
         prev_db = {"theme_rank": []}  # topix キー無し
-        captured, p_get, p_save, p_theme = self._patch_common(prev_db)
+        captured, p_get, p_save, p_theme, p_fng = self._patch_common(prev_db)
 
         empty_maker = lambda: {"topix": {}}
         good = lambda key, rs: (lambda: {key: self._good_index_dict(rs=rs)})
 
-        with p_get, p_save, p_theme, \
+        with p_get, p_save, p_theme, p_fng, \
                 patch.object(make_market_db, "make_topix_db", side_effect=empty_maker), \
                 patch.object(make_market_db, "make_mothers_db", side_effect=good("mothers", 1.08)), \
                 patch.object(make_market_db, "make_nikkei_db", side_effect=good("nikkei225", 1.29)), \
@@ -1514,3 +1537,26 @@ class TestUpdateMarketDbSkipsOnFetchFailure:
 
         assert "topix" in captured["saved"]
         assert captured["saved"]["topix"] == {}
+
+    def test_fng_fetch_failure_keeps_previous_value(self):
+        """Fear & Greed 取得失敗時は前回値を保持する"""
+        prev_fng = {
+            "score": 44.0,
+            "rating": "neutral",
+            "score_5d_ago": 40.0,
+            "score_20d_ago": 30.0,
+        }
+        prev_db = {"theme_rank": [], "fear_and_greed": prev_fng}
+        captured, p_get, p_save, p_theme, _ = self._patch_common(prev_db)
+        good = lambda key, rs: (lambda: {key: self._good_index_dict(rs=rs)})
+
+        with p_get, p_save, p_theme, \
+                patch.object(make_market_db, "make_fng_db", side_effect=RuntimeError("boom")), \
+                patch.object(make_market_db, "make_topix_db", side_effect=good("topix", 1.17)), \
+                patch.object(make_market_db, "make_mothers_db", side_effect=good("mothers", 1.08)), \
+                patch.object(make_market_db, "make_nikkei_db", side_effect=good("nikkei225", 1.29)), \
+                patch.object(make_market_db, "make_nasdaq_db", side_effect=good("nasdaq", 1.17)), \
+                patch.object(make_market_db, "make_sp500_db", side_effect=good("sp500", 1.11)):
+            make_market_db.update_market_db()
+
+        assert captured["saved"]["fear_and_greed"] == prev_fng

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -1560,3 +1560,20 @@ class TestUpdateMarketDbSkipsOnFetchFailure:
             make_market_db.update_market_db()
 
         assert captured["saved"]["fear_and_greed"] == prev_fng
+
+    def test_fng_fetch_failure_sets_empty_on_first_run(self):
+        """Fear & Greed 初回取得失敗時もキーを確保する"""
+        prev_db = {"theme_rank": []}
+        captured, p_get, p_save, p_theme, _ = self._patch_common(prev_db)
+        good = lambda key, rs: (lambda: {key: self._good_index_dict(rs=rs)})
+
+        with p_get, p_save, p_theme, \
+                patch.object(make_market_db, "make_fng_db", side_effect=RuntimeError("boom")), \
+                patch.object(make_market_db, "make_topix_db", side_effect=good("topix", 1.17)), \
+                patch.object(make_market_db, "make_mothers_db", side_effect=good("mothers", 1.08)), \
+                patch.object(make_market_db, "make_nikkei_db", side_effect=good("nikkei225", 1.29)), \
+                patch.object(make_market_db, "make_nasdaq_db", side_effect=good("nasdaq", 1.17)), \
+                patch.object(make_market_db, "make_sp500_db", side_effect=good("sp500", 1.11)):
+            make_market_db.update_market_db()
+
+        assert captured["saved"]["fear_and_greed"] == {}


### PR DESCRIPTION
## 概要

issue #193 対応です。

- CNN Fear & Greed Index の取得・パース用 `scripts/fng.py` を追加
- `make_market_db.update_market_db()` で `market_db["fear_and_greed"]` に保存
- 取得失敗時は前回値を保持
- 市場セクションに現在値、5営業日前比、20営業日前比、rating ラベルを表示

## 確認

- `.venv/bin/python -m pytest tests/test_fng.py tests/test_make_market_db.py tests/test_functional_market.py -q`
- 結果: `132 passed, 1 warning`
- Playwright で生成 HTML の Fear & Greed カード表示を確認
- CNN API の live smoke を 1 回確認

Closes #193