### PR TITLE
theme: 持続強度ウィンドウを40日に揃え + 過去HTMLから遡及再構築

### DIFF
--- a/doc/plan/theme_rank_history_backfill.md
+++ b/doc/plan/theme_rank_history_backfill.md
@@ -1,0 +1,79 @@
+# テーマランク履歴 遡及再構築プラン (A+C)
+
+## 背景
+
+`scripts/make_market_db.py:24` で `THEME_STRENGTH_WINDOW_DAYS = 40` 営業日と定義されているが、現状の `market_db.theme_rank_history` は2日分しか蓄積されておらず、テーマカードの持続強度バーが実質的に「直近2日の合算」しか反映していない。
+
+一方ファイルシステム上には:
+
+- `data/market_data/theme_rank/theme_rank_YYMMDD.html` … 直近28営業日 (mtime ≤ 30日)
+- `data/market_data/theme_rank/history/theme_rank_YYMMDD.html` … 30日超の過去アーカイブ (2023年以降ぶん全て)
+
+が残っており、既存パーサーで遡及計算が可能。
+
+加えて `_archive_old_theme_rank(days=30)` が30日超で `history/` に追い出してしまうため、ウィンドウ40日と整合していない（バグ）。
+
+## ゴール (A+C)
+
+1. **A**: 40営業日ぶんの `theme_rank_*.html` (`theme_rank/` + `history/` から不足分を補う) を読み込み、`market_db.theme_rank_history / theme_strength / theme_strength_days` を遡及再構築する
+2. **C**: `_archive_old_theme_rank` のデフォルト `days` を `THEME_STRENGTH_WINDOW_DAYS` と揃え、今後 history/ に追い出される前に40営業日ぶんは `theme_rank/` 直下に残る運用に変更する
+
+## 実装内容
+
+### 1. `scripts/make_market_db.py` の修正 (最小)
+
+`_archive_old_theme_rank` のデフォルト値を `THEME_STRENGTH_WINDOW_DAYS` と揃える:
+
+```python
+def _archive_old_theme_rank(theme_rank_dir, days=THEME_STRENGTH_WINDOW_DAYS):
+    """{days}日以前のtheme_rank_YYMMDD.htmlをhistory/に移動"""
+```
+
+呼び出し側 (`get_theme_rank_list` 内) はデフォルト引数を使うので変更不要。
+
+### 2. 新規ワンショット移行スクリプト `scripts/migrate_theme_rank_history.py`
+
+責務:
+
+- `theme_rank/` 直下と `theme_rank/history/` から `theme_rank_YYMMDD.html` を全て列挙
+- 各ファイルの **mtime を `get_price_day()` に通して** 営業日日付 (YYYY-MM-DD) を導出
+  - 本番 `_theme_rank_history_date()` (`make_market_db.py:180`) と同じロジックで揃え、17:00前スクレイピング分が前日扱いになる仕様と整合させる
+  - ファイル名の YYMMDD は `backup_file` がスクレイピング時刻 mtime から付与するため、本番ロジックと不一致になる可能性があり採用しない
+- 同一営業日に複数ファイルが該当した場合は mtime が新しい方を採用 (本番ロジックでも同日2回目の実行は上書きされる)
+- 日付昇順にソートし、末尾 `THEME_STRENGTH_WINDOW_DAYS` 営業日ぶんを採用
+- 各ファイルを `parse_theme_html()` で読み、既存の `update_theme_rank_history()` を逐次呼んで history を構築
+- `market_db.theme_rank_history / theme_strength / theme_strength_days` を **常に上書き** 保存
+  - 「既存が揃っているか」での no-op 分岐は設けない (日付ずれ・重複・欠損が混ざった壊れた状態を固定化するリスクのほうが大きい)
+  - 冪等性は「同じ入力ファイル群に対して常に同じ結果を上書きする」ことで担保
+- ドライランオプション `--dry-run` で構築予定の件数・日付範囲・上位10テーマだけ表示し、DB は更新しない
+
+CLI:
+
+```bash
+cd scripts && python migrate_theme_rank_history.py --dry-run
+cd scripts && python migrate_theme_rank_history.py
+```
+
+### 3. テスト
+
+`tests/test_migrate_theme_rank_history.py` を新規作成。3本に抑える (parametrize で集約):
+
+- ファイル mtime → 営業日変換が `get_price_day` と同じ結果になる (17時前後の境界2ケース)
+- 過去ファイル群から `THEME_STRENGTH_WINDOW_DAYS` 日ぶんの history が末尾採用で構築される
+- ドライランで DB が変更されない
+
+実 HTML は使わず一時ディレクトリにダミーファイルを作り、`parse_theme_html` を monkeypatch する。
+`update_theme_rank_history` 単体ロジックは既存テストで担保済みのため、ここでは移行スクリプトの I/O・日付変換フローのみ検証。
+
+## 検証手順
+
+1. `pytest tests/test_make_market_db.py tests/test_migrate_theme_rank_history.py -v`
+2. `cd scripts && python migrate_theme_rank_history.py --dry-run` で件数を目視確認
+3. 本実行後、`/market` を再生成し持続強度バーが上位テーマで days=40 相当になることを確認
+
+## 影響範囲
+
+- 既存パーサー (`parse_theme_html`)・強度計算 (`update_theme_rank_history`) は無変更
+- DB スキーマ変更なし (`theme_rank_history` の値が増えるだけ)
+- `_archive_old_theme_rank` のデフォルト引数のみ変更 (40日まで `theme_rank/` 直下に残る)
+- 本番運用への影響: 翌日 `make_theme_data` 実行時に新しい強度値で `market_data.html` が再生成される

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -73,8 +73,8 @@ def _migrate_theme_rank_files():
             shutil.move(os.path.join(old_dir, fname), os.path.join(new_dir, fname))
 
 
-def _archive_old_theme_rank(theme_rank_dir, days=30):
-    """30日以前のtheme_rank_YYMMDD.htmlをhistory/に移動"""
+def _archive_old_theme_rank(theme_rank_dir, days=THEME_STRENGTH_WINDOW_DAYS):
+    """強度ウィンドウ日数より古いtheme_rank_YYMMDD.htmlをhistory/に移動"""
     history_dir = os.path.join(theme_rank_dir, "history")
     today = datetime.today()
     for fname in os.listdir(theme_rank_dir):

--- a/scripts/migrate_theme_rank_history.py
+++ b/scripts/migrate_theme_rank_history.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""テーマランク履歴を過去のtheme_rank_YYMMDD.htmlから遡及再構築する。
+
+- theme_rank/ 直下 + theme_rank/history/ の全 HTML から営業日日付を導出
+- mtime を get_price_day() に通して本番ロジック (_theme_rank_history_date) と整合
+- 同一営業日に複数ファイルがある場合は mtime が新しい方を採用
+- 末尾 THEME_STRENGTH_WINDOW_DAYS 営業日ぶんを使って history を構築
+- 既存 market_db.theme_rank_history / theme_strength / theme_strength_days を上書き
+- --dry-run: DB を更新せず構築予定の件数・上位10テーマを表示
+"""
+
+import argparse
+import os
+import re
+from datetime import datetime
+
+from db_shelve import MARKET_SHELVE, ShelveDB
+from ks_util import DATA_DIR, file_read, get_price_day, log_print, log_warning
+from make_market_db import (
+    THEME_STRENGTH_WINDOW_DAYS,
+    parse_theme_html,
+    update_theme_rank_history,
+)
+
+
+THEME_RANK_FNAME_RE = re.compile(r"^theme_rank_\d{6}\.html$")
+
+
+def collect_theme_rank_files(theme_rank_dir):
+    """theme_rank/ と history/ から theme_rank_YYMMDD.html を全て収集する。
+
+    Returns:
+        list of (mtime_datetime, fpath) — mtime 昇順ソート済み
+    """
+    candidates = []
+    for sub in (theme_rank_dir, os.path.join(theme_rank_dir, "history")):
+        if not os.path.isdir(sub):
+            continue
+        for fname in os.listdir(sub):
+            if not THEME_RANK_FNAME_RE.match(fname):
+                continue
+            fpath = os.path.join(sub, fname)
+            mtime = datetime.fromtimestamp(os.stat(fpath).st_mtime)
+            candidates.append((mtime, fpath))
+    candidates.sort(key=lambda x: x[0])
+    return candidates
+
+
+def select_latest_per_business_day(candidates):
+    """営業日ごとに mtime が最新の1ファイルを採用する。
+
+    Args:
+        candidates: list of (mtime, fpath) — mtime 昇順想定
+    Returns:
+        list of (date_str, fpath) — date_str 昇順
+    """
+    by_day = {}
+    for mtime, fpath in candidates:
+        date_str = get_price_day(mtime).isoformat()
+        by_day[date_str] = fpath  # 後勝ち=mtime新しい方
+    return sorted(by_day.items(), key=lambda x: x[0])
+
+
+def build_history(theme_rank_dir, window_days=THEME_STRENGTH_WINDOW_DAYS):
+    """過去ファイル群から history / strength / strength_days を再構築する。"""
+    candidates = collect_theme_rank_files(theme_rank_dir)
+    if not candidates:
+        log_warning("theme_rank_*.html が見つかりません:", theme_rank_dir)
+        return [], {}, {}
+    per_day = select_latest_per_business_day(candidates)
+    per_day = per_day[-window_days:]
+
+    history = []
+    strength = {}
+    strength_days = {}
+    for date_str, fpath in per_day:
+        html = file_read(fpath)
+        theme_list = parse_theme_html(html)
+        if not theme_list:
+            log_warning("空のtheme_rank:", fpath)
+            continue
+        history, strength, strength_days = update_theme_rank_history(
+            history, date_str, theme_list, window_days=window_days,
+        )
+    return history, strength, strength_days
+
+
+def report(history, strength, strength_days):
+    """構築結果を log_print で出力する。"""
+    log_print("再構築history件数:", len(history))
+    if history:
+        log_print("日付範囲:", history[0][0], "〜", history[-1][0])
+    log_print("上位10テーマ (strength desc):")
+    top = sorted(strength.items(), key=lambda x: -x[1])[:10]
+    for theme, pt in top:
+        log_print("  %-30s pt=%4d days=%2d" % (theme, pt, strength_days.get(theme, 0)))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="DB を更新せず構築結果のみ表示")
+    args = parser.parse_args()
+
+    theme_rank_dir = os.path.join(DATA_DIR, "market_data", "theme_rank")
+    history, strength, strength_days = build_history(theme_rank_dir)
+    report(history, strength, strength_days)
+
+    if args.dry_run:
+        log_print("--dry-run: DB は更新しません")
+        return
+    if not history:
+        log_print("再構築結果が空のため DB 更新をスキップします")
+        return
+
+    with ShelveDB(MARKET_SHELVE) as db:
+        db["theme_rank_history"] = history
+        db["theme_strength"] = strength
+        db["theme_strength_days"] = strength_days
+    log_print("market_db の theme_rank_history / theme_strength / theme_strength_days を更新しました")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_migrate_theme_rank_history.py
+++ b/tests/test_migrate_theme_rank_history.py
@@ -1,0 +1,126 @@
+"""migrate_theme_rank_history.py の移行ロジックテスト
+
+実 HTML は使わず、tmp_path にダミーファイルを配置し、
+parse_theme_html を monkeypatch して I/O・日付変換のフローのみ検証する。
+"""
+
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+import migrate_theme_rank_history as mig
+
+
+def _touch(path, mtime_dt, content="<dummy/>"):
+    """指定 mtime でダミーファイルを作成する。"""
+    with open(path, "w") as f:
+        f.write(content)
+    ts = mtime_dt.timestamp()
+    os.utime(path, (ts, ts))
+
+
+class TestMtimeToBusinessDay:
+    """mtime → 営業日変換が get_price_day と整合することを確認。"""
+
+    @pytest.mark.parametrize("hour,expected_offset", [
+        (16, -1),  # 17時前 → 前日扱い
+        (18, 0),   # 17時以降 → 当日
+    ])
+    def test_get_price_day_boundary(self, tmp_path, hour, expected_offset):
+        theme_dir = tmp_path / "theme_rank"
+        theme_dir.mkdir()
+        base = datetime(2026, 4, 10, hour, 0, 0)
+        fpath = theme_dir / "theme_rank_260410.html"
+        _touch(str(fpath), base)
+
+        result = mig.collect_theme_rank_files(str(theme_dir))
+        per_day = mig.select_latest_per_business_day(result)
+        assert len(per_day) == 1
+        expected_date = (base + timedelta(days=expected_offset)).date().isoformat()
+        assert per_day[0][0] == expected_date
+
+
+class TestBuildHistory:
+    """過去ファイル群から window 日数ぶんの history を末尾採用で構築する。"""
+
+    def test_window_truncation_and_construction(self, tmp_path, monkeypatch):
+        # 50日分のダミーファイルを生成 (window=40 なので末尾40日が採用される想定)
+        theme_dir = tmp_path / "theme_rank"
+        theme_dir.mkdir()
+        base = datetime(2026, 1, 1, 18, 0, 0)  # 17時以降で当日扱い
+        for i in range(50):
+            day = base + timedelta(days=i)
+            fname = "theme_rank_%02d%02d%02d.html" % (
+                day.year - 2000, day.month, day.day,
+            )
+            _touch(str(theme_dir / fname), day)
+
+        # parse_theme_html はファイル内容に関わらず固定テーマ列を返す
+        monkeypatch.setattr(
+            mig, "parse_theme_html",
+            lambda html: ["AI", "半導体", "防衛"],
+        )
+
+        history, strength, strength_days = mig.build_history(
+            str(theme_dir), window_days=40,
+        )
+
+        assert len(history) == 40
+        # 末尾採用: 末尾日付は base + 49日
+        last_day = (base + timedelta(days=49)).date().isoformat()
+        assert history[-1][0] == last_day
+        # AI は 31 - 1 = 30 pt × 40日 = 1200 pt
+        assert strength["AI"] == 30 * 40
+        assert strength_days["AI"] == 40
+
+    def test_history_and_subdir_merged_and_dedup_by_day(self, tmp_path, monkeypatch):
+        """theme_rank/ と history/ の両方から読み、同一営業日は mtime 新しい方を採用。"""
+        theme_dir = tmp_path / "theme_rank"
+        history_dir = theme_dir / "history"
+        history_dir.mkdir(parents=True)
+
+        # 同じ営業日 2026-04-10 に対し history/ 側 (古) と theme_rank/ 側 (新) を用意
+        old_mtime = datetime(2026, 4, 10, 18, 0, 0)
+        new_mtime = datetime(2026, 4, 10, 19, 30, 0)
+        _touch(str(history_dir / "theme_rank_260410.html"), old_mtime, "<old/>")
+        _touch(str(theme_dir / "theme_rank_260410.html"), new_mtime, "<new/>")
+
+        captured = []
+        def fake_parse(html):
+            captured.append(html)
+            return ["AI"]
+        monkeypatch.setattr(mig, "parse_theme_html", fake_parse)
+
+        history, _, _ = mig.build_history(str(theme_dir), window_days=40)
+
+        assert len(history) == 1
+        # 新しい方 (theme_rank/ 直下) が採用される
+        assert "<new/>" in captured
+        assert "<old/>" not in captured
+
+
+class TestDryRun:
+    """--dry-run 時に DB が更新されないことを確認。"""
+
+    def test_dry_run_skips_db_write(self, tmp_path, monkeypatch):
+        market_dir = tmp_path / "market_data"
+        theme_dir = market_dir / "theme_rank"
+        theme_dir.mkdir(parents=True)
+        _touch(
+            str(theme_dir / "theme_rank_260410.html"),
+            datetime(2026, 4, 10, 18, 0, 0),
+        )
+
+        monkeypatch.setattr(mig, "parse_theme_html", lambda html: ["AI"])
+        monkeypatch.setattr(mig, "DATA_DIR", str(tmp_path))
+
+        # ShelveDB を呼ばれたら例外で検知
+        class _Boom:
+            def __enter__(self): raise AssertionError("DB should not be opened in dry-run")
+            def __exit__(self, *a): pass
+        monkeypatch.setattr(mig, "ShelveDB", lambda *a, **kw: _Boom())
+        monkeypatch.setattr("sys.argv", ["migrate_theme_rank_history.py", "--dry-run"])
+
+        # 例外なく完了すれば OK
+        mig.main()


### PR DESCRIPTION
## Summary

- `_archive_old_theme_rank` のデフォルト保持日数を `THEME_STRENGTH_WINDOW_DAYS`(=40) と揃え、強度ウィンドウとバックアップ保持日数のミスマッチ（40 vs 30）を解消
- `migrate_theme_rank_history.py` を追加し、`theme_rank/` + `history/` の過去HTMLから `market_db.theme_rank_history / theme_strength / theme_strength_days` を遡及再構築できるようにした
- これまで `theme_rank_history` は2日分しか蓄積されておらず、持続強度バーが実質「直近2日の合算」になっていた問題を解消

## 設計上の要点

- ファイル mtime を `get_price_day()` に通して、本番 `_theme_rank_history_date()` と日付ロジックを揃えた（ファイル名 YYMMDD は `backup_file` がスクレイピング時刻 mtime から付与するため不採用）
- 同一営業日に複数ファイルがある場合は mtime が新しい方を採用
- no-op 分岐は設けず常に上書き（壊れた状態を固定化するリスクを回避）

## Test plan

- [x] `pytest tests/test_migrate_theme_rank_history.py tests/test_make_market_db.py -v` 全 pass
- [x] `python migrate_theme_rank_history.py --dry-run` で 40日分 (2026-04-10〜05-23) 構築を目視
- [x] 本実行 → `create_market_html` 再生成 → `/market` で持続強度バーが上位テーマで `days=40` 反映を確認（半導体 1180pt / 100%バー など）
- [x] codex プランレビュー通過（初回2件の重大指摘を反映済み）