### PR TITLE
webapp: 検索の全角半角ゆれを NFKC で吸収

### DIFF
--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -21,6 +21,7 @@ import fcntl
 import os
 import re
 import threading
+import unicodedata
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional
 
@@ -806,8 +807,19 @@ def _parse_rating_filter(rating: Optional[str]) -> Optional[set]:
     return set(tokens)
 
 
-def _matches_keyword(record: Dict[str, Any], keyword_lower: str) -> bool:
-    """レコードが keyword (小文字) を含むかを判定する。
+def normalize_for_search(text: str) -> str:
+    """検索照合用に文字列を正規化する。
+
+    NFKC で全角英数字記号を半角へ畳み込み (例: 'ＫＯＡ' → 'KOA')、
+    さらに小文字化する。これにより半角キーワードで全角データに
+    マッチできる (逆も同様)。比較する keyword 側・フィールド値側の
+    双方に同じ正規化をかけて使う。
+    """
+    return unicodedata.normalize("NFKC", text).lower()
+
+
+def _matches_keyword(record: Dict[str, Any], keyword_norm: str) -> bool:
+    """レコードが keyword (正規化済み) を含むかを判定する。
 
     HTML タグが含まれるフィールドではタグを除去してから検索する。
     """
@@ -818,7 +830,7 @@ def _matches_keyword(record: Dict[str, Any], keyword_lower: str) -> bool:
         if not isinstance(value, str):
             continue
         plain = strip_html_tags(value)
-        if keyword_lower in plain.lower():
+        if keyword_norm in normalize_for_search(plain):
             return True
     return False
 
@@ -837,7 +849,7 @@ def list_research_records(
     - 結果は code_s 昇順
     """
     rating_set = _parse_rating_filter(rating)
-    keyword_lower = keyword.lower() if keyword else None
+    keyword_norm = normalize_for_search(keyword) if keyword else None
     path = _resolve_db_path(db_path)
 
     results: List[Dict[str, Any]] = []
@@ -848,8 +860,8 @@ def list_research_records(
             if rating_set is not None:
                 if record.get("overall_rating", "") not in rating_set:
                     continue
-            if keyword_lower is not None:
-                if not _matches_keyword(record, keyword_lower):
+            if keyword_norm is not None:
+                if not _matches_keyword(record, keyword_norm):
                     continue
             results.append(record)
 

--- a/scripts/webapp/routes/search.py
+++ b/scripts/webapp/routes/search.py
@@ -5,6 +5,7 @@ GET / : 銘柄コード/名前/評価でフィルタし一覧表示
 """
 
 import os
+import unicodedata
 from datetime import datetime
 
 from flask import Blueprint, render_template, request, redirect, url_for, flash
@@ -68,7 +69,8 @@ def index():
 
     if q:
         # q は code_s 部分一致 OR keyword 一致 (search_records が見る複数フィールド)
-        q_upper = q.upper()
+        # NFKC で全角コード入力 (例: '６９９９') も半角登録の code_s にマッチさせる
+        q_upper = unicodedata.normalize("NFKC", q).upper()
         code_match = [
             r for r in search_records(rating=rating)
             if q_upper in r.get("code_s", "")
@@ -85,7 +87,8 @@ def index():
     else:
         records = search_records(rating=rating, keyword=keyword)
         if code_s:
-            records = [r for r in records if code_s.upper() in r.get("code_s", "")]
+            code_s_norm = unicodedata.normalize("NFKC", code_s).upper()
+            records = [r for r in records if code_s_norm in r.get("code_s", "")]
 
     # コード/銘柄名検索で1件のみヒットした場合は詳細ページへ直接ジャンプ
     if (q or code_s) and len(records) == 1:
@@ -93,7 +96,7 @@ def index():
 
     # issue #216: q がコード形式 (4桁数字 or 3桁数字+大文字) で 0 件ヒット時のみ
     # 「この銘柄を追加」フォームを出す。銘柄名検索や不正フォーマットでは出さない。
-    q_normalized = q.upper()
+    q_normalized = unicodedata.normalize("NFKC", q).upper()
     can_add = (
         bool(q)
         and not records

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -578,6 +578,14 @@ class TestListFilter:
         assert len(results) == 1
         assert results[0]["code_s"] == "9999"
 
+    # --- 全角半角ゆれ吸収 (NFKC): 実データ 6999 銘柄名が全角 'ＫＯＡ' のケース ---
+    @pytest.mark.parametrize("keyword", ["KOA", "koa", "ＫＯＡ"])
+    def test_filter_keyword_fullwidth_normalize(self, db_path, keyword):
+        rec = rs.create_research_record("6999", "ＫＯＡ", overall_rating="B")
+        rs.upsert_research_record(rec, db_path=db_path)
+        results = rs.list_research_records(keyword=keyword, db_path=db_path)
+        assert [r["code_s"] for r in results] == ["6999"]
+
     # --- issue #236: stock_name_prev も検索対象 (エイリアス) ---
     def test_filter_keyword_stock_name_prev(self, db_path):
         rec = rs.create_research_record(


### PR DESCRIPTION
## Summary
- 半角キーワード `KOA` で全角登録の銘柄名 `ＫＯＡ` (6999) にマッチしない問題を修正
- 検索照合時に NFKC 正規化を keyword 側・フィールド値側の双方へ適用 (`normalize_for_search`)
- コード部分一致でも全角コード入力 (`６９９９`) を半角登録 `code_s` に揃える
- 表示データは元の表記のまま壊さず、既存レコードへの破壊的変更なし (検索時吸収方式)

## Test plan
- [x] pytest tests/test_research_shelve.py tests/test_webapp_routes.py → 177 passed
- [x] 追加した全角半角 parametrize テスト (`KOA`/`koa`/`ＫＯＡ` → 6999) pass
- [x] webapp 起動 + ブラウザで `?q=KOA` (半角) → `/stock/6999` (ＫＯＡ) へリダイレクト確認
- [x] 全角コード `?code_s=６９９９` → `/stock/6999` へリダイレクト確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)