### PR TITLE
[codex] portfolio列クリックソート追加

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1678,6 +1678,7 @@ def list_portfolio_with_indicators(
             r.get("code_s", ""),
         ))
     else:
+        # position は保有ポジション確認用。1保以外は評価せずコード順で末尾に寄せる。
         rows.sort(key=lambda r: (
             r.get("status") != "1保",
             -(r.get("position_value") or 0),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1588,6 +1588,7 @@ def _gyoutai_first_line(row: Dict[str, Any]) -> str:
 
 def list_portfolio_with_indicators(
     records: List[Dict[str, Any]],
+    sort_key: str = "position",
 ) -> List[Dict[str, Any]]:
     """portfolio_shelve のレコード列に stocks_shelve から最新指標を補完する (Phase 3b)。
 
@@ -1596,6 +1597,7 @@ def list_portfolio_with_indicators(
 
     Args:
         records: portfolio_shelve.list_records の戻り値 (既に status 等で絞り込み済み)
+        sort_key: "position" / "rank" / "gyoutai" のいずれか。不正値は position 扱い。
 
     Returns:
         各 dict: portfolio レコード + {stock_name, rank, kessanbi_md, per, market_cap,
@@ -1603,7 +1605,7 @@ def list_portfolio_with_indicators(
                                      quarter, progress_diff, trend_template, tags,
                                      theoretical_diff, gyoseki, indicators_raw,
                                      status_query, status_label}
-        並び順は業態 1 行目昇順 → 順位昇順 → コード (issue #215: 順位ソート廃止、空業態/None順位は末尾)。
+        並び順は sort_key で切替 (issue #274)。
     """
     if not records:
         return []
@@ -1660,14 +1662,27 @@ def list_portfolio_with_indicators(
             if r.get("status") == "1保" and r["position_value"] > 0:
                 r["position_ratio"] = r["position_value"] / max_position * 100.0
 
-    # 業態順: 業態 1 行目 (空は末尾) → 順位昇順 (None は末尾) → コード
-    rows.sort(key=lambda r: (
-        r["gyoutai_first"] == "",
-        r["gyoutai_first"],
-        r.get("rank") is None,
-        r.get("rank") or 0,
-        r.get("code_s", ""),
-    ))
+    if sort_key == "rank":
+        rows.sort(key=lambda r: (
+            r.get("rank") is None,
+            r.get("rank") or 0,
+            r.get("code_s", ""),
+        ))
+    elif sort_key == "gyoutai":
+        # 業態順: 業態 1 行目 (空は末尾) → 順位昇順 (None は末尾) → コード
+        rows.sort(key=lambda r: (
+            r["gyoutai_first"] == "",
+            r["gyoutai_first"],
+            r.get("rank") is None,
+            r.get("rank") or 0,
+            r.get("code_s", ""),
+        ))
+    else:
+        rows.sort(key=lambda r: (
+            r.get("status") != "1保",
+            -(r.get("position_value") or 0),
+            r.get("code_s", ""),
+        ))
     return rows
 
 

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -55,6 +55,8 @@ STATUS_CHOICES = [
     ("watch", "3監", STATUS_VALUE_TO_LABEL["3監"]),
 ]
 DEFAULT_STATUS_QUERY = STATUS_CHOICES[0][0]  # "hold" — 書き込み POST 後フォールバック先
+PORTFOLIO_SORT_KEYS = {"position", "rank", "gyoutai"}
+DEFAULT_SORT_KEY = "position"
 
 
 def _parse_status_filter(args) -> Optional[str]:
@@ -86,17 +88,35 @@ def _parse_gyoutai_theme(args) -> Optional[str]:
     return raw or None
 
 
-def _build_query_string(status: Optional[str], gyoutai_theme: Optional[str]) -> str:
-    """フィルタから URL クエリ文字列を組み立てる (issue #215)。
+def _parse_sort_key(args) -> str:
+    """request.args から portfolio 一覧の sort key を取り出す (issue #274)。"""
+    raw = (args.get("sort") or "").strip().lower()
+    if raw in PORTFOLIO_SORT_KEYS:
+        return raw
+    return DEFAULT_SORT_KEY
 
-    POST → リダイレクトの戻り先として使う。両方 None なら空文字を返し、
-    呼び出し側 (`_redirect_with_return_query`) でデフォルトに落ちる。
+
+def _build_query_string(
+    status: Optional[str],
+    gyoutai_theme: Optional[str],
+    sort_key: Optional[str] = None,
+) -> str:
+    """フィルタ / ソートから URL クエリ文字列を組み立てる。
+
+    status None は「すべて」の明示選択として `status=` を出す。
     """
     params = []
     if status and status in STATUS_VALUE_TO_QUERY:
         params.append(("status", STATUS_VALUE_TO_QUERY[status]))
+    elif status is None:
+        params.append(("status", ""))
     if gyoutai_theme:
         params.append(("gyoutai_theme", gyoutai_theme))
+    if sort_key:
+        params.append((
+            "sort",
+            sort_key if sort_key in PORTFOLIO_SORT_KEYS else DEFAULT_SORT_KEY,
+        ))
     return urlencode(params)
 
 
@@ -529,16 +549,18 @@ def _build_fallback_records() -> list[dict]:
 
 @portfolio_bp.route("/portfolio")
 def dashboard():
-    """フィルタ型ダッシュボード (issue #215 でページング/ソートは廃止)。
+    """フィルタ型ダッシュボード。
 
     URL クエリ:
-      status:        hold / semi / watch のいずれか単一 (省略時=全ステータス)
+      status:        hold / semi / watch のいずれか単一 (省略時=hold、空文字=全ステータス)
       gyoutai_theme: 業態/テーマ名の完全一致 (省略時=全業態テーマ)
                      指定時は status を無視して全銘柄から該当業態/テーマを抽出。
-    並び順は常時業態順。`sort` / `page` パラメータは silent に無視 (旧 URL 互換)。
+      sort:          position / rank / gyoutai (省略時=position)
+    `page` パラメータは silent に無視 (旧 URL 互換)。
     """
     active_status = _parse_status_filter(request.args)
     active_gyoutai_theme = _parse_gyoutai_theme(request.args)
+    active_sort = _parse_sort_key(request.args)
 
     # issue #186: fallback 判定は除外含む全件で行う (全件除外時の誤判定を避ける)。
     # 表示・件数カウントは除外を弾いた visible_records を使う。
@@ -567,7 +589,7 @@ def dashboard():
         filtered_records = visible_records
     else:
         filtered_records = [r for r in visible_records if r.get("status") == active_status]
-    rows = list_portfolio_with_indicators(filtered_records)
+    rows = list_portfolio_with_indicators(filtered_records, sort_key=active_sort)
 
     # 行ごとに transitions を埋める。fallback 中は空。
     for row in rows:
@@ -582,7 +604,7 @@ def dashboard():
     )
 
     # POST → リダイレクトの戻り先として使う現状クエリ (status/gyoutai_theme)
-    return_query = _build_query_string(active_status, active_gyoutai_theme)
+    return_query = _build_query_string(active_status, active_gyoutai_theme, active_sort)
     # テンプレートで select の selected 判定に使う、active_status の query 形式 (例: "hold")
     active_status_query = (
         STATUS_VALUE_TO_QUERY[active_status] if active_status in STATUS_VALUE_TO_QUERY else ""
@@ -593,6 +615,11 @@ def dashboard():
         gyoutai_theme_choices: list = []
     else:
         gyoutai_theme_choices = collect_gyoutai_theme_choices(all_records_inc)
+
+    sort_urls = {
+        k: "?" + _build_query_string(active_status, active_gyoutai_theme, k)
+        for k in ("position", "rank", "gyoutai")
+    }
 
     # 保有フィルタ表示時のみ、運用総額と PF 全体の qty 最終更新日を集計
     hold_summary = None
@@ -612,6 +639,8 @@ def dashboard():
         status_choices=STATUS_CHOICES,
         active_status_query=active_status_query,
         active_gyoutai_theme=active_gyoutai_theme or "",
+        active_sort=active_sort,
+        sort_urls=sort_urls,
         counts=counts,
         rows=rows,
         total=len(rows),

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -100,15 +100,18 @@ def _build_query_string(
     status: Optional[str],
     gyoutai_theme: Optional[str],
     sort_key: Optional[str] = None,
+    include_empty_status: bool = False,
 ) -> str:
     """フィルタ / ソートから URL クエリ文字列を組み立てる。
 
-    status None は「すべて」の明示選択として `status=` を出す。
+    include_empty_status=True のときだけ、status None を「すべて」の
+    明示選択として `status=` にする。POST 後の素の /portfolio fallback と
+    画面上の「すべて」選択維持を混同しないため、呼び出し側で明示する。
     """
     params = []
     if status and status in STATUS_VALUE_TO_QUERY:
         params.append(("status", STATUS_VALUE_TO_QUERY[status]))
-    elif status is None:
+    elif status is None and include_empty_status:
         params.append(("status", ""))
     if gyoutai_theme:
         params.append(("gyoutai_theme", gyoutai_theme))
@@ -175,8 +178,7 @@ def _redirect_with_return_query(
     そのまま受け取り、URL に付与する。これで POST 後も直前のフィルタが復元できる。
 
     空 or 未指定時の戻り先 (issue #215):
-      - `default_status_query=None` (デフォルト): 素の `/portfolio` (= 全件表示) に戻す。
-        引数なし /portfolio の全件状態からの POST を復元するためのフォールバック。
+      - `default_status_query=None` (デフォルト): 素の `/portfolio` (= 保有デフォルト) に戻す。
       - `default_status_query="watch"` 等: `?status=<value>` を付与。`add()` から
         追加直後の銘柄が見えるよう監視フィルタに切り替えたい場合に使う。
 
@@ -604,7 +606,13 @@ def dashboard():
     )
 
     # POST → リダイレクトの戻り先として使う現状クエリ (status/gyoutai_theme)
-    return_query = _build_query_string(active_status, active_gyoutai_theme, active_sort)
+    preserve_all_status = "status" in request.args and active_status is None
+    return_query = _build_query_string(
+        active_status,
+        active_gyoutai_theme,
+        active_sort,
+        include_empty_status=preserve_all_status,
+    )
     # テンプレートで select の selected 判定に使う、active_status の query 形式 (例: "hold")
     active_status_query = (
         STATUS_VALUE_TO_QUERY[active_status] if active_status in STATUS_VALUE_TO_QUERY else ""
@@ -617,7 +625,12 @@ def dashboard():
         gyoutai_theme_choices = collect_gyoutai_theme_choices(all_records_inc)
 
     sort_urls = {
-        k: "?" + _build_query_string(active_status, active_gyoutai_theme, k)
+        k: "?" + _build_query_string(
+            active_status,
+            active_gyoutai_theme,
+            k,
+            include_empty_status=preserve_all_status,
+        )
         for k in ("position", "rank", "gyoutai")
     }
 

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -148,6 +148,7 @@
 {# issue #215: フィルタは status / gyoutai_theme の単一選択 select 2 つ。onchange で即送信。 #}
 <form id="portfolio-filter-form" action="/portfolio" method="GET"
       style="display:flex;flex-wrap:wrap;gap:1.2em;align-items:center;margin-bottom:0.6em;padding:0.5em 0.6em;background:#f5f7fa;border:1px solid #d8dee6;border-radius:4px;font-size:0.9em;">
+  <input type="hidden" name="sort" value="{{ active_sort }}">
   <label style="display:inline-flex;align-items:center;gap:0.4em;margin:0;">
     <span style="color:#666;">ステータス</span>
     <select name="status" onchange="this.form.submit()" style="padding:0.2em 0.3em;font-size:0.9em;margin:0;">
@@ -211,9 +212,9 @@
       <th></th>
       <th>コード</th>
       <th>銘柄名</th>
-      <th>状態</th>
-      <th>業態・テーマ</th>
-      <th>順位</th>
+      <th><a href="{{ sort_urls.position }}">状態</a></th>
+      <th><a href="{{ sort_urls.gyoutai }}">業態・テーマ</a></th>
+      <th><a href="{{ sort_urls.rank }}">順位</a></th>
       <th>売上成長(%)</th>
       <th>利益成長(%)</th>
       <th>PER</th>
@@ -236,8 +237,8 @@
     {% for row in rows %}
     {# issue #178: 前行と業態 1 行目が異なる行は境界線を入れる。
        row.gyoutai_first は helpers.list_portfolio_with_indicators が precompute 済み。
-       issue #215: ソート分岐廃止に伴い常時有効。 #}
-    <tr data-code="{{ row.code_s }}"{% if not loop.first and loop.previtem.gyoutai_first != row.gyoutai_first %} class="gyoutai-boundary"{% endif %}>
+       issue #274: 業態順以外では境界線を出さない。 #}
+    <tr data-code="{{ row.code_s }}"{% if active_sort == "gyoutai" and not loop.first and loop.previtem.gyoutai_first != row.gyoutai_first %} class="gyoutai-boundary"{% endif %}>
       {% if delete_mode_allowed %}
       {# codex 指摘 P2: 1保 は bulk_exclude() で reject されるため checkbox を出さない #}
       <td class="bulk-col">

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1828,11 +1828,10 @@ class TestCollectGyoutaiThemeChoices:
 
 
 class TestListPortfolioWithIndicators:
-    """list_portfolio_with_indicators の業態順ソート / status_query / status_label 検証 (issue #178, #215)。
+    """list_portfolio_with_indicators のソート / status_query / status_label 検証。
 
     外部参照 (_bulk_get_stock_data, _bulk_resolve_stock_names, compute_cell_styles) は
     monkeypatch でスタブし、並び順とフィールド埋めだけを検証する。
-    issue #215: 順位ソートを廃止し業態順固定。sort_key 引数は撤廃済み。
     """
 
     @pytest.fixture
@@ -1858,7 +1857,7 @@ class TestListPortfolioWithIndicators:
             self._make("0002", "1保", rank=10, themes=["半導体"]),
             self._make("0003", "1保", rank=5, themes=["人材"]),
         ]
-        rows = helpers.list_portfolio_with_indicators(records)
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
         # 業態順 (人材→半導体) かつ業態内は rank 昇順
         assert [r["code_s"] for r in rows] == ["0003", "0001", "0002"]
 
@@ -1868,7 +1867,7 @@ class TestListPortfolioWithIndicators:
             self._make("0002", "1保", rank=20, themes=["半導体"]),
             self._make("0003", "1保", rank=5, themes=None),
         ]
-        rows = helpers.list_portfolio_with_indicators(records)
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
         # 半導体が先頭、空 themes は末尾 (末尾内は rank 昇順)
         assert [r["code_s"] for r in rows] == ["0002", "0003", "0001"]
 
@@ -1878,7 +1877,7 @@ class TestListPortfolioWithIndicators:
             self._make("0001", "1保", rank=10, themes=["AI", "人材"]),
             self._make("0002", "1保", rank=20, themes=["人材", "AI"]),
         ]
-        rows = helpers.list_portfolio_with_indicators(records)
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="gyoutai")
         # 0001 の themes[0]=AI が先、0002 の themes[0]=人材 が後
         assert [r["code_s"] for r in rows] == ["0001", "0002"]
 
@@ -1896,6 +1895,34 @@ class TestListPortfolioWithIndicators:
         assert by_code["0002"]["status_label"] == "準保有"
         assert by_code["0003"]["status_query"] == "watch"
         assert by_code["0003"]["status_label"] == "監視"
+
+    @pytest.mark.parametrize(
+        "sort_key, expected",
+        [
+            ("position", ["0003", "0001", "0004", "0002"]),
+            ("rank", ["0002", "0003", "0001", "0004"]),
+            ("gyoutai", ["0003", "0001", "0002", "0004"]),
+        ],
+        ids=["position", "rank", "gyoutai"],
+    )
+    def test_sort_key_switches_order(self, monkeypatch, sort_key, expected):
+        prices = {"0001": 1000, "0003": 500, "0004": 10000}
+        monkeypatch.setattr(
+            helpers, "_bulk_get_stock_data",
+            lambda codes: {c: {"price": prices[c]} for c in codes if c in prices},
+        )
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: "" for c in codes})
+        monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
+        monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
+
+        records = [
+            {**self._make("0001", "1保", rank=30, themes=["人材"]), "qty": 100},
+            {**self._make("0002", "2準", rank=5, themes=["半導体"]), "qty": 100},
+            {**self._make("0003", "1保", rank=10, themes=["AI"]), "qty": 300},
+            {**self._make("0004", "1保", rank=None, themes=[]), "qty": 0},
+        ]
+        rows = helpers.list_portfolio_with_indicators(records, sort_key=sort_key)
+        assert [r["code_s"] for r in rows] == expected
 
     # ===== issue #269: position_ratio 集計 =====
     @pytest.mark.parametrize(

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -954,8 +954,8 @@ class TestDashboardFilter:
         assert "トヨタ" not in html
         assert "ハーモニック" not in html
 
-    def test_legacy_sort_param_silently_ignored(self, client):
-        """旧 URL ?sort=rank&page=2 が混ざっても 200 で返る (issue #215 silent 無視)。
+    def test_sort_param_still_returns_dashboard(self, client):
+        """?sort=rank&page=2 が混ざっても 200 で返る。
         status 未指定なので デフォルト hold フィルタが効く。"""
         resp = client.get("/portfolio?sort=rank&page=2")
         assert resp.status_code == 200
@@ -963,6 +963,34 @@ class TestDashboardFilter:
         assert "アズーム" in html
         assert "トヨタ" not in html
         assert "ハーモニック" not in html
+
+    def test_sort_links_and_filter_hidden_are_rendered(self, client):
+        """issue #274: 対象ヘッダの sort リンクと filter form の hidden sort を出す"""
+        resp = client.get("/portfolio?status=hold&sort=rank")
+        html = resp.data.decode()
+        assert 'name="sort" value="rank"' in html
+        assert "sort=position" in html
+        assert "sort=rank" in html
+        assert "sort=gyoutai" in html
+
+    def test_sort_links_preserve_all_status_filter(self, client):
+        """issue #274: status= の全件表示から sort を変えても全件表示を維持する"""
+        resp = client.get("/portfolio?status=&sort=rank")
+        html = resp.data.decode()
+        assert "status=&amp;sort=position" in html
+        assert "status=&amp;sort=gyoutai" in html
+
+    def test_gyoutai_boundary_only_for_gyoutai_sort(self, client, portfolio_db_path):
+        """issue #274: 業態境界線は gyoutai sort のときだけ出す"""
+        ps.update_memo("3496", {"gyoutai_themes": ["AI"]}, db_path=portfolio_db_path)
+        ps.update_memo("7203", {"gyoutai_themes": ["自動車"]}, db_path=portfolio_db_path)
+        ps.update_memo("6324", {"gyoutai_themes": ["ロボット"]}, db_path=portfolio_db_path)
+
+        html = client.get("/portfolio?status=&sort=gyoutai").data.decode()
+        assert 'class="gyoutai-boundary"' in html
+
+        html = client.get("/portfolio?status=&sort=rank").data.decode()
+        assert 'class="gyoutai-boundary"' not in html
 
     def test_invalid_status_falls_back_to_all(self, client):
         """不正値だけのフィルタは全件表示にフォールバック (None 扱い)"""


### PR DESCRIPTION
## 概要
- `/portfolio` に `sort=position|rank|gyoutai` を追加
- 状態 / 業態・テーマ / 順位ヘッダをクリックしてサーバサイドソートを切り替え
- フィルタフォーム、ヘッダリンク、POST 後の `return_query` で `sort` を保持
- 業態境界線は `gyoutai` ソート時のみ表示

## 変更内容
- `list_portfolio_with_indicators()` に `sort_key` を追加
- `/portfolio` で `sort` クエリを正規化してテンプレートへ渡す
- `portfolio_list.html` の対象ヘッダをリンク化
- helper / route テストを追加・更新
- `position` ソートは 1保 のポジション確認を主目的とし、1保以外はコード順で末尾に寄せることを明確化
- `status=` の全件表示保持は、実際に `status` クエリが指定されていた場合だけに限定

## 検証
- `../.venv/bin/python -m pytest ../tests/test_webapp_portfolio_routes.py ../tests/test_webapp_helpers.py::TestListPortfolioWithIndicators -q`
  - `100 passed, 1 warning`
- Playwright で `/portfolio` を開き、順位ヘッダクリック後に `?status=hold&sort=rank` へ遷移することを確認

Closes #274