### PR TITLE
disclosure: 「さらに前の決算」開閉状態をlocalStorageで記憶

### DIFF
--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -474,3 +474,15 @@ document.addEventListener('change', function(e) {
   var li = el.closest('.kessan-stock');
   if (li) saveKessanFromEditor(li);
 });
+
+/* id 付き details 要素の開閉状態を localStorage に記憶し、ページ再訪時に復元する。
+   現状は disclosure ページの「さらに前の決算」(#kessan-older-past) を主対象とする。 */
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('details[id]').forEach(function(d) {
+    var key = 'details-open:' + d.id;
+    if (localStorage.getItem(key) === '1') d.open = true;
+    d.addEventListener('toggle', function() {
+      localStorage.setItem(key, d.open ? '1' : '0');
+    });
+  });
+});

--- a/scripts/webapp/templates/disclosure.html
+++ b/scripts/webapp/templates/disclosure.html
@@ -141,9 +141,9 @@
   </div>
   {% endif %}
 
-  {# それ以前の過去決算: 折りたたみ #}
+  {# それ以前の過去決算: 折りたたみ (開閉状態を localStorage で記憶) #}
   {% if kessan_data.older_past_entries %}
-  <details>
+  <details id="kessan-older-past">
     <summary style="cursor:pointer; color:#666; margin:8px 0;">▶ さらに前の決算を表示 ({{ kessan_data.older_past_entries|length }}件)</summary>
     <div class="kessan-grid">
       {% for kessanbi, stocks in kessan_data.older_past_entries %}


### PR DESCRIPTION
## 背景

`/disclosure` ページの「▶ さらに前の決算を表示」セクションは `<details>` 要素で折りたたまれており、ページ遷移して戻ってくると毎回閉じた状態にリセットされていた。過去決算を確認している最中に銘柄詳細ページなどへ移動すると毎回開き直す必要があり、体験が悪い。

## 変更内容

### 1. `scripts/webapp/templates/disclosure.html`

`<details>` に `id="kessan-older-past"` を付与 (記憶対象を識別するため)。

### 2. `scripts/webapp/static/app.js`

末尾に `DOMContentLoaded` リスナーを追加し、`details[id]` を全件走査して:
- ページロード時に localStorage の `details-open:<id>` が `\"1\"` なら `d.open = true`
- `toggle` イベントで開閉状態を localStorage に保存

汎用形にしたので、将来 `id` 付きで details を増やせば自動的に同じ記憶対象になる。

## 動作確認

Playwright で以下を確認:

| 操作 | 期待 | 結果 |
|---|---|---|
| 初回ロード | デフォルト閉 | `isOpen: false` ✅ |
| 開く → `/` に移動 → `/disclosure` に戻る | 開いた状態 | `isOpen: true` ✅ |
| 閉じる → `/` に移動 → `/disclosure` に戻る | 閉じた状態 | `isOpen: false` ✅ |

## Test plan

- [x] Playwright で開閉状態がページ遷移後も保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)