### PR TITLE
disclosure: 決算反応の欠損期間を表示から省略

### DIFF
--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -409,10 +409,11 @@
             {% set pc5 = entry.post_price_changes['5d'] %}
             {% set pc20 = entry.post_price_changes['20d'] %}
             {% if pc1 or pc5 or pc20 %}
-              {% if pc1 %}<span class="kessan-price-change {% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-              <span class="kessan-pc-sep">|</span>
-              <span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
-              <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>
+              {# 値があるものだけ表示。1d と 5d/20d の境目に | を入れる (どちらか欠ければ | も出さない) #}
+              {% if pc1 %}<span class="kessan-price-change {% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% endif %}
+              {% if pc1 and (pc5 or pc20) %}<span class="kessan-pc-sep">|</span>{% endif %}
+              {% if pc5 %}<span class="{% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% endif %}
+              {% if pc20 %}<span class="{% if pc20.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc20 }}%</span>{% endif %}
             {% else %}-{% endif %}
           </td>
           <td class="col-outlook kessan-ellipsis" title="{{ entry.pre_outlook or '' }}">{{ entry.pre_outlook or '' }}</td>

--- a/scripts/webapp/templates/disclosure.html
+++ b/scripts/webapp/templates/disclosure.html
@@ -40,10 +40,12 @@
           {% set pc1 = s.post_price_changes['1d'] %}
           {% set pc5 = s.post_price_changes['5d'] %}
           {% set pc20 = s.post_price_changes['20d'] %}
-          <span class="kessan-pc-1d">{% if pc1 %}{{ pc1 }}%{% else %}-{% endif %}</span>
-          <span class="kessan-pc-sep">|</span>
-          <span class="kessan-pc-5d">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
-          <span class="kessan-pc-20d">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>
+          {# 値があるものだけ表示。1d と 5d/20d の境目に | を入れる (どちらか欠ければ | も出さない) #}
+          {% if pc1 %}<span class="kessan-pc-1d">{{ pc1 }}%</span>{% endif %}
+          {% if pc1 and (pc5 or pc20) %}<span class="kessan-pc-sep">|</span>{% endif %}
+          {% if pc5 %}<span class="kessan-pc-5d">{{ pc5 }}%</span>{% endif %}
+          {% if pc20 %}<span class="kessan-pc-20d">{{ pc20 }}%</span>{% endif %}
+          {% if not (pc1 or pc5 or pc20) %}-{% endif %}
         </span>
       </div>
       <div class="kessan-editor-row">
@@ -82,10 +84,11 @@
         <span class="kessan-price-change">
           {% if pcp %}<span class="kessan-pts-label">PTS</span><span class="{% if pcp.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pcp }}%</span>{% endif %}
           {% if pc1 or pc5 or pc20 %}
-            {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% else %}<span>-</span>{% endif %}
-            <span class="kessan-pc-sep">|</span>
-            <span class="{% if pc5 and pc5.startswith('-') %}rate-neg{% elif pc5 %}rate-pos{% endif %}">{% if pc5 %}{{ pc5 }}%{% else %}-{% endif %}</span>
-            <span class="{% if pc20 and pc20.startswith('-') %}rate-neg{% elif pc20 %}rate-pos{% endif %}">{% if pc20 %}{{ pc20 }}%{% else %}-{% endif %}</span>
+            {# 値があるものだけ表示。1d と 5d/20d の境目に | を入れる (どちらか欠ければ | も出さない) #}
+            {% if pc1 %}<span class="{% if pc1.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc1 }}%</span>{% endif %}
+            {% if pc1 and (pc5 or pc20) %}<span class="kessan-pc-sep">|</span>{% endif %}
+            {% if pc5 %}<span class="{% if pc5.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc5 }}%</span>{% endif %}
+            {% if pc20 %}<span class="{% if pc20.startswith('-') %}rate-neg{% else %}rate-pos{% endif %}">{{ pc20 }}%</span>{% endif %}
           {% endif %}
         </span>
       {% endif %}


### PR DESCRIPTION
## Summary

決算反応表示で値が無い期間 (`-`) を非表示にし、計算済みの期間だけを並べる。

| パターン | 表示 |
|---|---|
| 1d/5d/20d 全部 | `+10% \| +12% +5%` |
| 1d/5d のみ | `+10% \| +12%` |
| 1d のみ | `+10%` |
| 1d なし / 5d/20d あり | `+12% +5%` |

`\|` セパレータは 1d と 5d/20d の両方がある時だけ出す。

## Test plan

- [x] `pytest tests/test_webapp_routes.py tests/test_webapp_helpers.py -q` 332 passed
- [x] `/disclosure` で `+17.2%` 単独表示・`-2.2% \| -3.2%` 2項表示を Playwright で確認