### PR TITLE
webapp: トップに Shintakane Result / Code Rank の Spreadsheet リンクを追加 (#98)

### DIFF
--- a/scripts/webapp/routes/search.py
+++ b/scripts/webapp/routes/search.py
@@ -4,12 +4,49 @@
 GET / : 銘柄コード/名前/評価でフィルタし一覧表示
 """
 
+import os
+from datetime import datetime
+
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 
+from ks_util import DATA_DIR
 from research_shelve import CODE_S_PATTERN
 from webapp.helpers import search_records, add_stock
 
 search_bp = Blueprint("search", __name__)
+
+# issue #98: トップページに統合する Google Spreadsheet 一覧
+# 最終更新日はローカル CSV の mtime (スプシ upload 直前に書かれる) を流用する
+PORTAL_SPREADSHEETS = (
+    {
+        "title": "Shintakane Result",
+        "url": "https://docs.google.com/spreadsheets/d/1KxOFvfgT7o_XGDASGylxA0Rn9yEqPLSv6Yweb_jGsHk/edit?usp=sharing",
+        "mtime_csv": "shintakane_result_data/shintakane_result.csv",
+    },
+    {
+        "title": "Code Rank",
+        "url": "https://docs.google.com/spreadsheets/d/1zto-8-fZ5hTZfXY6k2C49HZHbyA3OE8BgkReAViLSNU/edit?usp=sharing",
+        "mtime_csv": "code_rank_data/code_rank.csv",
+    },
+)
+
+
+def _portal_spreadsheets():
+    """PORTAL_SPREADSHEETS に最終更新日を付与して返す"""
+    cards = []
+    for sp in PORTAL_SPREADSHEETS:
+        csv_path = os.path.join(DATA_DIR, sp["mtime_csv"])
+        try:
+            ts = os.path.getmtime(csv_path)
+            updated_at = datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+        except OSError:
+            updated_at = "—"
+        cards.append({
+            "title": sp["title"],
+            "url": sp["url"],
+            "updated_at": updated_at,
+        })
+    return cards
 
 
 @search_bp.route("/")
@@ -69,6 +106,7 @@ def index():
         can_add=can_add,
         q_normalized=q_normalized,
         has_query=has_query,
+        portal_spreadsheets=_portal_spreadsheets() if not has_query else None,
     )
 
 

--- a/scripts/webapp/templates/search.html
+++ b/scripts/webapp/templates/search.html
@@ -84,10 +84,21 @@
 {% endif %}
 
 {% else %}
-{# issue #244: クエリなしトップアクセスは銘柄一覧ではなく What's new プレースホルダーを表示 #}
-<section id="whats-new" style="margin-top:1.5em;padding:1.2em 1.4em;background:#f6f8fa;border:1px solid #e1e5ea;border-radius:6px;">
-  <h3 style="margin-top:0;font-size:1.05em;color:#2c3e50;">📌 What's new — 今日の注目要素</h3>
-  <p style="color:#888;font-size:0.9em;margin-bottom:0;">準備中。市況・テーマ・保有銘柄など、その日にチェックすべき要素を後日ここに集約予定。</p>
+{# issue #98: クエリなしトップアクセスは Google Spreadsheets リンクカードを表示 #}
+<section id="portal-spreadsheets" style="margin-top:1.5em;display:flex;flex-wrap:wrap;gap:0.6em;">
+  {% for sp in portal_spreadsheets %}
+  <article style="margin:0;padding:0.5em 0.8em;background:#f6f8fa;border:1px solid #e1e5ea;border-radius:6px;">
+    <h3 style="margin:0;font-size:1em;line-height:1.3;">
+      <a href="{{ sp.url }}" target="_blank" rel="noopener">{{ sp.title }}</a>
+    </h3>
+    <p style="margin:0.15em 0 0 0;font-size:0.72em;color:#888;line-height:1.2;">最終更新: {{ sp.updated_at }}</p>
+  </article>
+  {% endfor %}
+</section>
+{# issue #244: What's new プレースホルダー (将来的にその日の注目要素を集約予定) #}
+<section id="whats-new" style="margin-top:1em;padding:0.8em 1em;background:#f6f8fa;border:1px solid #e1e5ea;border-radius:6px;">
+  <h3 style="margin:0 0 0.3em 0;font-size:1em;color:#2c3e50;">📌 What's new — 今日の注目要素</h3>
+  <p style="color:#888;font-size:0.8em;margin:0;">準備中。市況・テーマ・保有銘柄など、その日にチェックすべき要素を後日ここに集約予定。</p>
 </section>
 {% endif %}
 {% endblock %}

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -75,16 +75,18 @@ class TestSearchRoute:
         resp = client.get("/")
         assert resp.status_code == 200
 
-    def test_index_no_query_hides_records_and_shows_whats_new(self, client):
-        """issue #244: クエリなしトップでは銘柄一覧を出さず What's new プレースホルダーを表示"""
+    def test_index_no_query_hides_records_and_shows_portal(self, client):
+        """issue #98: クエリなしトップでは銘柄一覧を出さず Spreadsheet ポータルを表示"""
         resp = client.get("/")
         html = resp.data.decode()
         # 銘柄一覧テーブルは描画されない
         assert "アズーム" not in html
         assert '<table' not in html
-        # What's new プレースホルダーが存在する
-        assert 'id="whats-new"' in html
-        assert "What's new" in html
+        # Spreadsheet ポータルカードが存在する
+        assert 'id="portal-spreadsheets"' in html
+        assert "Shintakane Result" in html
+        assert "Code Rank" in html
+        assert "最終更新" in html
 
     def test_index_with_keyword_shows_records(self, client):
         """issue #244: 検索クエリ付き (keyword) では従来通り一覧を表示"""


### PR DESCRIPTION
## Summary
- クエリなしトップに Shintakane Result / Code Rank の Spreadsheet リンクをコンパクトな2カードで表示
- 各カードに対応する CSV の mtime を「最終更新日」として併記 (= 直近スプシ upload 時刻)
- What's new プレースホルダーはカードの下に維持

## 仕様メモ
- issue #98 のうち今回は「Shintakane Result」「Code Rank」の2枚のみ対象
  - Market Data → /market ページに統合済みのためスコープ外
  - 銘柄調査 → 各銘柄ページに統合済みのためスコープ外
- 最終更新日のソースは Google Sheets API 呼び出しではなく、ローカル CSV (`shintakane_result.csv` / `code_rank.csv`) の mtime。スプシ upload 直前に書き込まれるため近似値として実用十分
- CSV が存在しない場合は「—」を表示

Closes #98

## Test plan
- [x] \`pytest tests/test_webapp_routes.py\` 85 件 PASS
- [x] ローカル webapp 起動で / にアクセスし、カード表示と Spreadsheet リンクを確認 (\`.playwright-mcp/issue98-portal-top-v5.png\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)