### PR TITLE
disclosure: 決算反応に 20営業日後を追加 + 桁数ルールとtooltip整備

### DIFF
--- a/doc/plan/kessan_reaction_20d.md
+++ b/doc/plan/kessan_reaction_20d.md
@@ -1,0 +1,101 @@
+# 決算反応に 20営業日後 を追加 + 表示桁数ルール変更プラン
+
+## 背景・ゴール
+
+disclosure 決算日セクションの反応率表示 (例: `[2Q] +16.2% / +51.3%`) は現状「翌営業日 / 5営業日後」の2つ。
+ここに **20営業日後** を追加する。あわせて表示桁数ルールを以下に変更:
+
+- `|x| >= 10` のとき: 整数表示 (例: `+16%`, `+51%`)
+- `|x| < 10` のとき: 小数1桁 (例: `+2.7%`, `-0.3%`)
+
+## 前提確認 (既に検証済み)
+
+- `KESSAN_REACTION_PERIODS = (("1d", 1), ("5d", 5))` (`scripts/research_shelve.py:94`) が唯一の期間定義 (の SoT)
+- 計算ロジック `_price_reactions_from_log` は periods をループするので汎用
+- 永続化先 `post_price_changes` は dict (`{"1d": "+3.2", "5d": "+5.1"}` 形式) でスキーマ変更不要
+- `price_log` 保持件数は `LOG_DAY=30` (`scripts/price.py:546`) で 20営業日後は理論上計算可能
+- ただしテンプレ `scripts/webapp/templates/disclosure.html:40,42,73-76` は `'1d'/'5d'/'pts'` を**ハードコード**しているため、20d 表示には手当てが必要
+
+## 実装内容
+
+### 1. `scripts/research_shelve.py:94`
+
+```python
+KESSAN_REACTION_PERIODS = (("1d", 1), ("5d", 5), ("20d", 20))
+```
+
+これだけで:
+- 計算: `_price_reactions_from_log` が `20d` キーを自動算出
+- 保存: `update_pts_reactions` / `kessan_comments` 書込時に `20d` キーが入る
+- backfill: `_backfill_post_price_changes_for_entries` (`webapp/helpers.py:57`) が次回ページ表示時に既存決算の `20d` を `price_log` から補完 (補完可否は LOG_DAY マージン次第)
+
+### 2. `scripts/webapp/helpers.py:_format_reaction` (654行)
+
+桁数ルールを変更:
+
+```python
+def _format_reaction(before_price, after_price):
+    if before_price is None or before_price == 0:
+        return ""
+    try:
+        change = (float(after_price) / float(before_price) - 1.0) * 100.0
+    except (ValueError, ZeroDivisionError):
+        return ""
+    sign = "+" if change >= 0 else ""
+    # |x| >= 10 → 整数 / |x| < 10 → 小数1桁
+    if abs(change) >= 10:
+        return f"{sign}{change:.0f}"
+    return f"{sign}{change:.1f}"
+```
+
+### 3. テンプレート / JS の 20d 対応 (画面間で揃える)
+
+ハードコードしている全箇所に `'20d'` を追加する:
+
+**a. `scripts/webapp/templates/disclosure.html`**
+- 40,42行付近: `'1d'/'5d'` の隣に `'20d'` を追加
+- 73-76行: `{% set pc20 = s.post_price_changes['20d'] %}` を追加し、出力ブロックも併記
+
+**b. `scripts/webapp/templates/detail.html` (codex指摘1)**
+- 408-409行: `pc1/pc5` 周辺に `pc20 = entry.post_price_changes['20d']` を追加し、表示も併記
+  - disclosure と detail で表示行が揃うように
+
+**c. JS 側の `updatePostPriceChangeDisplay` (codex 出力 298-309行付近)**
+- `kessan-pc-20d` クラスを増設し、`changes['20d']` を反映するブロックを追加
+- editor 内のスパン (templates 側) にも `kessan-pc-20d` クラスのスパンを追加
+
+CSS で `.kessan-pc-20d` のスタイルが必要なら最小限あわせる (既存 1d/5d と同等で十分)。
+
+### 4. `scripts/make_market_db.py` の決算日カード
+
+`_html_kessan` (1632行〜) は反応率を描画していないことを再確認。変更なし。
+
+### 5. 既存決算データへの反映 (codex指摘2を反映)
+
+- **新規決算 (これから発表される分)**: 次回 `update_pts_reactions` / 決算コメント保存時に `20d` が自動付与され、20営業日経過後の表示更新で値が埋まる
+- **既存決算**: backfill (`_backfill_post_price_changes_for_entries`, `webapp/helpers.py:57`) は `price_log` (LOG_DAY=30) を参照するため、決算日が `price_log[-1]` (最古) より古いと補完不能
+  - 結果: 過去の決算カードの `20d` は多くが恒久的に空表示 (`-`) になる
+  - **これは要件「これから先の決算で20日後も見たい」と合致する範囲**であり、過去履歴を遡って埋める追加対応 (yfinance 再取得など) は今回スコープ外とする
+  - 「過去履歴の `20d` を全部埋めたい」という追加要件が出たら別 PR で yfinance による単発再取得スクリプトを書く方針
+
+## テスト
+
+`tests/test_webapp_helpers.py` に既存の `_price_reactions_from_log` / `_format_reaction` テストがあるはず。そこに次の3本を追加 (parametrize で集約):
+
+1. `_format_reaction` の桁数ルール: `|x| >= 10` は小数なし、`|x| < 10` は小数1桁、`|x| == 10.0` ぴったりも整数
+2. `_price_reactions_from_log` が `20d` キーを返す (price_log が十分長いケース)
+3. `price_log` が20件未満の場合 `20d` が "" になる
+
+## 検証手順
+
+1. `pytest tests/test_webapp_helpers.py tests/test_research_shelve.py -v`
+2. 開発サーバを再起動 (= `KESSAN_REACTION_PERIODS` 反映)
+3. `/disclosure` で過去決算カードに 1d/5d/20d の3値が並び、桁数ルールが守られていることを目視
+
+## 影響範囲
+
+- `KESSAN_REACTION_PERIODS` 変更1行: 計算/保存/backfill が自動追従
+- `_format_reaction` 変更: 桁数ルールが全反応率表示で変わる (disclosure 決算日カードに限らず portfolio 等の決算反応列も対象)
+- テンプレ disclosure.html: 20d 表示用の固定キー追加 (kessan-pc-20d クラスを CSS で揃える必要あれば対応)
+- DB スキーマ変更なし
+- 既存 `post_price_changes` dict には `20d` キーが順次追加されていく

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -91,7 +91,7 @@ RECORD_FIELDS = frozenset(
 
 # 決算コメントの反応率を計算する期間 (キー名, 営業日数) のタプル列
 # 表示・保存・後方互換正規化すべての場面でこの定数を参照する
-KESSAN_REACTION_PERIODS = (("1d", 1), ("5d", 5))
+KESSAN_REACTION_PERIODS = (("1d", 1), ("5d", 5), ("20d", 20))
 
 # 決算コメントエントリの既知フィールド
 KESSAN_COMMENT_FIELDS = frozenset(

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -652,7 +652,10 @@ def _split_log_around_kessanbi(
 
 
 def _format_reaction(before_price: Optional[int], after_price: int) -> str:
-    """前営業日終値 → N営業日後終値の変動率を符号付き文字列で返す。失敗時は ""。"""
+    """前営業日終値 → N営業日後終値の変動率を符号付き文字列で返す。失敗時は ""。
+
+    桁数: |x| >= 10 のとき整数 (例 +16) / |x| < 10 のとき小数1桁 (例 +2.7)
+    """
     if before_price is None or before_price == 0:
         return ""
     try:
@@ -660,6 +663,8 @@ def _format_reaction(before_price: Optional[int], after_price: int) -> str:
     except (ValueError, ZeroDivisionError):
         return ""
     sign = "+" if change >= 0 else ""
+    if abs(change) >= 10:
+        return f"{sign}{change:.0f}"
     return f"{sign}{change:.1f}"
 
 

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -297,7 +297,8 @@ function rememberKessanInitialValues(editor) {
 
 /* 1d/5d/20d 反応率を editor の post-price-change スパンに反映する。
    API が空文字を返したときは、テンプレ初期描画で入っている値を
-   上書きしない（market 側の補完計算結果が消えないようにするため）。 */
+   上書きしない（market 側の補完計算結果が消えないようにするため）。
+   API の生値 (+3.2) にテンプレと同じ % 単位を付けて表示する。 */
 function updatePostPriceChangeDisplay(editor, data) {
   var postPc = editor.querySelector('.kessan-post-price-change');
   if (!postPc) return;
@@ -305,9 +306,9 @@ function updatePostPriceChangeDisplay(editor, data) {
   var pc1Span = postPc.querySelector('.kessan-pc-1d');
   var pc5Span = postPc.querySelector('.kessan-pc-5d');
   var pc20Span = postPc.querySelector('.kessan-pc-20d');
-  if (pc1Span && changes['1d']) pc1Span.textContent = changes['1d'];
-  if (pc5Span && changes['5d']) pc5Span.textContent = changes['5d'];
-  if (pc20Span && changes['20d']) pc20Span.textContent = changes['20d'];
+  if (pc1Span && changes['1d']) pc1Span.textContent = changes['1d'] + '%';
+  if (pc5Span && changes['5d']) pc5Span.textContent = changes['5d'] + '%';
+  if (pc20Span && changes['20d']) pc20Span.textContent = changes['20d'] + '%';
 }
 
 function isKessanDirty(editor) {

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -295,7 +295,7 @@ function rememberKessanInitialValues(editor) {
   });
 }
 
-/* 1d/5d 反応率を editor の post-price-change スパンに反映する。
+/* 1d/5d/20d 反応率を editor の post-price-change スパンに反映する。
    API が空文字を返したときは、テンプレ初期描画で入っている値を
    上書きしない（market 側の補完計算結果が消えないようにするため）。 */
 function updatePostPriceChangeDisplay(editor, data) {
@@ -304,8 +304,10 @@ function updatePostPriceChangeDisplay(editor, data) {
   var changes = data.post_price_changes || {};
   var pc1Span = postPc.querySelector('.kessan-pc-1d');
   var pc5Span = postPc.querySelector('.kessan-pc-5d');
+  var pc20Span = postPc.querySelector('.kessan-pc-20d');
   if (pc1Span && changes['1d']) pc1Span.textContent = changes['1d'];
   if (pc5Span && changes['5d']) pc5Span.textContent = changes['5d'];
+  if (pc20Span && changes['20d']) pc20Span.textContent = changes['20d'];
 }
 
 function isKessanDirty(editor) {

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -262,13 +262,14 @@ nav .quick-search {
   font-weight: bold;
   margin-left: 4px;
 }
-/* 5d / 20d は補助情報として控えめに表示 (フォントサイズは 1d と同じ) */
+/* 5d / 20d は | 区切りで併記。色は通常 (rate-pos/neg) のまま */
 .kessan-pc-mid {
-  color: #888;
   margin-left: 3px;
 }
-.kessan-pc-mid .rate-pos { color: #d88; }
-.kessan-pc-mid .rate-neg { color: #88a; }
+.kessan-pc-sep {
+  color: #888;
+  margin: 0 4px;
+}
 .kessan-pts-label {
   display: inline-block;
   background: #34495e;

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -262,9 +262,8 @@ nav .quick-search {
   font-weight: bold;
   margin-left: 4px;
 }
-/* 5d / 20d は補助情報として控えめに表示 */
+/* 5d / 20d は補助情報として控えめに表示 (フォントサイズは 1d と同じ) */
 .kessan-pc-mid {
-  font-size: 0.8em;
   color: #888;
   margin-left: 3px;
 }

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -262,6 +262,14 @@ nav .quick-search {
   font-weight: bold;
   margin-left: 4px;
 }
+/* 5d / 20d は補助情報として控えめに表示 */
+.kessan-pc-mid {
+  font-size: 0.8em;
+  color: #888;
+  margin-left: 3px;
+}
+.kessan-pc-mid .rate-pos { color: #d88; }
+.kessan-pc-mid .rate-neg { color: #88a; }
 .kessan-pts-label {
   display: inline-block;
   background: #34495e;

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -407,10 +407,11 @@
           <td class="col-change">
             {% set pc1 = entry.post_price_changes['1d'] %}
             {% set pc5 = entry.post_price_changes['5d'] %}
-            {% if pc1 or pc5 %}
+            {% set pc20 = entry.post_price_changes['20d'] %}
+            {% if pc1 or pc5 or pc20 %}
               {% if pc1 %}<span class="kessan-price-change {% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-              /
-              {% if pc5 %}<span class="kessan-price-change {% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% else %}<span>-</span>{% endif %}
+              <span class="kessan-pc-mid">(<span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{{ pc5 or '-' }}</span>
+              <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{{ pc20 or '-' }}</span>)</span>
             {% else %}-{% endif %}
           </td>
           <td class="col-outlook kessan-ellipsis" title="{{ entry.pre_outlook or '' }}">{{ entry.pre_outlook or '' }}</td>

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -410,8 +410,8 @@
             {% set pc20 = entry.post_price_changes['20d'] %}
             {% if pc1 or pc5 or pc20 %}
               {% if pc1 %}<span class="kessan-price-change {% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-              <span class="kessan-pc-mid">(<span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{{ pc5 or '-' }}</span>
-              <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{{ pc20 or '-' }}</span>)</span>
+              <span class="kessan-pc-mid">(<span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
+              <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>)</span>
             {% else %}-{% endif %}
           </td>
           <td class="col-outlook kessan-ellipsis" title="{{ entry.pre_outlook or '' }}">{{ entry.pre_outlook or '' }}</td>

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -410,8 +410,9 @@
             {% set pc20 = entry.post_price_changes['20d'] %}
             {% if pc1 or pc5 or pc20 %}
               {% if pc1 %}<span class="kessan-price-change {% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-              <span class="kessan-pc-mid">(<span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
-              <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>)</span>
+              <span class="kessan-pc-sep">|</span>
+              <span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
+              <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>
             {% else %}-{% endif %}
           </td>
           <td class="col-outlook kessan-ellipsis" title="{{ entry.pre_outlook or '' }}">{{ entry.pre_outlook or '' }}</td>

--- a/scripts/webapp/templates/disclosure.html
+++ b/scripts/webapp/templates/disclosure.html
@@ -17,7 +17,7 @@
 {% endif %}
 
 {# 動的決算セクション (市場ページから移設) #}
-<h2 title="株価変動率の表記: 翌営業日 | 5営業日後 20営業日後 / 例: +16.2% | +51% +30%&#10;・PTS は決算日夜のPTS価格 / 1d は決算前営業日終値 → 翌営業日終値&#10;・|変動率| ≧ 10% は整数表記、未満は小数1桁">決算日 <span style="font-size:0.55em; color:#888; cursor:help;">[?]</span></h2>
+<h2 title="株価変動率の表記: 翌営業日 | 5営業日後 20営業日後 / 例: +16.2% | +51% +30%">決算日 <span style="font-size:0.55em; color:#888; cursor:help;">[?]</span></h2>
 <div id="kessan-section">
   {% macro render_kessan_editor(s, is_past) -%}
     <div class="kessan-editor" style="display:none;" data-loaded="0">

--- a/scripts/webapp/templates/disclosure.html
+++ b/scripts/webapp/templates/disclosure.html
@@ -17,7 +17,7 @@
 {% endif %}
 
 {# 動的決算セクション (市場ページから移設) #}
-<h2>決算日</h2>
+<h2 title="株価変動率の表記: 翌営業日 (5営業日後 20営業日後) / 例: +16.2% (+51 +30)&#10;・PTS は決算日夜のPTS価格 / 1d は決算前営業日終値 → 翌営業日終値&#10;・|変動率| ≧ 10% は整数表記、未満は小数1桁">決算日 <span style="font-size:0.55em; color:#888; cursor:help;">[?]</span></h2>
 <div id="kessan-section">
   {% macro render_kessan_editor(s, is_past) -%}
     <div class="kessan-editor" style="display:none;" data-loaded="0">
@@ -38,8 +38,7 @@
         <label>株価変動率:</label>
         <span class="kessan-field-display kessan-post-price-change">
           <span class="kessan-pc-1d">{{ s.post_price_changes['1d'] or '-' }}</span>
-          /
-          <span class="kessan-pc-5d">{{ s.post_price_changes['5d'] or '-' }}</span>
+          <span class="kessan-pc-mid">(<span class="kessan-pc-5d">{{ s.post_price_changes['5d'] or '-' }}</span> <span class="kessan-pc-20d">{{ s.post_price_changes['20d'] or '-' }}</span>)</span>
         </span>
       </div>
       <div class="kessan-editor-row">
@@ -70,16 +69,17 @@
       <a href="/stock/{{ s.code_s }}">{% if s.stock_name %}{{ macros.stock_name_with_prev(s) }}{% else %}-{% endif %}</a>
       {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}
       {% if s.pre_expectation %}<span class="kessan-expectation-badge exp-{{ s.pre_expectation }}">{{ s.pre_expectation }}</span>{% endif %}
-      {% if is_past and (s.post_price_changes['pts'] or s.post_price_changes['1d'] or s.post_price_changes['5d']) %}
+      {% if is_past and (s.post_price_changes['pts'] or s.post_price_changes['1d'] or s.post_price_changes['5d'] or s.post_price_changes['20d']) %}
         {% set pcp = s.post_price_changes['pts'] %}
         {% set pc1 = s.post_price_changes['1d'] %}
         {% set pc5 = s.post_price_changes['5d'] %}
+        {% set pc20 = s.post_price_changes['20d'] %}
         <span class="kessan-price-change">
           {% if pcp %}<span class="kessan-pts-label">PTS</span><span class="{% if pcp.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pcp }}%</span>{% endif %}
-          {% if pc1 or pc5 %}
+          {% if pc1 or pc5 or pc20 %}
             {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-            /
-            {% if pc5 %}<span class="{% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% else %}<span>-</span>{% endif %}
+            <span class="kessan-pc-mid">(<span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{{ pc5 or '-' }}</span>
+            <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{{ pc20 or '-' }}</span>)</span>
           {% endif %}
         </span>
       {% endif %}

--- a/scripts/webapp/templates/disclosure.html
+++ b/scripts/webapp/templates/disclosure.html
@@ -17,7 +17,7 @@
 {% endif %}
 
 {# 動的決算セクション (市場ページから移設) #}
-<h2 title="株価変動率の表記: 翌営業日 (5営業日後 20営業日後) / 例: +16.2% (+51 +30)&#10;・PTS は決算日夜のPTS価格 / 1d は決算前営業日終値 → 翌営業日終値&#10;・|変動率| ≧ 10% は整数表記、未満は小数1桁">決算日 <span style="font-size:0.55em; color:#888; cursor:help;">[?]</span></h2>
+<h2 title="株価変動率の表記: 翌営業日 | 5営業日後 20営業日後 / 例: +16.2% | +51% +30%&#10;・PTS は決算日夜のPTS価格 / 1d は決算前営業日終値 → 翌営業日終値&#10;・|変動率| ≧ 10% は整数表記、未満は小数1桁">決算日 <span style="font-size:0.55em; color:#888; cursor:help;">[?]</span></h2>
 <div id="kessan-section">
   {% macro render_kessan_editor(s, is_past) -%}
     <div class="kessan-editor" style="display:none;" data-loaded="0">
@@ -41,7 +41,9 @@
           {% set pc5 = s.post_price_changes['5d'] %}
           {% set pc20 = s.post_price_changes['20d'] %}
           <span class="kessan-pc-1d">{% if pc1 %}{{ pc1 }}%{% else %}-{% endif %}</span>
-          <span class="kessan-pc-mid">(<span class="kessan-pc-5d">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span> <span class="kessan-pc-20d">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>)</span>
+          <span class="kessan-pc-sep">|</span>
+          <span class="kessan-pc-5d">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
+          <span class="kessan-pc-20d">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>
         </span>
       </div>
       <div class="kessan-editor-row">
@@ -81,8 +83,9 @@
           {% if pcp %}<span class="kessan-pts-label">PTS</span><span class="{% if pcp.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pcp }}%</span>{% endif %}
           {% if pc1 or pc5 or pc20 %}
             {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-            <span class="kessan-pc-mid">(<span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
-            <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>)</span>
+            <span class="kessan-pc-sep">|</span>
+            <span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
+            <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>
           {% endif %}
         </span>
       {% endif %}

--- a/scripts/webapp/templates/disclosure.html
+++ b/scripts/webapp/templates/disclosure.html
@@ -37,8 +37,11 @@
       <div class="kessan-editor-row">
         <label>株価変動率:</label>
         <span class="kessan-field-display kessan-post-price-change">
-          <span class="kessan-pc-1d">{{ s.post_price_changes['1d'] or '-' }}</span>
-          <span class="kessan-pc-mid">(<span class="kessan-pc-5d">{{ s.post_price_changes['5d'] or '-' }}</span> <span class="kessan-pc-20d">{{ s.post_price_changes['20d'] or '-' }}</span>)</span>
+          {% set pc1 = s.post_price_changes['1d'] %}
+          {% set pc5 = s.post_price_changes['5d'] %}
+          {% set pc20 = s.post_price_changes['20d'] %}
+          <span class="kessan-pc-1d">{% if pc1 %}{{ pc1 }}%{% else %}-{% endif %}</span>
+          <span class="kessan-pc-mid">(<span class="kessan-pc-5d">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span> <span class="kessan-pc-20d">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>)</span>
         </span>
       </div>
       <div class="kessan-editor-row">
@@ -78,8 +81,8 @@
           {% if pcp %}<span class="kessan-pts-label">PTS</span><span class="{% if pcp.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pcp }}%</span>{% endif %}
           {% if pc1 or pc5 or pc20 %}
             {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-            <span class="kessan-pc-mid">(<span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{{ pc5 or '-' }}</span>
-            <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{{ pc20 or '-' }}</span>)</span>
+            <span class="kessan-pc-mid">(<span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
+            <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>)</span>
           {% endif %}
         </span>
       {% endif %}

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -260,7 +260,7 @@ class TestCrud:
         rs.upsert_research_record(rec, db_path=db_path)
         loaded = rs.get_research_record("5032", db_path=db_path)
         entry = loaded["kessan_comments"][0]
-        assert entry["post_price_changes"] == {"1d": "-15", "5d": ""}
+        assert entry["post_price_changes"] == {"1d": "-15", "5d": "", "20d": ""}
 
     def test_get_research_record_preserves_post_price_changes_dict(self, db_path):
         """新形式 post_price_changes は読出時もそのまま"""
@@ -270,13 +270,13 @@ class TestCrud:
             "quarter": 3,
             "pre_expectation": "○",
             "pre_outlook": "見通し",
-            "post_price_changes": {"1d": "+3.2", "5d": "+5.1"},
+            "post_price_changes": {"1d": "+3.2", "5d": "+5.1", "20d": "+12"},
             "post_comment": "",
         }]
         rs.upsert_research_record(rec, db_path=db_path)
         loaded = rs.get_research_record("5032", db_path=db_path)
         entry = loaded["kessan_comments"][0]
-        assert entry["post_price_changes"] == {"1d": "+3.2", "5d": "+5.1"}
+        assert entry["post_price_changes"] == {"1d": "+3.2", "5d": "+5.1", "20d": "+12"}
 
     def test_get_research_record_preserves_pts_key(self, db_path):
         """PTS キー (issue #154) は normalize 後も保持される"""

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -117,7 +117,7 @@ class TestGetResearchDetail:
             "quarter": 1,
             "pre_expectation": "",
             "pre_outlook": "",
-            "post_price_changes": {"1d": "", "5d": ""},
+            "post_price_changes": {"1d": "", "5d": "", "20d": ""},
             "post_comment": "",
             "kessan_matagi": False,
             "held_before_kessan": False,
@@ -128,7 +128,7 @@ class TestGetResearchDetail:
         detail = helpers.get_research_detail("3496")
         entry = detail["kessan_comments"][0]
         # 未来エントリなので補完されず空のまま
-        assert entry["post_price_changes"] == {"1d": "", "5d": ""}
+        assert entry["post_price_changes"] == {"1d": "", "5d": "", "20d": ""}
 
 
 class TestGetMarketKessanData:
@@ -1049,63 +1049,89 @@ class TestPriceReactionFromLog:
         assert helpers._price_reaction_from_log(log, kessan, n_business_days=0) == ""
 
 
+class TestFormatReactionDigits:
+    """_format_reaction の桁数ルール: |x|>=10 は整数 / <10 は小数1桁"""
+
+    @pytest.mark.parametrize("before,after,expected", [
+        # |x| < 10 → 小数1桁
+        (1000, 1032, "+3.2"),
+        (1000, 985, "-1.5"),
+        (1000, 1099, "+9.9"),
+        (1000, 999, "-0.1"),
+        # |x| >= 10 → 整数
+        (1000, 1100, "+10"),
+        (1000, 899, "-10"),
+        (1000, 1162, "+16"),
+        (1000, 1513, "+51"),
+        (1000, 700, "-30"),
+    ])
+    def test_format_rule(self, before, after, expected):
+        assert helpers._format_reaction(before, after) == expected
+
+
 class TestCalcPriceReactions:
     """calc_price_reactions の dict 返却 (issue #133)"""
 
-    def test_returns_dict_with_both_periods(self, monkeypatch):
+    def test_returns_dict_with_all_periods(self, monkeypatch):
         from datetime import date, timedelta
         kessan = date(2026, 4, 1)
         log = [(kessan - timedelta(days=1), 1000)]
-        for i, pr in enumerate([1032, 1040, 1045, 1048, 1051], start=1):
+        # 1d=+3.2, 5d=+5.1, 20d=+12 (>=10 で整数表記)
+        prs = [1032, 1040, 1045, 1048, 1051,
+               1055, 1060, 1062, 1065, 1070,
+               1075, 1078, 1082, 1085, 1090,
+               1095, 1100, 1105, 1110, 1120]
+        for i, pr in enumerate(prs, start=1):
             log.append((kessan + timedelta(days=i), pr))
         monkeypatch.setattr(helpers, "get_stock_data", lambda c: {"price_log": log})
         result = helpers.calc_price_reactions("5032", "2026/04/01")
-        assert result == {"1d": "+3.2", "5d": "+5.1"}
+        assert result == {"1d": "+3.2", "5d": "+5.1", "20d": "+12"}
 
     def test_invalid_kessanbi_returns_empty_dict(self):
         result = helpers.calc_price_reactions("5032", "invalid-date")
-        assert result == {"1d": "", "5d": ""}
+        assert result == {"1d": "", "5d": "", "20d": ""}
 
     def test_partial_log_returns_partial_dict(self, monkeypatch):
         from datetime import date, timedelta
         kessan = date(2026, 4, 1)
-        # 後ろ1本しか無い → 1d は取れて 5d は ""
+        # 後ろ1本しか無い → 1d は取れて 5d / 20d は ""
         log = [(kessan - timedelta(days=1), 1000), (kessan + timedelta(days=1), 1050)]
         monkeypatch.setattr(helpers, "get_stock_data", lambda c: {"price_log": log})
         result = helpers.calc_price_reactions("5032", "2026/04/01")
         assert result["1d"] == "+5.0"
         assert result["5d"] == ""
+        assert result["20d"] == ""
 
 
 class TestNormalizePostPriceChanges:
     """normalize_kessan_post_price_changes の後方互換正規化 (issue #133)"""
 
     def test_new_format_passthrough(self):
-        entry = {"post_price_changes": {"1d": "+3", "5d": "+5"}}
+        entry = {"post_price_changes": {"1d": "+3", "5d": "+5", "20d": "+12"}}
         result = rs.normalize_kessan_post_price_changes(entry)
-        assert result == {"1d": "+3", "5d": "+5"}
+        assert result == {"1d": "+3", "5d": "+5", "20d": "+12"}
 
     def test_old_format_lifts_to_1d(self):
         entry = {"post_price_change": "-15"}
         result = rs.normalize_kessan_post_price_changes(entry)
-        assert result == {"1d": "-15", "5d": ""}
+        assert result == {"1d": "-15", "5d": "", "20d": ""}
 
     def test_both_present_prefers_new(self):
         entry = {
             "post_price_change": "-15",
-            "post_price_changes": {"1d": "+2", "5d": "+3"},
+            "post_price_changes": {"1d": "+2", "5d": "+3", "20d": "+5"},
         }
         result = rs.normalize_kessan_post_price_changes(entry)
-        assert result == {"1d": "+2", "5d": "+3"}
+        assert result == {"1d": "+2", "5d": "+3", "20d": "+5"}
 
     def test_neither_present_returns_empty(self):
         result = rs.normalize_kessan_post_price_changes({})
-        assert result == {"1d": "", "5d": ""}
+        assert result == {"1d": "", "5d": "", "20d": ""}
 
     def test_partial_new_format_filled_with_empty(self):
-        entry = {"post_price_changes": {"1d": "+3"}}  # 5d 欠落
+        entry = {"post_price_changes": {"1d": "+3"}}  # 5d / 20d 欠落
         result = rs.normalize_kessan_post_price_changes(entry)
-        assert result == {"1d": "+3", "5d": ""}
+        assert result == {"1d": "+3", "5d": "", "20d": ""}
 
 
 class TestSaveKessanCommentMultiPeriod:

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -714,7 +714,7 @@ class TestKessanCommentApiContract:
         assert resp.status_code == 200
         data = resp.get_json()
         assert "post_price_changes" in data
-        assert data["post_price_changes"] == {"1d": "", "5d": ""}
+        assert data["post_price_changes"] == {"1d": "", "5d": "", "20d": ""}
         assert "post_price_change" not in data
 
     def test_get_legacy_record_returns_normalized_dict(self, client):
@@ -723,7 +723,7 @@ class TestKessanCommentApiContract:
         resp = client.get("/api/kessan_comment/3496?kessanbi=2024/05/14")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["post_price_changes"] == {"1d": "-3.1", "5d": ""}
+        assert data["post_price_changes"] == {"1d": "-3.1", "5d": "", "20d": ""}
         assert "post_price_change" not in data
 
     def test_get_new_format_record_passthrough(self, client, db_path):
@@ -735,7 +735,7 @@ class TestKessanCommentApiContract:
             "quarter": 4,
             "pre_expectation": "○",
             "pre_outlook": "テスト",
-            "post_price_changes": {"1d": "+2.5", "5d": "+4.0"},
+            "post_price_changes": {"1d": "+2.5", "5d": "+4.0", "20d": "+8.0"},
             "post_comment": "新形式",
             "kessan_matagi": False,
             "held_before_kessan": False,
@@ -744,7 +744,7 @@ class TestKessanCommentApiContract:
         rs.upsert_research_record(rec, db_path=db_path)
         resp = client.get("/api/kessan_comment/3496?kessanbi=2026/03/15")
         data = resp.get_json()
-        assert data["post_price_changes"] == {"1d": "+2.5", "5d": "+4.0"}
+        assert data["post_price_changes"] == {"1d": "+2.5", "5d": "+4.0", "20d": "+8.0"}
         assert "post_price_change" not in data
 
     def test_post_response_returns_only_new_schema(self, client, monkeypatch):
@@ -752,7 +752,7 @@ class TestKessanCommentApiContract:
         from webapp import helpers as _helpers
         monkeypatch.setattr(
             _helpers, "calc_price_reactions",
-            lambda c, k: {"1d": "+1.0", "5d": "+2.0"},
+            lambda c, k: {"1d": "+1.0", "5d": "+2.0", "20d": "+3.0"},
         )
         monkeypatch.setattr(_helpers, "_is_possess_now", lambda c: False)
         resp = client.post("/api/kessan_comment/3496", data={
@@ -764,7 +764,7 @@ class TestKessanCommentApiContract:
         })
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["post_price_changes"] == {"1d": "+1.0", "5d": "+2.0"}
+        assert data["post_price_changes"] == {"1d": "+1.0", "5d": "+2.0", "20d": "+3.0"}
         assert "post_price_change" not in data
 
 
@@ -824,7 +824,7 @@ class TestDisclosureRouteKessanCard:
             "quarter": 4,
             "pre_expectation": "",
             "pre_outlook": "",
-            "post_price_changes": {"1d": "", "5d": ""},
+            "post_price_changes": {"1d": "", "5d": "", "20d": ""},
             "post_comment": "",
             "has_comment": False,
             "is_possess": False,


### PR DESCRIPTION
## Summary

- 決算反応に **20営業日後** を追加 (`KESSAN_REACTION_PERIODS` に `("20d", 20)` 追加)
- 表記桁数ルール変更: `|x|>=10` は整数 (`+16`) / `<10` は小数1桁 (`+2.7`)
- 表示を `+16.2% (+51 +30)` の **翌日 (5d 20d)** 表記に変更 (翌日が主要、5d/20d は補助)
- 決算日 h2 に表記説明ツールチップを追加

## 設計上の要点

- `KESSAN_REACTION_PERIODS` 1か所変更で計算/保存/backfill/正規化が自動追従 (SoT パターン)
- 5d/20d は CSS `.kessan-pc-mid` で控えめな色・小サイズにし、情報密度を抑えた
- 既存決算の `20d` は `price_log` (LOG_DAY=30) が決算日まで遡れない場合に空表示 (`-`) となる。今後の決算は 20営業日経過後に自動で埋まる

## Test plan

- [x] `pytest tests/test_webapp_helpers.py tests/test_research_shelve.py tests/test_make_market_db.py` 475 passed
- [x] 桁数ルール parametrize テスト (`TestFormatReactionDigits`) 追加
- [x] 既存テストを 20d 含む形に更新 (TestNormalizePostPriceChanges 他)
- [x] `/disclosure` で `+16.2% (+51 +30)` 表記と tooltip 表示を Playwright で確認
- [x] codex プランレビュー通過 (初回2件の重大指摘を反映)