### PR TITLE
market: 市場指標表に日経VI・新高値-新安値を追加し表全体を整理 (#292)

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -1358,6 +1358,26 @@ def _vi_rating_html(vi):
     return '<span class="fng-rating fng-rating-greed">安穏</span>'
 
 
+# 新高値-新安値 の天井圏/底値圏バッジ閾値。
+# 一般指標が無いため過去 2 年 (2024-05〜2026-05, 503 営業日) の分布から算出した
+# 10/90 percentile。新高値超過 (相場が強い) ほど高く、順相関なので高=天井圏/低=底値圏。
+_BREADTH_CEILING_THRESHOLD = 181   # >=181 で上位 10% (天井圏)
+_BREADTH_BOTTOM_THRESHOLD = -29    # <=-29 で下位 10% (底値圏)
+
+
+def _breadth_rating_html(diff):
+    """新高値-新安値 の天井圏/底値圏バッジ HTML を返す。中間水準は空文字。
+
+    値 (新高値-新安値) は相場と順相関。高い (新高値が多い) ほど過熱=天井圏 (greed 系緑)、
+    低い (新安値が多い) ほど売られすぎ=底値圏 (fear 系) で fng-rating の配色を流用する。
+    """
+    if diff >= _BREADTH_CEILING_THRESHOLD:
+        return '<span class="fng-rating fng-rating-greed">天井圏</span>'
+    if diff <= _BREADTH_BOTTOM_THRESHOLD:
+        return '<span class="fng-rating fng-rating-fear">底値圏</span>'
+    return ''
+
+
 def _load_breadth_json(filename):
     """$KS_DATA_DIR/code_rank_data/<filename> の history リストを返す。
 
@@ -1455,7 +1475,7 @@ def _breadth_row(market_db):
     return (
         label,
         value_html,
-        '',
+        _breadth_rating_html(diff),
         '<span class="%s">%s</span>' % (html_mod.escape(d5_cls), html_mod.escape(d5)),
         '<span class="%s">%s</span>' % (html_mod.escape(d20_cls), html_mod.escape(d20)),
         _format_short_date(latest.get("date", "")),

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -964,6 +964,11 @@ tr:hover { background: #f5f5f5; }
 /* 市場指標サマリー表 (Fear & Greed / 信用評価損益率 統合。信用倍率は tooltip) */
 .market-indicators { border-collapse: collapse; margin: 0 0 10px 0; background: #fff; width: auto; }
 .market-indicators th, .market-indicators td { padding: 3px 8px; border: 1px solid #ddd; text-align: left; white-space: nowrap; }
+.market-indicators thead th { background: #f0f0f0; font-weight: bold; color: #555; }
+.market-indicators thead th.mi-value { text-align: right; }
+.market-indicators thead th.mi-rating { text-align: center; }
+.market-indicators thead th.mi-delta { text-align: right; }
+.market-indicators thead th.mi-date { text-align: right; }
 .market-indicators th.mi-label { font-weight: bold; }
 .market-indicators td.mi-value { font-weight: bold; text-align: right; }
 .market-indicators td.mi-rating { text-align: center; padding: 3px 6px; }
@@ -1453,8 +1458,19 @@ def _html_market_indicators(market_db):
             '</tr>' % (title_attr, label, value, rating, d1, d4,
                       html_mod.escape(date_text))
         )
+    header = (
+        '<thead><tr>'
+        '<th class="mi-label">指標</th>'
+        '<th class="mi-value">値</th>'
+        '<th class="mi-rating">評価</th>'
+        '<th class="mi-delta">直近</th>'
+        '<th class="mi-delta">中期</th>'
+        '<th class="mi-date">更新日</th>'
+        '</tr></thead>\n'
+    )
     return (
         '<table class="market-indicators">\n'
+        + header +
         '<tbody>\n' + '\n'.join(body) + '\n</tbody>\n'
         '</table>\n'
     )

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -961,13 +961,14 @@ tr:hover { background: #f5f5f5; }
 /* DD 進行度の警告色 */
 .dd-pressure  { background: #fffbe6; color: #b8860b; font-weight: bold; }
 .dd-correction { background: #fdedec; color: #c0392b; font-weight: bold; }
-/* 市場指標サマリー表 (Fear & Greed / 信用評価損益率 / 信用倍率 統合) */
+/* 市場指標サマリー表 (Fear & Greed / 信用評価損益率 統合。信用倍率は tooltip) */
 .market-indicators { border-collapse: collapse; margin: 0 0 10px 0; background: #fff; width: auto; }
 .market-indicators th, .market-indicators td { padding: 3px 8px; border: 1px solid #ddd; text-align: left; white-space: nowrap; }
 .market-indicators th.mi-label { font-weight: bold; }
 .market-indicators td.mi-value { font-weight: bold; text-align: right; }
 .market-indicators td.mi-rating { text-align: center; padding: 3px 6px; }
 .market-indicators td.mi-delta { text-align: right; }
+.market-indicators td.mi-date { text-align: right; color: #888; font-size: 0.85em; }
 .market-indicators .mi-unit { color: #888; font-size: 0.85em; margin-right: 2px; }
 .fng-rating { padding: 1px 6px; border-radius: 999px; font-size: 0.85em; font-weight: bold; color: #fff; }
 .fng-rating-extreme-fear { background: #a93226; }
@@ -1304,6 +1305,38 @@ def _format_credit_delta(latest, prev):
     return "%+.2f" % delta, cls
 
 
+def _format_short_date(value):
+    """日付を "26/5/22" 形式 (yy/M/d, ゼロ埋めなし) に整形する。
+
+    value は date/datetime か "2026-05-22" 形式の文字列。整形不能なら空文字。
+    """
+    if hasattr(value, "year"):
+        return "%d/%d/%d" % (value.year % 100, value.month, value.day)
+    try:
+        y, m, d = str(value).split("-")[:3]
+        return "%d/%d/%d" % (int(y) % 100, int(m), int(d))
+    except (ValueError, AttributeError):
+        return ""
+
+
+# 信用評価損益率の天井圏/底値圏バッジ閾値。一般目安 (天井 -3% 以上 / 底 -15% 以下)。
+_CREDIT_CEILING_THRESHOLD = -3.0
+_CREDIT_BOTTOM_THRESHOLD = -15.0
+
+
+def _credit_rating_html(eval_rate):
+    """信用評価損益率の天井圏/底値圏バッジ HTML を返す。中間水準は空文字。
+
+    天井圏 (買われすぎ) は greed 系、底値圏 (売られすぎ) は fear 系の
+    fng-rating 配色を流用する。
+    """
+    if eval_rate >= _CREDIT_CEILING_THRESHOLD:
+        return '<span class="fng-rating fng-rating-greed">天井圏</span>'
+    if eval_rate <= _CREDIT_BOTTOM_THRESHOLD:
+        return '<span class="fng-rating fng-rating-fear">底値圏</span>'
+    return ''
+
+
 def _fng_row(market_db):
     """Fear & Greed の表 1 行分 (label_html, value_html, rating_html, d1_html, d4_html, title)。
     取得失敗時は None。"""
@@ -1319,10 +1352,8 @@ def _fng_row(market_db):
     rating_class = "fng-rating-" + rating.replace(" ", "-") if rating else "fng-rating-neutral"
     d5_text, d5_cls = _format_fng_delta(score, fng_db.get("score_5d_ago"))
     d20_text, d20_cls = _format_fng_delta(score, fng_db.get("score_20d_ago"))
-    access_date = fng_db.get("access_date")
-    title = ""
-    if hasattr(access_date, "strftime"):
-        title = "更新: " + access_date.strftime("%Y-%m-%d %H:%M")
+    date_text = _format_short_date(fng_db.get("access_date"))
+    title = "直近=5日前比 / 中期=20日前比"
     label_html = (
         '<a href="https://edition.cnn.com/markets/fear-and-greed"'
         ' target="_blank" rel="noopener">Fear &amp; Greed</a>'
@@ -1331,21 +1362,18 @@ def _fng_row(market_db):
     rating_html = '<span class="fng-rating %s">%s</span>' % (
         html_mod.escape(rating_class), html_mod.escape(rating_label),
     )
-    d1_html = (
-        '<span class="mi-unit">5日</span> '
-        '<span class="%s">%s</span>'
-    ) % (html_mod.escape(d5_cls), html_mod.escape(d5_text))
-    d4_html = (
-        '<span class="mi-unit">20日</span> '
-        '<span class="%s">%s</span>'
-    ) % (html_mod.escape(d20_cls), html_mod.escape(d20_text))
-    return label_html, value_html, rating_html, d1_html, d4_html, title
+    d1_html = '<span class="%s">%s</span>' % (
+        html_mod.escape(d5_cls), html_mod.escape(d5_text))
+    d4_html = '<span class="%s">%s</span>' % (
+        html_mod.escape(d20_cls), html_mod.escape(d20_text))
+    return label_html, value_html, rating_html, d1_html, d4_html, date_text, title
 
 
 def _credit_rows(market_db):
-    """信用評価損益率と信用倍率の表行リストを返す ([(label,value,rating,d1,d4,title), ...])。
+    """信用評価損益率の表行リストを返す ([(label,value,rating,d1,d4,title)])。
     取得失敗時は []。
 
+    信用倍率は独立行をやめ、信用評価損益率行の tooltip に統合する (issue #292)。
     market_db は使わず、$KS_DATA_DIR/code_rank_data/credit_balance.json を読む (issue #211)。
     """
     path = os.path.join(DATA_DIR, "code_rank_data", "credit_balance.json")
@@ -1365,48 +1393,41 @@ def _credit_rows(market_db):
     if eval_rate is None:
         return []
     date_str = latest.get("date", "")
-    title = "%s 基準" % date_str if date_str else ""
 
     def _prev(field, n):
         if len(history) < n + 1:
             return None
         return history[-(n + 1)].get(field)
 
-    rows = []
     e1, e1_cls = _format_credit_delta(eval_rate, _prev("credit_eval_rate", 1))
     e4, e4_cls = _format_credit_delta(eval_rate, _prev("credit_eval_rate", 4))
     eval_label = (
         '<a href="https://nikkei225jp.com/data/sinyou.php"'
         ' target="_blank" rel="noopener">信用評価損益率</a>'
     )
-    rows.append((
-        eval_label,
-        '%.2f%%' % eval_rate,
-        '',
-        '<span class="mi-unit">1週</span> <span class="%s">%s</span>pt' % (
-            html_mod.escape(e1_cls), html_mod.escape(e1)),
-        '<span class="mi-unit">4週</span> <span class="%s">%s</span>pt' % (
-            html_mod.escape(e4_cls), html_mod.escape(e4)),
-        title,
-    ))
+    # tooltip: 期間の意味 + 信用倍率 (値と 1週/4週変化) を統合
+    title_parts = ["直近=1週前比 / 中期=4週前比"]
     if bairitsu is not None:
         b1, b1_cls = _format_credit_delta(bairitsu, _prev("credit_bairitsu", 1))
         b4, b4_cls = _format_credit_delta(bairitsu, _prev("credit_bairitsu", 4))
-        rows.append((
-            '信用倍率',
-            '%.2f' % bairitsu,
-            '',
-            '<span class="mi-unit">1週</span> <span class="%s">%s</span>' % (
-                html_mod.escape(b1_cls), html_mod.escape(b1)),
-            '<span class="mi-unit">4週</span> <span class="%s">%s</span>' % (
-                html_mod.escape(b4_cls), html_mod.escape(b4)),
-            title,
-        ))
-    return rows
+        title_parts.append(
+            "信用倍率 %.2f (1週 %s / 4週 %s)" % (bairitsu, b1, b4))
+    title = " / ".join(title_parts)
+    return [(
+        eval_label,
+        '%.2f%%' % eval_rate,
+        _credit_rating_html(eval_rate),
+        '<span class="%s">%s</span>pt' % (
+            html_mod.escape(e1_cls), html_mod.escape(e1)),
+        '<span class="%s">%s</span>pt' % (
+            html_mod.escape(e4_cls), html_mod.escape(e4)),
+        _format_short_date(date_str),
+        title,
+    )]
 
 
 def _html_market_indicators(market_db):
-    """Fear & Greed と信用評価損益率 / 信用倍率を 1 つの表に統合した HTML を返す。
+    """Fear & Greed と信用評価損益率を 1 つの表に統合した HTML を返す。
 
     取得できる行が 1 つもなければ空文字。
     """
@@ -1419,7 +1440,7 @@ def _html_market_indicators(market_db):
         return ""
 
     body = []
-    for label, value, rating, d1, d4, title in rows:
+    for label, value, rating, d1, d4, date_text, title in rows:
         title_attr = (' title="%s"' % html_mod.escape(title)) if title else ''
         body.append(
             '<tr%s>'
@@ -1428,7 +1449,9 @@ def _html_market_indicators(market_db):
             '<td class="mi-rating">%s</td>'
             '<td class="mi-delta">%s</td>'
             '<td class="mi-delta">%s</td>'
-            '</tr>' % (title_attr, label, value, rating, d1, d4)
+            '<td class="mi-date">%s</td>'
+            '</tr>' % (title_attr, label, value, rating, d1, d4,
+                      html_mod.escape(date_text))
         )
     return (
         '<table class="market-indicators">\n'

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -1342,6 +1342,127 @@ def _credit_rating_html(eval_rate):
     return ''
 
 
+# 日経VI の評価バッジ閾値。一般目安 (平常時 20 前後、30 超で恐怖、40 超でパニック)。
+def _vi_rating_html(vi):
+    """日経VI の安穏/警戒/恐怖/パニックバッジ HTML を返す。
+
+    <20=安穏 (greed 系緑) / 20-30=警戒 (neutral 系) / 30-40=恐怖 (fear 系) /
+    >=40=パニック (extreme-fear 系) で fng-rating の配色を流用する。
+    """
+    if vi >= 40:
+        return '<span class="fng-rating fng-rating-extreme-fear">パニック</span>'
+    if vi >= 30:
+        return '<span class="fng-rating fng-rating-fear">恐怖</span>'
+    if vi >= 20:
+        return '<span class="fng-rating fng-rating-neutral">警戒</span>'
+    return '<span class="fng-rating fng-rating-greed">安穏</span>'
+
+
+def _load_breadth_json(filename):
+    """$KS_DATA_DIR/code_rank_data/<filename> の history リストを返す。
+
+    ファイル無し・形式不正・history 空なら None。
+    """
+    path = os.path.join(DATA_DIR, "code_rank_data", filename)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, ValueError):
+        return None
+    history = payload.get("history") or []
+    return history or None
+
+
+def _vi_row(market_db):
+    """日経VI の表 1 行分タプルを返す。取得失敗時は None。
+
+    値=最新VI、評価=安穏/警戒/恐怖/パニック、直近=5日前比、中期=20日前比。
+    """
+    history = _load_breadth_json("nikkei_vi.json")
+    if not history:
+        return None
+    latest = history[-1]
+    vi = latest.get("nikkei_vi")
+    if vi is None:
+        return None
+
+    def _prev(n):
+        if len(history) < n + 1:
+            return None
+        return history[-(n + 1)].get("nikkei_vi")
+
+    d5, d5_cls = _format_fng_delta(vi, _prev(5))
+    d20, d20_cls = _format_fng_delta(vi, _prev(20))
+    label = (
+        '<a href="https://nikkei225jp.com/data/vix.php"'
+        ' target="_blank" rel="noopener">日経VI</a>'
+    )
+    return (
+        label,
+        '%.2f' % vi,
+        _vi_rating_html(vi),
+        '<span class="%s">%s</span>' % (html_mod.escape(d5_cls), html_mod.escape(d5)),
+        '<span class="%s">%s</span>' % (html_mod.escape(d20_cls), html_mod.escape(d20)),
+        _format_short_date(latest.get("date", "")),
+        "直近=5日前比 / 中期=20日前比",
+    )
+
+
+def _breadth_row(market_db):
+    """新高値-新安値 の差分を 1 項目にまとめた表 1 行分タプルを返す。取得失敗時は None。
+
+    値=最新の(新高値-新安値)、直近=5日前の差分との変化量、中期=20日前の差分との変化量。
+    tooltip に新高値/新安値の内訳を併記する。
+    """
+    history = _load_breadth_json("new_high_low.json")
+    if not history:
+        return None
+    latest = history[-1]
+    high, low = latest.get("new_high"), latest.get("new_low")
+    if high is None or low is None:
+        return None
+    diff = high - low
+
+    def _prev_diff(n):
+        if len(history) < n + 1:
+            return None
+        rec = history[-(n + 1)]
+        h, l = rec.get("new_high"), rec.get("new_low")
+        if h is None or l is None:
+            return None
+        return h - l
+
+    def _int_delta(prev):
+        """差分 (整数) の変化量を +N/-N 形式で返す。prev が None なら ('—', '')。"""
+        if prev is None:
+            return "—", ""
+        delta = diff - prev
+        cls = "fng-delta-pos" if delta >= 0 else "fng-delta-neg"
+        return "%+d" % delta, cls
+
+    d5, d5_cls = _int_delta(_prev_diff(5))
+    d20, d20_cls = _int_delta(_prev_diff(20))
+    # diff 自体は符号付き整数。+N/-N 表記に揃える
+    value_html = '%+d' % diff
+    title = "新高値 %d / 新安値 %d / 直近=5日前差分との変化 / 中期=20日前差分との変化" % (
+        high, low)
+    label = (
+        '<a href="https://nikkei225jp.com/data/new.php"'
+        ' target="_blank" rel="noopener">新高値-新安値</a>'
+    )
+    return (
+        label,
+        value_html,
+        '',
+        '<span class="%s">%s</span>' % (html_mod.escape(d5_cls), html_mod.escape(d5)),
+        '<span class="%s">%s</span>' % (html_mod.escape(d20_cls), html_mod.escape(d20)),
+        _format_short_date(latest.get("date", "")),
+        title,
+    )
+
+
 def _fng_row(market_db):
     """Fear & Greed の表 1 行分 (label_html, value_html, rating_html, d1_html, d4_html, title)。
     取得失敗時は None。"""
@@ -1432,7 +1553,7 @@ def _credit_rows(market_db):
 
 
 def _html_market_indicators(market_db):
-    """Fear & Greed と信用評価損益率を 1 つの表に統合した HTML を返す。
+    """Fear & Greed / 信用評価損益率 / 日経VI / 新高値-新安値 を 1 つの表に統合した HTML を返す。
 
     取得できる行が 1 つもなければ空文字。
     """
@@ -1441,6 +1562,12 @@ def _html_market_indicators(market_db):
     if fng is not None:
         rows.append(fng)
     rows.extend(_credit_rows(market_db))
+    vi = _vi_row(market_db)
+    if vi is not None:
+        rows.append(vi)
+    breadth = _breadth_row(market_db)
+    if breadth is not None:
+        rows.append(breadth)
     if not rows:
         return ""
 

--- a/scripts/market_breadth.py
+++ b/scripts/market_breadth.py
@@ -1,10 +1,10 @@
-"""市場ブレッドス・信用評価データの取得モジュール (issue #209 / #211)。
+"""市場ブレッドス・信用評価データの取得モジュール (issue #209 / #211 / #292)。
 
 nikkei225jp.com が公開している JS データを HTTP 取得し、JSON 配列としてパースする。
 
-このファイルでは issue #211 のスコープ (信用評価損益率・信用倍率の週次取得) のみ実装している。
-issue #209 (新高値・新安値) は同モジュールに `fetch_market_breadth_daily()` として
-後追いで追加する想定。
+- 信用評価損益率・信用倍率 (週次): fetch_credit_balance_weekly (issue #211)
+- 新高値・新安値 銘柄数 (日次): fetch_new_high_low (issue #292)
+- 日経VI 恐怖指数 (日次): fetch_nikkei_vi (issue #292)
 """
 
 import json
@@ -18,6 +18,12 @@ JST = timezone(timedelta(hours=9))
 CREDIT_BALANCE_URL = "https://nikkei225jp.com/_data/_nfsWEB/DAY/dailyweek2.json"
 # Referer が無いと 404 を返すサーバー設定 (2026-05 時点で確認)
 CREDIT_BALANCE_REFERER = "https://nikkei225jp.com/data/sinyou.php"
+
+NEW_HIGH_LOW_URL = "https://nikkei225jp.com/_data/_nfsWEB/DAY/daily2year.json"
+NEW_HIGH_LOW_REFERER = "https://nikkei225jp.com/data/new.php"
+
+NIKKEI_VI_URL = "https://nikkei225jp.com/_data/_nfsWEB/HS_DATA_DAY/SL621_1990.json"
+NIKKEI_VI_REFERER = "https://nikkei225jp.com/data/vix.php"
 
 
 def fetch_credit_balance_weekly():
@@ -70,4 +76,81 @@ def parse_credit_balance(text):
             "credit_eval_rate": float(eval_rate),
             "credit_bairitsu": float(bairitsu) if bairitsu is not None else None,
         })
+    return out
+
+
+def _fetch_nikkei_json(url, referer):
+    """nikkei225jp.com の JS データを取得し本文を返す (共通ヘッダ/Referer)。"""
+    headers = {"User-Agent": "Mozilla/5.0", "Referer": referer}
+    res = requests.get(url, headers=headers, timeout=15)
+    res.raise_for_status()
+    return res.text
+
+
+def _parse_js_rows(text, var_name):
+    """`var NAME = [[...],[...]];` 形式の各行を個別に dict 化せず list で返す。
+
+    daily2year.json は最終行 (当日未確定) に連続カンマ ([..,,,..]) を含み
+    配列全体の json.loads が失敗するため、行単位で抽出し連続カンマを null に
+    補正してからパースする。パース不能な行はスキップする。
+    """
+    # 同一レスポンスに複数 var が並ぶ場合に別配列まで巻き込まないよう非貪欲
+    m = re.search(r"var\s+%s\s*=\s*\[(.*?)\]\s*;" % re.escape(var_name), text, re.S)
+    if not m:
+        raise ValueError("%s 配列が見つからない" % var_name)
+    body = m.group(1)
+    rows = []
+    for row_text in re.findall(r"\[[^\[\]]*\]", body):
+        # 連続カンマ (空要素) と先頭/末尾カンマを null に補正
+        fixed = re.sub(r",(?=\s*[,\]])", ",null", row_text)
+        fixed = re.sub(r"\[\s*,", "[null,", fixed)
+        try:
+            rows.append(json.loads(fixed))
+        except ValueError:
+            continue
+    return rows
+
+
+def fetch_new_high_low():
+    """daily2year.json から年初来 新高値/新安値 銘柄数の時系列を返す。
+
+    出典: nikkei225jp.com 経由 (new.php と同データ)。
+          列 [8]=新高値数, [9]=新安値数 (2026-05 時点で実データ突き合わせ確認済)。
+
+    Returns:
+        list of dict: [{date, new_high, new_low}, ...] 日付昇順。
+                      新高値/新安値が数値でない行 (最新の未確定行など) はスキップ。
+    """
+    text = _fetch_nikkei_json(NEW_HIGH_LOW_URL, NEW_HIGH_LOW_REFERER)
+    rows = _parse_js_rows(text, "DAILY")
+    out = []
+    for r in rows:
+        if len(r) <= 9 or not isinstance(r[0], (int, float)):
+            continue
+        high, low = r[8], r[9]
+        if not isinstance(high, (int, float)) or not isinstance(low, (int, float)):
+            continue
+        d = datetime.fromtimestamp(r[0] / 1000, tz=JST).date().isoformat()
+        out.append({"date": d, "new_high": int(high), "new_low": int(low)})
+    return out
+
+
+def fetch_nikkei_vi():
+    """SL621_1990.json から 日経VI (恐怖指数) の時系列を返す。
+
+    出典: nikkei225jp.com 経由 (vix.php の var S621)。
+          [0]=unix timestamp(ms), [1]=日経VI (2026-05 時点で確認)。
+
+    Returns:
+        list of dict: [{date, nikkei_vi}, ...] 日付昇順。値が数値でない行はスキップ。
+    """
+    text = _fetch_nikkei_json(NIKKEI_VI_URL, NIKKEI_VI_REFERER)
+    rows = _parse_js_rows(text, "S621")
+    out = []
+    for r in rows:
+        if len(r) < 2 or not isinstance(r[0], (int, float)) \
+                or not isinstance(r[1], (int, float)):
+            continue
+        d = datetime.fromtimestamp(r[0] / 1000, tz=JST).date().isoformat()
+        out.append({"date": d, "nikkei_vi": float(r[1])})
     return out

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -1575,6 +1575,82 @@ def update_credit_balance():
     )
 
 
+def update_new_high_low():
+    """年初来 新高値/新安値 銘柄数を nikkei225jp.com から取得して JSON 保存 (issue #292)。
+
+    キャッシュ・失敗時の扱いは update_credit_balance と同じ (デイリー全体は止めない)。
+    """
+    import market_breadth
+
+    out_path = os.path.join(DATA_DIR, "code_rank_data", "new_high_low.json")
+    today = get_price_day(datetime.today())
+    if _credit_cache_is_fresh(out_path, today):
+        log_print(f"---- 新高値新安値 キャッシュ有効のためスキップ (generated_at={today.isoformat()})")
+        return
+
+    log_print("----> 新高値新安値 更新")
+    try:
+        rows = market_breadth.fetch_new_high_low()
+    except Exception as e:
+        log_warning(f"[new_high_low] 取得失敗のためスキップ: {e}")
+        return
+    if not rows:
+        log_warning("[new_high_low] 取得結果が空")
+        return
+    history = rows[-30:]
+    payload = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "source": "nikkei225jp.com (new.php)",
+        "latest": history[-1],
+        "history": history,
+    }
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    log_print(
+        f"<---- 新高値新安値 更新完了 latest={history[-1]['date']} "
+        f"高={history[-1]['new_high']} 安={history[-1]['new_low']}"
+    )
+
+
+def update_nikkei_vi():
+    """日経VI (恐怖指数) を nikkei225jp.com から取得して JSON 保存 (issue #292)。
+
+    キャッシュ・失敗時の扱いは update_credit_balance と同じ (デイリー全体は止めない)。
+    """
+    import market_breadth
+
+    out_path = os.path.join(DATA_DIR, "code_rank_data", "nikkei_vi.json")
+    today = get_price_day(datetime.today())
+    if _credit_cache_is_fresh(out_path, today):
+        log_print(f"---- 日経VI キャッシュ有効のためスキップ (generated_at={today.isoformat()})")
+        return
+
+    log_print("----> 日経VI 更新")
+    try:
+        rows = market_breadth.fetch_nikkei_vi()
+    except Exception as e:
+        log_warning(f"[nikkei_vi] 取得失敗のためスキップ: {e}")
+        return
+    if not rows:
+        log_warning("[nikkei_vi] 取得結果が空")
+        return
+    history = rows[-30:]
+    payload = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "source": "nikkei225jp.com (vix.php)",
+        "latest": history[-1],
+        "history": history,
+    }
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    log_print(
+        f"<---- 日経VI 更新完了 latest={history[-1]['date']} "
+        f"vi={history[-1]['nikkei_vi']}"
+    )
+
+
 def main(force=False):
     """メイン関数"""
     # TODO: 新高値更新タイミングをタグで
@@ -1595,6 +1671,8 @@ def main(force=False):
         get_todays_pts(force=force)
         update_todays_news()
         update_credit_balance()
+        update_new_high_low()
+        update_nikkei_vi()
     # 新高値銘柄の各種解析
     if "analyze" in args:
         todays_shintakane(UPD_INTERVAL)  # UPD_FORCE/UPD_INTERVAL/UPD_CACHE/UPD_REEVAL

--- a/tests/test_live_html.py
+++ b/tests/test_live_html.py
@@ -204,6 +204,32 @@ class TestLiveHtmlCreditBalance:
         _sleep()
 
 
+class TestLiveHtmlNikkei225jp:
+    """market_breadth.py — nikkei225jp.com 日経VI / 新高値新安値 取得→パース (issue #292)
+
+    JSON ファイル名 (SL621_1990.json / daily2year.json) や列構成が変わると失敗する。
+    """
+
+    def test_日経VIの抽出(self):
+        rows = market_breadth.fetch_nikkei_vi()
+        assert isinstance(rows, list) and len(rows) > 0
+        recent = rows[-30:]
+        assert all(isinstance(r["nikkei_vi"], float) for r in recent)
+        dates = [r["date"] for r in recent]
+        assert dates == sorted(dates)
+        _sleep()
+
+    def test_新高値新安値の抽出(self):
+        rows = market_breadth.fetch_new_high_low()
+        assert isinstance(rows, list) and len(rows) > 0
+        recent = rows[-30:]
+        assert all(isinstance(r["new_high"], int) and isinstance(r["new_low"], int)
+                   for r in recent)
+        dates = [r["date"] for r in recent]
+        assert dates == sorted(dates)
+        _sleep()
+
+
 class TestLiveHtmlDisclosure:
     """disclosure.py — kabutanニュースHTML取得→パース"""
 

--- a/tests/test_market_breadth.py
+++ b/tests/test_market_breadth.py
@@ -222,6 +222,21 @@ def test_vi_rating_html(vi, expected):
     assert expected in make_market_db._vi_rating_html(vi)
 
 
+@pytest.mark.parametrize("diff, expected_badge, absent_badge", [
+    (200, "天井圏", "底値圏"),   # >=181 で天井圏
+    (-50, "底値圏", "天井圏"),   # <=-29 で底値圏
+    (45, None, None),           # 中間 (中央値付近): バッジなし
+])
+def test_breadth_rating_html(diff, expected_badge, absent_badge):
+    """新高値-新安値 バッジが閾値 (天井>=+181/底<=-29) で出し分けされる (issue #292)。"""
+    html = make_market_db._breadth_rating_html(diff)
+    if expected_badge is None:
+        assert "天井圏" not in html and "底値圏" not in html
+    else:
+        assert expected_badge in html
+        assert absent_badge not in html
+
+
 def _build_history(records, n, key_fn):
     """index -1=最新 / -6=5日前 / -21=20日前 に狙った値が来る 21 件の history を組む。
 

--- a/tests/test_market_breadth.py
+++ b/tests/test_market_breadth.py
@@ -65,7 +65,7 @@ def _write_credit_json(tmp_path, history):
 
 
 def test_market_indicators_renders_eval_and_bairitsu(tmp_path, monkeypatch):
-    """評価率・倍率いずれも 1週/4週前比 pt 差付きで統合表に出る。"""
+    """評価率は値・変化セルに、倍率は tooltip (title) に統合される (issue #292)。"""
     history = [
         {"date": "2026-04-03", "credit_eval_rate": -7.67, "credit_bairitsu": 6.07},
         {"date": "2026-04-10", "credit_eval_rate": -6.59, "credit_bairitsu": 5.30},
@@ -81,13 +81,40 @@ def test_market_indicators_renders_eval_and_bairitsu(tmp_path, monkeypatch):
     assert "信用評価損益率" in html
     assert 'href="https://nikkei225jp.com/data/sinyou.php"' in html
     assert "-4.82%" in html  # 最新 evaluation rate
-    assert "6.85" in html    # 最新 bairitsu
     # 1週比 (latest - 1個前): -4.82 - (-5.45) = +0.63
     assert "+0.63" in html
     # 4週比 (latest - 4個前): -4.82 - (-7.67) = +2.85
     assert "+2.85" in html
-    # 倍率の 1週比: 6.85 - 5.74 = +1.11
+    # 信用倍率は独立行をやめ tooltip (title 属性) に移設
+    assert 'title="' in html
+    assert "信用倍率 6.85" in html
+    # 倍率の 1週比: 6.85 - 5.74 = +1.11 も tooltip 内
     assert "+1.11" in html
+    # -4.82% は中間水準なのでバッジは出ない
+    assert "天井圏" not in html
+    assert "底値圏" not in html
+    # 更新日は独立列 (mi-date) に 26/5/1 形式 (ゼロ埋めなし) で出る
+    assert 'class="mi-date"' in html
+    assert "26/5/1" in html
+
+
+@pytest.mark.parametrize("eval_rate, expected_badge, absent_badge", [
+    (-2.5, "天井圏", "底値圏"),   # >= -3.0 で天井圏
+    (-16.0, "底値圏", "天井圏"),  # <= -15.0 で底値圏
+    (-8.0, None, None),          # 中間: バッジなし
+])
+def test_market_indicators_credit_badge(tmp_path, monkeypatch, eval_rate, expected_badge, absent_badge):
+    """信用評価損益率の天井圏/底値圏バッジが閾値で出し分けされる (issue #292)。"""
+    _write_credit_json(tmp_path, [
+        {"date": "2026-05-01", "credit_eval_rate": eval_rate, "credit_bairitsu": 6.0},
+    ])
+    monkeypatch.setattr(make_market_db, "DATA_DIR", str(tmp_path))
+    html = make_market_db._html_market_indicators({})
+    if expected_badge is None:
+        assert "天井圏" not in html and "底値圏" not in html
+    else:
+        assert expected_badge in html
+        assert absent_badge not in html
 
 
 def test_market_indicators_returns_empty_when_no_data(tmp_path, monkeypatch):

--- a/tests/test_market_breadth.py
+++ b/tests/test_market_breadth.py
@@ -1,4 +1,4 @@
-"""market_breadth / 信用評価関連のテスト (issue #211)。"""
+"""market_breadth / 信用評価・日経VI・新高値新安値関連のテスト (issue #211, #292)。"""
 
 import json
 import os
@@ -176,3 +176,95 @@ def test_update_credit_balance_fetches_when_cache_stale(tmp_path, monkeypatch):
         fake_fetch.assert_called_once()
     payload = json.loads(cache.read_text(encoding="utf-8"))
     assert payload["latest"]["date"] == "2026-05-22"
+
+
+# --- issue #292: 日経VI / 新高値-新安値 ----------------------------------
+
+def test_parse_js_rows_handles_trailing_empty_row():
+    """daily2year.json の最終行は連続カンマ ([..,,,]) を含むため null 補正でパースする。
+
+    新高値/新安値が空の最終行は fetch_new_high_low 側でスキップされる。
+    """
+    text = (
+        "var DAILY = [\n"
+        "[%d,64999.41,2461,\"\",\"\",720,790,84.14,88,131,1510],\n"
+        "[%d,64693.12,2608,\"\",\"\",767,748,86.66,,,1515]\n"
+        "];" % (TS_0424, TS_0501)
+    )
+    rows = market_breadth._parse_js_rows(text, "DAILY")
+    assert len(rows) == 2
+    assert rows[0][8] == 88 and rows[0][9] == 131
+    # 連続カンマ箇所は null (None) に補正される
+    assert rows[1][8] is None and rows[1][9] is None
+
+
+def test_fetch_new_high_low_skips_unconfirmed_row():
+    """新高値/新安値が数値でない最終行 (当日未確定) はスキップされる。"""
+    text = (
+        "var DAILY = [\n"
+        "[%d,0,0,0,0,0,0,0,88,131,0],\n"
+        "[%d,0,0,0,0,0,0,0,,,0]\n"
+        "];" % (TS_0424, TS_0501)
+    )
+    with patch("market_breadth._fetch_nikkei_json", return_value=text):
+        out = market_breadth.fetch_new_high_low()
+    assert out == [{"date": "2026-04-24", "new_high": 88, "new_low": 131}]
+
+
+@pytest.mark.parametrize("vi, expected", [
+    (16.77, "安穏"),
+    (24.0, "警戒"),
+    (33.0, "恐怖"),
+    (45.0, "パニック"),
+])
+def test_vi_rating_html(vi, expected):
+    """日経VI バッジが閾値 (<20/20-30/30-40/>=40) で出し分けされる。"""
+    assert expected in make_market_db._vi_rating_html(vi)
+
+
+def _build_history(records, n, key_fn):
+    """index -1=最新 / -6=5日前 / -21=20日前 に狙った値が来る 21 件の history を組む。
+
+    records は {0: 最新, 5: 5日前, 20: 20日前} の dict (キーは「N営業日前」)。
+    指定の無い index はダミー値 key_fn(i) で埋める。
+    """
+    hist = []
+    for i in range(20, -1, -1):  # 20日前 → 最新 の順
+        hist.append({"date": "2026-05-%02d" % (21 - i), **(records.get(i) or key_fn(i))})
+    return hist
+
+
+def test_vi_and_breadth_rows_in_indicators(tmp_path, monkeypatch):
+    """日経VI と 新高値-新安値 が変化量付きで統合表に出る (issue #292)。
+
+    index -1=最新 / -6=5日前 / -21=20日前 を基準に直近/中期の変化量を検証する。
+    """
+    code_rank = tmp_path / "code_rank_data"
+    code_rank.mkdir(parents=True)
+    # 日経VI: 最新 16.77 / 5日前 16.5 (直近 +0.3) / 20日前 17.0 (中期 -0.2)
+    vi_hist = _build_history(
+        {0: {"nikkei_vi": 16.77}, 5: {"nikkei_vi": 16.5}, 20: {"nikkei_vi": 17.0}},
+        20, lambda i: {"nikkei_vi": 16.0})
+    (code_rank / "nikkei_vi.json").write_text(
+        json.dumps({"history": vi_hist}), encoding="utf-8")
+    # 新高値-新安値: 最新 -43 (88-131) / 5日前 -80 (直近 +37) / 20日前 -140 (中期 +97)
+    nhl_hist = _build_history(
+        {0: {"new_high": 88, "new_low": 131},
+         5: {"new_high": 70, "new_low": 150},
+         20: {"new_high": 60, "new_low": 200}},
+        20, lambda i: {"new_high": 50, "new_low": 50})
+    (code_rank / "new_high_low.json").write_text(
+        json.dumps({"history": nhl_hist}), encoding="utf-8")
+    monkeypatch.setattr(make_market_db, "DATA_DIR", str(tmp_path))
+
+    html = make_market_db._html_market_indicators({})
+    # 日経VI 行: 値 + バッジ + 直近 +0.3 / 中期 -0.2
+    assert "日経VI" in html
+    assert "16.77" in html
+    assert "安穏" in html
+    assert "+0.3" in html and "-0.2" in html
+    # 新高値-新安値 行: 値 -43、直近 +37 / 中期 +97、内訳は tooltip
+    assert "新高値-新安値" in html
+    assert "-43" in html
+    assert "+37" in html and "+97" in html
+    assert "新高値 88 / 新安値 131" in html


### PR DESCRIPTION
Closes #292

## Summary
`/market` の market-indicators 表を整理し、日経VI・新高値-新安値を追加。3 コミット構成。

- **表の整理** (`8ac4854`): 信用倍率の独立行を削除し信用評価損益率行の tooltip に統合 / 信用評価損益率に天井圏(≧-3%)・底値圏(≦-15%)バッジ追加 / 変化セルの期間ラベル(5日/20日・1週/4週)を削除し数値のみ表示(期間は tooltip) / 更新日を独立列(`26/5/22` 形式)に
- **ヘッダ行** (`3a0ee3b`): 指標/値/評価/直近/中期/更新日 の列見出しを追加
- **日経VI・新高値-新安値** (`f3b1b20`): nikkei225jp.com から 1日1回キャッシュ取得し 2 行追加
  - 日経VI: 安穏/警戒/恐怖/パニックバッジ (<20 / 20-30 / 30-40 / >=40)、ラベルは vix.php へリンク
  - 新高値-新安値: **(新高値-新安値) を 1 項目に集約**(issue 本文は別行 2 つだったがユーザー指示で 1 項目化)。変化量は「差分の変化」、内訳は tooltip、ラベルは new.php へリンク

## issue 本文との差分
- 新高値・新安値を別行ではなく **(新高値-新安値) の 1 項目** に集約(ユーザー指示)
- 日経VI バッジ閾値は実データ確認の上 4 段階(<20/20-30/30-40/>=40)に確定
- 表の整理(信用倍率削除・バッジ・ヘッダ・更新日列)は issue 本文外だが同じ表のため同梱

## データソース (実データ突き合わせ確認済)
- 日経VI: `HS_DATA_DAY/SL621_1990.json` (var S621)
- 新高値/新安値: `DAY/daily2year.json` (var DAILY, 列[8]=新高値/[9]=新安値)

## Test plan
- [x] pytest tests/test_market_breadth.py / test_make_market_db.py / test_functional_market.py / test_shintakane.py 全 188 件 pass
- [x] pytest tests/test_live_html.py::TestLiveHtmlNikkei225jp (実エンドポイント健全性) pass
- [x] webapp 起動 + Playwright で /market の 4 行レンダリング・リンク・バッジ確認
- [x] daily2year.json 最終行の連続カンマ補正・timestamp 欠落行スキップを単体テストで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)