### PR TITLE
portfolio: テーマをマスター管理し、編集画面を追加 (#282)

### DIFF
--- a/doc/plan/portfolio_theme_master.md
+++ b/doc/plan/portfolio_theme_master.md
@@ -1,0 +1,273 @@
+# プラン: ポートフォリオ — 業態・テーマのマスター管理と編集画面
+
+## 目的
+
+現在、業態・テーマは銘柄の `memo["gyoutai_themes"]` (list[str]) に文字列として直接保存され、入力欄の datalist 候補は「全銘柄に実際に入力されている値を集計」して生成している。マスターテーブルが無いため:
+
+- 同義語・誤字が混在しやすい
+- テーマの一括リネーム / 削除ができない
+- テーマに説明文を持たせられない
+
+GitHub Labels に近い体験で、テーマをマスター管理しつつ、編集画面 (`/portfolio/themes`) から追加・編集・削除できるようにする。
+
+## スコープ
+
+1. portfolio_shelve に「テーママスター」キー名前空間を追加
+2. `/portfolio/themes` 編集画面 (Flask ルート + テンプレート) を新規追加
+3. ポートフォリオ画面ヘッダのテーマフィルタ select の横に「✏️ テーマを編集」ボタンを追加
+4. 銘柄行のテーマ入力 UI を datalist 入力欄から `<select>` 2 個に置き換え
+   - マスター登録済みテーマのみ選択可
+   - 先頭に `— (未設定)` 項目を置き、それを選ぶと当該スロットがクリア
+   - **テーマ名そのもの (文字列) の編集機能は廃止** — 銘柄行で行えるのは「選ぶ / 外す」のみ。テーマ名のリネームはマスター編集画面 (`/portfolio/themes`) でのみ可能。これにより「銘柄から書き換え」と「マスター編集」の二重導線による曖昧さを排除する
+   - 既存の Ctrl/Cmd+クリック → テーマフィルタ機能は select 上でも維持
+5. 既存データ → マスター移行スクリプト (`scripts/migrate_themes_to_master.py`) を 1 本作成、1 回だけ実行
+
+スロット上限 `GYOUTAI_THEMES_MAX_SLOTS = 2` は維持する。
+
+## 非スコープ
+
+- テーマに「色」を持たせる
+- 「お気に入りテーマ」のピン留め
+- マスター未登録テーマの自由入力 (登録済みのみ選択可)
+- 複数 PR / Phase 分割 (1 issue / 1 PR で完結)
+
+---
+
+## データモデル
+
+### 新規キー名前空間 (portfolio_shelve)
+
+```
+theme:<name>     -> {"name": str, "description": str, "created_at": str(iso)}
+```
+
+- name は重複不可 (キー自体がユニーク制約)
+- description は説明文 (空文字許容)
+- created_at は ISO 形式 (`now_iso()`)
+- 既存の `record:` / `action_log:` / `_seq:` とは完全分離
+
+#### name の文字種制約 (URL 安全のため)
+
+ルートで `<name>` をパスパラメータとして使うため、URL に含めると曖昧になる文字を name に許可しない:
+
+- 禁止: `/` `?` `#` `&` `%` `+` 制御文字 (`\x00-\x1F`)
+- 許可: 日本語・英数字・空白・ハイフン・アンダースコア・中点・記号など上記禁止文字以外
+
+`create_theme` / `update_theme` のリネーム時に正規表現でバリデーションして ValueError。これにより `AI/半導体` のような name が作れず、URL `/portfolio/themes/<name>/delete` でルーティングが破綻しない。
+
+### 既存スキーマ (変更なし)
+
+`memo["gyoutai_themes"]: list[str]` はそのまま。マスター登録済み name と照合して整合性を保つ。
+
+### portfolio_shelve.py 追加定数
+
+```python
+KEY_THEME_PREFIX = "theme:"
+THEME_FIELDS = frozenset({"name", "description", "created_at"})
+THEME_NAME_MAX_LEN = 30  # UI バッジを崩さない上限
+```
+
+---
+
+## API 追加 (portfolio_shelve.py)
+
+すべて既存の `_flock` + `ShelveDB` パターンに従う。
+
+### `list_themes(*, db_path=None) -> List[Dict[str, Any]]`
+
+- 全 `theme:*` キーを読み、name 昇順でリストを返す
+- 各要素は `{"name", "description", "created_at"}`
+
+### `create_theme(name: str, description: str = "", *, db_path=None) -> Dict[str, Any]`
+
+- name バリデーション:
+  - `isinstance(name, str)` でない → TypeError
+  - `name.strip() == ""` → ValueError
+  - `len(name) > THEME_NAME_MAX_LEN` → ValueError
+- description は `str` のみ (None は `""` に正規化)
+- 既存キー `theme:<name>` あり → ValueError (重複)
+- 成功時は作成済みレコードを返す
+
+### `update_theme(name: str, new_name: str | None = None, description: str | None = None, *, db_path=None) -> Dict[str, Any]`
+
+- 既存キーが無ければ KeyError
+- `new_name` が指定され、かつ現行と異なれば **リネーム**:
+  1. `theme:<new_name>` が既存なら ValueError (重複)
+  2. 旧キー削除 + 新キー作成 (created_at は維持)
+  3. **全 record:* を走査し、memo["gyoutai_themes"] 内の旧 name を new_name に書き換え**
+     - 変更があった record は updated_at 更新 + action_log "メモ更新" 追加
+- `description` が指定されていればその値で上書き
+- 戻り値は更新後の theme レコード
+
+### `delete_theme(name: str, *, db_path=None) -> int`
+
+- 既存キーが無ければ KeyError
+- `theme:<name>` を削除
+- **全 record:* を走査し、memo["gyoutai_themes"] から name を除去**
+  - 変更があった record は updated_at 更新 + action_log "メモ更新" 追加
+- 戻り値: 影響を受けた銘柄数
+
+### `count_theme_usage(*, db_path=None) -> Dict[str, int]`
+
+- 全 record:* を 1 回スキャンし、各 theme name → 使用銘柄数を返す
+- 編集画面表示用
+
+### 並行性・原子性
+
+- `update_theme` のリネームと `delete_theme` の銘柄側除去は **1 つの `_flock` + 1 つの ShelveDB セッション** 内で実行する (途中失敗で不整合が残らないようにする)
+- 影響を受けた record の updated_at 更新と action_log 追記は同 flock 内で完了させる
+
+### 既存 `update_memo` の変更
+
+`gyoutai_themes` の値の扱いは「**マスター未登録値を保持したまま保存を許可する (ただし新規追加は不可)**」とする:
+
+- POST されたリストの各値について:
+  - 空文字なら除去 (スロットクリア)
+  - マスター登録済み name ならそのまま採用
+  - マスター未登録 name で **かつ現行レコードの memo[gyoutai_themes] にも入っていない** → ValueError (UI を経由した新規付与は登録済みのみ)
+  - マスター未登録 name で **かつ現行レコードに既に入っている** → 移行漏れの既存値なので保持を許可
+
+これにより以下のシナリオが破綻しない:
+
+- 移行漏れで未登録 name が残っている銘柄で、もう片方のスロットだけ別テーマに変更したい → 未登録値はそのまま、もう片方は登録済み name に更新できる
+- 未登録 name を select で「— (未設定)」にすれば外せる (空文字扱いなので除去される)
+- routes/portfolio.py のフォームハンドラ側は現行レコードを load してから上記判定を行う
+
+---
+
+## 移行スクリプト (`scripts/migrate_themes_to_master.py`)
+
+- 全 record:* の memo["gyoutai_themes"] を走査し、ユニーク化
+- 各 name について:
+  - 既にマスター登録済みならスキップ
+  - 未登録なら `create_theme(name, description="")` を呼ぶ
+- 実行サマリーを log_print (新規登録件数、既存件数、影響銘柄数)
+- 冪等 (再実行しても重複作成しない)
+- `--dry-run` フラグで集計のみ
+- name バリデーション (URL 安全制約) で弾かれる既存値があれば、件数と code_s を一覧して **失敗終了**。ユーザーに手動でリネーム判断させる
+- **旧 `memo["gyoutai_theme"]` (str 単数フィールド、issue #187 移行期間用) の残存検知**:
+  - 旧フィールドに非空値が残っている record があれば件数と code_s を一覧
+  - デフォルトは **失敗終了** (新フィールドへの移行を先に済ませる必要があるため)
+  - `--include-legacy` フラグを付けた場合のみ、旧フィールドの値も改行/カンマ分割してマスター登録対象に含める (運用判断で残存データを救済したい場合の逃げ道)
+
+---
+
+## WebApp 変更
+
+### 新規ルート (`scripts/webapp/routes/portfolio.py` に追加)
+
+| メソッド | パス | 用途 |
+|---|---|---|
+| GET | `/portfolio/themes` | 一覧 + 編集フォーム表示 |
+| POST | `/portfolio/themes/create` | 新規作成 |
+| POST | `/portfolio/themes/<name>/update` | リネーム/説明文編集 |
+| POST | `/portfolio/themes/<name>/delete` | 削除 (確認ダイアログは JS 側で confirm()) |
+
+すべてフォーム送信 → 完了後 `/portfolio/themes` に redirect (PRG パターン)。AJAX 化はしない (シンプル優先)。
+
+### 新規テンプレート (`scripts/webapp/templates/portfolio_themes.html`)
+
+レイアウト:
+
+```
+[← ポートフォリオに戻る]                    [+ 新規テーマ]
+
+テーマ一覧 (14 件)
+─────────────────────────────────────────
+| 名前        | 説明           | 使用 | 操作        |
+| 半導体      | 半導体製造装置 | 12   | [編集][削除] |
+| 防衛        |                |  3   | [編集][削除] |
+| ...                                            |
+─────────────────────────────────────────
+```
+
+- 新規作成: モーダルではなく一覧上部のインラインフォーム (name 入力 + description 入力 + 作成ボタン)
+- 編集: 行内で「編集」ボタンを押すと行が name/description の input に切り替わる (JS で行単位トグル)
+- 削除: ボタンクリックで `confirm("テーマ 「XXX」 を削除しますか? N 銘柄から除去されます。")` → POST
+
+### 既存 portfolio_list.html の変更
+
+#### ヘッダのテーマフィルタ select の横にボタン追加 (162-167 行付近)
+
+```html
+<a href="{{ url_for('portfolio.themes_index') }}"
+   style="..." title="テーマを編集">✏️ テーマを編集</a>
+```
+
+#### 銘柄行のテーマ入力 (276-288 行付近)
+
+`<input list="gyoutai-theme-choices">` 2 個を `<select name="gyoutai_themes_0">` / `<select name="gyoutai_themes_1">` 2 個に置き換える。
+
+```html
+<select name="gyoutai_themes_0" class="theme-select" ...>
+  <option value="">— (未設定)</option>
+  {% for theme in theme_master %}
+  <option value="{{ theme.name }}" {% if theme.name == current[0] %}selected{% endif %}>{{ theme.name }}</option>
+  {% endfor %}
+</select>
+```
+
+- `theme_master` は `list_themes()` の結果を `routes/portfolio.py` のリスト表示ハンドラで context 注入
+- 現行値がマスター未登録 (移行漏れ等) の場合は、選択肢に **「⚠️ <name>」をその場限り追加 + selected** で表示崩れを防ぐ (移行スクリプト実行後は基本起こらない想定)
+- `update_memo` 側は「現行レコードに既に入っている未登録値」の保持を許可するため、ユーザーは未登録値が残った銘柄でも他方のスロットを編集可能。未登録値を外したいときは select で「— (未設定)」を選べばよい
+- 既存の `<datalist id="gyoutai-theme-choices">` (381-384 行) は削除
+- `collect_gyoutai_theme_choices()` (helpers.py:1661) は使われなくなるので削除
+
+#### Ctrl/Cmd+クリック → フィルタ機能 (870-878 行付近)
+
+`<select>` でも `onmousedown` イベントは発火するため、現行ロジックをほぼそのまま使える。ただし `mousedown` 時点では `select.value` が選択中項目で固定されているため、`event.target` がドロップダウン項目 (`<option>`) であることを使って判定する必要がある (要動作確認。実装難なら **select の横に小さなフィルタアイコンを置く** に fallback)。
+
+### routes/portfolio.py の memo 更新ハンドラ (345-371 / 386-426 行)
+
+- スロット入力値が空文字 (`— (未設定)` を選んだケース) なら list から除去
+- マスター未登録の値については `update_memo` の判定に委ねる:
+  - 現行レコードに既に入っている未登録 name はそのまま保持 (保存成功)
+  - 純新規の未登録 name (現行レコードに無い) は `update_memo` が ValueError を投げるので 400 を返す
+
+---
+
+## テスト追加
+
+`tests/test_portfolio_shelve.py` に以下を parametrize で集約 (CLAUDE.md: 1 PR で 5 本以下、自明な動作は書かない):
+
+1. `create_theme` 重複・空文字・上限超過・URL 禁止文字のバリデーション
+2. `update_theme` のリネームで既存銘柄の `memo["gyoutai_themes"]` も書き換わる
+3. `delete_theme` で既存銘柄から name が除去され、影響件数が返る
+4. `update_memo` の未登録 name 判定 (parametrize):
+   - 純新規の未登録 name → ValueError
+   - 現行レコードに既にある未登録 name を維持 → 成功
+   - 未登録 name を「— (未設定)」相当で外す (空文字経由で list から除去) → 成功
+5. リネーム / 削除中の例外で部分書き込みが残らない (同 flock 内完結確認)
+
+WebApp 側のテストは既存 `test_webapp_routes.py` パターンに合わせて smoke のみ:
+
+- `GET /portfolio/themes` が 200
+- `POST /portfolio/themes/create` で DB に 1 件追加される
+- `POST /portfolio/themes/<name>/delete` で削除される
+
+---
+
+## 検証ポイント
+
+1. `pytest tests/test_portfolio_shelve.py tests/test_webapp_routes.py -v`
+2. 移行スクリプト dry-run → 実行 → 再実行 (冪等性確認)
+3. `python -m webapp.app` 起動 → `/portfolio` でテーマ select が表示される
+4. `/portfolio/themes` で作成・編集・削除が動く
+5. リネーム後、`/portfolio` の銘柄行の表示が新 name に追従する
+6. 削除後、`/portfolio` の銘柄行から該当 name が消える
+7. Ctrl/Cmd+クリック → テーマフィルタが select でも動く
+
+---
+
+## ロールバック
+
+- shelve は単一ファイル。事前に portfolio_shelve のバックアップを取れば、`theme:*` キー削除 + 移行スクリプト未実行で完全に戻せる
+- portfolio_list.html / routes/portfolio.py は git revert で巻き戻し
+
+---
+
+## 想定リスク
+
+- **リネーム/削除中のクラッシュ**: 同 flock 内で完結させるため、ShelveDB の writeback タイミングが鍵。`ShelveDB` ラッパが `with` ブロック終了時に flush する前提を再確認する
+- **マスター未登録テーマの「⚠️」表示**: 移行漏れがあると select に出るが、ユーザーが select 操作した時点でマスターに無い値は選択肢から消える (実害は表示のみ)
+- **`collect_gyoutai_theme_choices` の削除**: 他から参照されていないか grep で確認すること

--- a/doc/plan/portfolio_theme_summary.md
+++ b/doc/plan/portfolio_theme_summary.md
@@ -1,0 +1,223 @@
+# プラン: ポートフォリオ — 業態テーマ別サマリー表示
+
+## 目的
+
+監視ユニバース (portfolio_shelve に登録された全銘柄、保有 / 準保有 / 監視) を、ユーザーが手動で付けた **業態・テーマ** (`memo["gyoutai_themes"]`) でグルーピングし、テーマごとに既存指標 `momentum_pt` を集約して「自分の投資仮説ごとのテーマ強弱」を一目で把握できる画面を webapp に追加する。
+
+O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブル + リーダー株の同行表示) を参考にしつつ、用途を「市場全体のテーマローテーション検知」ではなく **「自分が組んだ投資仮説の事後評価 / 銘柄入れ替え判断」** に限定する。
+
+### 既存資産との役割分担
+
+| 機能 | 用途 | 構成銘柄ソース |
+|---|---|---|
+| `market_db["theme_rank"]` (既存) | 市場全体のテーマローテーション検知 (仕入れ前) | Kabutan アクセスランキング |
+| **業態テーマサマリー (本機能)** | 自分の投資仮説の事後評価 (仕入れ後) | portfolio_shelve `memo["gyoutai_themes"]` |
+
+両者は補完関係。スコープ・データソース・UI 配置すべて独立させる。
+
+## スコープ
+
+1. webapp に新規ルート `/portfolio/themes/summary` を追加 (一覧表示のみ、編集機能なし)
+2. テンプレート `portfolio_theme_summary.html` を新規追加
+3. helpers に集計関数 `build_portfolio_theme_summary()` を 1 本追加
+4. `/portfolio` 画面のヘッダから本画面へのリンクを追加
+5. テーマ別の指標は **既存 stocks_shelve の値の集約のみ** で完結 — DB 書込みなし、新規スキーマなし、新規キャリブレーションなし
+
+## 非スコープ
+
+- テーマ指数 (price_log 累積) の構築
+- TOPIX 比 RS の再計算 (個別銘柄の `momentum_pt` が既に TOPIX 比正規化済みのため流用)
+- breadth 指標 (新高値率、25日線上比率、出来高増加率 等)
+- 時系列での 3 週前 / 6 週前ランク比較
+- 株探テーマ (`stock["themes"]`) ベースの指数
+- 銘柄スコアへの組込 (既存 40/20/25/15 配点は変更しない)
+- portfolio_theme_master の完了待ち (本機能は移行漏れ未登録テーマも含めてグルーピング)
+- DB 書込み (本画面は閲覧専用、リクエストごとに集計)
+
+---
+
+## データソース
+
+すべて既存スキーマ。新規スキーマなし。
+
+| ソース | キー / フィールド | 用途 |
+|---|---|---|
+| portfolio_shelve | `record:<code_s>` の `memo["gyoutai_themes"]: list[str]` | テーマ → 銘柄の逆引き |
+| portfolio_shelve | `record:<code_s>` の `status` | excluded 除外、status ラベル表示 |
+| stocks_shelve | `<code_s>` の `momentum_pt` | テーマ集約 (平均 / 最大) の主指標 |
+| stocks_shelve | `<code_s>` の `price_log` | 20日 / 65日リターン算出 |
+| stocks_shelve | `<code_s>` の `stock_name` | リーダー株表示 |
+
+### 構成銘柄の選定ルール
+
+- `portfolio_shelve.list_records(include_excluded=False)` で取得 (excluded 銘柄は除外、既存ヘルパーに従う)
+- `memo["gyoutai_themes"]` のスロット (最大 2) を **両方とも展開** し、テーマ → `[code_s, ...]` の逆引きを作る
+  - 同一銘柄が 2 テーマに属する場合は両方にカウント (テーマ視点では独立集計)
+- 空文字 / `None` のスロットは無視
+- `memo` 自体が無い (旧データ) レコードは寄与なし
+
+### 最小構成銘柄数
+
+- 制限なし。**1 銘柄のテーマも表示する**
+  - 軽量版の目的は「自分が組んだテーマ別の強弱を見る」ことなので、1 銘柄でも「そのテーマに自分が持っている / 監視している銘柄が 1 つしかない」という事実が見えるべき
+  - 構成銘柄数カラムを必ず表示し、ユーザーが少数構成の不安定さを目視で判断できるようにする
+
+---
+
+## 集計指標
+
+各テーマについて以下を計算。すべて構成銘柄の既存指標を **等加重で集約**。
+
+| 指標 | 定義 | 計算ソース |
+|---|---|---|
+| `member_count` | 構成銘柄数 | 逆引き結果の長さ |
+| `momentum_pt_avg` | momentum_pt の平均 (None は除外) | stocks_shelve `momentum_pt` |
+| `momentum_pt_max` | momentum_pt の最大 (None は除外) | stocks_shelve `momentum_pt` |
+| `ret_20d_avg` | 20 営業日リターン (%) の平均 | stocks_shelve `price_log` |
+| `ret_65d_avg` | 65 営業日リターン (%) の平均 | stocks_shelve `price_log` |
+| `leaders` | momentum_pt 降順上位 3 銘柄 | (code_s, stock_name, momentum_pt) の list |
+
+### momentum_pt が無い銘柄の扱い
+
+- `momentum_pt` が None / 欠損のものは集計対象から除外 (count にも入れない方針は採らず、count はテーマに属する全銘柄数とする)
+- 集計対象が 0 銘柄ならその指標は `None` (テンプレ側で "—" 表示)
+
+### リターン計算
+
+- `price_log` は `[(date, price), ...]` 形式で最新が先頭
+- `ret_Nd = (price_log[0][1] - price_log[N][1]) / price_log[N][1] * 100`
+- `len(price_log) <= N` の銘柄はその指標から除外
+- 計算自体は既存の他箇所で行われているはずだが、helpers 内で完結する小関数 `_calc_return_pct(price_log, days)` を本機能用に追加してよい。既存の似たユーティリティが見つかればそれを流用 (実装時に grep で確認)
+
+### ソートキー
+
+デフォルト: `momentum_pt_avg` 降順 (None は末尾)
+将来のソート列追加は非スコープ (まずは単一ソートで運用)
+
+---
+
+## API 追加 (`webapp/helpers.py`)
+
+```python
+def build_portfolio_theme_summary(
+    records: list[dict] | None = None,
+) -> list[dict]:
+    """portfolio_shelve のユニバースを memo['gyoutai_themes'] でグルーピングし、
+    テーマごとの集約指標と上位リーダー株を返す。
+
+    Args:
+        records: portfolio_shelve.list_records(include_excluded=False) の戻り値。
+            None なら関数内で取得する (テスト時に注入できるよう引数化)。
+
+    Returns:
+        list[dict]: 各要素は
+            {
+                "theme": str,
+                "member_count": int,
+                "momentum_pt_avg": float | None,
+                "momentum_pt_max": float | None,
+                "ret_20d_avg": float | None,
+                "ret_65d_avg": float | None,
+                "leaders": list[{"code_s": str, "stock_name": str, "momentum_pt": float}],
+                "members": list[{"code_s": str, "stock_name": str, "momentum_pt": float | None,
+                                 "status": str}],
+            }
+        並び順は momentum_pt_avg 降順 (None は末尾) → テーマ名昇順。
+    """
+```
+
+- 既存 `_bulk_get_stock_data` を流用して 1 回でまとめて stock dict を取る
+- 銘柄名は `_bulk_resolve_stock_names` を流用
+- `members` フィールドはテンプレ側で行 expand 表示に使う (詳細表示)
+- 戻り値は完全な dict (テンプレで `.get` フォールバックを書かなくて済むようにキーは常に存在)
+
+---
+
+## WebApp 変更
+
+### 新規ルート (`scripts/webapp/routes/portfolio.py` に追加)
+
+| メソッド | パス | 用途 |
+|---|---|---|
+| GET | `/portfolio/themes/summary` | 業態テーマサマリー一覧表示 |
+
+- 既存 `portfolio` blueprint に追加
+- POST 操作なし、PRG 不要
+- fallback_mode (= portfolio_shelve 空、`_build_fallback_records` で代用) の場合は空テーブル + 案内文を表示
+
+### 新規テンプレート (`scripts/webapp/templates/portfolio_theme_summary.html`)
+
+レイアウト:
+
+```
+[← ポートフォリオに戻る]
+
+業態テーマサマリー (NN テーマ / MM 銘柄)
+
+| テーマ        | 構成銘柄 | momentum_pt 平均 | 最大 | 20日 平均 | 65日 平均 | リーダー株 (top3)           |
+|--------------|---------|------------------|------|----------|----------|----------------------------|
+| AI半導体CAPEX | 6       | 78               | 92   | +12.4%   | +24.1%   | 6324 (92), 4063 (85), ...  |
+| 防衛          | 4       | 65               | 80   |  +5.1%   |  +9.2%   | 7011 (80), 6208 (72), ...  |
+| ...                                                                                                  |
+
+(各行は折り畳み可。展開で構成銘柄一覧を表示)
+```
+
+- リーダー株表示: `{code_s} ({momentum_pt})` 形式、`url_for("detail.stock_detail", code_s=row.code_s)` (実 URL: `/stock/<code_s>`) で既存銘柄詳細ページにリンク (portfolio_list.html line 249 と同じ導線)
+- 行クリック (または ▶ ボタン) で構成銘柄一覧を展開 (JS は最小限、`<details>` タグで実装可能)
+- momentum_pt 平均は条件付き書式: ≥ 70 で太字 + 緑、≤ 30 で赤 (既存 portfolio_list.html のスタイル流用)
+- 構成銘柄数が 1 の行は薄いマーカー (背景色) で「少数構成」とわかるようにする (ユーザーが信頼度を即判断できる)
+
+### 既存 portfolio_list.html の変更
+
+ヘッダのテーマフィルタ select 付近 (162-167 行付近、`portfolio_theme_master` プランで「✏️ テーマを編集」ボタンを追加する位置と同じ領域) に **「📊 テーマサマリー」リンク** を追加。
+
+```html
+<a href="{{ url_for('portfolio.theme_summary') }}"
+   style="..." title="業態テーマ別サマリー">📊 テーマサマリー</a>
+```
+
+portfolio_theme_master プランとは UI 上は別ボタンとして共存させる (「✏️ テーマを編集」= マスター管理、「📊 テーマサマリー」= 集約閲覧)。
+
+---
+
+## テスト追加
+
+`tests/test_webapp_helpers.py` に parametrize で集約 (CLAUDE.md: 1 PR で 5 本以下):
+
+1. `build_portfolio_theme_summary` 基本ケース: 2 テーマ × 3 銘柄ずつで集約値が期待通り
+2. 同一銘柄が 2 テーマに属する場合、両テーマで集計される
+3. `momentum_pt` 欠損銘柄は集計から除外されるが member_count には含まれる
+4. `price_log` 長さ不足の銘柄は ret_Nd_avg から除外される
+5. `leaders` は momentum_pt 降順上位 3 (同点時は code_s 昇順で安定ソート)
+
+WebApp ルートのテストは `tests/test_webapp_routes.py` に 1 本追加:
+
+- `GET /portfolio/themes/summary` が 200 で返り、テンプレートに「業態テーマサマリー」文字列を含む (smoke)
+
+---
+
+## 検証ポイント
+
+1. `pytest tests/test_webapp_helpers.py tests/test_webapp_routes.py -v` 通過
+2. `python -m webapp.app` 起動 → `/portfolio` ヘッダから「📊 テーマサマリー」リンクが見える
+3. `/portfolio/themes/summary` でテーマ一覧が momentum_pt 平均降順に並ぶ
+4. 構成銘柄数 1 のテーマも表示され、視覚マーカーが付く
+5. 行展開で構成銘柄が momentum_pt 降順で並ぶ
+6. fallback_mode (portfolio_shelve 空) では空テーブル + 案内文が出る
+
+---
+
+## ロールバック
+
+- webapp / helpers / templates の追加のみで、既存スキーマ・既存テンプレ・既存挙動への破壊的変更なし
+- git revert で完全に戻せる
+- DB 書込みなしのため、ロールバック後のデータ整合性問題は発生しない
+
+---
+
+## 想定リスク
+
+- **テーマ名の表記揺れ**: portfolio_theme_master 完了前は同義語・誤字が別テーマとして集計される。本機能は移行漏れも「そのまま」表示する方針なので、ユーザーは表記揺れに気づいて手動修正できる (むしろ可視化の副次効果として有用)。
+- **構成銘柄 1 のテーマ**: momentum_pt 平均 = その銘柄自体になり「テーマ集約」としては意味が薄い。マーカー表示で目視抑制し、ユーザー判断に委ねる (除外しない)。
+- **集計コスト**: テーマ数 30、銘柄数 200 想定で 1 リクエストあたり数十 ms 程度の見込み。`_bulk_get_stock_data` 流用で N+1 を回避すれば問題なし。リクエストごとに再計算するが、キャッシュは入れない (シンプル優先)。

--- a/scripts/migrate_themes_to_master.py
+++ b/scripts/migrate_themes_to_master.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""portfolio_shelve.memo[gyoutai_themes] の既存値をテーママスター (theme:<name>) に移行する (issue #282)。
+
+要件:
+- 全 record:* の memo["gyoutai_themes"] を走査し、ユニーク化
+- 各 name について theme:<name> が未登録なら create_theme(name) を呼ぶ
+- 既に登録済みならスキップ (冪等)
+- name バリデーション (URL 安全) で弾かれる既存値があれば一覧して失敗終了
+- 旧 memo["gyoutai_theme"] (str, 旧フィールド) の残存検知:
+    - 非空が残っている record があればデフォルトは失敗終了
+    - `--include-legacy` を付けた場合のみ旧フィールド値も改行/カンマ分割してマスター対象に含める
+- excluded 銘柄も対象 (移行漏れさせない)
+- デフォルト dry-run、`--apply` で実書き込み
+
+usage:
+    python migrate_themes_to_master.py            # dry-run (デフォルト)
+    python migrate_themes_to_master.py --apply    # 本番実行
+    python migrate_themes_to_master.py --apply --include-legacy   # 旧フィールド残存も救済して取り込み
+"""
+
+import argparse
+import os
+import re
+import sys
+from typing import Dict, List, Optional, Set
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import log_print
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+
+_LEGACY_SPLIT_RE = re.compile(r"[\n,]")
+
+
+def _collect_names_from_records(
+    *,
+    include_legacy: bool,
+    db_path: Optional[str],
+) -> tuple:
+    """全 record から (new_names, legacy_codes, legacy_names, affected_count) の 4 値タプルを返す。
+
+    - new_names: 新フィールド gyoutai_themes から抽出したユニーク name 集合
+    - legacy_codes: 旧 gyoutai_theme フィールドに非空値が残っている code_s 一覧
+    - legacy_names: include_legacy=True のとき旧値から抽出した name 集合 (False なら空)
+    - affected_count: gyoutai_themes 非空の record 数
+    """
+    records = ps.list_records(include_excluded=True, db_path=db_path)
+    new_names: Set[str] = set()
+    legacy_codes: List[str] = []
+    legacy_names: Set[str] = set()
+    affected_count = 0
+
+    for rec in records:
+        code_s = rec.get("code_s", "")
+        memo = rec.get("memo") or {}
+        themes = memo.get("gyoutai_themes") or []
+        if themes:
+            affected_count += 1
+        for t in themes:
+            if isinstance(t, str) and t.strip():
+                new_names.add(t.strip())
+
+        legacy = memo.get("gyoutai_theme") or ""
+        if isinstance(legacy, str) and legacy.strip():
+            legacy_codes.append(code_s)
+            if include_legacy:
+                for part in _LEGACY_SPLIT_RE.split(legacy):
+                    p = part.strip()
+                    if p:
+                        legacy_names.add(p)
+
+    return new_names, legacy_codes, legacy_names, affected_count
+
+
+def migrate_themes_to_master(
+    *,
+    apply: bool = False,
+    include_legacy: bool = False,
+    db_path: Optional[str] = None,
+) -> Dict[str, int]:
+    """既存 memo[gyoutai_themes] からテーママスターを作成する。
+
+    Returns: {"new_count": int, "existing_count": int, "affected_records": int, "skipped_invalid": int}
+    """
+    new_names, legacy_codes, legacy_names, affected_count = _collect_names_from_records(
+        include_legacy=include_legacy, db_path=db_path
+    )
+
+    # 旧 gyoutai_theme フィールド残存検知
+    if legacy_codes and not include_legacy:
+        log_print(
+            "migrate_themes_to_master: ERROR — 旧 memo[gyoutai_theme] が "
+            f"{len(legacy_codes)} 銘柄に残存しています: {legacy_codes[:10]}"
+            + ("..." if len(legacy_codes) > 10 else "")
+        )
+        log_print(
+            "  先に migrate_gyoutai_theme_to_list.py を実行してください "
+            "(もしくは本スクリプトに --include-legacy を付けて旧値も救済)"
+        )
+        sys.exit(2)
+
+    all_candidate_names: Set[str] = set(new_names) | set(legacy_names)
+
+    # name バリデーション (URL 安全)
+    valid: List[str] = []
+    invalid: List[str] = []
+    for name in sorted(all_candidate_names):
+        try:
+            ps.validate_theme_name(name)
+            valid.append(name)
+        except (ValueError, TypeError) as e:
+            invalid.append(f"{name!r} ({e})")
+
+    if invalid:
+        log_print(
+            f"migrate_themes_to_master: ERROR — name バリデーションで弾かれた既存値が "
+            f"{len(invalid)} 件あります:"
+        )
+        for s in invalid:
+            log_print(f"  - {s}")
+        log_print(
+            "  該当 record の memo[gyoutai_themes] を手動でリネームしてから再実行してください"
+        )
+        sys.exit(2)
+
+    existing = {t["name"] for t in ps.list_themes(db_path=db_path)}
+    to_create = [n for n in valid if n not in existing]
+    already = [n for n in valid if n in existing]
+
+    log_print(
+        f"migrate_themes_to_master: 対象 record={affected_count} (excluded 含む全件中) "
+        f"unique_names={len(all_candidate_names)} new={len(to_create)} existing={len(already)}"
+    )
+    if include_legacy and legacy_names:
+        log_print(
+            f"  legacy 救済モード: 旧 gyoutai_theme から {len(legacy_names)} name 抽出"
+        )
+    log_print(f"  作成予定: {sorted(to_create)[:20]}{'...' if len(to_create) > 20 else ''}")
+
+    if not apply:
+        log_print("migrate_themes_to_master: dry-run (--apply で実書き込み)")
+        return {
+            "new_count": len(to_create),
+            "existing_count": len(already),
+            "affected_records": affected_count,
+            "skipped_invalid": 0,
+        }
+
+    created = 0
+    for name in to_create:
+        try:
+            ps.create_theme(name, description="", db_path=db_path)
+            created += 1
+        except ValueError as e:
+            log_print(f"  skip {name!r}: {e}")
+
+    log_print(
+        f"migrate_themes_to_master: 完了 created={created} already_existed={len(already)}"
+    )
+    return {
+        "new_count": created,
+        "existing_count": len(already),
+        "affected_records": affected_count,
+        "skipped_invalid": 0,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="実書き込みする (default: dry-run)")
+    parser.add_argument(
+        "--include-legacy",
+        action="store_true",
+        help="旧 memo[gyoutai_theme] (str) の残存値も改行/カンマ分割でマスター対象に含める",
+    )
+    parser.add_argument("--db-path", default=None, help="portfolio_shelve のパス上書き (テスト用)")
+    args = parser.parse_args()
+
+    migrate_themes_to_master(
+        apply=args.apply,
+        include_legacy=args.include_legacy,
+        db_path=args.db_path,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -68,6 +68,14 @@ VALID_ACTION_TYPES = frozenset(
 KEY_RECORD_PREFIX = "record:"
 KEY_ACTION_LOG_PREFIX = "action_log:"
 KEY_SEQ_PREFIX = "_seq:"
+KEY_THEME_PREFIX = "theme:"
+
+# テーママスター (issue #282)
+THEME_FIELDS = frozenset({"name", "description", "created_at"})
+THEME_NAME_MAX_LEN = 30  # UI バッジを崩さない上限
+# URL に含めると曖昧になる文字 + HTML/JS リテラルを破壊する文字を name に許可しない
+# (`/portfolio/themes/<name>/...` ルートの破綻防止 + テンプレ展開時の注入予防)
+_THEME_NAME_FORBIDDEN_RE = re.compile(r"[\/\?\#\&\%\+\<\>\"\'\\\x00-\x1F]")
 
 # PF 全体で 1 つだけ保持するメタキー (どこかの銘柄で qty が変化したら更新)
 KEY_QTY_GLOBAL_UPDATED_AT = "_meta:qty_global_updated_at"
@@ -884,6 +892,277 @@ def exclude_from_universe(
     return True
 
 
+# ===========================================
+# テーママスター (issue #282)
+# ===========================================
+
+def _theme_key(name: str) -> str:
+    return f"{KEY_THEME_PREFIX}{name}"
+
+
+def validate_theme_name(name: Any) -> str:
+    """テーマ name を検証して正規化済み name を返す。
+
+    - str でない → TypeError
+    - strip() 後に空 → ValueError
+    - 長さ > THEME_NAME_MAX_LEN → ValueError
+    - URL 禁止文字 (/ ? # & % + 制御文字) を含む → ValueError
+
+    正規化: strip() のみ (大文字小文字は維持、内部空白も維持)
+    """
+    if not isinstance(name, str):
+        raise TypeError(f"theme name must be str, got {type(name).__name__}")
+    normalized = name.strip()
+    if not normalized:
+        raise ValueError("theme name は空にできません")
+    if len(normalized) > THEME_NAME_MAX_LEN:
+        raise ValueError(
+            f"theme name は {THEME_NAME_MAX_LEN} 文字以内: {name!r} ({len(normalized)} 文字)"
+        )
+    m = _THEME_NAME_FORBIDDEN_RE.search(normalized)
+    if m:
+        raise ValueError(
+            f"theme name に使用できない文字が含まれています: {name!r} (禁止: / ? # & % + 制御文字)"
+        )
+    return normalized
+
+
+def _validate_theme_description(description: Any) -> str:
+    if description is None:
+        return ""
+    if not isinstance(description, str):
+        raise TypeError(
+            f"theme description must be str or None, got {type(description).__name__}"
+        )
+    return description
+
+
+def list_themes(*, db_path: Optional[str] = None) -> List[Dict[str, Any]]:
+    """テーママスターを name 昇順で取得する。"""
+    path = _resolve_db_path(db_path)
+    results: List[Dict[str, Any]] = []
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_THEME_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            results.append(dict(value))
+    results.sort(key=lambda r: r.get("name", ""))
+    return results
+
+
+def get_theme(name: str, *, db_path: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """1件取得 (存在しなければ None)。"""
+    normalized = validate_theme_name(name)
+    path = _resolve_db_path(db_path)
+    with ShelveDB(path) as db:
+        value = db.get(_theme_key(normalized))
+    return dict(value) if isinstance(value, dict) else None
+
+
+def create_theme(
+    name: str,
+    description: str = "",
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """テーマを新規作成する。重複は ValueError。"""
+    normalized = validate_theme_name(name)
+    desc = _validate_theme_description(description)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _theme_key(normalized)
+            if key in db:
+                raise ValueError(f"theme {normalized!r} は既に存在します")
+            record = {
+                "name": normalized,
+                "description": desc,
+                "created_at": now_iso(),
+            }
+            db[key] = record
+    log_print("portfolio_shelve: theme 作成", normalized)
+    return dict(record)
+
+
+def update_theme(
+    name: str,
+    new_name: Optional[str] = None,
+    description: Optional[str] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """テーマを更新する (リネーム / 説明文編集)。
+
+    - new_name が現行と異なれば旧キー削除 + 新キー作成 + 全 record の memo[gyoutai_themes] 書き換え
+    - description が None でなければその値で上書き
+    - 同 _flock + 同 ShelveDB セッション内で完結 (途中失敗で不整合を残さない)
+
+    戻り値: 更新後の theme レコード
+    """
+    normalized = validate_theme_name(name)
+    new_normalized = validate_theme_name(new_name) if new_name is not None else None
+    desc_value = _validate_theme_description(description) if description is not None else None
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            old_key = _theme_key(normalized)
+            if old_key not in db:
+                raise KeyError(f"theme {normalized!r} は存在しません")
+            current = dict(db[old_key])
+
+            renaming = new_normalized is not None and new_normalized != normalized
+            if renaming:
+                new_key = _theme_key(new_normalized)
+                if new_key in db:
+                    raise ValueError(f"theme {new_normalized!r} は既に存在します")
+                current["name"] = new_normalized
+            if desc_value is not None:
+                current["description"] = desc_value
+
+            if renaming:
+                # 旧キー削除 + 新キー作成 + 銘柄側書き換え
+                del db[old_key]
+                db[new_key] = current
+                affected_codes = _rewrite_theme_in_records(
+                    db, normalized, new_normalized
+                )
+            else:
+                db[old_key] = current
+                affected_codes = []
+
+            # 影響を受けた record の action_log は flock 内で追記 (リエントラント対応済み)
+            for code in affected_codes:
+                _append_action_log_inner(db, code, "メモ更新")
+    if renaming:
+        log_print(
+            "portfolio_shelve: theme リネーム",
+            f"{normalized} -> {new_normalized}",
+            f"affected={len(affected_codes)}",
+        )
+    else:
+        log_print("portfolio_shelve: theme 更新", normalized)
+    return dict(current)
+
+
+def delete_theme(name: str, *, db_path: Optional[str] = None) -> int:
+    """テーマを削除する。全 record から該当 name を除去。
+
+    戻り値: 影響を受けた銘柄数
+    """
+    normalized = validate_theme_name(name)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _theme_key(normalized)
+            if key not in db:
+                raise KeyError(f"theme {normalized!r} は存在しません")
+            del db[key]
+            affected_codes = _rewrite_theme_in_records(db, normalized, None)
+            for code in affected_codes:
+                _append_action_log_inner(db, code, "メモ更新")
+    log_print(
+        "portfolio_shelve: theme 削除",
+        normalized,
+        f"affected={len(affected_codes)}",
+    )
+    return len(affected_codes)
+
+
+def count_theme_usage(*, db_path: Optional[str] = None) -> Dict[str, int]:
+    """name -> 使用銘柄数 を返す (編集画面表示用)。"""
+    path = _resolve_db_path(db_path)
+    counts: Dict[str, int] = {}
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_RECORD_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            memo = value.get("memo") or {}
+            for theme in (memo.get("gyoutai_themes") or []):
+                if isinstance(theme, str) and theme:
+                    counts[theme] = counts.get(theme, 0) + 1
+    return counts
+
+
+def _rewrite_theme_in_records(
+    db: ShelveDB,
+    old_name: str,
+    new_name: Optional[str],
+) -> List[str]:
+    """全 record:* を走査し、memo[gyoutai_themes] 内の old_name を new_name に置換する。
+
+    - new_name=None なら除去 (削除)
+    - new_name 指定で同一スロットに新 name が既に存在する場合は重複除去
+    - 変更があった record は updated_at を now_iso() に更新
+    - 戻り値: 変更があった code_s のリスト (action_log 追記用)
+
+    呼び出し側で _flock + ShelveDB セッションを保持していること前提。
+    """
+    affected: List[str] = []
+    record_keys = [k for k in db.keys() if k.startswith(KEY_RECORD_PREFIX)]
+    for key in record_keys:
+        record = db[key]
+        if not isinstance(record, dict):
+            continue
+        memo = record.get("memo") or {}
+        themes = memo.get("gyoutai_themes") or []
+        if not isinstance(themes, list) or old_name not in themes:
+            continue
+        new_themes: List[str] = []
+        for t in themes:
+            if t == old_name:
+                if new_name is None:
+                    continue
+                if new_name in new_themes:
+                    continue  # リネーム後に重複する場合は除去
+                new_themes.append(new_name)
+            else:
+                if t in new_themes:
+                    continue
+                new_themes.append(t)
+        if new_themes == list(themes):
+            continue
+        new_memo = dict(memo)
+        new_memo["gyoutai_themes"] = new_themes
+        new_record = dict(record)
+        new_record["memo"] = new_memo
+        new_record["updated_at"] = now_iso()
+        db[key] = new_record
+        affected.append(record.get("code_s") or key[len(KEY_RECORD_PREFIX):])
+    return affected
+
+
+def _append_action_log_inner(
+    db: ShelveDB,
+    code_s: str,
+    action_type: str,
+    *,
+    reason: str = "",
+) -> None:
+    """既にオープン済みの ShelveDB に action_log を直接書き込む (flock 内専用)。
+
+    append_action_log は内部で _flock + ShelveDB を再オープンするため、
+    リネーム/削除のような巨大トランザクション内ではこちらを使って同一セッションに収める。
+    """
+    validate_action_type(action_type)
+    normalized = normalize_code_s(code_s)
+    seq = _next_seq(db, normalized)
+    entry = {
+        "code_s": normalized,
+        "seq": seq,
+        "timestamp": now_iso(),
+        "action_type": action_type,
+        "status_from": None,
+        "status_to": None,
+        "reason": reason,
+    }
+    db[_action_log_key(normalized, seq)] = entry
+
+
 def update_memo(
     code_s: str,
     fields: Dict[str, Any],
@@ -960,6 +1239,33 @@ def update_memo(
                 )
             record = db[key]
             current_memo = record.get("memo", {}) or {}
+
+            # gyoutai_themes (list[str]) のマスター整合性チェック (issue #282)
+            # - 空文字は除去 (スロットクリア)
+            # - マスター登録済み name は採用
+            # - 未登録 name で現行レコードに既に存在する場合は保持を許可 (移行漏れ救済)
+            # - 純新規の未登録 name は ValueError
+            if "gyoutai_themes" in normalized_fields:
+                cleaned: List[str] = []
+                current_themes = current_memo.get("gyoutai_themes") or []
+                master_names = {
+                    k[len(KEY_THEME_PREFIX):]
+                    for k in db.keys()
+                    if k.startswith(KEY_THEME_PREFIX)
+                }
+                for raw in normalized_fields["gyoutai_themes"]:
+                    t = raw.strip()
+                    if not t:
+                        continue
+                    if t in master_names or t in current_themes:
+                        if t not in cleaned:
+                            cleaned.append(t)
+                        continue
+                    raise ValueError(
+                        f"portfolio_shelve: theme {t!r} はマスター未登録のため新規付与できません"
+                    )
+                normalized_fields["gyoutai_themes"] = cleaned
+
             changed = any(
                 current_memo.get(k, _current_default(k)) != v
                 for k, v in normalized_fields.items()

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1687,24 +1687,6 @@ def list_portfolio_with_indicators(
     return rows
 
 
-def collect_gyoutai_theme_choices(records: List[Dict[str, Any]]) -> List[str]:
-    """portfolio_shelve 全レコードの memo.gyoutai_themes をフラット化して候補リストを返す (issue #187)。
-
-    空要素除去・ユニーク化・アルファベット/五十音昇順ソート済み。
-    datalist の選択肢として使う想定。
-    """
-    seen = set()
-    for rec in records:
-        memo = rec.get("memo") or {}
-        for theme in (memo.get("gyoutai_themes") or []):
-            if not isinstance(theme, str):
-                continue
-            t = theme.strip()
-            if t:
-                seen.add(t)
-    return sorted(seen)
-
-
 def _format_tags(stock: Dict[str, Any]) -> str:
     """code_rank.csv「タグ」列と同じ表記を返す。
 

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -13,7 +13,6 @@ from webapp.helpers import (
     get_stock_data,
     get_disclosures,
     has_recent_disclosure,
-    collect_gyoutai_theme_choices,
 )
 from webapp.routes.portfolio import (
     STATUS_VALUE_TO_LABEL,
@@ -88,10 +87,8 @@ def stock_detail(code_s: str):
     if not isinstance(_memo, dict):
         _memo = {}
     gyoutai_themes = _memo.get("gyoutai_themes") or []
-    gyoutai_theme_choices = (
-        collect_gyoutai_theme_choices(ps.list_records(include_excluded=True))
-        if not portfolio_fallback_mode else []
-    )
+    # issue #282: テーママスターから候補を取得
+    theme_master = [] if portfolio_fallback_mode else ps.list_themes()
 
     # issue #227: 株価 + RSライン 統合チャート (フル版)
     # market_db のロード失敗時は RS 無しの株価のみで描画 (500 にしない)
@@ -122,6 +119,6 @@ def stock_detail(code_s: str):
         portfolio_fallback_mode=portfolio_fallback_mode,
         portfolio_transitions=portfolio_transitions,
         gyoutai_themes=gyoutai_themes,
-        gyoutai_theme_choices=gyoutai_theme_choices,
+        theme_master=theme_master,
         gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
     )

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -22,7 +22,6 @@ from flask import Blueprint, flash, jsonify, redirect, render_template, request,
 import portfolio
 import portfolio_shelve as ps
 from webapp.helpers import (
-    collect_gyoutai_theme_choices,
     compute_cell_styles,
     get_stock_data,
     list_portfolio_with_indicators,
@@ -618,11 +617,11 @@ def dashboard():
         STATUS_VALUE_TO_QUERY[active_status] if active_status in STATUS_VALUE_TO_QUERY else ""
     )
 
-    # issue #187: datalist 候補は表示フィルタ/excluded と独立、shelve 内の全レコードから集計
+    # issue #282: テーママスターから候補を取得 (フィルタ select / 入力 select 兼用)
     if fallback_mode:
-        gyoutai_theme_choices: list = []
+        theme_master: list = []
     else:
-        gyoutai_theme_choices = collect_gyoutai_theme_choices(all_records_inc)
+        theme_master = ps.list_themes()
 
     sort_urls = {
         k: "?" + _build_query_string(
@@ -661,7 +660,97 @@ def dashboard():
         delete_mode_allowed=delete_mode_allowed,
         status_label=STATUS_VALUE_TO_LABEL,
         fallback_mode=fallback_mode,
-        gyoutai_theme_choices=gyoutai_theme_choices,
+        theme_master=theme_master,
         gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
         hold_summary=hold_summary,
     )
+
+
+# ===========================================
+# テーママスター編集 (issue #282)
+# ===========================================
+
+@portfolio_bp.route("/portfolio/themes", methods=["GET"])
+def themes_index():
+    """テーママスター一覧・編集画面を表示する。"""
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+    themes = ps.list_themes()
+    usage = ps.count_theme_usage()
+    return render_template(
+        "portfolio_themes.html",
+        themes=themes,
+        usage=usage,
+        theme_name_max_len=ps.THEME_NAME_MAX_LEN,
+    )
+
+
+@portfolio_bp.route("/portfolio/themes/create", methods=["POST"])
+def themes_create():
+    """テーマを新規作成して /portfolio/themes に戻る (PRG)。"""
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+    name = (request.form.get("name") or "").strip()
+    description = (request.form.get("description") or "").strip()
+    try:
+        ps.create_theme(name, description)
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return redirect(url_for("portfolio.themes_index"))
+    flash(f"テーマ「{name}」を作成しました", "info")
+    return redirect(url_for("portfolio.themes_index"))
+
+
+@portfolio_bp.route("/portfolio/themes/<name>/update", methods=["POST"])
+def themes_update(name: str):
+    """テーマのリネーム / 説明文編集。
+
+    フォームは name + description の両方を常に送る (portfolio_themes.html は
+    edit 開始時に両 input を同時に表示する設計)。よって description フィールドが
+    POST に含まれている場合は空文字でも意図的なクリアとして上書きする。
+    """
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+    new_name = (request.form.get("name") or "").strip()
+    description = request.form.get("description")
+    try:
+        ps.update_theme(
+            name,
+            new_name=new_name if new_name and new_name != name else None,
+            description=description if description is not None else None,
+        )
+    except KeyError:
+        flash(f"テーマ「{name}」が見つかりません", "error")
+        return redirect(url_for("portfolio.themes_index"))
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return redirect(url_for("portfolio.themes_index"))
+    if new_name and new_name != name:
+        flash(f"テーマを「{name}」→「{new_name}」にリネームしました", "info")
+    else:
+        flash(f"テーマ「{name}」を更新しました", "info")
+    return redirect(url_for("portfolio.themes_index"))
+
+
+@portfolio_bp.route("/portfolio/themes/<name>/delete", methods=["POST"])
+def themes_delete(name: str):
+    """テーマを削除し、全銘柄から除去する。"""
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+    try:
+        affected = ps.delete_theme(name)
+    except KeyError:
+        flash(f"テーマ「{name}」が見つかりません", "error")
+        return redirect(url_for("portfolio.themes_index"))
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return redirect(url_for("portfolio.themes_index"))
+    flash(
+        f"テーマ「{name}」を削除しました (影響: {affected} 銘柄)",
+        "info",
+    )
+    return redirect(url_for("portfolio.themes_index"))

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -64,7 +64,7 @@
                 name="gyoutai_themes_{{ i }}"
                 title="Ctrl/Cmd+クリックでこのテーマで portfolio 絞り込み (新タブ)"
                 style="font-size:0.9em;padding:0.1em 0.3em;width:auto;min-width:8em;margin:0 0.1em;border:1px solid #ddd;">
-          <option value="">— (未設定)</option>
+          <option value="">—</option>
           {% if current and current not in master_names %}
           <option value="{{ current }}" selected>⚠️ {{ current }}</option>
           {% endif %}

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -55,24 +55,28 @@
       {% if stock.kessanbi %} | 決算日: {{ stock.kessanbi[2:] }}{% endif %}
       {# issue #205: 業態・テーマを同じ行に配置。change/blur で AJAX 即時保存 (portfolio_list と同方式) #}
       {% if portfolio_status_query and not portfolio_fallback_mode %}
+      {% set master_names = theme_master | map(attribute='name') | list %}
       | <span class="gyoutai-themes-inline" data-code="{{ record.code_s }}">
         業態・テーマ:
         {% for i in range(gyoutai_themes_max_slots) %}
-        <input type="text"
-               list="gyoutai-theme-choices"
-               class="gyoutai-input-detail"
-               name="gyoutai_themes_{{ i }}"
-               value="{{ gyoutai_themes[i] if i < (gyoutai_themes|length) else '' }}"
-               placeholder="—"
-               title="Ctrl/Cmd+クリックでこのテーマで portfolio 絞り込み (新タブ)"
-               style="font-size:0.9em;padding:0.1em 0.3em;width:8em;margin:0 0.1em;border:1px solid #ddd;">
+        {% set current = gyoutai_themes[i] if i < (gyoutai_themes|length) else '' %}
+        <select class="gyoutai-input-detail"
+                name="gyoutai_themes_{{ i }}"
+                title="Ctrl/Cmd+クリックでこのテーマで portfolio 絞り込み (新タブ)"
+                style="font-size:0.9em;padding:0.1em 0.3em;width:auto;min-width:8em;margin:0 0.1em;border:1px solid #ddd;">
+          <option value="">— (未設定)</option>
+          {% if current and current not in master_names %}
+          <option value="{{ current }}" selected>⚠️ {{ current }}</option>
+          {% endif %}
+          {% for theme in theme_master %}
+          <option value="{{ theme.name }}" {% if theme.name == current %}selected{% endif %}>{{ theme.name }}</option>
+          {% endfor %}
+        </select>
         {% endfor %}
+        <a href="{{ url_for('portfolio.themes_index') }}"
+           style="font-size:0.85em;color:#555;text-decoration:none;padding:0 0.3em;"
+           title="テーママスターを編集">✏️</a>
       </span>
-      <datalist id="gyoutai-theme-choices">
-        {% for choice in gyoutai_theme_choices %}
-        <option value="{{ choice }}">
-        {% endfor %}
-      </datalist>
       {% endif %}
       <form method="POST" action="/stock/{{ record.code_s }}/refresh" style="display:inline;margin-left:0.5em;">
         <button type="submit" title="業績・指標・株価などの最新データを再取得します"
@@ -690,10 +694,7 @@ function excludeFromUniverse(codeS) {
 
   inputs.forEach(function(inp) {
     inp.addEventListener('change', save);
-    inp.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter') { e.preventDefault(); inp.blur(); }
-    });
-    // issue #230: Ctrl/Cmd+左クリックでこのテーマで portfolio 絞り込みを新タブで開く
+    // issue #230 + #282: Ctrl/Cmd+左クリックで現在値での portfolio 絞り込みを新タブで開く
     inp.addEventListener('mousedown', function(e) {
       if (e.button !== 0) return;
       if (!(e.ctrlKey || e.metaKey)) return;

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -162,11 +162,14 @@
     <span style="color:#666;">業態・テーマ</span>
     <select name="gyoutai_theme" onchange="this.form.submit()" style="padding:0.2em 0.3em;font-size:0.9em;margin:0;max-width:18em;">
       <option value="">すべて</option>
-      {% for choice in gyoutai_theme_choices %}
-      <option value="{{ choice }}" {% if choice == active_gyoutai_theme %}selected{% endif %}>{{ choice }}</option>
+      {% for theme in theme_master %}
+      <option value="{{ theme.name }}" {% if theme.name == active_gyoutai_theme %}selected{% endif %}>{{ theme.name }}</option>
       {% endfor %}
     </select>
   </label>
+  <a href="{{ url_for('portfolio.themes_index') }}"
+     style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
+     title="テーママスターを編集">✏️ テーマを編集</a>
 </form>
 
 <p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">
@@ -284,16 +287,22 @@
       <td class="gyoutai-themes-cell" data-code="{{ row.code_s }}"
           style="max-width:11em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
         {% set themes = row.memo.gyoutai_themes or [] %}
+        {% set master_names = theme_master | map(attribute='name') | list %}
         {% for i in range(gyoutai_themes_max_slots) %}
-        <input type="text"
-               list="gyoutai-theme-choices"
-               name="gyoutai_themes_{{ i }}"
-               value="{{ themes[i] if i < (themes|length) else '' }}"
-               data-slot="{{ i }}"
-               class="gyoutai-input"
-               placeholder="—"
-               title="Ctrl/Cmd+クリックでこのテーマで絞り込み (新タブ)"
-               {% if fallback_mode %}disabled{% endif %}>
+        {% set current = themes[i] if i < (themes|length) else '' %}
+        <select name="gyoutai_themes_{{ i }}"
+                data-slot="{{ i }}"
+                class="gyoutai-input"
+                title="Ctrl/Cmd+クリックでこのテーマで絞り込み (新タブ)"
+                {% if fallback_mode %}disabled{% endif %}>
+          <option value="">— (未設定)</option>
+          {% if current and current not in master_names %}
+          <option value="{{ current }}" selected>⚠️ {{ current }}</option>
+          {% endif %}
+          {% for theme in theme_master %}
+          <option value="{{ theme.name }}" {% if theme.name == current %}selected{% endif %}>{{ theme.name }}</option>
+          {% endfor %}
+        </select>
         {% endfor %}
       </td>
       <td style="{{ row.styles.rank or '' }}">{{ row.rank if row.rank is not none else "—" }}</td>
@@ -387,12 +396,6 @@
 </table>
 </div>
 
-<datalist id="gyoutai-theme-choices">
-  {% for choice in gyoutai_theme_choices %}
-  <option value="{{ choice }}">
-  {% endfor %}
-</datalist>
-
 {% if not fallback_mode %}
 <div id="portfolio-modal" class="portfolio-modal-overlay" style="display:none;" onclick="closePortfolioModalOnOverlay(event)">
   <div class="portfolio-modal-content" role="dialog" aria-labelledby="portfolio-modal-title">
@@ -462,6 +465,14 @@
 .gyoutai-themes-cell .gyoutai-input:focus { outline: 1px solid #4285f4; background: #fff; }
 .gyoutai-themes-cell .gyoutai-input.saving { background: #fff8c4; }
 .gyoutai-themes-cell .gyoutai-input.error { background: #fce4e4; border-color: #d33; }
+/* issue #282: select でも行高を input と揃える */
+.gyoutai-themes-cell select.gyoutai-input {
+  height: auto;
+  padding: 0 2px;
+  background-image: none;
+  -webkit-appearance: menulist;
+  appearance: menulist;
+}
 </style>
 
 <script>
@@ -871,12 +882,10 @@ function excludeFromUniverse(codeS) {
     var inputs = td.querySelectorAll('.gyoutai-input');
     inputs.forEach(function(inp) {
       if (inp.disabled) return;
-      // datalist 選択 (change) / 自由入力後の blur で保存
+      // select の選択変更で保存 (issue #282)
       inp.addEventListener('change', function() { saveCell(td); });
-      inp.addEventListener('keydown', function(e) {
-        if (e.key === 'Enter') { e.preventDefault(); inp.blur(); }
-      });
-      // issue #230: Ctrl/Cmd+左クリックでこのテーマで portfolio 絞り込みを新タブで開く
+      // issue #230 + #282: Ctrl/Cmd+左クリックで現在値での portfolio 絞り込みを新タブで開く。
+      // select は mousedown 時点で .value が選択中の値で安定しているのでそのまま使う。
       inp.addEventListener('mousedown', function(e) {
         if (e.button !== 0) return;
         if (!(e.ctrlKey || e.metaKey)) return;

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -295,7 +295,7 @@
                 class="gyoutai-input"
                 title="Ctrl/Cmd+クリックでこのテーマで絞り込み (新タブ)"
                 {% if fallback_mode %}disabled{% endif %}>
-          <option value="">— (未設定)</option>
+          <option value="">—</option>
           {% if current and current not in master_names %}
           <option value="{{ current }}" selected>⚠️ {{ current }}</option>
           {% endif %}

--- a/scripts/webapp/templates/portfolio_themes.html
+++ b/scripts/webapp/templates/portfolio_themes.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+{% block title %}テーマ管理 | Shintakane Research{% endblock %}
+
+{% block content %}
+<style>
+  table.themes-table { width: 100%; font-size: 0.9em; }
+  table.themes-table th, table.themes-table td { padding: 0.4em 0.6em; vertical-align: middle; }
+  table.themes-table td.name-cell { font-weight: 600; max-width: 14em; word-break: break-word; }
+  table.themes-table td.desc-cell { color: #555; max-width: 28em; word-break: break-word; }
+  table.themes-table td.usage-cell { text-align: right; color: #666; width: 4em; }
+  table.themes-table td.op-cell { width: 14em; white-space: nowrap; }
+  table.themes-table input[type="text"] { font-size: 0.9em; padding: 0.2em 0.4em; margin: 0; height: auto; width: 100%; }
+  table.themes-table button { font-size: 0.85em; padding: 0.2em 0.6em; margin: 0 0.2em 0 0; height: auto; }
+  .themes-create-form { background: #f5f7fa; border: 1px solid #d8dee6; border-radius: 4px; padding: 0.6em 0.8em; margin-bottom: 1em; }
+  .themes-create-form input[type="text"] { font-size: 0.9em; padding: 0.3em 0.5em; margin: 0; height: auto; }
+  .themes-create-form button { font-size: 0.9em; padding: 0.3em 0.8em; margin: 0; height: auto; }
+</style>
+
+<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6em;">
+  <h2 style="margin:0;">テーマ管理</h2>
+  <a href="{{ url_for('portfolio.dashboard') }}" style="font-size:0.9em;">← ポートフォリオに戻る</a>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+  {% for category, message in messages %}
+  <div style="padding:0.5em 1em;margin-bottom:1em;border-radius:4px;font-size:0.9em;{% if category == 'error' %}background:#ffeaea;color:#c00;border:1px solid #fcc;{% else %}background:#eaffea;color:#060;border:1px solid #cfc;{% endif %}">{{ message }}</div>
+  {% endfor %}
+{% endif %}
+{% endwith %}
+
+<form method="POST" action="{{ url_for('portfolio.themes_create') }}" class="themes-create-form">
+  <div style="display:flex;gap:0.6em;align-items:center;flex-wrap:wrap;">
+    <label style="margin:0;">
+      <span style="color:#666;font-size:0.85em;">名前</span>
+      <input type="text" name="name" required maxlength="{{ theme_name_max_len }}"
+             placeholder="例: 半導体" style="width:12em;">
+    </label>
+    <label style="margin:0;flex:1;min-width:18em;">
+      <span style="color:#666;font-size:0.85em;">説明 (任意)</span>
+      <input type="text" name="description" placeholder="" style="width:100%;">
+    </label>
+    <button type="submit">+ 追加</button>
+  </div>
+</form>
+
+<p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">テーマ {{ themes|length }} 件</p>
+
+{# 各行の編集 / 削除フォームは HTML5 の form="id" 属性でセル横断的に関連付け、
+   td の入れ子構造を壊さない。 #}
+{% for theme in themes %}
+<form id="theme-update-{{ loop.index }}" method="POST"
+      action="{{ url_for('portfolio.themes_update', name=theme.name) }}" style="display:none;"></form>
+<form id="theme-delete-{{ loop.index }}" method="POST"
+      action="{{ url_for('portfolio.themes_delete', name=theme.name) }}" style="display:none;"></form>
+{% endfor %}
+
+<table class="themes-table">
+  <thead>
+    <tr>
+      <th style="text-align:left;">名前</th>
+      <th style="text-align:left;">説明</th>
+      <th style="text-align:right;">使用</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for theme in themes %}
+    {% set uses = usage.get(theme.name, 0) %}
+    {% set fid = 'theme-update-' ~ loop.index %}
+    {% set did = 'theme-delete-' ~ loop.index %}
+    <tr data-name="{{ theme.name }}" data-delete-form="{{ did }}">
+      <td class="name-cell">
+        <span class="display-name">{{ theme.name }}</span>
+        <input type="text" name="name" value="{{ theme.name }}" form="{{ fid }}"
+               required maxlength="{{ theme_name_max_len }}"
+               class="edit-input edit-name" style="display:none;">
+      </td>
+      <td class="desc-cell">
+        <span class="display-desc">{{ theme.description or '' }}</span>
+        <input type="text" name="description" value="{{ theme.description or '' }}" form="{{ fid }}"
+               class="edit-input edit-desc" style="display:none;">
+      </td>
+      <td class="usage-cell">{{ uses }}</td>
+      <td class="op-cell">
+        <span class="display-ops">
+          <button type="button" class="edit-btn" onclick="toggleEdit(this, true)">編集</button>
+          <button type="button" class="delete-btn"
+                  onclick="confirmDeleteTheme({{ theme.name|tojson }}, {{ uses }})">削除</button>
+        </span>
+        <span class="edit-ops" style="display:none;">
+          <button type="submit" form="{{ fid }}">保存</button>
+          <button type="button" onclick="toggleEdit(this, false)">キャンセル</button>
+        </span>
+      </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="4" style="text-align:center;color:#999;padding:1em;">登録済みテーマがありません。上のフォームから追加してください。</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<script>
+function toggleEdit(btn, openEdit) {
+  var tr = btn.closest('tr');
+  if (!tr) return;
+  tr.querySelectorAll('.display-name, .display-desc, .display-ops').forEach(function(el) {
+    el.style.display = openEdit ? 'none' : '';
+  });
+  tr.querySelectorAll('.edit-input, .edit-ops').forEach(function(el) {
+    el.style.display = openEdit ? '' : 'none';
+  });
+}
+
+function confirmDeleteTheme(name, uses) {
+  var msg = uses > 0
+    ? 'テーマ「' + name + '」を削除しますか?\n' + uses + ' 銘柄から除去されます。'
+    : 'テーマ「' + name + '」を削除しますか?';
+  if (!confirm(msg)) return;
+  var tr = document.querySelector('tr[data-name="' + CSS.escape(name) + '"]');
+  if (!tr) return;
+  var formId = tr.dataset.deleteForm;
+  var form = document.getElementById(formId);
+  if (form) form.submit();
+}
+</script>
+{% endblock %}

--- a/tests/test_migrate_gyoutai_theme_to_list.py
+++ b/tests/test_migrate_gyoutai_theme_to_list.py
@@ -16,9 +16,21 @@ def _set_legacy_gyoutai_theme(code_s: str, value: str, db_path: str) -> None:
 
     update_memo 経由で gyoutai_theme を直接書き込むことで、
     新フィールド gyoutai_themes は [] のまま残る (移行前の状態)。
+
+    issue #282: 移行スクリプトは update_memo で gyoutai_themes を書き込むため、
+    旧値を分割した各 name をテーママスターに事前登録しておく。
     """
     ps.add_to_watch(code_s, db_path=db_path)
     ps.update_memo(code_s, {"gyoutai_theme": value}, db_path=db_path)
+    # 移行先 list に入る name を先にマスター登録
+    for raw in value.split("\n"):
+        name = raw.strip()
+        if not name:
+            continue
+        try:
+            ps.create_theme(name, db_path=db_path)
+        except ValueError:
+            pass  # 重複は無視
 
 
 class TestMigrateGyoutaiThemeToList:
@@ -72,6 +84,7 @@ class TestMigrateGyoutaiThemeToList:
     def test_skips_record_with_existing_gyoutai_themes(self, db_path):
         # 既に gyoutai_themes に値がある → スキップ (上書きしない)
         ps.add_to_watch("4377", db_path=db_path)
+        ps.create_theme("新データ", db_path=db_path)  # issue #282: マスター事前登録
         ps.update_memo(
             "4377",
             {"gyoutai_theme": "旧データ", "gyoutai_themes": ["新データ"]},

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -497,7 +497,17 @@ class TestUpdateMemo:
 
 
 class TestGyoutaiThemesField:
-    """issue #187: gyoutai_themes (list[str]) フィールドの読み書き / バリデーション。"""
+    """issue #187: gyoutai_themes (list[str]) フィールドの読み書き / バリデーション。
+
+    issue #282: update_memo がマスター登録済み name のみ受け付けるよう変更されたため、
+    テストはマスター登録を前提に動作させる。
+    """
+
+    @pytest.fixture(autouse=True)
+    def _seed_master(self, db_path):
+        """テストで使う name (半導体 / AI) をマスター登録しておく"""
+        ps.create_theme("半導体", db_path=db_path)
+        ps.create_theme("AI", db_path=db_path)
 
     def test_create_memo_defaults_empty_list(self):
         memo = ps.create_memo()
@@ -931,3 +941,108 @@ class TestQtyGlobalUpdatedAt:
         ps.update_qty("4377", 100, db_path=db_path)
         ts_after = ps.get_qty_global_updated_at(db_path=db_path)
         assert ts_after == ts_before
+
+
+# ==================================================
+# テーママスター (issue #282)
+# ==================================================
+class TestThemeMaster:
+    """create / update / delete / count + update_memo の整合性"""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",                        # 空文字
+            "   ",                     # 空白のみ
+            "x" * 31,                  # 上限超過 (THEME_NAME_MAX_LEN=30)
+            "AI/半導体",                # URL 禁止 /
+            "AI?半導体",                # URL 禁止 ?
+            "AI&半導体",                # URL 禁止 &
+            "AI\nNL",                  # 制御文字
+        ],
+    )
+    def test_create_theme_rejects_invalid_names(self, db_path, name):
+        with pytest.raises(ValueError):
+            ps.create_theme(name, db_path=db_path)
+
+    def test_create_theme_rejects_duplicate(self, db_path):
+        ps.create_theme("半導体", db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.create_theme("半導体", db_path=db_path)
+
+    def test_update_theme_renames_records(self, db_path):
+        """リネームで既存銘柄の memo[gyoutai_themes] も新 name に追従し、削除では除去される。
+        action_log にも "メモ更新" が追記され、影響件数が delete_theme の戻り値と一致する。
+        """
+        ps.create_theme("半導体", db_path=db_path)
+        ps.create_theme("AI", db_path=db_path)
+        ps.add_to_watch("6324", db_path=db_path)
+        ps.update_memo(
+            "6324", {"gyoutai_themes": ["半導体", "AI"]}, db_path=db_path
+        )
+
+        # リネーム
+        ps.update_theme("半導体", new_name="セミコン", db_path=db_path)
+        rec = ps.get_record("6324", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["セミコン", "AI"]
+        assert ps.get_theme("半導体", db_path=db_path) is None
+        assert ps.get_theme("セミコン", db_path=db_path)["name"] == "セミコン"
+
+        # 削除 → 影響 1 銘柄、該当 name が消える
+        affected = ps.delete_theme("セミコン", db_path=db_path)
+        assert affected == 1
+        rec = ps.get_record("6324", db_path=db_path)
+        assert rec["memo"]["gyoutai_themes"] == ["AI"]
+
+        # action_log に "メモ更新" が 2 回 (リネーム + 削除) 追記されている
+        logs = ps.list_action_logs("6324", db_path=db_path)
+        memo_logs = [l for l in logs if l["action_type"] == "メモ更新"]
+        assert len(memo_logs) >= 2
+
+    @pytest.mark.parametrize(
+        "current,posted,expected,should_raise",
+        [
+            # 純新規の未登録 name は ValueError
+            (["半導体"], ["半導体", "未登録新規"], None, True),
+            # 現行レコードに既にある未登録 name は保持を許可 (移行漏れ救済)
+            (["未登録既存"], ["未登録既存"], ["未登録既存"], False),
+            # 未登録 name を空文字に置き換えれば除去できる
+            (["未登録既存"], [""], [], False),
+            # マスター登録済み name は採用
+            (["半導体"], ["AI"], ["AI"], False),
+            # 重複は除去される
+            (["半導体"], ["AI", "AI"], ["AI"], False),
+        ],
+    )
+    def test_update_memo_master_validation(
+        self, db_path, current, posted, expected, should_raise
+    ):
+        """update_memo の gyoutai_themes マスター未登録判定 (issue #282)"""
+        ps.create_theme("半導体", db_path=db_path)
+        ps.create_theme("AI", db_path=db_path)
+        ps.add_to_watch("6324", db_path=db_path)
+        # 現行値を直書き込みで仕込む (未登録 name を含むケースを作るため)
+        rec = ps.get_record("6324", db_path=db_path)
+        rec["memo"]["gyoutai_themes"] = current
+        ps.upsert_record(rec, db_path=db_path)
+
+        if should_raise:
+            with pytest.raises(ValueError):
+                ps.update_memo(
+                    "6324", {"gyoutai_themes": posted}, db_path=db_path
+                )
+        else:
+            ps.update_memo(
+                "6324", {"gyoutai_themes": posted}, db_path=db_path
+            )
+            after = ps.get_record("6324", db_path=db_path)
+            assert after["memo"]["gyoutai_themes"] == expected
+
+    def test_count_theme_usage(self, db_path):
+        ps.create_theme("AI", db_path=db_path)
+        ps.create_theme("半導体", db_path=db_path)
+        ps.add_to_watch("6324", db_path=db_path)
+        ps.add_to_watch("9984", db_path=db_path)
+        ps.update_memo("6324", {"gyoutai_themes": ["AI", "半導体"]}, db_path=db_path)
+        ps.update_memo("9984", {"gyoutai_themes": ["AI"]}, db_path=db_path)
+        assert ps.count_theme_usage(db_path=db_path) == {"AI": 2, "半導体": 1}

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1797,36 +1797,6 @@ class TestProgressQuarterAndDiff:
         assert diff == "—"
 
 
-class TestCollectGyoutaiThemeChoices:
-    """issue #187: portfolio_shelve 全レコードから datalist 候補を集計する。
-
-    主機能 (flatten + unique + sort + strip) と防御的な missing/empty 系を統合。
-    """
-
-    def test_flatten_unique_sort_with_strip(self):
-        """重複除去 + 五十音/アルファベット昇順ソート + 空白 strip + 空要素除去"""
-        records = [
-            {"memo": {"gyoutai_themes": ["半導体", "AI"]}},
-            {"memo": {"gyoutai_themes": [" AI ", "ロボット", "", "  "]}},  # strip + 空除去
-            {"memo": {"gyoutai_themes": ["半導体"]}},  # 重複
-        ]
-        assert helpers.collect_gyoutai_theme_choices(records) == [
-            "AI", "ロボット", "半導体",
-        ]
-
-    def test_missing_or_invalid_returns_empty(self):
-        """memo 無 / gyoutai_themes None / 空 records / 非str 要素 を防御"""
-        assert helpers.collect_gyoutai_theme_choices([]) == []
-        assert helpers.collect_gyoutai_theme_choices([{}]) == []
-        assert helpers.collect_gyoutai_theme_choices(
-            [{"memo": {"gyoutai_themes": None}}]
-        ) == []
-        # 非str 要素 (None, int) が混入してもクラッシュしない
-        assert helpers.collect_gyoutai_theme_choices(
-            [{"memo": {"gyoutai_themes": ["AI", None, 123, "半導体"]}}]
-        ) == ["AI", "半導体"]
-
-
 class TestListPortfolioWithIndicators:
     """list_portfolio_with_indicators のソート / status_query / status_label 検証。
 

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -49,6 +49,13 @@ def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
     ps.add_to_watch("7203", reason="テスト 2準 用", db_path=portfolio_db_path)
     ps.transition_status("7203", "2準", reason="テスト 2準 へ昇格 (3監→2準)", db_path=portfolio_db_path)
 
+    # issue #282: テストで使うテーマ name をマスター登録
+    for name in ("半導体", "AI", "X", "既存", "EV", "Robotics", "ロボット", "自動車"):
+        try:
+            ps.create_theme(name, db_path=portfolio_db_path)
+        except ValueError:
+            pass  # 重複は無視
+
     # stocks_shelve にダミーデータ
     with ShelveDB(stocks_db_path) as db:
         db["6324"] = {
@@ -777,8 +784,8 @@ class TestGyoutaiThemesPost:
         assert rec["memo"]["gyoutai_themes"] == ["既存"]
         assert rec["memo"]["trade_idea"] == "X"
 
-    def test_dashboard_renders_datalist(self, client, portfolio_db_path):
-        # 候補集計が dashboard のテンプレに渡って HTML に含まれる
+    def test_dashboard_renders_theme_select_options(self, client, portfolio_db_path):
+        """issue #282: テーママスターの name がフィルタ select / 行 select の選択肢として出る"""
         ps.update_memo(
             "6324",
             {"gyoutai_themes": ["半導体", "AI"]},
@@ -787,9 +794,11 @@ class TestGyoutaiThemesPost:
         resp = client.get("/portfolio?status=hold")
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
-        assert 'id="gyoutai-theme-choices"' in html
-        assert "半導体" in html
-        assert "AI" in html
+        # マスター登録済み name が option として描画される
+        assert '<option value="半導体"' in html
+        assert '<option value="AI"' in html
+        # 旧 datalist は廃止
+        assert 'id="gyoutai-theme-choices"' not in html
 
 
 # ==================================================

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1075,6 +1075,10 @@ class TestDetailGyoutaiThemes:
 
         ps.add_to_watch("3496", reason="テスト用", db_path=portfolio_db)
         ps.transition_status("3496", "1保", reason="テスト用 1保 へ", db_path=portfolio_db)
+        # issue #282: テーママスター必須化に伴い、テストで使う name を登録
+        ps.create_theme("AI", db_path=portfolio_db)
+        ps.create_theme("半導体", db_path=portfolio_db)
+        ps.create_theme("新規テーマ", db_path=portfolio_db)
 
         app = create_app()
         app.config["TESTING"] = True
@@ -1086,7 +1090,7 @@ class TestDetailGyoutaiThemes:
         return app.test_client()
 
     def test_registered_stock_renders_inline_inputs(self, portfolio_client):
-        """登録済銘柄: 業態・テーマ inline edit (data-code 付き wrapper + 2 input) が出る"""
+        """登録済銘柄: 業態・テーマ inline edit (data-code 付き wrapper + 2 select) が出る"""
         html = portfolio_client.get("/stock/3496").data.decode()
         assert 'class="gyoutai-themes-inline" data-code="3496"' in html
         assert 'name="gyoutai_themes_0"' in html
@@ -1094,23 +1098,20 @@ class TestDetailGyoutaiThemes:
         # AJAX 化したので保存ボタンは無い、form タグも無い
         assert "action=\"/portfolio/3496/memo\"" not in html
 
-    def test_registered_stock_renders_datalist(self, portfolio_client):
-        """datalist#gyoutai-theme-choices が出る (候補は空でもタグは描画)"""
-        html = portfolio_client.get("/stock/3496").data.decode()
-        assert '<datalist id="gyoutai-theme-choices">' in html
-
     def test_existing_themes_prefilled(self, portfolio_app):
-        """事前に保存したテーマが input value にプリフィルされる"""
+        """事前に保存したテーマが select の selected 属性として出力される"""
         import portfolio_shelve as ps
         app, portfolio_db = portfolio_app
         ps.update_memo("3496", {"gyoutai_themes": ["AI", "半導体"]}, db_path=portfolio_db)
 
         html = app.test_client().get("/stock/3496").data.decode()
+        # select 化されたので value="X" selected の形式で確認
         assert 'value="AI"' in html
         assert 'value="半導体"' in html
+        assert 'selected' in html
 
     def test_unregistered_stock_hides_inline_inputs(self, portfolio_client):
-        """未登録銘柄では inline edit (gyoutai_themes_0 input) が出ない"""
+        """未登録銘柄では inline edit (gyoutai_themes_0 入力) が出ない"""
         html = portfolio_client.get("/stock/1234").data.decode()
         assert 'name="gyoutai_themes_0"' not in html
         assert 'class="gyoutai-themes-inline"' not in html
@@ -1306,3 +1307,65 @@ class TestPortfolioHoldSummary:
             html = resp.data.decode()
             assert "運用総額:" not in html, f"status={status} でサマリーが漏れている"
             assert "保有株数更新日:" not in html, f"status={status} でサマリーが漏れている"
+
+
+# ==================================================
+# /portfolio/themes (issue #282)
+# ==================================================
+class TestPortfolioThemes:
+    """テーママスター編集画面の smoke テスト"""
+
+    @pytest.fixture
+    def themes_app(self, db_path, tmp_path, monkeypatch):
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        # fallback_mode を外すため最低 1 件 record を入れる
+        ps.add_to_watch("3496", db_path=portfolio_db)
+        ps.create_theme("半導体", "test", db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        return app, portfolio_db
+
+    def test_index_returns_200(self, themes_app):
+        app, _ = themes_app
+        client = app.test_client()
+        resp = client.get("/portfolio/themes")
+        assert resp.status_code == 200
+        assert "半導体" in resp.data.decode()
+
+    def test_create_and_delete_roundtrip(self, themes_app):
+        import portfolio_shelve as ps
+        app, portfolio_db = themes_app
+        client = app.test_client()
+        # 作成
+        resp = client.post(
+            "/portfolio/themes/create",
+            data={"name": "防衛", "description": "防衛関連"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert ps.get_theme("防衛", db_path=portfolio_db) is not None
+        # 削除
+        resp = client.post(
+            "/portfolio/themes/防衛/delete", follow_redirects=False
+        )
+        assert resp.status_code == 302
+        assert ps.get_theme("防衛", db_path=portfolio_db) is None
+
+    def test_update_renames(self, themes_app):
+        import portfolio_shelve as ps
+        app, portfolio_db = themes_app
+        client = app.test_client()
+        resp = client.post(
+            "/portfolio/themes/半導体/update",
+            data={"name": "セミコン", "description": "renamed"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert ps.get_theme("半導体", db_path=portfolio_db) is None
+        assert ps.get_theme("セミコン", db_path=portfolio_db)["description"] == "renamed"


### PR DESCRIPTION
Closes #282

## Summary
- 業態・テーマを文字列直書きから `theme:<name>` マスターに分離し、リネーム/削除で全銘柄が追従するように
- `/portfolio/themes` 編集画面を新設 (GitHub Labels 風の一覧 + 追加 / 編集 / 削除)
- 銘柄行のテーマ入力を datalist→select 2 個に置換、マスター登録済み name のみ選択可能 (未登録値は ⚠️ 表示で保持)
- 移行スクリプト `scripts/migrate_themes_to_master.py` (冪等、`--dry-run` / `--apply` / `--include-legacy`)

## Test plan
- [x] `pytest tests/test_portfolio_shelve.py tests/test_webapp_routes.py tests/test_webapp_portfolio_routes.py tests/test_webapp_helpers.py tests/test_migrate_gyoutai_theme_to_list.py` 全 550 pass
- [x] `pytest tests/ -m "not local_db and not live_html"` 全 1623 pass
- [x] webapp 起動 → `/portfolio` で「✏️ テーマを編集」ボタン + 行 select 描画確認 (Playwright)
- [x] `/portfolio/themes` 200 + 一覧/フォーム描画確認
- [x] 移行スクリプト dry-run → apply → 再 apply の冪等性確認
- [x] simplify レビュー: テーマ名禁止文字 (`' " \\ < >`) 追加、onclick の JS 注入対策 (`|tojson`)、private API 公開化、docstring 不一致修正

## 本番反映時の注意
- マージ後、運用環境で `cd scripts && python migrate_themes_to_master.py --dry-run` で件数確認 → `--apply` で本実行が必要
- 旧 `memo[gyoutai_theme]` 残存があるとデフォルトで失敗終了 → 先に `migrate_gyoutai_theme_to_list.py` を実行するか `--include-legacy` を付ける

🤖 Generated with [Claude Code](https://claude.com/claude-code)