### PR TITLE
market: /market 市場セクションに信用評価損益率 (2市場) を表示 (#211)

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -971,6 +971,7 @@ tr:hover { background: #f5f5f5; }
 .fng-rating-extreme-greed { background: #145a32; }
 .fng-delta-pos { color: #c0392b; }
 .fng-delta-neg { color: #2980b9; }
+.credit-divider { display: inline-block; width: 1px; height: 1em; background: #ccc; margin: 0 4px; }
 
 /* 決算 */
 .kessan-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
@@ -1324,6 +1325,87 @@ def _html_fear_and_greed(market_db):
     )
 
 
+def _format_credit_delta(latest, prev):
+    """信用評価/倍率の差分表示 (pt) と方向クラス。
+
+    pt 差が + なら "天井圏寄り" として赤系 (fng-delta-pos 流用)、
+    - なら "底値圏寄り" として青系 (fng-delta-neg 流用) を返す。
+    値が None なら ("—", "") を返す。
+    """
+    try:
+        delta = float(latest) - float(prev)
+    except (TypeError, ValueError):
+        return "—", ""
+    cls = "fng-delta-pos" if delta >= 0 else "fng-delta-neg"
+    return "%+.2f" % delta, cls
+
+
+def _html_credit_balance(market_db):
+    """信用評価損益率/倍率のサマリーHTML を生成する (issue #211)。
+
+    market_db は使わず、$KS_DATA_DIR/code_rank_data/credit_balance.json を読む。
+    fng-card と並べて表示する用途。
+    """
+    path = os.path.join(DATA_DIR, "code_rank_data", "credit_balance.json")
+    if not os.path.exists(path):
+        return ""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, ValueError):
+        return ""
+    history = payload.get("history") or []
+    if not history:
+        return ""
+    latest = history[-1]
+    eval_rate = latest.get("credit_eval_rate")
+    bairitsu = latest.get("credit_bairitsu")
+    if eval_rate is None:
+        return ""
+    date_str = latest.get("date", "")
+
+    def _prev(field, n):
+        if len(history) < n + 1:
+            return None
+        return history[-(n + 1)].get(field)
+
+    eval_1w, eval_1w_cls = _format_credit_delta(eval_rate, _prev("credit_eval_rate", 1))
+    eval_4w, eval_4w_cls = _format_credit_delta(eval_rate, _prev("credit_eval_rate", 4))
+
+    bairitsu_html = ""
+    if bairitsu is not None:
+        bai_1w, bai_1w_cls = _format_credit_delta(bairitsu, _prev("credit_bairitsu", 1))
+        bai_4w, bai_4w_cls = _format_credit_delta(bairitsu, _prev("credit_bairitsu", 4))
+        bairitsu_html = (
+            '  <span class="credit-divider"></span>\n'
+            '  <span>信用倍率</span>\n'
+            '  <span class="fng-score">%.2f</span>\n'
+            '  <span>1週比 <span class="%s">%s</span></span>\n'
+            '  <span>4週比 <span class="%s">%s</span></span>\n'
+        ) % (
+            bairitsu,
+            html_mod.escape(bai_1w_cls), html_mod.escape(bai_1w),
+            html_mod.escape(bai_4w_cls), html_mod.escape(bai_4w),
+        )
+
+    return (
+        '<div class="fng-card" title="%s 基準">\n'
+        '  <strong><a href="https://nikkei225jp.com/data/sinyou.php"'
+        ' target="_blank" rel="noopener">信用評価</a></strong>\n'
+        '  <span class="fng-score">%.2f%%</span>\n'
+        '  <span>1週比 <span class="%s">%s</span>pt</span>\n'
+        '  <span>4週比 <span class="%s">%s</span>pt</span>\n'
+        '%s'
+        '</div>\n'
+    ) % (
+        html_mod.escape(date_str),
+        eval_rate,
+        html_mod.escape(eval_1w_cls), html_mod.escape(eval_1w),
+        html_mod.escape(eval_4w_cls), html_mod.escape(eval_4w),
+        bairitsu_html,
+    )
+
+
 _SPR_GAUGE_WIDTH = 100      # バー本体の幅 (= SPR 0〜100 のスケール)
 _SPR_GAUGE_BAR_H = 14       # 1 本のバーの高さ
 _SPR_GAUGE_BAR_GAP = 3      # 5日バーと20日バーの縦間隔
@@ -1622,6 +1704,7 @@ def _html_market(market_db):
         return ""
 
     fng_html = _html_fear_and_greed(market_db)
+    credit_html = _html_credit_balance(market_db)
     header_static = (
         '<table class="market-table">\n'
         '<thead><tr>\n'
@@ -1631,7 +1714,7 @@ def _html_market(market_db):
         '</tr></thead>\n'
         '<tbody>'
     )
-    header = '<h2>市場</h2>\n' + fng_html + header_static
+    header = '<h2>市場</h2>\n' + fng_html + credit_html + header_static
     return header + '\n'.join(rows_html) + '\n</tbody></table>'
 
 

--- a/scripts/market_breadth.py
+++ b/scripts/market_breadth.py
@@ -1,0 +1,73 @@
+"""市場ブレッドス・信用評価データの取得モジュール (issue #209 / #211)。
+
+nikkei225jp.com が公開している JS データを HTTP 取得し、JSON 配列としてパースする。
+
+このファイルでは issue #211 のスコープ (信用評価損益率・信用倍率の週次取得) のみ実装している。
+issue #209 (新高値・新安値) は同モジュールに `fetch_market_breadth_daily()` として
+後追いで追加する想定。
+"""
+
+import json
+import re
+from datetime import datetime, timezone, timedelta
+
+import requests
+
+JST = timezone(timedelta(hours=9))
+
+CREDIT_BALANCE_URL = "https://nikkei225jp.com/_data/_nfsWEB/DAY/dailyweek2.json"
+# Referer が無いと 404 を返すサーバー設定 (2026-05 時点で確認)
+CREDIT_BALANCE_REFERER = "https://nikkei225jp.com/data/sinyou.php"
+
+
+def fetch_credit_balance_weekly():
+    """dailyweek2.json を取得し、信用評価損益率の週次時系列を返す。
+
+    出典: nikkei225jp.com 経由、2市場（東証＋名証）信用評価損益率。
+          日経新聞が JPX 公表の信用残高から平均建値を推計して算出した値。
+
+    Returns:
+        list of dict: [{date: 'YYYY-MM-DD', credit_eval_rate: float,
+                        credit_bairitsu: float|None}, ...]
+                      日付昇順、信用評価率が空文字の行はスキップする。
+    """
+    headers = {
+        "User-Agent": "Mozilla/5.0",
+        "Referer": CREDIT_BALANCE_REFERER,
+    }
+    res = requests.get(CREDIT_BALANCE_URL, headers=headers, timeout=15)
+    res.raise_for_status()
+    return parse_credit_balance(res.text)
+
+
+def parse_credit_balance(text):
+    """dailyweek2.json のレスポンス本文 (var DAILY = [...];) をパース。
+
+    Args:
+        text: HTTP レスポンス本文 (JS 配列リテラル)
+
+    Returns:
+        list of dict: 日付昇順、信用評価率が空文字の行はスキップ。
+    """
+    m = re.search(r"var DAILY\s*=\s*(\[.*\])\s*;", text, re.S)
+    if not m:
+        raise ValueError("DAILY 配列が見つからない")
+    rows = json.loads(m.group(1))
+    # 列構成 (2026-05 時点で実データ突き合わせ確認済):
+    #   [0] unix timestamp (ms)
+    #   [7] 信用評価損益率 (%)   ← 負値あり、最新行は公表前で "" のことがある
+    #   [8] 信用倍率 (買い残/売り残)
+    out = []
+    for r in rows:
+        eval_rate = r[7]
+        if eval_rate == "":
+            continue
+        ts_ms = r[0]
+        d = datetime.fromtimestamp(ts_ms / 1000, tz=JST).date().isoformat()
+        bairitsu = r[8] if len(r) > 8 and r[8] != "" else None
+        out.append({
+            "date": d,
+            "credit_eval_rate": float(eval_rate),
+            "credit_bairitsu": float(bairitsu) if bairitsu is not None else None,
+        })
+    return out

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -6,6 +6,7 @@ import os
 import re
 from datetime import datetime, timedelta
 import csv
+import json
 import shutil
 import traceback
 import glob
@@ -1514,6 +1515,66 @@ def update_pf_kessan_db(stocks):
     kessan.save_pf_kessan_db(stocks)
 
 
+def _credit_cache_is_fresh(out_path, today):
+    """credit_balance.json の generated_at が today と同日なら True (取得スキップ可)。
+
+    元データは週次更新 (公表ラグ含めて週1) のため、同一日に再取得する意味はない。
+    日付が変われば取りに行く。
+    """
+    if not os.path.exists(out_path):
+        return False
+    try:
+        with open(out_path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        gen_at = payload.get("generated_at")
+        if not gen_at:
+            return False
+        gen_date = datetime.fromisoformat(gen_at).date()
+    except (OSError, ValueError, KeyError):
+        return False
+    return gen_date == today
+
+
+def update_credit_balance():
+    """信用評価損益率 (2市場) を nikkei225jp.com から取得して JSON 保存 (issue #211)。
+
+    キャッシュ: generated_at が今日と同日なら HTTP 取得をスキップする。
+    取得失敗時は log_warning で残し、既存ファイルがあればそのまま使う。
+    デイリー全体は止めない。
+    """
+    import market_breadth
+
+    out_path = os.path.join(DATA_DIR, "code_rank_data", "credit_balance.json")
+    today = get_price_day(datetime.today())
+    if _credit_cache_is_fresh(out_path, today):
+        log_print(f"---- 信用評価損益率 キャッシュ有効のためスキップ (generated_at={today.isoformat()})")
+        return
+
+    log_print("----> 信用評価損益率 (2市場) 更新")
+    try:
+        rows = market_breadth.fetch_credit_balance_weekly()
+    except Exception as e:
+        log_warning(f"[credit_balance] 取得失敗のためスキップ: {e}")
+        return
+    if not rows:
+        log_warning("[credit_balance] 取得結果が空")
+        return
+    history = rows[-30:]
+    payload = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "source": "nikkei225jp.com (2市場・日経新聞算出)",
+        "latest": history[-1],
+        "history": history,
+    }
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    log_print(
+        f"<---- 信用評価損益率 更新完了 latest={history[-1]['date']} "
+        f"eval={history[-1]['credit_eval_rate']}%"
+    )
+
+
 def main(force=False):
     """メイン関数"""
     # TODO: 新高値更新タイミングをタグで
@@ -1533,6 +1594,7 @@ def main(force=False):
         get_todays_dekidakaup(force=force)
         get_todays_pts(force=force)
         update_todays_news()
+        update_credit_balance()
     # 新高値銘柄の各種解析
     if "analyze" in args:
         todays_shintakane(UPD_INTERVAL)  # UPD_FORCE/UPD_INTERVAL/UPD_CACHE/UPD_REEVAL

--- a/tests/test_live_html.py
+++ b/tests/test_live_html.py
@@ -20,6 +20,7 @@ import gyoseki
 import disclosure
 import shintakane
 import make_market_db
+import market_breadth
 import rironkabuka
 from ks_util import http_get_html
 
@@ -183,6 +184,23 @@ class TestLiveHtmlTheme:
         result = make_market_db.parse_theme_html(html)
         assert isinstance(result, list)
         assert len(result) > 0  # テーマランクは常にデータがある
+        _sleep()
+
+
+class TestLiveHtmlCreditBalance:
+    """market_breadth.py — nikkei225jp.com dailyweek2.json 取得→パース (issue #211)"""
+
+    def test_信用評価損益率の抽出(self):
+        """dailyweek2.json から直近 30 週以内に float 化可能な確定値があること"""
+        rows = market_breadth.fetch_credit_balance_weekly()
+        assert isinstance(rows, list)
+        assert len(rows) > 0, "信用評価率の確定値が 1 件も取れていない"
+        # 直近 30 週分に float 化可能な値があるか
+        recent = rows[-30:]
+        assert all(isinstance(r["credit_eval_rate"], float) for r in recent)
+        # 日付昇順 (parse_credit_balance の契約)
+        dates = [r["date"] for r in recent]
+        assert dates == sorted(dates)
         _sleep()
 
 

--- a/tests/test_market_breadth.py
+++ b/tests/test_market_breadth.py
@@ -1,0 +1,150 @@
+"""market_breadth / 信用評価関連のテスト (issue #211)。"""
+
+import json
+import os
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+import market_breadth
+import make_market_db
+import shintakane
+
+
+# --- market_breadth.parse_credit_balance ----------------------------------
+
+# 2026-04-24 12:00 JST と 2026-05-01 12:00 JST に相当する unix ms
+TS_0424 = 1776999600000
+TS_0501 = 1777604400000
+
+
+def _make_daily_js(rows):
+    """parse_credit_balance に食わせる JS テキストを組み立て。"""
+    items = []
+    for r in rows:
+        items.append(
+            "[" + ",".join(("\"\"" if v == "" else str(v)) for v in r) + "]"
+        )
+    return "var DAILY = [" + ",".join(items) + "];"
+
+
+def test_parse_credit_balance_skips_empty_eval():
+    """信用評価カラム [7] が空文字の行はスキップされる。"""
+    rows = [
+        [TS_0424, 0, 0, 0, 0, 0, 0, -5.45, 5.74],
+        [TS_0501, 0, 0, 0, 0, 0, 0, "", ""],
+    ]
+    out = market_breadth.parse_credit_balance(_make_daily_js(rows))
+    assert len(out) == 1
+    assert out[0]["date"] == "2026-04-24"
+    assert out[0]["credit_eval_rate"] == -5.45
+    assert out[0]["credit_bairitsu"] == 5.74
+
+
+def test_parse_credit_balance_bairitsu_can_be_none():
+    """信用倍率カラムが空でも評価率さえあれば bairitsu=None で取り込む。"""
+    rows = [[TS_0501, 0, 0, 0, 0, 0, 0, -4.82, ""]]
+    out = market_breadth.parse_credit_balance(_make_daily_js(rows))
+    assert out == [{
+        "date": "2026-05-01",
+        "credit_eval_rate": -4.82,
+        "credit_bairitsu": None,
+    }]
+
+
+# --- make_market_db._html_credit_balance ---------------------------------
+
+def _write_credit_json(tmp_path, history):
+    """credit_balance.json を $KS_DATA_DIR/code_rank_data/ に書く。"""
+    code_rank = tmp_path / "code_rank_data"
+    code_rank.mkdir(parents=True, exist_ok=True)
+    path = code_rank / "credit_balance.json"
+    path.write_text(json.dumps({"history": history}), encoding="utf-8")
+    return path
+
+
+def test_html_credit_balance_renders_eval_and_bairitsu(tmp_path, monkeypatch):
+    """評価率・倍率いずれも 1週比/4週比 pt 差付きで HTML 化される。"""
+    history = [
+        {"date": "2026-04-03", "credit_eval_rate": -7.67, "credit_bairitsu": 6.07},
+        {"date": "2026-04-10", "credit_eval_rate": -6.59, "credit_bairitsu": 5.30},
+        {"date": "2026-04-17", "credit_eval_rate": -4.46, "credit_bairitsu": 5.81},
+        {"date": "2026-04-24", "credit_eval_rate": -5.45, "credit_bairitsu": 5.74},
+        {"date": "2026-05-01", "credit_eval_rate": -4.82, "credit_bairitsu": 6.85},
+    ]
+    _write_credit_json(tmp_path, history)
+    monkeypatch.setattr(make_market_db, "DATA_DIR", str(tmp_path))
+
+    html = make_market_db._html_credit_balance({})
+    assert "信用評価" in html
+    assert 'href="https://nikkei225jp.com/data/sinyou.php"' in html
+    assert "-4.82%" in html  # 最新 evaluation rate
+    assert "6.85" in html    # 最新 bairitsu
+    # 1週比 (latest - 1個前): -4.82 - (-5.45) = +0.63
+    assert "+0.63" in html
+    # 4週比 (latest - 4個前): -4.82 - (-7.67) = +2.85
+    assert "+2.85" in html
+    # 倍率の 1週比: 6.85 - 5.74 = +1.11
+    assert "+1.11" in html
+
+
+def test_html_credit_balance_returns_empty_when_no_file(tmp_path, monkeypatch):
+    """credit_balance.json が無ければ空文字を返し、市場HTMLを壊さない。"""
+    monkeypatch.setattr(make_market_db, "DATA_DIR", str(tmp_path))
+    assert make_market_db._html_credit_balance({}) == ""
+
+
+@pytest.mark.parametrize("latest, prev, expected_text, expected_cls", [
+    (-4.82, -5.45, "+0.63", "fng-delta-pos"),
+    (-5.45, -4.46, "-0.99", "fng-delta-neg"),
+    (-4.82, None, "—", ""),
+])
+def test_format_credit_delta(latest, prev, expected_text, expected_cls):
+    text, cls = make_market_db._format_credit_delta(latest, prev)
+    assert text == expected_text
+    assert cls == expected_cls
+
+
+# --- shintakane.update_credit_balance キャッシュ判定 ----------------------
+
+def _write_cache(tmp_path, generated_at, latest_date="2026-05-15"):
+    code_rank = tmp_path / "code_rank_data"
+    code_rank.mkdir(parents=True)
+    cache = code_rank / "credit_balance.json"
+    cache.write_text(json.dumps({
+        "generated_at": generated_at,
+        "latest": {"date": latest_date, "credit_eval_rate": -4.47, "credit_bairitsu": 6.84},
+        "history": [{"date": latest_date, "credit_eval_rate": -4.47, "credit_bairitsu": 6.84}],
+    }), encoding="utf-8")
+    return cache
+
+
+def test_update_credit_balance_skips_when_cache_fresh(tmp_path, monkeypatch):
+    """generated_at が today と同日なら fetch を呼ばずに return する。"""
+    _write_cache(tmp_path, generated_at="2026-05-26T22:00:00")
+
+    monkeypatch.setattr(shintakane, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(shintakane, "get_price_day", lambda dt: date(2026, 5, 26))
+
+    with patch("market_breadth.fetch_credit_balance_weekly") as fake_fetch:
+        shintakane.update_credit_balance()
+        fake_fetch.assert_not_called()
+
+
+def test_update_credit_balance_fetches_when_cache_stale(tmp_path, monkeypatch):
+    """generated_at が today より古ければ fetch する。"""
+    cache = _write_cache(tmp_path, generated_at="2026-05-25T10:00:00")
+
+    monkeypatch.setattr(shintakane, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(shintakane, "get_price_day", lambda dt: date(2026, 5, 26))
+
+    fake_rows = [
+        {"date": "2026-05-15", "credit_eval_rate": -4.47, "credit_bairitsu": 6.84},
+        {"date": "2026-05-22", "credit_eval_rate": -4.10, "credit_bairitsu": 6.66},
+    ]
+    with patch("market_breadth.fetch_credit_balance_weekly", return_value=fake_rows) as fake_fetch:
+        shintakane.update_credit_balance()
+        fake_fetch.assert_called_once()
+    payload = json.loads(cache.read_text(encoding="utf-8"))
+    assert payload["latest"]["date"] == "2026-05-22"


### PR DESCRIPTION
## Summary
- shintakane デイリーで nikkei225jp.com から信用評価損益率・信用倍率を取得し `$KS_DATA_DIR/code_rank_data/credit_balance.json` に保存
- `make_market_db.create_market_html` で Fear & Greed カードの隣に「信用評価」カードを描画 (評価率・倍率とも 1週比/4週比の pt 差付き)
- データ源は週次更新のため、`generated_at` が当日と同じならデイリー再実行時に HTTP 取得をスキップ (1日1回)

Closes #211

## 仕様メモ
- 出典: nikkei225jp.com 経由 (2市場・日経新聞算出、JPX 残高ベース推計値)。Referer ヘッダ必須 (issue 本文の「Referer 不要」は実機で 404 を返したため修正)
- 表示位置: 当初は /market ページ上部の独立セクションだったが、Fear & Greed と並べた方が見比べやすいというフィードバックを受け market セクション内に統合
- 色分け: 評価率・倍率いずれも + は天井圏寄り (赤 = `fng-delta-pos`)、- は底値圏寄り (青 = `fng-delta-neg`)
- 見出し「信用評価」は https://nikkei225jp.com/data/sinyou.php へリンク

## Test plan
- [x] `pytest tests/test_market_breadth.py -v` (9 件 PASS)
- [x] `pytest tests/test_live_html.py::TestLiveHtmlCreditBalance -v` (実 HTTP、PASS)
- [x] 関連 webapp/market テストスイート 473 件 PASS
- [x] ローカルで `shintakane.update_credit_balance()` → `credit_balance.json` 生成確認
- [x] `make_market_db.create_market_html` 再生成 → /market ブラウザ確認 (信用評価カードが Fear & Greed の隣に表示)
- [x] 2回目実行で「キャッシュ有効のためスキップ」ログを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)