### PR TITLE
code_rank: "R高" タグ出力を削除

### DIFF
--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -964,7 +964,7 @@ def get_index_trend_template_expr(stock):
 def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
     """銘柄DBデータから、シグナル情報を作成する。
 
-    market_db を渡すと rs_line ベースのタグ (R高 / 強乖 / 弱乖) も付与される。
+    market_db を渡すと rs_line ベースのタグ (強乖 / 弱乖) も付与される。
     後方互換のため market_db=None ならスキップ。
     rs_line を渡せば再計算をスキップする。
     """
@@ -1058,8 +1058,6 @@ def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
         topix_log = market_db.get("topix", {}).get("price_log", [])
         latest_date = topix_log[0][0] if topix_log else None
         if rs_line and latest_date and rs_line[0][0] == latest_date:
-            if compute_rs_line_new_high(stock, market_db, rs_line=rs_line):
-                tags.append("R高")
             div = compute_rs_line_divergence(stock, market_db, rs_line=rs_line)
             if div == "bullish":
                 tags.append("強乖")

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1693,7 +1693,7 @@ def _format_tags(stock: Dict[str, Any]) -> str:
     """code_rank.csv「タグ」列と同じ表記を返す。
 
     make_stock_db.make_signal() の tags リストを "/" join する。
-    market_db を渡さないので R高/強乖/弱乖 タグは出ない (Phase 4 送り)。
+    market_db を渡さないので 強乖/弱乖 タグは出ない (Phase 4 送り)。
     """
     if not stock:
         return "—"

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -1021,21 +1021,8 @@ class TestMakeSignalRsLine:
             "price_log": [(d0 - timedelta(days=i), 2000 + (25 - i) * 10) for i in range(25)],
         }
         _, tags = make_stock_db.make_signal(stock)
-        assert "R高" not in tags
         assert "強乖" not in tags
         assert "弱乖" not in tags
-
-    def test_rs_line_new_high_tag(self):
-        """rs_line 新高値発生時に R高 タグが付く"""
-        d0 = date(2026, 4, 28)
-        stock = {
-            "price_log": [(d0 - timedelta(days=i), 2000 + (25 - i) * 10) for i in range(25)],
-        }
-        market_db = {
-            "topix": {"price_log": [(d0 - timedelta(days=i), 1000) for i in range(25)]},
-        }
-        _, tags = make_stock_db.make_signal(stock, market_db=market_db)
-        assert "R高" in tags
 
     def test_rs_line_bullish_divergence_tag(self):
         """強気ダイバージェンス発生時に 強乖 タグが付く"""
@@ -1060,31 +1047,15 @@ class TestMakeSignalRsLine:
         古い銘柄が混じる。連日同じシグナルが残らないように当日限定にする必要がある。
         """
         d0 = date(2026, 4, 28)
-        # 銘柄 price_log は1週間前まで (新高値が立つ条件のデータ)
-        stock = {
-            "price_log": [(d0 - timedelta(days=7 + i), 2000 + (25 - i) * 10) for i in range(25)],
-        }
-        # TOPIX は当日 (d0) まで
-        market_db = {
-            "topix": {"price_log": [(d0 - timedelta(days=i), 1000) for i in range(32)]},
-        }
+        stock_log, topix_log = _make_div_logs(1900, 2000, 900, 1000)
+        # 銘柄 price_log は1週間ずらした古いデータ
+        stale_stock_log = [(d - timedelta(days=7), p) for d, p in stock_log]
+        stock = {"price_log": stale_stock_log}
+        market_db = {"topix": {"price_log": topix_log}}
         _, tags = make_stock_db.make_signal(stock, market_db=market_db)
-        # rs_line[0] は1週間前の日付なので当日扱いにならず、タグは付かない
-        assert "R高" not in tags
+        # rs_line[0] は当日と一致しないため、強乖/弱乖は付かない
         assert "強乖" not in tags
         assert "弱乖" not in tags
-
-    def test_rs_line_tags_emit_when_latest_date_matches(self):
-        """銘柄 price_log[0] の日付が TOPIX price_log[0] と一致する場合はタグが立つ"""
-        d0 = date(2026, 4, 28)
-        stock = {
-            "price_log": [(d0 - timedelta(days=i), 2000 + (25 - i) * 10) for i in range(25)],
-        }
-        market_db = {
-            "topix": {"price_log": [(d0 - timedelta(days=i), 1000) for i in range(25)]},
-        }
-        _, tags = make_stock_db.make_signal(stock, market_db=market_db)
-        assert "R高" in tags
 
 
 # ==================================================


### PR DESCRIPTION
## Summary
- code_rank の \"R高\" (RS-Line 新高値) タグはヒット件数が多すぎて意図したシグナルとして機能しないため、`make_signal` のタグ追加処理を削除
- 強乖/弱乖 タグは維持
- `compute_rs_line_new_high` 関数自体は他用途の余地があるため残す

## Test plan
- [x] pytest tests/test_make_stock_db.py → 94 passed
- [x] 失われたアサーション (test_rs_line_new_high_tag / test_rs_line_tags_emit_when_latest_date_matches) を削除
- [x] stale ケースのテストを強乖/弱乖のみで検証する形に整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)