### PR TITLE
detail: 銘柄名エイリアス表記から「旧」プレフィックスを削除

### DIFF
--- a/scripts/webapp/templates/_macros.html
+++ b/scripts/webapp/templates/_macros.html
@@ -1,9 +1,9 @@
 {# 共通テンプレートマクロ #}
 
-{# 銘柄名と旧名 (issue #183)
+{# 銘柄名とエイリアス (issue #183 で旧名、現在はエイリアス: 旧名・俗称・別表記)
    record は dict like で stock_name / stock_name_prev を持つ。
-   旧名があれば「新名 (旧○○)」形式で出す。
+   エイリアスがあれば「銘柄名 (エイリアス)」形式で出す。
 #}
 {% macro stock_name_with_prev(record) -%}
-{{ record.stock_name or '' }}{% if record.stock_name_prev %} (旧{{ record.stock_name_prev }}){% endif %}
+{{ record.stock_name or '' }}{% if record.stock_name_prev %} ({{ record.stock_name_prev }}){% endif %}
 {%- endmacro %}

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -19,18 +19,18 @@
       {% endif %}
       <small style="color:#888;font-size:0.5em;">{{ record.code_s }}</small>
       {{ record.stock_name or '' }}
-      {# issue #236: stock_name_prev を inline 編集化。旧名 / エイリアス (俗称・旧表記) #}
+      {# issue #236: stock_name_prev を inline 編集化。エイリアス (旧名・俗称・別表記) #}
       {% if record.stock_name_prev %}
       <span class="stock-name-prev-edit"
             title="クリックで編集 (空欄で削除)"
             data-code="{{ record.code_s }}"
             data-current="{{ record.stock_name_prev }}"
             onclick="editStockNamePrev(this)">
-        (旧{{ record.stock_name_prev }})
+        ({{ record.stock_name_prev }})
       </span>
       {% else %}
       <button type="button" class="stock-name-prev-add"
-              title="旧名・俗称などのエイリアスを追加 (検索でヒットするようになります)"
+              title="エイリアス (旧名・俗称・別表記) を追加 (検索でヒットするようになります)"
               data-code="{{ record.code_s }}"
               data-current=""
               onclick="editStockNamePrev(this)">✎</button>

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -208,20 +208,23 @@ class TestDetailStockNamePrev:
     """issue #183: stock_name_prev の併記表示"""
 
     def test_detail_displays_stock_name_prev(self, client, db_path):
-        """stock_name_prev が入っていれば「新名 (旧○○)」併記される"""
-        # 既存テストデータの 3496 に旧名を入れる
+        """stock_name_prev が入っていれば「銘柄名 (エイリアス)」併記される"""
+        # 既存テストデータの 3496 にエイリアスを入れる
         rs.sync_stock_name("3496", "アズームニューネーム", db_path=db_path)
         resp = client.get("/stock/3496")
         html = resp.data.decode()
         assert "アズームニューネーム" in html
-        assert "(旧アズーム)" in html
+        assert "(アズーム)" in html
 
     def test_detail_no_paren_when_stock_name_prev_none(self, client, db_path):
-        """stock_name_prev が None なら旧名併記なし (デフォルト状態)"""
+        """stock_name_prev が None ならエイリアス併記なし (デフォルト状態)"""
         resp = client.get("/stock/3496")
         html = resp.data.decode()
         assert "アズーム" in html
-        assert "(旧" not in html
+        # stock_name_prev 由来の編集 span (class 属性に stock-name-prev-edit) は出ない
+        # (CSS 定義の `.stock-name-prev-edit { ... }` には引っかからないよう class 属性形で見る)
+        assert 'class="stock-name-prev-edit"' not in html
+        assert 'class="stock-name-prev-add"' in html
 
 
 class TestStockNamePrevRoute:


### PR DESCRIPTION
## Summary

- 銘柄名エイリアス表記を `(旧M&A総研)` → `(M&A総研)` に変更
- `stock_name_prev` はもともと「旧名」想定だったが、現在は俗称・別表記・旧名すべて含む汎用エイリアスとして使われている。「旧」を付けると俗称ケースで誤読されるため削除

## 変更点

- `_macros.html`: `stock_name_with_prev` マクロから「旧」削除
- `detail.html`: stock_name_prev 表示と add button のラベル更新 (`(旧○○)` → `(○○)`, button title「旧名・俗称」→「エイリアス」)
- `test_webapp_routes.py`: 期待文字列更新 + CSS 定義に誤マッチしないよう `class="..."` 属性形で assertion

## Test plan

- [x] `pytest tests/test_webapp_routes.py tests/test_webapp_helpers.py -q` 332 passed
- [x] `/stock/9552 (クオンツ総研HD)` で `(M&A総研)` 表記を Playwright で確認