### PR TITLE
disclosure: 決算反応 20d を計算可能にする (yfinance period 1mo → 2mo)

### DIFF
--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1993,6 +1993,23 @@ def refresh_stock(code_list):
     log_print("[refresh_stock] 強制再取得を完了しました")
 
 
+def refresh_price(code_list):
+    """指定銘柄の price のみを UPD_FORCE で強制再取得する。
+
+    yfinance キャッシュ (.json) と stocks_shelve の price_log を更新する。
+    master/shihyo/gyoseki/rironkabuka は再取得しないため Kabutan スクレイピング
+    負荷が無く、price_log の取得期間設定 (period) 変更後の反映確認などに使う。
+    """
+    if not code_list:
+        log_warning("[refresh_price] 銘柄コードが指定されていません")
+        return
+    codes = list(code_list)
+    log_print("=" * 30)
+    log_print(f"[refresh_price] price 強制再取得を開始します: {codes}")
+    update_db_rows(codes, upd=UPD_FORCE, tables=["price"])
+    log_print("[refresh_price] price 強制再取得を完了しました")
+
+
 # ==================================================
 # main
 # ==================================================
@@ -2125,6 +2142,11 @@ def main():
             log_warning("refresh_stock: 銘柄コードを 1 つ以上指定してください")
         else:
             refresh_stock(list(args.codes))
+    elif command == "refresh_price":  # 指定銘柄の price のみ強制再取得 (yfinanceキャッシュ + price_log)
+        if not args.codes:
+            log_warning("refresh_price: 銘柄コードを 1 つ以上指定してください")
+        else:
+            refresh_price(list(args.codes))
     elif command == "test":
         test()
 

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -972,7 +972,9 @@ def get_daily_data_yfinance(code_s, stock={}, upd=UPD_INTERVAL):
     try:
         with sema:
             ticker = yf.Ticker(ticker_symbol)
-            df = ticker.history(period="1mo", auto_adjust=True)
+            # 2mo: 決算反応20d (決算前 + 20営業日後) と rs_line 20日前比に必要な
+            # 営業日 ~40日分を確保する (1mo だと暦日30日 ≒ 営業日19日で不足)
+            df = ticker.history(period="2mo", auto_adjust=True)
     except Exception as e:
         log_warning("yfinance取得エラー(%s): %s" % (code_s, e))
         return None, None
@@ -1369,7 +1371,9 @@ def prefetch_yfinance_batch(code_s_list, stocks=None):
         try:
             df = yf.download(
                 ticker_str,
-                period="1mo",
+                # 2mo: 個別取得側 (get_daily_data_yfinance) と揃える。
+                # 決算反応20d / rs_line 20日前比に必要な営業日 ~40日分を確保。
+                period="2mo",
                 auto_adjust=True,
                 threads=True,
                 progress=False,


### PR DESCRIPTION
## 背景

#276 で決算反応セクションに 20営業日後の変動率 (20d) を追加したが、目視確認すると全銘柄で `-` のままだった。原因を調査した結果、`stocks_shelve.price_log` が **直近 19営業日分しか入っていない** ことが判明。

`price_log` は `make_stock_db.py` 経由で yfinance から取得した日足を `LOG_DAY = 30` (営業日30件想定) で詰める実装だが、肝心の yfinance 取得が `period=\"1mo\"` (暦月1ヶ月 ≒ 営業日19日) だったため、定数 30 は実質意味を持たず常に 19件で頭打ちになっていた。

これだと:
- 決算日が price_log の最古日より新しい → 「+20営業日後」が範囲外
- 決算日が price_log の最古日付近 → 「決算日前営業日終値」が範囲外

の二択になり、**どの決算日でも 20d は原理的に計算不能** という構造的詰みだった。

## 変更内容

### 1. yfinance 取得期間を `period=\"1mo\"` → `\"2mo\"` (約40営業日)

- `scripts/price.py` の `get_daily_data_yfinance()` (個別取得) と `prefetch_yfinance_batch()` (バッチ prefetch) の2箇所
- これで `price_log` が 30件 (`LOG_DAY=30` の頭打ちまで) 入り、決算日から20営業日経過した過去決算分から順次 20d 反応が埋まる

### 2. `make_stock_db.py refresh_price <codes>` コマンドを追加

- yfinance キャッシュと `stocks_shelve.price_log` のみ UPD_FORCE で再取得
- Kabutan スクレイピング (master/shihyo/gyoseki/rironkabuka) は触らない軽量版
- 既存の `refresh_stock` (全テーブル再取得) と対をなす
- 今回のような period 変更の反映確認や、price_log だけ最新化したい運用で使う

## 副作用調査

`price_log` のサイズ拡大に依存する処理を全箇所追ったが、**悪い意味の副作用は無し**。むしろ現状ぎりぎり / 不十分に動いていた処理が、本来の仕様通り動くようになる「改善側」の影響がほとんど:

| 処理 | 現状 (~19件) | 変更後 (~40件) |
|---|---|---|
| DD/FTD候補, daily_history (21件必要) | 19件しかない | 21件取れる |
| `calc_sell_pressure_ratio` (DAY_L=19) | ぎりぎり | 余裕 |
| `calc_avg_volume_d20` (20件必要) | 1件不足 | 揃う |
| `pocket_pivot` (最大 ind+j+1=19) | 末尾が IndexError で break | 末尾までスキャン |
| `breakout` (最大 ind+1+j=29) | 大半が `continue` でスキップ | 全範囲スキャン |
| `_rs_line_changes_from_line` 20日比 | 常に `B_approx` (15-19日代替, `*` 表記) | 本来の20日比が取れる |
| `compute_rs_line_new_high(lookback=20)` | 大半 False | 本来の判定が動く |
| **決算反応 20d** | **全部 \"-\"** | **20営業日経過分は埋まる** |

### ネットワーク・データ容量

- yfinance API: 1銘柄あたり 19→41行、全銘柄バッチで **+5.4 MB/日**
- キャッシュ JSON (`yfinance_price_*.json`): **+4.5 MB** (3.95 → 8.5 MB)
- `stocks_shelve` 本体: price_log が 0.93→2.0 MB、全体 (1,381 MB) の **+0.1%未満**

いずれも誤差レベル。

## 動作確認

`refresh_price` で保有28銘柄の price_log を 19→30件に更新後、`/disclosure` で目視確認:

- **4413 (4/14決算、保有銘柄)**: `+15.3% | +12% +5.2%` (1d / 5d / 20d) で20dが期待通り表示
- 4417 (4/30決算、保有銘柄): `PTS+9.33% / +7.4% | +20%` (1d / 5d、20dはまだ未来で欠損 = 仕様通り)
- 5/15決算など20営業日未経過の銘柄は1d/5dのみ表示 (仕様通り)

## 反映の進み方 (運用上の注意)

既存の yfinance キャッシュは `INTERVAL_DAY_D` 期限内なら古い19件版が再利用される。以下のいずれかで順次40件版に置き換わる:

- **通常運用**: キャッシュ期限切れの銘柄から自動で再取得
- **強制再取得**: `python make_stock_db.py refresh_price <codes>` (今回追加コマンド) または `python shintakane.py --force` で全銘柄

## Test plan

- [x] `pytest tests/test_price.py -v` (108 passed)
- [x] `pytest tests/test_make_stock_db.py tests/test_make_market_db.py tests/test_webapp_helpers.py -v` (481 passed)
- [x] `make_stock_db.py refresh_price` で保有28銘柄の price_log が 30件に拡張されることを確認
- [x] `/disclosure` で4413 (4/14決算保有) の 20d=+5.2% 表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)