### PR TITLE
portfolio: 業態テーマ別RSサマリー画面を追加 (#283)

### DIFF
--- a/doc/plan/portfolio_theme_summary.md
+++ b/doc/plan/portfolio_theme_summary.md
@@ -4,7 +4,7 @@
 
 監視ユニバース (portfolio_shelve に登録された全銘柄、保有 / 準保有 / 監視) を、ユーザーが手動で付けた **業態・テーマ** (`memo["gyoutai_themes"]`) でグルーピングし、テーマごとに既存指標を集約して **「手動付けした業態テーマ (自分の分類軸) による市場のテーマローテーション検知」** を行う画面を webapp に追加する。
 
-株探テーマベースの `theme_rank` (自動分類) を **自分の分類軸で補完する** もの。中長期の強弱 (リーダーシップ) に加え、短期の値動き傾向 (RS ラインのスロープ) も併記する。
+株探テーマベースの `theme_rank` (自動分類) を **自分の分類軸で補完する** もの。中長期の強弱 (リーダーシップ) に加え、短期の勢い (RS ラインの移動平均乖離オシレーター) も併記する。
 
 O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブル + リーダー株の同行表示) を参考にする。
 
@@ -13,7 +13,7 @@ O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブ�
 当初は用途を「自分が組んだ投資仮説の事後評価 / 銘柄入れ替え判断」に限定していたが、**「手動業態テーマによる市場ローテーション検知」に改める**。
 
 - 既存 `theme_rank` は **株探の自動テーマ分類** でローテーションを検知する。本機能は同じ "市場ローテーション検知" を **自分の分類軸で行う** もの。用途は同じ (ローテーション検知)、テーマ分類の出所が違う (株探自動 vs 手動) という補完関係
-- ローテーション検知が主目的である以上、「今どの業態が強いか (中長期)」だけでなく **「今どの業態の値動きが上向きつつあるか (短期スロープ)」も併せて示す**
+- ローテーション検知が主目的である以上、「今どの業態が強いか (中長期)」だけでなく **「今どの業態が直近平均より上振れ/過熱しているか (短期の勢いオシレーター)」も併せて示す**
 
 ### MarketSmith のグループ強弱の見せ方と本機能の位置づけ (事実整理)
 
@@ -23,7 +23,7 @@ issue #283 の検討過程で「グループの点火を RS ライン新高値 (
 - MarketSmith における **Blue Dot (RS ライン新高値の点火シグナル) は「個別銘柄」チャートの機能**であり、グループ (セクター) 単位の Blue Dot という標準機能は無い。追記コメントの「MarketSmith の点火検知は RS ライン」は銘柄レベルの話の転用だった
 - 銘柄レベルの RS ライン新高値判定は本システムで既に実装済み (`compute_rs_line_new_high` / 銘柄詳細チャートの Blue Dot 表示)。これをテーマ単位で集約すると「銘柄 Blue Dot の breadth」という独自指標になるが、無用な複雑化を避けるため **今回は採用しない**
 
-→ 本機能の短期層は、MarketSmith の「グループランクの時系列変化 (= 上昇しているグループを点火候補とする)」の思想に沿いつつ、**永続化不要で即動く既存資産** = RS ラインの 5日/20日スロープ (既存 `compute_rs_line_changes`) のテーマ平均で代替する。
+→ 本機能の短期層は、MarketSmith の「グループランクの時系列変化 (= 上昇しているグループを点火候補とする)」の思想に沿いつつ、**永続化不要で即動く既存資産** = RS ラインの移動平均乖離オシレーター (既存 `compute_rs_line_changes` を MA 化したもの、後述) のテーマ平均で代替する。
 
 ### 既存資産との役割分担 (slow × fast / 自動 × 手動)
 
@@ -32,7 +32,7 @@ issue #283 の検討過程で「グループの点火を RS ライン新高値 (
 |  | 株探テーマ (自動分類) | 手動業態テーマ (自分の分類軸) |
 |---|---|---|
 | **中長期リーダーシップ (slow)** | `theme_rank` (既存) | **momentum_pt 集約 (本機能)** |
-| **短期の値動き傾向 (fast)** | `theme_momentum` 1日騰落率 (既存・部分的) | **rs_line スロープ集約 (本機能)** |
+| **短期の勢い (fast)** | `theme_momentum` 1日騰落率 (既存・部分的) | **rs_line 移動平均乖離オシレーター集約 (本機能)** |
 
 - 株探自動分類 (左列) と手動分類軸 (右列) が揃うことで、「市場が見ているテーマ」と「自分が見ているテーマ」のローテーションを両軸で比較できる
 - スコープ・データソース・UI 配置は既存機能と独立させる
@@ -50,16 +50,16 @@ issue #283 の検討過程で「グループの点火を RS ライン新高値 (
 2. テンプレート `portfolio_theme_summary.html` を新規追加
 3. helpers に集計関数 `build_portfolio_theme_summary()` を 1 本追加
 4. `/portfolio` 画面のヘッダから本画面へのリンクを追加
-5. 中長期層: **既存 stocks_shelve の `momentum_pt` / `price_log` の集約** — DB 書込みなし、新規スキーマなし
-6. 短期層: **既存 `compute_rs_line_changes` の 5日前比 (A) / 20日前比 (B) を業態テーマ単位で平均**。rs_line は都度計算 (永続化しない) 方針につき DB 書込み・新規スキーマ不要
-7. 点火検知用に短期スロープ (A 平均) での再ソート切替を用意
+5. 中長期層: **既存 stocks_shelve の `momentum_pt` の集約** — DB 書込みなし、新規スキーマなし
+6. 短期層: **`compute_rs_line_changes` を MA 乖離オシレーター化し (#155 系指標ごと変更)、A (5日平均乖離) / B (20日平均乖離) を業態テーマ単位で平均**。rs_line は都度計算 (永続化しない) 方針につき DB 書込み・新規スキーマ不要
+7. 点火検知用に短期の勢い (A 平均) での再ソート切替を用意
 
 ## 非スコープ
 
 - **Blue Dot 率 (rs_line 新高値) のグループ集計** (上記「事実整理」のとおり今回は採用しない)
 - momentum_pt (0〜99) の日次履歴の永続化とそのスロープ (= 案B、将来の再検討候補)
   - momentum_pt は現状 stocks_shelve に最新値のみ保持 (`price.py:682`)。過去日の正確な遡及には過去時点の TOPIX rs_raw + calib が必要で都度計算は不正確。永続化は本機能の「DB 書込みなし」方針を破る
-  - MarketSmith の「グループランク (パーセンタイル) の時系列変化」に最も忠実なのは案B だが、本 PR では永続化不要で即動く案A (rs_line スロープ) を採用する。**案A の短期スロープがローテーション検知としてしっくりこない場合に、案B (momentum_pt 履歴) を別 issue で改めて検討する**
+  - MarketSmith の「グループランク (パーセンタイル) の時系列変化」に最も忠実なのは案B だが、本 PR では永続化不要で即動く案A (rs_line の MA 乖離オシレーター) を採用する。**案A の短期勢い指標がローテーション検知としてしっくりこない場合に、案B (momentum_pt 履歴) を別 issue で改めて検討する**
 - rs_line そのものの永続化 (#155 方針どおり都度計算)
 - テーマ指数 (price_log 累積) の構築
 - TOPIX 比 RS の再計算 (個別銘柄の `momentum_pt` が既に TOPIX 比正規化済みのため流用)
@@ -80,7 +80,7 @@ issue #283 の検討過程で「グループの点火を RS ライン新高値 (
 | portfolio_shelve | `record:<code_s>` の `memo["gyoutai_themes"]: list[str]` | テーマ → 銘柄の逆引き |
 | portfolio_shelve | `record:<code_s>` の `status` | excluded 除外、status ラベル表示 |
 | stocks_shelve | `<code_s>` の `momentum_pt` | 中長期層: テーマ集約 (平均 / 最大) の主指標 |
-| stocks_shelve | `<code_s>` の `price_log` | 20日 / 65日リターン算出 + rs_line 計算 |
+| stocks_shelve | `<code_s>` の `price_log` | rs_line 計算 (= 銘柄終値 / TOPIX 終値) |
 | stocks_shelve | `<code_s>` の `stock_name` | リーダー株表示 |
 | market_db (topix) | `price_log` | rs_line (= 銘柄終値 / TOPIX 終値) 計算の分母 |
 
@@ -111,18 +111,38 @@ issue #283 の検討過程で「グループの点火を RS ライン新高値 (
 | `member_count` | 構成銘柄数 | 逆引き結果の長さ |
 | `momentum_pt_avg` | momentum_pt の平均 (None は除外) | stocks_shelve `momentum_pt` |
 | `momentum_pt_max` | momentum_pt の最大 (None は除外) | stocks_shelve `momentum_pt` |
-| `ret_20d_avg` | 20 営業日リターン (%) の平均 | stocks_shelve `price_log` |
-| `ret_65d_avg` | 65 営業日リターン (%) の平均 | stocks_shelve `price_log` |
 | `leaders` | momentum_pt 降順上位 3 銘柄 | (code_s, stock_name, momentum_pt) の list |
 
-### 短期の値動き傾向層 (fast)
+### 短期の値動き傾向層 (fast) = rs_line の「勢い / 過熱」オシレーター
 
-既存 rs_line スロープ関数を業態テーマ単位で集約する。**新規 rs_line ロジックは書かず、既存純粋関数を呼び出して平均を取るだけ。**
+構成銘柄の rs_line オシレーターを業態テーマ単位で平均する。指標の定義は **#155 の「N日前の1点との比」から「今の rs vs N日移動平均の乖離率」に変更する** (下記「rs_line オシレーター化」参照)。
 
 | 指標 | 定義 | 計算ソース (既存関数) |
 |---|---|---|
-| `slope_a_avg` | テーマ短期スロープ: 構成銘柄の rs_line 5日前比 (A) の平均 | `compute_rs_line_changes()` の A (`make_stock_db.py`) |
-| `slope_b_avg` | テーマ中期スロープ: 構成銘柄の rs_line 20日前比 (B) の平均 | `compute_rs_line_changes()` の B (`make_stock_db.py`) |
+| `dev_a_avg` | テーマ短期の勢い: 構成銘柄の「今日 vs 直近 5 日移動平均」乖離率 (A) の平均 | `compute_rs_line_changes()` の A (`make_stock_db.py`) |
+| `dev_b_avg` | テーマ中期の勢い: 構成銘柄の「今日 vs 直近 20 日移動平均」乖離率 (B) の平均 | `compute_rs_line_changes()` の B (`make_stock_db.py`) |
+
+UI ラベルは「5日乖離 / 20日乖離」(または「短期勢い / 中期勢い」)。値が大きいほど「今、直近平均より rs_line が上振れている = 勢い/過熱が強い」。
+
+#### rs_line オシレーター化 (この PR で #155 系指標ごと変更)
+
+**背景**: 現状は「今日の rs_line vs ちょうど N 日前の 1 点」の比 (`_rs_line_changes_from_line` の `_change(offset)`)。基準が 1 点なので、今日か N 日前のどちらかがヒゲ・急変した日だと値が大きくブレる。基準を N 日移動平均にすればブレが 1/N に薄まり、勢い・過熱の度合いをより安定して捉えられる。
+
+**新定義 (今の rs vs 移動平均の乖離率 = オシレーター)**:
+- 短期 A = `(rs_line[0] − mean(rs_line[0:5])) / mean(rs_line[0:5]) × 100` (今日を含む直近 5 日平均との乖離率%)
+- 中期 B = `(rs_line[0] − mean(rs_line[0:20])) / mean(rs_line[0:20]) × 100` (今日を含む直近 20 日平均との乖離率%)
+- これは「傾き (slope)」ではなく **平均からの乖離 (オシレーター / 過熱度)**。codex 指摘を踏まえ、命名は slope を避け `dev`(deviation) 系に統一。上昇トレンド中でも直近反落で符号が負になりうるが、それは「勢いが一服した」を意味し、ローテーション検知の用途に合致する
+- B の代替: 20 本に満たないとき直近 19,18,...,15 本の平均で代替 (現行の offset 代替と同じ思想、`b_is_approx=True`)
+- 必要本数: A は 5 本以上、B は 15 本以上 (代替込み)。不足は None。移動平均 (分母) が 0 の場合も None
+
+**影響範囲 (この PR で一括変更、ユーザー確認済み)**:
+1. `_rs_line_changes_from_line` (make_stock_db.py:332): `_change(offset)` の「過去 1 点との比」を「今日を含む直近 N 日平均との乖離率」に書き換え (本体)。戻り値の型・タプル形状 (A, B, b_is_approx) は不変
+2. `compute_rs_line_changes` / `get_rs_line_changes_expr`: 上記を呼ぶだけなのでシグネチャ・戻り値の型は不変。**値の意味と数値が変わる**
+3. code_rank.csv モメンタム列 (`get_rs_line_changes_expr` 経由、make_stock_db.py:1499): 「N日前比」→「N日平均乖離率」に意味が変わる。CSV 表記フォーマット ("中期/短期") は据え置き。表示のみの利用で運用影響は小さい
+4. webapp 詳細チャート tooltip の `_format_total_change` (helpers.py:2139): 別系統の「2 点比較」だが、同じく「今 vs N日平均乖離率」に揃え、銘柄側 tooltip も一貫させる
+5. テスト: `test_make_stock_db.py` の `compute_rs_line_changes` 8 本 + `get_rs_line_changes_expr` 7 本の期待値を新定義で再計算。tooltip 系テストも該当あれば更新
+
+→ **これは表示機能追加にとどまらず、#155 由来の rs_line 系指標 (code_rank.csv のモメンタム列・銘柄詳細 tooltip) の定義変更を含む。リスク節・ロールバック節もこれを前提に記載する。**
 
 #### rs_line 集約の計算量対策 (都度計算・キャッシュなし)
 
@@ -130,27 +150,20 @@ issue #283 の検討過程で「グループの点火を RS ライン新高値 (
 - N+1 を避けるため、`make_stock_db._topix_close_map(market_db)` で **TOPIX 終値マップを 1 回だけ構築**し、全銘柄の rs_line 計算に `topix_map=` で渡す
 - **公開 API を使い private 関数には依存しない** (simplify レビューでの方針確定): 銘柄ごとに公開関数 `compute_rs_line_changes(stock, market_db, topix_map=topix_map)` を呼んで `(A, B)` を得る。`topix_map` を渡すことで内部 `compute_rs_line` の TOPIX マップ再構築を避ける
   - 当初は再計算回避のため内部関数 `_rs_line_changes_from_line(rs_line)` を直接呼ぶ案だったが、private 関数への越境依存 (カプセル化の崩れ・テストの脆さ) を避けるため公開 API に統一。`compute_rs_line` の二重計算は発生するが、ポートフォリオは数百銘柄規模で影響は無視できる
-  - 既存関数のシグネチャは一切変更しない (API 変更なし)
+  - `compute_rs_line_changes` のシグネチャ・戻り値の型は不変 (API 形状は変えない)。ただし算出ロジック (=値の意味) は MA 乖離率に変更する
 - 銘柄数 200・テーマ数 30 想定で 1 リクエスト数百 ms 見込み。rs_line 計算は price_log のスライス比較のみで重くない
 
 ### 欠損銘柄の扱い
 
 - `momentum_pt` が None / 欠損のものは集計対象から除外 (count には含める = テーマに属する全銘柄数)
-- rs_line がデータ不足 (`compute_rs_line_changes` が A / B に None を返す) の銘柄は、その指標 (slope_a / slope_b) の平均から個別に除外する (A は取れるが B は None、というケースもあるため指標ごとに有効銘柄数で平均)
+- rs_line がデータ不足 (`compute_rs_line_changes` が A / B に None を返す) の銘柄は、その指標 (dev_a / dev_b) の平均から個別に除外する (A は取れるが B は None、というケースもあるため指標ごとに有効銘柄数で平均)
 - 集計対象が 0 銘柄ならその指標は `None` (テンプレ側で "—" 表示)
-
-### リターン計算
-
-- `price_log` は `[(date, price), ...]` 形式で最新が先頭
-- `ret_Nd = (price_log[0][1] - price_log[N][1]) / price_log[N][1] * 100`
-- `len(price_log) <= N` の銘柄はその指標から除外
-- helpers 内で完結する小関数 `_calc_return_pct(price_log, days)` を追加してよい
 
 ### ソートキー (再ソート切替)
 
 - **デフォルト (1次ソート)**: `momentum_pt_avg` 降順 (None は末尾) → 中長期リーダーシップ
-- **短期検知用の再ソート**: `slope_a_avg` (短期スロープ) 降順を切替可能にし、値動きが上向きつつある業態が上に来るようにする
-  - サーバ側でクエリパラメータ `?sort=momentum|slope_a` を受けて並べ替える
+- **短期検知用の再ソート**: `dev_a_avg` (短期の勢い) 降順を切替可能にし、今最も上振れ/過熱している業態が上に来るようにする
+  - サーバ側でクエリパラメータ `?sort=momentum|dev_a` を受けて並べ替える
   - 同点時は `member_count` 降順 → テーマ名昇順で安定ソート
 
 ---
@@ -163,10 +176,10 @@ def build_portfolio_theme_summary(
     sort_key: str = "momentum",
 ) -> list[dict]:
     """portfolio_shelve のユニバースを memo['gyoutai_themes'] でグルーピングし、
-    テーマごとの中長期 (momentum_pt) + 短期 (rs_line スロープ) 集約指標と
+    テーマごとの中長期 (momentum_pt) + 短期 (rs_line 勢いオシレーター) 集約指標と
     上位リーダー株を返す。
 
-    sort_key: "momentum" | "slope_a"。
+    sort_key: "momentum" | "dev_a"。
     並び順は sort_key に従う (None は末尾) → member_count 降順 → テーマ名昇順。
     """
 ```
@@ -186,18 +199,18 @@ def build_portfolio_theme_summary(
 |---|---|---|
 | GET | `/portfolio/themes/summary` | 業態テーマ別 RS サマリー一覧表示 |
 
-- 既存 `portfolio` blueprint に追加、クエリ `?sort=momentum|slope_a` を受ける
+- 既存 `portfolio` blueprint に追加、クエリ `?sort=momentum|dev_a` を受ける
 - POST 操作なし、PRG 不要
 - fallback_mode (portfolio_shelve 空) は空テーブル + 案内文
 
 ### 新規テンプレート (`scripts/webapp/templates/portfolio_theme_summary.html`)
 
-中長期 slow と 短期スロープ fast を 1 行に併記。
+中長期 slow と 短期の勢い fast を 1 行に併記。
 
 - リーダー株: `{code_s} ({momentum_pt})`、`url_for("detail.stock_detail", code_s=...)` でリンク
 - 行クリックで構成銘柄一覧を展開 (`<details>` タグ、JS 最小限)
 - 並べ替えリンクは現在の sort をハイライト
-- 条件付き書式: momentum_pt 平均 ≥70 緑太字 / ≤30 赤、スロープ 正で緑 / 負で赤
+- 条件付き書式: momentum_pt 平均 ≥70 緑太字 / ≤30 赤、勢い (乖離率) 正で緑 / 負で赤
 - 構成銘柄数 1 の行は薄いマーカー (背景色) で「少数構成」を明示
 
 ### 既存 portfolio_list.html の変更
@@ -213,12 +226,12 @@ def build_portfolio_theme_summary(
 1. 基本ケース: 2 テーマ × 3 銘柄で中長期集約値が期待通り
 2. 同一銘柄が 2 テーマに属する場合、両テーマで集計される
 3. `momentum_pt` 欠損銘柄は集計から除外されるが member_count には含まれる
-4. 短期層: slope_a_avg / slope_b_avg が既存 rs_line 関数の集約値と一致し、データ不足銘柄は各指標から除外
-5. `sort_key` 切替: momentum / slope_a でそれぞれ期待順に並ぶ
+4. 短期層: dev_a_avg / dev_b_avg が既存 rs_line 関数の集約値と一致し、データ不足銘柄は各指標から除外
+5. `sort_key` 切替: momentum / dev_a でそれぞれ期待順に並ぶ
 
 WebApp ルートのテストは `tests/test_webapp_routes.py` に 1 本追加:
 
-- `GET /portfolio/themes/summary` および `?sort=slope_a` が 200 で返り、テンプレートに「業態テーマ別 RS サマリー」文字列を含む
+- `GET /portfolio/themes/summary` および `?sort=dev_a` が 200 で返り、テンプレートに「業態テーマ別 RS サマリー」文字列を含む
 
 ---
 
@@ -227,8 +240,8 @@ WebApp ルートのテストは `tests/test_webapp_routes.py` に 1 本追加:
 1. `pytest tests/test_webapp_helpers.py tests/test_webapp_routes.py -v` 通過
 2. `python -m webapp.app` 起動 → `/portfolio` ヘッダから「📊 テーマサマリー」リンクが見える
 3. `/portfolio/themes/summary` でテーマ一覧が momentum_pt 平均降順に並ぶ
-4. 並べ替えを「短期スロープ(A)」に切替で順序が変わる
-5. 短期スロープ / 中期スロープカラムが表示され、rs_line 計算可能な銘柄で値が入る
+4. 並べ替えを「短期の勢い(A)」に切替で順序が変わる
+5. 5日乖離 / 20日乖離カラムが表示され、rs_line 計算可能な銘柄で値が入る
 6. 構成銘柄数 1 のテーマも表示され、視覚マーカーが付く
 7. 行展開で構成銘柄が momentum_pt 降順で並ぶ
 8. fallback_mode (portfolio_shelve 空) では空テーブル + 案内文が出る
@@ -237,9 +250,11 @@ WebApp ルートのテストは `tests/test_webapp_routes.py` に 1 本追加:
 
 ## ロールバック
 
-- webapp / helpers / templates の追加のみで、既存スキーマ・既存挙動への破壊的変更なし
-- 既存 rs_line 関数は呼び出すだけ (改変しない、API 変更なし)
-- git revert で完全に戻せる。DB 書込みなし
+- 本 PR は **2 種の変更を含む**:
+  1. webapp 表示追加 (サマリー画面・ルート・テンプレート・導線リンク) — 新規追加のみ、既存スキーマ・既存挙動への影響なし
+  2. **#155 由来 rs_line 系指標の定義変更** (`_rs_line_changes_from_line` / `compute_rs_line_changes` の算出ロジックを MA 乖離率に変更) — code_rank.csv モメンタム列・銘柄詳細 tooltip の **表示値が変わる挙動変更**
+- DB スキーマ・DB 書込みは無し (rs_line は従来どおり都度計算)。値の意味が変わるだけでデータ整合性問題は起きない
+- git revert で完全に戻せる。ただし revert すると CSV・tooltip の rs_line 表示も旧定義 (N日前比) に戻る点に留意
 
 ---
 
@@ -253,7 +268,8 @@ WebApp ルートのテストは `tests/test_webapp_routes.py` に 1 本追加:
 
 - **テーマ名の表記揺れ**: portfolio_theme_master 完了前は同義語・誤字が別テーマとして集計される。可視化の副次効果として有用なのでそのまま表示
 - **構成銘柄 1 のテーマ**: momentum_pt 平均 = その銘柄自体。マーカー表示で目視抑制
-- **rs_line 計算コスト**: `_topix_close_map` を 1 回構築 + 銘柄ごと `compute_rs_line_changes` を呼ぶ (同一銘柄が複数テーマに属しても slope_by_code で 1 回に集約)。数百銘柄規模で数百 ms 程度。キャッシュなし
+- **rs_line 計算コスト**: `_topix_close_map` を 1 回構築 + 銘柄ごと `compute_rs_line_changes` を呼ぶ (同一銘柄が複数テーマに属しても銘柄単位キャッシュで 1 回に集約)。数百銘柄規模で数百 ms 程度。キャッシュなし
+- **#155 系指標の定義変更の波及**: code_rank.csv のモメンタム列・銘柄詳細 tooltip の rs_line 表示値が「N日前比」→「N日平均乖離率」に変わる。いずれも表示用途で、スコアリング (業績40/モメンタム25/…) には組み込まれていない (momentum_pt は別系統の rs_raw 由来) ため、ランキング順位には影響しない。ユーザー確認済み
 
 ## 実装規模見込み
 

--- a/doc/plan/portfolio_theme_summary.md
+++ b/doc/plan/portfolio_theme_summary.md
@@ -1,19 +1,48 @@
-# プラン: ポートフォリオ — 業態テーマ別サマリー表示
+# プラン: ポートフォリオ — 業態テーマ別 RS サマリー表示
 
 ## 目的
 
-監視ユニバース (portfolio_shelve に登録された全銘柄、保有 / 準保有 / 監視) を、ユーザーが手動で付けた **業態・テーマ** (`memo["gyoutai_themes"]`) でグルーピングし、テーマごとに既存指標 `momentum_pt` を集約して「自分の投資仮説ごとのテーマ強弱」を一目で把握できる画面を webapp に追加する。
+監視ユニバース (portfolio_shelve に登録された全銘柄、保有 / 準保有 / 監視) を、ユーザーが手動で付けた **業態・テーマ** (`memo["gyoutai_themes"]`) でグルーピングし、テーマごとに既存指標を集約して **「手動付けした業態テーマ (自分の分類軸) による市場のテーマローテーション検知」** を行う画面を webapp に追加する。
 
-O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブル + リーダー株の同行表示) を参考にしつつ、用途を「市場全体のテーマローテーション検知」ではなく **「自分が組んだ投資仮説の事後評価 / 銘柄入れ替え判断」** に限定する。
+株探テーマベースの `theme_rank` (自動分類) を **自分の分類軸で補完する** もの。中長期の強弱 (リーダーシップ) に加え、短期の値動き傾向 (RS ラインのスロープ) も併記する。
 
-### 既存資産との役割分担
+O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブル + リーダー株の同行表示) を参考にする。
 
-| 機能 | 用途 | 構成銘柄ソース |
+### 用途の再定義 (issue #283 追記 2026-05-29)
+
+当初は用途を「自分が組んだ投資仮説の事後評価 / 銘柄入れ替え判断」に限定していたが、**「手動業態テーマによる市場ローテーション検知」に改める**。
+
+- 既存 `theme_rank` は **株探の自動テーマ分類** でローテーションを検知する。本機能は同じ "市場ローテーション検知" を **自分の分類軸で行う** もの。用途は同じ (ローテーション検知)、テーマ分類の出所が違う (株探自動 vs 手動) という補完関係
+- ローテーション検知が主目的である以上、「今どの業態が強いか (中長期)」だけでなく **「今どの業態の値動きが上向きつつあるか (短期スロープ)」も併せて示す**
+
+### MarketSmith のグループ強弱の見せ方と本機能の位置づけ (事実整理)
+
+issue #283 の検討過程で「グループの点火を RS ライン新高値 (Blue Dot) で出す」案を検討したが、事実関係を確認した結果、**Blue Dot のグループ集計は本機能のスコープから外す**。
+
+- MarketSmith のグループ強弱の標準表示は **「Industry Group Rank」(1〜197 位、6ヶ月価格パフォーマンスでランク付けしたレベル値)**。グループは slow なランク数値で見るのが基本設計
+- MarketSmith における **Blue Dot (RS ライン新高値の点火シグナル) は「個別銘柄」チャートの機能**であり、グループ (セクター) 単位の Blue Dot という標準機能は無い。追記コメントの「MarketSmith の点火検知は RS ライン」は銘柄レベルの話の転用だった
+- 銘柄レベルの RS ライン新高値判定は本システムで既に実装済み (`compute_rs_line_new_high` / 銘柄詳細チャートの Blue Dot 表示)。これをテーマ単位で集約すると「銘柄 Blue Dot の breadth」という独自指標になるが、無用な複雑化を避けるため **今回は採用しない**
+
+→ 本機能の短期層は、MarketSmith の「グループランクの時系列変化 (= 上昇しているグループを点火候補とする)」の思想に沿いつつ、**永続化不要で即動く既存資産** = RS ラインの 5日/20日スロープ (既存 `compute_rs_line_changes`) のテーマ平均で代替する。
+
+### 既存資産との役割分担 (slow × fast / 自動 × 手動)
+
+軸を「テーマ分類の出所 × 時間軸」に整理する。**本機能は右列 (手動分類軸) の slow + fast 両方を担う。**
+
+|  | 株探テーマ (自動分類) | 手動業態テーマ (自分の分類軸) |
 |---|---|---|
-| `market_db["theme_rank"]` (既存) | 市場全体のテーマローテーション検知 (仕入れ前) | Kabutan アクセスランキング |
-| **業態テーマサマリー (本機能)** | 自分の投資仮説の事後評価 (仕入れ後) | portfolio_shelve `memo["gyoutai_themes"]` |
+| **中長期リーダーシップ (slow)** | `theme_rank` (既存) | **momentum_pt 集約 (本機能)** |
+| **短期の値動き傾向 (fast)** | `theme_momentum` 1日騰落率 (既存・部分的) | **rs_line スロープ集約 (本機能)** |
 
-両者は補完関係。スコープ・データソース・UI 配置すべて独立させる。
+- 株探自動分類 (左列) と手動分類軸 (右列) が揃うことで、「市場が見ているテーマ」と「自分が見ているテーマ」のローテーションを両軸で比較できる
+- スコープ・データソース・UI 配置は既存機能と独立させる
+
+#### 妥当性確認: momentum_pt 集約 = MarketSmith「インダストリーグループ・ランク」相当
+
+- MarketSmith のグループ強弱 = 全銘柄を業種に分け、6ヶ月価格パフォーマンスでランク。個別 RS の土台式は 3/6/9/12ヶ月の加重 → パーセンタイル化
+- 既存 `momentum_pt` = `rs_rel` (銘柄 rs_raw / TOPIX rs_raw) を対数正規 CDF でパーセンタイル化。`rs_raw` は 13/26/39/52週 = 3/6/9/12ヶ月の加重
+
+→ 期間構成・相対正規化・パーセンタイル化のいずれもグループランクと整合。「テーマ指数を新規構築せず `momentum_pt` を集約」する判断は中長期リーダーシップ層を正しく再現できている。
 
 ## スコープ
 
@@ -21,15 +50,21 @@ O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブ�
 2. テンプレート `portfolio_theme_summary.html` を新規追加
 3. helpers に集計関数 `build_portfolio_theme_summary()` を 1 本追加
 4. `/portfolio` 画面のヘッダから本画面へのリンクを追加
-5. テーマ別の指標は **既存 stocks_shelve の値の集約のみ** で完結 — DB 書込みなし、新規スキーマなし、新規キャリブレーションなし
+5. 中長期層: **既存 stocks_shelve の `momentum_pt` / `price_log` の集約** — DB 書込みなし、新規スキーマなし
+6. 短期層: **既存 `compute_rs_line_changes` の 5日前比 (A) / 20日前比 (B) を業態テーマ単位で平均**。rs_line は都度計算 (永続化しない) 方針につき DB 書込み・新規スキーマ不要
+7. 点火検知用に短期スロープ (A 平均) での再ソート切替を用意
 
 ## 非スコープ
 
+- **Blue Dot 率 (rs_line 新高値) のグループ集計** (上記「事実整理」のとおり今回は採用しない)
+- momentum_pt (0〜99) の日次履歴の永続化とそのスロープ (= 案B、将来の再検討候補)
+  - momentum_pt は現状 stocks_shelve に最新値のみ保持 (`price.py:682`)。過去日の正確な遡及には過去時点の TOPIX rs_raw + calib が必要で都度計算は不正確。永続化は本機能の「DB 書込みなし」方針を破る
+  - MarketSmith の「グループランク (パーセンタイル) の時系列変化」に最も忠実なのは案B だが、本 PR では永続化不要で即動く案A (rs_line スロープ) を採用する。**案A の短期スロープがローテーション検知としてしっくりこない場合に、案B (momentum_pt 履歴) を別 issue で改めて検討する**
+- rs_line そのものの永続化 (#155 方針どおり都度計算)
 - テーマ指数 (price_log 累積) の構築
 - TOPIX 比 RS の再計算 (個別銘柄の `momentum_pt` が既に TOPIX 比正規化済みのため流用)
 - breadth 指標 (新高値率、25日線上比率、出来高増加率 等)
-- 時系列での 3 週前 / 6 週前ランク比較
-- 株探テーマ (`stock["themes"]`) ベースの指数
+- 株探テーマ (`stock["themes"]`) ベースの指数 (既存 `theme_rank` がカバー)
 - 銘柄スコアへの組込 (既存 40/20/25/15 配点は変更しない)
 - portfolio_theme_master の完了待ち (本機能は移行漏れ未登録テーマも含めてグルーピング)
 - DB 書込み (本画面は閲覧専用、リクエストごとに集計)
@@ -44,9 +79,10 @@ O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブ�
 |---|---|---|
 | portfolio_shelve | `record:<code_s>` の `memo["gyoutai_themes"]: list[str]` | テーマ → 銘柄の逆引き |
 | portfolio_shelve | `record:<code_s>` の `status` | excluded 除外、status ラベル表示 |
-| stocks_shelve | `<code_s>` の `momentum_pt` | テーマ集約 (平均 / 最大) の主指標 |
-| stocks_shelve | `<code_s>` の `price_log` | 20日 / 65日リターン算出 |
+| stocks_shelve | `<code_s>` の `momentum_pt` | 中長期層: テーマ集約 (平均 / 最大) の主指標 |
+| stocks_shelve | `<code_s>` の `price_log` | 20日 / 65日リターン算出 + rs_line 計算 |
 | stocks_shelve | `<code_s>` の `stock_name` | リーダー株表示 |
+| market_db (topix) | `price_log` | rs_line (= 銘柄終値 / TOPIX 終値) 計算の分母 |
 
 ### 構成銘柄の選定ルール
 
@@ -59,14 +95,16 @@ O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブ�
 ### 最小構成銘柄数
 
 - 制限なし。**1 銘柄のテーマも表示する**
-  - 軽量版の目的は「自分が組んだテーマ別の強弱を見る」ことなので、1 銘柄でも「そのテーマに自分が持っている / 監視している銘柄が 1 つしかない」という事実が見えるべき
-  - 構成銘柄数カラムを必ず表示し、ユーザーが少数構成の不安定さを目視で判断できるようにする
+  - 「そのテーマに自分が持っている / 監視している銘柄が 1 つしかない」という事実が見えるべき
+  - 構成銘柄数カラムを必ず表示し、少数構成の不安定さを目視で判断できるようにする
 
 ---
 
 ## 集計指標
 
 各テーマについて以下を計算。すべて構成銘柄の既存指標を **等加重で集約**。
+
+### 中長期リーダーシップ層 (slow)
 
 | 指標 | 定義 | 計算ソース |
 |---|---|---|
@@ -77,9 +115,28 @@ O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブ�
 | `ret_65d_avg` | 65 営業日リターン (%) の平均 | stocks_shelve `price_log` |
 | `leaders` | momentum_pt 降順上位 3 銘柄 | (code_s, stock_name, momentum_pt) の list |
 
-### momentum_pt が無い銘柄の扱い
+### 短期の値動き傾向層 (fast)
 
-- `momentum_pt` が None / 欠損のものは集計対象から除外 (count にも入れない方針は採らず、count はテーマに属する全銘柄数とする)
+既存 rs_line スロープ関数を業態テーマ単位で集約する。**新規 rs_line ロジックは書かず、既存純粋関数を呼び出して平均を取るだけ。**
+
+| 指標 | 定義 | 計算ソース (既存関数) |
+|---|---|---|
+| `slope_a_avg` | テーマ短期スロープ: 構成銘柄の rs_line 5日前比 (A) の平均 | `compute_rs_line_changes()` の A (`make_stock_db.py`) |
+| `slope_b_avg` | テーマ中期スロープ: 構成銘柄の rs_line 20日前比 (B) の平均 | `compute_rs_line_changes()` の B (`make_stock_db.py`) |
+
+#### rs_line 集約の計算量対策 (都度計算・キャッシュなし)
+
+- **キャッシュは入れない** (シンプル優先、既存 `theme_rank` / 銘柄詳細と同じく都度計算)
+- N+1 を避けるため、`make_stock_db._topix_close_map(market_db)` で **TOPIX 終値マップを 1 回だけ構築**し、全銘柄の rs_line 計算に `topix_map=` で渡す
+- **再計算回避と既存 API 不変更の両立** (codex 指摘②への対応): 銘柄ごとに `rs_line = compute_rs_line(stock, market_db, topix_map=topix_map)` を 1 回だけ計算し、A/B は既存内部関数 `make_stock_db._rs_line_changes_from_line(rs_line)` を helpers から直接呼んで `(a, b, _)` を得る
+  - 理由: 公開関数 `compute_rs_line_changes()` は `rs_line=` 引数を持たず内部で `compute_rs_line` を再呼び出しするため、これを使うと rs_line が二重計算になる。`_rs_line_changes_from_line` は rs_line を直接受ける純粋関数なので、計算済み rs_line をそのまま渡せる
+  - 既存関数のシグネチャは一切変更しない (API 変更なし)
+- 銘柄数 200・テーマ数 30 想定で 1 リクエスト数百 ms 見込み。rs_line 計算は price_log のスライス比較のみで重くない
+
+### 欠損銘柄の扱い
+
+- `momentum_pt` が None / 欠損のものは集計対象から除外 (count には含める = テーマに属する全銘柄数)
+- rs_line がデータ不足 (`_rs_line_changes_from_line` が A / B に None を返す) の銘柄は、その指標 (slope_a / slope_b) の平均から個別に除外する (A は取れるが B は None、というケースもあるため指標ごとに有効銘柄数で平均)
 - 集計対象が 0 銘柄ならその指標は `None` (テンプレ側で "—" 表示)
 
 ### リターン計算
@@ -87,12 +144,14 @@ O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブ�
 - `price_log` は `[(date, price), ...]` 形式で最新が先頭
 - `ret_Nd = (price_log[0][1] - price_log[N][1]) / price_log[N][1] * 100`
 - `len(price_log) <= N` の銘柄はその指標から除外
-- 計算自体は既存の他箇所で行われているはずだが、helpers 内で完結する小関数 `_calc_return_pct(price_log, days)` を本機能用に追加してよい。既存の似たユーティリティが見つかればそれを流用 (実装時に grep で確認)
+- helpers 内で完結する小関数 `_calc_return_pct(price_log, days)` を追加してよい
 
-### ソートキー
+### ソートキー (再ソート切替)
 
-デフォルト: `momentum_pt_avg` 降順 (None は末尾)
-将来のソート列追加は非スコープ (まずは単一ソートで運用)
+- **デフォルト (1次ソート)**: `momentum_pt_avg` 降順 (None は末尾) → 中長期リーダーシップ
+- **短期検知用の再ソート**: `slope_a_avg` (短期スロープ) 降順を切替可能にし、値動きが上向きつつある業態が上に来るようにする
+  - サーバ側でクエリパラメータ `?sort=momentum|slope_a` を受けて並べ替える
+  - 同点時は `member_count` 降順 → テーマ名昇順で安定ソート
 
 ---
 
@@ -101,35 +160,21 @@ O'Neil / MarketSmith のセクター RS 表示思想 (テーマ別 RS テーブ�
 ```python
 def build_portfolio_theme_summary(
     records: list[dict] | None = None,
+    sort_key: str = "momentum",
 ) -> list[dict]:
     """portfolio_shelve のユニバースを memo['gyoutai_themes'] でグルーピングし、
-    テーマごとの集約指標と上位リーダー株を返す。
+    テーマごとの中長期 (momentum_pt) + 短期 (rs_line スロープ) 集約指標と
+    上位リーダー株を返す。
 
-    Args:
-        records: portfolio_shelve.list_records(include_excluded=False) の戻り値。
-            None なら関数内で取得する (テスト時に注入できるよう引数化)。
-
-    Returns:
-        list[dict]: 各要素は
-            {
-                "theme": str,
-                "member_count": int,
-                "momentum_pt_avg": float | None,
-                "momentum_pt_max": float | None,
-                "ret_20d_avg": float | None,
-                "ret_65d_avg": float | None,
-                "leaders": list[{"code_s": str, "stock_name": str, "momentum_pt": float}],
-                "members": list[{"code_s": str, "stock_name": str, "momentum_pt": float | None,
-                                 "status": str}],
-            }
-        並び順は momentum_pt_avg 降順 (None は末尾) → テーマ名昇順。
+    sort_key: "momentum" | "slope_a"。
+    並び順は sort_key に従う (None は末尾) → member_count 降順 → テーマ名昇順。
     """
 ```
 
-- 既存 `_bulk_get_stock_data` を流用して 1 回でまとめて stock dict を取る
-- 銘柄名は `_bulk_resolve_stock_names` を流用
-- `members` フィールドはテンプレ側で行 expand 表示に使う (詳細表示)
-- 戻り値は完全な dict (テンプレで `.get` フォールバックを書かなくて済むようにキーは常に存在)
+- `_bulk_get_stock_data` / `_bulk_resolve_stock_names` を流用
+- market_db は `from make_market_db import get_market_db` の遅延 import で取得
+- rs_line 系は `from make_stock_db import compute_rs_line, _topix_close_map, _rs_line_changes_from_line` を遅延 import
+- 戻り値は完全な dict (テンプレで `.get` フォールバック不要)
 
 ---
 
@@ -139,45 +184,25 @@ def build_portfolio_theme_summary(
 
 | メソッド | パス | 用途 |
 |---|---|---|
-| GET | `/portfolio/themes/summary` | 業態テーマサマリー一覧表示 |
+| GET | `/portfolio/themes/summary` | 業態テーマ別 RS サマリー一覧表示 |
 
-- 既存 `portfolio` blueprint に追加
+- 既存 `portfolio` blueprint に追加、クエリ `?sort=momentum|slope_a` を受ける
 - POST 操作なし、PRG 不要
-- fallback_mode (= portfolio_shelve 空、`_build_fallback_records` で代用) の場合は空テーブル + 案内文を表示
+- fallback_mode (portfolio_shelve 空) は空テーブル + 案内文
 
 ### 新規テンプレート (`scripts/webapp/templates/portfolio_theme_summary.html`)
 
-レイアウト:
+中長期 slow と 短期スロープ fast を 1 行に併記。
 
-```
-[← ポートフォリオに戻る]
-
-業態テーマサマリー (NN テーマ / MM 銘柄)
-
-| テーマ        | 構成銘柄 | momentum_pt 平均 | 最大 | 20日 平均 | 65日 平均 | リーダー株 (top3)           |
-|--------------|---------|------------------|------|----------|----------|----------------------------|
-| AI半導体CAPEX | 6       | 78               | 92   | +12.4%   | +24.1%   | 6324 (92), 4063 (85), ...  |
-| 防衛          | 4       | 65               | 80   |  +5.1%   |  +9.2%   | 7011 (80), 6208 (72), ...  |
-| ...                                                                                                  |
-
-(各行は折り畳み可。展開で構成銘柄一覧を表示)
-```
-
-- リーダー株表示: `{code_s} ({momentum_pt})` 形式、`url_for("detail.stock_detail", code_s=row.code_s)` (実 URL: `/stock/<code_s>`) で既存銘柄詳細ページにリンク (portfolio_list.html line 249 と同じ導線)
-- 行クリック (または ▶ ボタン) で構成銘柄一覧を展開 (JS は最小限、`<details>` タグで実装可能)
-- momentum_pt 平均は条件付き書式: ≥ 70 で太字 + 緑、≤ 30 で赤 (既存 portfolio_list.html のスタイル流用)
-- 構成銘柄数が 1 の行は薄いマーカー (背景色) で「少数構成」とわかるようにする (ユーザーが信頼度を即判断できる)
+- リーダー株: `{code_s} ({momentum_pt})`、`url_for("detail.stock_detail", code_s=...)` でリンク
+- 行クリックで構成銘柄一覧を展開 (`<details>` タグ、JS 最小限)
+- 並べ替えリンクは現在の sort をハイライト
+- 条件付き書式: momentum_pt 平均 ≥70 緑太字 / ≤30 赤、スロープ 正で緑 / 負で赤
+- 構成銘柄数 1 の行は薄いマーカー (背景色) で「少数構成」を明示
 
 ### 既存 portfolio_list.html の変更
 
-ヘッダのテーマフィルタ select 付近 (162-167 行付近、`portfolio_theme_master` プランで「✏️ テーマを編集」ボタンを追加する位置と同じ領域) に **「📊 テーマサマリー」リンク** を追加。
-
-```html
-<a href="{{ url_for('portfolio.theme_summary') }}"
-   style="..." title="業態テーマ別サマリー">📊 テーマサマリー</a>
-```
-
-portfolio_theme_master プランとは UI 上は別ボタンとして共存させる (「✏️ テーマを編集」= マスター管理、「📊 テーマサマリー」= 集約閲覧)。
+ヘッダのテーマ編集ボタン隣に **「📊 テーマサマリー」リンク** を追加。
 
 ---
 
@@ -185,15 +210,15 @@ portfolio_theme_master プランとは UI 上は別ボタンとして共存さ�
 
 `tests/test_webapp_helpers.py` に parametrize で集約 (CLAUDE.md: 1 PR で 5 本以下):
 
-1. `build_portfolio_theme_summary` 基本ケース: 2 テーマ × 3 銘柄ずつで集約値が期待通り
+1. 基本ケース: 2 テーマ × 3 銘柄で中長期集約値が期待通り
 2. 同一銘柄が 2 テーマに属する場合、両テーマで集計される
 3. `momentum_pt` 欠損銘柄は集計から除外されるが member_count には含まれる
-4. `price_log` 長さ不足の銘柄は ret_Nd_avg から除外される
-5. `leaders` は momentum_pt 降順上位 3 (同点時は code_s 昇順で安定ソート)
+4. 短期層: slope_a_avg / slope_b_avg が既存 rs_line 関数の集約値と一致し、データ不足銘柄は各指標から除外
+5. `sort_key` 切替: momentum / slope_a でそれぞれ期待順に並ぶ
 
 WebApp ルートのテストは `tests/test_webapp_routes.py` に 1 本追加:
 
-- `GET /portfolio/themes/summary` が 200 で返り、テンプレートに「業態テーマサマリー」文字列を含む (smoke)
+- `GET /portfolio/themes/summary` および `?sort=slope_a` が 200 で返り、テンプレートに「業態テーマ別 RS サマリー」文字列を含む
 
 ---
 
@@ -202,22 +227,36 @@ WebApp ルートのテストは `tests/test_webapp_routes.py` に 1 本追加:
 1. `pytest tests/test_webapp_helpers.py tests/test_webapp_routes.py -v` 通過
 2. `python -m webapp.app` 起動 → `/portfolio` ヘッダから「📊 テーマサマリー」リンクが見える
 3. `/portfolio/themes/summary` でテーマ一覧が momentum_pt 平均降順に並ぶ
-4. 構成銘柄数 1 のテーマも表示され、視覚マーカーが付く
-5. 行展開で構成銘柄が momentum_pt 降順で並ぶ
-6. fallback_mode (portfolio_shelve 空) では空テーブル + 案内文が出る
+4. 並べ替えを「短期スロープ(A)」に切替で順序が変わる
+5. 短期スロープ / 中期スロープカラムが表示され、rs_line 計算可能な銘柄で値が入る
+6. 構成銘柄数 1 のテーマも表示され、視覚マーカーが付く
+7. 行展開で構成銘柄が momentum_pt 降順で並ぶ
+8. fallback_mode (portfolio_shelve 空) では空テーブル + 案内文が出る
 
 ---
 
 ## ロールバック
 
-- webapp / helpers / templates の追加のみで、既存スキーマ・既存テンプレ・既存挙動への破壊的変更なし
-- git revert で完全に戻せる
-- DB 書込みなしのため、ロールバック後のデータ整合性問題は発生しない
+- webapp / helpers / templates の追加のみで、既存スキーマ・既存挙動への破壊的変更なし
+- 既存 rs_line 関数は呼び出すだけ (改変しない、API 変更なし)
+- git revert で完全に戻せる。DB 書込みなし
 
 ---
 
+## 依存関係
+
+- 短期層は **#155 (rs_line) の指標 A / B 実装完了が前提**。実装済み:
+  - `compute_rs_line_changes()` (A / B) / `_rs_line_changes_from_line()` — `make_stock_db.py:288 / 332`
+  - `compute_rs_line()` / `_topix_close_map()` — `make_stock_db.py`
+
 ## 想定リスク
 
-- **テーマ名の表記揺れ**: portfolio_theme_master 完了前は同義語・誤字が別テーマとして集計される。本機能は移行漏れも「そのまま」表示する方針なので、ユーザーは表記揺れに気づいて手動修正できる (むしろ可視化の副次効果として有用)。
-- **構成銘柄 1 のテーマ**: momentum_pt 平均 = その銘柄自体になり「テーマ集約」としては意味が薄い。マーカー表示で目視抑制し、ユーザー判断に委ねる (除外しない)。
-- **集計コスト**: テーマ数 30、銘柄数 200 想定で 1 リクエストあたり数十 ms 程度の見込み。`_bulk_get_stock_data` 流用で N+1 を回避すれば問題なし。リクエストごとに再計算するが、キャッシュは入れない (シンプル優先)。
+- **テーマ名の表記揺れ**: portfolio_theme_master 完了前は同義語・誤字が別テーマとして集計される。可視化の副次効果として有用なのでそのまま表示
+- **構成銘柄 1 のテーマ**: momentum_pt 平均 = その銘柄自体。マーカー表示で目視抑制
+- **rs_line 計算コスト**: `_topix_close_map` を 1 回構築 + 銘柄ごと rs_line 1 回計算 + `_rs_line_changes_from_line` に渡して再計算回避すれば数百 ms 程度。キャッシュなし
+- **内部関数 `_rs_line_changes_from_line` への依存**: 先頭 `_` の非公開関数を helpers から呼ぶ。既存 `get_rs_line_changes_expr` も同じ内部関数を使っており、変更時は両方が影響を受ける既知の結合
+
+## 実装規模見込み
+
+- helpers 1 関数 + 小ヘルパー (`~90 行`)、ルート 1 本 (`~40 行`)、テンプレート 1 枚 (`~110 行`)、テスト 6 本
+- 合計 250〜280 行程度。1 PR で完結予定

--- a/doc/plan/portfolio_theme_summary.md
+++ b/doc/plan/portfolio_theme_summary.md
@@ -128,15 +128,15 @@ issue #283 の検討過程で「グループの点火を RS ライン新高値 (
 
 - **キャッシュは入れない** (シンプル優先、既存 `theme_rank` / 銘柄詳細と同じく都度計算)
 - N+1 を避けるため、`make_stock_db._topix_close_map(market_db)` で **TOPIX 終値マップを 1 回だけ構築**し、全銘柄の rs_line 計算に `topix_map=` で渡す
-- **再計算回避と既存 API 不変更の両立** (codex 指摘②への対応): 銘柄ごとに `rs_line = compute_rs_line(stock, market_db, topix_map=topix_map)` を 1 回だけ計算し、A/B は既存内部関数 `make_stock_db._rs_line_changes_from_line(rs_line)` を helpers から直接呼んで `(a, b, _)` を得る
-  - 理由: 公開関数 `compute_rs_line_changes()` は `rs_line=` 引数を持たず内部で `compute_rs_line` を再呼び出しするため、これを使うと rs_line が二重計算になる。`_rs_line_changes_from_line` は rs_line を直接受ける純粋関数なので、計算済み rs_line をそのまま渡せる
+- **公開 API を使い private 関数には依存しない** (simplify レビューでの方針確定): 銘柄ごとに公開関数 `compute_rs_line_changes(stock, market_db, topix_map=topix_map)` を呼んで `(A, B)` を得る。`topix_map` を渡すことで内部 `compute_rs_line` の TOPIX マップ再構築を避ける
+  - 当初は再計算回避のため内部関数 `_rs_line_changes_from_line(rs_line)` を直接呼ぶ案だったが、private 関数への越境依存 (カプセル化の崩れ・テストの脆さ) を避けるため公開 API に統一。`compute_rs_line` の二重計算は発生するが、ポートフォリオは数百銘柄規模で影響は無視できる
   - 既存関数のシグネチャは一切変更しない (API 変更なし)
 - 銘柄数 200・テーマ数 30 想定で 1 リクエスト数百 ms 見込み。rs_line 計算は price_log のスライス比較のみで重くない
 
 ### 欠損銘柄の扱い
 
 - `momentum_pt` が None / 欠損のものは集計対象から除外 (count には含める = テーマに属する全銘柄数)
-- rs_line がデータ不足 (`_rs_line_changes_from_line` が A / B に None を返す) の銘柄は、その指標 (slope_a / slope_b) の平均から個別に除外する (A は取れるが B は None、というケースもあるため指標ごとに有効銘柄数で平均)
+- rs_line がデータ不足 (`compute_rs_line_changes` が A / B に None を返す) の銘柄は、その指標 (slope_a / slope_b) の平均から個別に除外する (A は取れるが B は None、というケースもあるため指標ごとに有効銘柄数で平均)
 - 集計対象が 0 銘柄ならその指標は `None` (テンプレ側で "—" 表示)
 
 ### リターン計算
@@ -173,7 +173,7 @@ def build_portfolio_theme_summary(
 
 - `_bulk_get_stock_data` / `_bulk_resolve_stock_names` を流用
 - market_db は `from make_market_db import get_market_db` の遅延 import で取得
-- rs_line 系は `from make_stock_db import compute_rs_line, _topix_close_map, _rs_line_changes_from_line` を遅延 import
+- rs_line 系は `from make_stock_db import compute_rs_line_changes, _topix_close_map` を遅延 import
 - 戻り値は完全な dict (テンプレで `.get` フォールバック不要)
 
 ---
@@ -246,15 +246,14 @@ WebApp ルートのテストは `tests/test_webapp_routes.py` に 1 本追加:
 ## 依存関係
 
 - 短期層は **#155 (rs_line) の指標 A / B 実装完了が前提**。実装済み:
-  - `compute_rs_line_changes()` (A / B) / `_rs_line_changes_from_line()` — `make_stock_db.py:288 / 332`
+  - `compute_rs_line_changes()` (A / B) — `make_stock_db.py:288`
   - `compute_rs_line()` / `_topix_close_map()` — `make_stock_db.py`
 
 ## 想定リスク
 
 - **テーマ名の表記揺れ**: portfolio_theme_master 完了前は同義語・誤字が別テーマとして集計される。可視化の副次効果として有用なのでそのまま表示
 - **構成銘柄 1 のテーマ**: momentum_pt 平均 = その銘柄自体。マーカー表示で目視抑制
-- **rs_line 計算コスト**: `_topix_close_map` を 1 回構築 + 銘柄ごと rs_line 1 回計算 + `_rs_line_changes_from_line` に渡して再計算回避すれば数百 ms 程度。キャッシュなし
-- **内部関数 `_rs_line_changes_from_line` への依存**: 先頭 `_` の非公開関数を helpers から呼ぶ。既存 `get_rs_line_changes_expr` も同じ内部関数を使っており、変更時は両方が影響を受ける既知の結合
+- **rs_line 計算コスト**: `_topix_close_map` を 1 回構築 + 銘柄ごと `compute_rs_line_changes` を呼ぶ (同一銘柄が複数テーマに属しても slope_by_code で 1 回に集約)。数百銘柄規模で数百 ms 程度。キャッシュなし
 
 ## 実装規模見込み
 

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -362,10 +362,11 @@ def _rs_line_changes_from_line(rs_line):
     b = _deviation(20)
     if b is not None:
         return (a, b, False)
-    for window in (19, 18, 17, 16, 15):
-        b = _deviation(window)
-        if b is not None:
-            return (a, b, True)
+    # 20 本に満たないときは、データ長に収まる最大 window (15-19 本) の平均で代替する。
+    # MA 版では _deviation(window) が None になるのは len < window のときだけなので、
+    # 試すべき window は min(len, 19) の 1 つに定まる (15 本未満なら代替不可)。
+    if len(rs_line) >= 15:
+        return (a, _deviation(min(len(rs_line), 19)), True)
     return (a, None, False)
 
 

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -286,17 +286,18 @@ def compute_rs_line(stock, market_db, topix_map=None):
 
 
 def compute_rs_line_changes(stock, market_db, topix_map=None):
-    """rs_line の 5日前比 A・20日前比 B 騰落率を%値で計算する。
+    """rs_line の「今日 vs 直近 N 日移動平均」乖離率 A・B を%値で計算する (issue #283)。
 
-    20日前データが無い場合は 19,18,17,16,15日前の順に代替 (B は近似値)。
+    A = 直近 5 日平均乖離率、B = 直近 20 日平均乖離率。20 本に満たない場合は
+    19,18,17,16,15 本平均で B を代替 (近似値)。
 
     Returns:
         tuple[float|None, float|None]: (短期A%, 中期B%)
-            - rs_line が 6本未満 → (None, None)
-            - rs_line が 6本以上16本未満 → (A, None)
-            - rs_line が 16本以上21本未満 → (A, B_approx) ※15-19日前で代替
-            - rs_line が 21本以上 → (A, B)
-            past値が0の場合も None
+            - rs_line が 5本未満 → (None, None)
+            - rs_line が 5本以上15本未満 → (A, None)
+            - rs_line が 15本以上20本未満 → (A, B_approx) ※15-19本平均で代替
+            - rs_line が 20本以上 → (A, B)
+            移動平均が0の場合も None
     """
     rs_line = compute_rs_line(stock, market_db, topix_map=topix_map)
     a, b, _ = _rs_line_changes_from_line(rs_line)
@@ -309,13 +310,14 @@ def _fmt_rs_change(v):
 
 
 def get_rs_line_changes_expr(stock, market_db, topix_map=None, rs_line=None):
-    """rs_line 騰落率を CSV 表示用の '中期B%/短期A%' 文字列にする。
+    """rs_line の移動平均乖離率を CSV 表示用の '中期B%/短期A%' 文字列にする。
 
+    A = 5日平均乖離率、B = 20日平均乖離率 (issue #283 で N日前比から MA 乖離率に変更)。
     rs_line を渡せば再計算をスキップする (CSV ループで複数の rs_line 系関数を
     呼ぶ際に共有するため)。
 
     Returns:
-        str: 例 "+12/+5"。20日比が 15-19日前で代替された場合は末尾 * を付ける
+        str: 例 "+12/+5"。20日比が 15-19本平均で代替された場合は末尾 * を付ける
             (例: "+12*/+5")。両方計算不能なら "" 、片方のみなら "-/+5" 等
     """
     if rs_line is None:
@@ -330,31 +332,38 @@ def get_rs_line_changes_expr(stock, market_db, topix_map=None, rs_line=None):
 
 
 def _rs_line_changes_from_line(rs_line):
-    """rs_line 系列から 5日前比 A・20日前比 B 騰落率を計算する内部関数
+    """rs_line 系列から「今日 vs 直近 N 日移動平均」の乖離率 A・B を計算する内部関数。
+
+    A = 直近 5 日平均乖離率、B = 直近 20 日平均乖離率 (いずれも今日 rs_line[0] を含む)。
+    1 点比較 (旧: N 日前の 1 点との比) ではヒゲ・急変でブレるため、基準を移動平均にして
+    ブレを 1/N に薄め、勢い・過熱の度合いを安定して捉える (issue #283)。
 
     Returns:
         tuple[float|None, float|None, bool]: (A, B, B が代替値か)
-            B は offset 20 で取れなければ 19,18,17,16,15 の順に代替。
-            代替を使った場合 b_is_approx=True。
+            乖離率 = (rs_line[0] - mean(直近 window 本)) / mean(直近 window 本) * 100。
+            A は window=5 (5 本未満は None)。
+            B は window=20、20 本未満なら 19,18,17,16,15 本平均で代替 (b_is_approx=True)。
+            平均が 0 の場合も None。
     """
     if not rs_line:
         return (None, None, False)
     current = rs_line[0][1]
 
-    def _change(offset):
-        if len(rs_line) <= offset:
+    def _deviation(window):
+        """今日 rs_line[0] と直近 window 本 (今日含む) の平均との乖離率%。"""
+        if len(rs_line) < window:
             return None
-        past = rs_line[offset][1]
-        if past == 0:
+        ma = sum(v for _, v in rs_line[:window]) / window
+        if ma == 0:
             return None
-        return (current - past) / past * 100
+        return (current - ma) / ma * 100
 
-    a = _change(5)
-    b = _change(20)
+    a = _deviation(5)
+    b = _deviation(20)
     if b is not None:
         return (a, b, False)
-    for offset in (19, 18, 17, 16, 15):
-        b = _change(offset)
+    for window in (19, 18, 17, 16, 15):
+        b = _deviation(window)
         if b is not None:
             return (a, b, True)
     return (a, None, False)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2965,6 +2965,14 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
 # 業態テーマ別 RS サマリー (issue #283)
 # ===========================================
 
+# sort_key (UI/URL) → 並べ替えに使う集計フィールド名。許可キーの真実はここに集約し、
+# ルート側の allowlist もこの keys() を参照する (二重定義を避ける)。
+THEME_SUMMARY_SORT_FIELDS = {
+    "momentum": "momentum_pt_avg",
+    "dev_a": "dev_a_avg",
+}
+
+
 def _avg_or_none(values: List[float]) -> Optional[float]:
     """None を含まない値リストの平均。空なら None。"""
     return sum(values) / len(values) if values else None
@@ -3088,7 +3096,7 @@ def build_portfolio_theme_summary(
         })
 
     # ソート: sort_key 降順 (None 末尾) → member_count 降順 → テーマ名昇順
-    primary = "dev_a_avg" if sort_key == "dev_a" else "momentum_pt_avg"
+    primary = THEME_SUMMARY_SORT_FIELDS.get(sort_key, "momentum_pt_avg")
     result.sort(key=lambda r: (
         r[primary] is None,
         -(r[primary] or 0),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2941,3 +2941,167 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
         styles["market_cap"] = bg("薄黄")
 
     return styles
+
+
+# ===========================================
+# 業態テーマ別 RS サマリー (issue #283)
+# ===========================================
+
+def _calc_return_pct(price_log: List, days: int) -> Optional[float]:
+    """price_log (新しい順 [(date, price), ...]) の days 営業日リターン (%) を返す。
+
+    len(price_log) <= days の銘柄は None (計算不能)。基準価格 0 も None。
+    """
+    if not price_log or len(price_log) <= days:
+        return None
+    cur = price_log[0][1]
+    past = price_log[days][1]
+    if not past:
+        return None
+    return (cur - past) / past * 100.0
+
+
+def _avg_or_none(values: List[float]) -> Optional[float]:
+    """None を含まない値リストの平均。空なら None。"""
+    return sum(values) / len(values) if values else None
+
+
+def build_portfolio_theme_summary(
+    records: Optional[List[Dict[str, Any]]] = None,
+    sort_key: str = "momentum",
+) -> List[Dict[str, Any]]:
+    """portfolio_shelve のユニバースを memo['gyoutai_themes'] でグルーピングし、
+    テーマごとの中長期 (momentum_pt) + 短期 (rs_line スロープ) 集約指標と
+    上位リーダー株を返す (issue #283)。
+
+    Args:
+        records: portfolio_shelve.list_records(include_excluded=False) の戻り値。
+            None なら関数内で取得する (テスト時に注入できるよう引数化)。
+        sort_key: "momentum" | "slope_a"。並べ替えキー。
+
+    Returns:
+        list[dict]: 各テーマの集約 dict。並び順は sort_key に従う
+            (None は末尾) → member_count 降順 → テーマ名昇順。
+    """
+    if records is None:
+        import portfolio_shelve as ps  # 遅延 import (循環回避)
+        records = ps.list_records(include_excluded=False)
+
+    # テーマ → [code_s, ...] の逆引き (スロット最大2を両方展開、空は無視)
+    theme_to_codes: Dict[str, List[str]] = {}
+    for rec in records:
+        code_s = rec.get("code_s", "")
+        if not code_s:
+            continue
+        themes = (rec.get("memo") or {}).get("gyoutai_themes") or []
+        for t in themes:
+            if not isinstance(t, str):
+                continue
+            name = t.strip()
+            if not name:
+                continue
+            theme_to_codes.setdefault(name, []).append(code_s)
+    if not theme_to_codes:
+        return []
+
+    # status ラベル参照用に code_s → status を引けるようにする
+    status_by_code = {r.get("code_s", ""): r.get("status", "") for r in records}
+
+    all_codes = sorted({c for codes in theme_to_codes.values() for c in codes})
+    stock_map = _bulk_get_stock_data(all_codes)
+    name_map = _bulk_resolve_stock_names(all_codes)
+
+    # rs_line 計算の共有リソース (issue #283: N+1 回避、再計算回避)
+    try:
+        from make_market_db import get_market_db  # 遅延 import (循環回避)
+        market_db = get_market_db()
+    except Exception:  # noqa: BLE001
+        market_db = None
+    topix_map = None
+    if market_db is not None:
+        try:
+            from make_stock_db import _topix_close_map  # 遅延 import
+            topix_map = _topix_close_map(market_db)
+        except Exception:  # noqa: BLE001
+            topix_map = None
+
+    # 銘柄ごとの rs_line スロープ (A, B) を 1 回だけ計算してキャッシュ。
+    # 公開 API compute_rs_line_changes を使う (private 関数には依存しない)。
+    # topix_map を渡すことで内部 compute_rs_line の TOPIX マップ再構築を避ける。
+    slope_by_code: Dict[str, tuple] = {}
+    if market_db is not None and topix_map:
+        from make_stock_db import compute_rs_line_changes  # 遅延 import
+        for code_s in all_codes:
+            stock = stock_map.get(code_s) or {}
+            try:
+                a, b = compute_rs_line_changes(stock, market_db, topix_map=topix_map)
+            except Exception:  # noqa: BLE001
+                a, b = None, None
+            slope_by_code[code_s] = (a, b)
+
+    result: List[Dict[str, Any]] = []
+    for theme, codes in theme_to_codes.items():
+        members: List[Dict[str, Any]] = []
+        mom_values: List[float] = []
+        ret20_values: List[float] = []
+        ret65_values: List[float] = []
+        slope_a_values: List[float] = []
+        slope_b_values: List[float] = []
+        for code_s in codes:
+            stock = stock_map.get(code_s) or {}
+            mom = stock.get("momentum_pt")
+            if isinstance(mom, (int, float)):
+                mom_values.append(float(mom))
+            price_log = stock.get("price_log") or []
+            r20 = _calc_return_pct(price_log, 20)
+            r65 = _calc_return_pct(price_log, 65)
+            if r20 is not None:
+                ret20_values.append(r20)
+            if r65 is not None:
+                ret65_values.append(r65)
+            a, b = slope_by_code.get(code_s, (None, None))
+            if a is not None:
+                slope_a_values.append(a)
+            if b is not None:
+                slope_b_values.append(b)
+            members.append({
+                "code_s": code_s,
+                "stock_name": name_map.get(code_s, "") or "",
+                "momentum_pt": float(mom) if isinstance(mom, (int, float)) else None,
+                "status": _PORTFOLIO_STATUS_LABEL.get(
+                    status_by_code.get(code_s, ""), status_by_code.get(code_s, "")
+                ),
+            })
+        # members を momentum_pt 降順 (None 末尾) → code_s 昇順で並べる
+        members.sort(key=lambda m: (
+            m["momentum_pt"] is None,
+            -(m["momentum_pt"] or 0),
+            m["code_s"],
+        ))
+        leaders = [
+            {"code_s": m["code_s"], "stock_name": m["stock_name"],
+             "momentum_pt": m["momentum_pt"]}
+            for m in members if m["momentum_pt"] is not None
+        ][:3]
+        result.append({
+            "theme": theme,
+            "member_count": len(codes),
+            "momentum_pt_avg": _avg_or_none(mom_values),
+            "momentum_pt_max": max(mom_values) if mom_values else None,
+            "ret_20d_avg": _avg_or_none(ret20_values),
+            "ret_65d_avg": _avg_or_none(ret65_values),
+            "slope_a_avg": _avg_or_none(slope_a_values),
+            "slope_b_avg": _avg_or_none(slope_b_values),
+            "leaders": leaders,
+            "members": members,
+        })
+
+    # ソート: sort_key 降順 (None 末尾) → member_count 降順 → テーマ名昇順
+    primary = "slope_a_avg" if sort_key == "slope_a" else "momentum_pt_avg"
+    result.sort(key=lambda r: (
+        r[primary] is None,
+        -(r[primary] or 0),
+        -r["member_count"],
+        r["theme"],
+    ))
+    return result

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2155,6 +2155,23 @@ def _format_total_change(values: List[float], window: int) -> str:
     return f"{pct:+.1f}%"
 
 
+def _format_ma_deviation(values: List[float], window: int) -> str:
+    """最新値 (values[-1]) と直近 window 本 (今日含む) の移動平均との乖離率を整形する。
+
+    RSライン tooltip 用 (issue #283)。1 点比較ではなく移動平均基準にすることで
+    ヒゲ・急変のブレを薄め、勢い・過熱の度合いを安定して見せる。
+    values は古い順 (最新が末尾)。データ不足時は取得できるだけで計算。0 除算は "—"。
+    """
+    if not values or window <= 0:
+        return "—"
+    recent = values[-window:] if len(values) >= window else values
+    ma = sum(recent) / len(recent)
+    if ma == 0:
+        return "—"
+    pct = (values[-1] - ma) / ma * 100
+    return f"{pct:+.1f}%"
+
+
 def _build_chart_tooltip(
     price_values: List[float],
     rs_values: List[float],
@@ -2163,15 +2180,16 @@ def _build_chart_tooltip(
 ) -> str:
     """チャート tooltip (title 属性向け) を生成する。
 
-    20本 / 5本 の合計騰落率を見せる。平均ではなく合計なので、期間内の動きが
-    そのまま % で読める (例: 「20で +5%, 5で -26%」のような乖離パターンが分かる)。
+    株価行は 20本 / 5本 の合計騰落率 (期間内の動きがそのまま % で読める)。
+    RSライン行は移動平均乖離率 (今日 vs 直近 20本/5本平均、issue #283)。1 点比較
+    だとヒゲでブレるため、平均基準で勢い・過熱を安定して見せる。
     unit_label は "日" (日足 mini) / "週" (週足 full) を切り替える。
     """
     lines = [
         f"株価: 20{unit_label} {_format_total_change(price_values, _SPARK_LOOKBACK)}, "
         f"5{unit_label} {_format_total_change(price_values, _SPARK_RECENT)}",
-        f"RSライン: 20{unit_label} {_format_total_change(rs_values, _SPARK_LOOKBACK)}, "
-        f"5{unit_label} {_format_total_change(rs_values, _SPARK_RECENT)}",
+        f"RSライン乖離: 20{unit_label}平均 {_format_ma_deviation(rs_values, _SPARK_LOOKBACK)}, "
+        f"5{unit_label}平均 {_format_ma_deviation(rs_values, _SPARK_RECENT)}",
     ]
     if has_blue_dot:
         lines.append("新高値: ●")
@@ -2947,20 +2965,6 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
 # 業態テーマ別 RS サマリー (issue #283)
 # ===========================================
 
-def _calc_return_pct(price_log: List, days: int) -> Optional[float]:
-    """price_log (新しい順 [(date, price), ...]) の days 営業日リターン (%) を返す。
-
-    len(price_log) <= days の銘柄は None (計算不能)。基準価格 0 も None。
-    """
-    if not price_log or len(price_log) <= days:
-        return None
-    cur = price_log[0][1]
-    past = price_log[days][1]
-    if not past:
-        return None
-    return (cur - past) / past * 100.0
-
-
 def _avg_or_none(values: List[float]) -> Optional[float]:
     """None を含まない値リストの平均。空なら None。"""
     return sum(values) / len(values) if values else None
@@ -2977,7 +2981,7 @@ def build_portfolio_theme_summary(
     Args:
         records: portfolio_shelve.list_records(include_excluded=False) の戻り値。
             None なら関数内で取得する (テスト時に注入できるよう引数化)。
-        sort_key: "momentum" | "slope_a"。並べ替えキー。
+        sort_key: "momentum" | "dev_a"。並べ替えキー。
 
     Returns:
         list[dict]: 各テーマの集約 dict。並び順は sort_key に従う
@@ -3028,7 +3032,8 @@ def build_portfolio_theme_summary(
     # 銘柄ごとの rs_line スロープ (A, B) を 1 回だけ計算してキャッシュ。
     # 公開 API compute_rs_line_changes を使う (private 関数には依存しない)。
     # topix_map を渡すことで内部 compute_rs_line の TOPIX マップ再構築を避ける。
-    slope_by_code: Dict[str, tuple] = {}
+    # (a, b) = 今日 vs 直近5日/20日移動平均の乖離率 = 勢いオシレーター。
+    dev_by_code: Dict[str, tuple] = {}
     if market_db is not None and topix_map:
         from make_stock_db import compute_rs_line_changes  # 遅延 import
         for code_s in all_codes:
@@ -3037,33 +3042,24 @@ def build_portfolio_theme_summary(
                 a, b = compute_rs_line_changes(stock, market_db, topix_map=topix_map)
             except Exception:  # noqa: BLE001
                 a, b = None, None
-            slope_by_code[code_s] = (a, b)
+            dev_by_code[code_s] = (a, b)
 
     result: List[Dict[str, Any]] = []
     for theme, codes in theme_to_codes.items():
         members: List[Dict[str, Any]] = []
         mom_values: List[float] = []
-        ret20_values: List[float] = []
-        ret65_values: List[float] = []
-        slope_a_values: List[float] = []
-        slope_b_values: List[float] = []
+        dev_a_values: List[float] = []
+        dev_b_values: List[float] = []
         for code_s in codes:
             stock = stock_map.get(code_s) or {}
             mom = stock.get("momentum_pt")
             if isinstance(mom, (int, float)):
                 mom_values.append(float(mom))
-            price_log = stock.get("price_log") or []
-            r20 = _calc_return_pct(price_log, 20)
-            r65 = _calc_return_pct(price_log, 65)
-            if r20 is not None:
-                ret20_values.append(r20)
-            if r65 is not None:
-                ret65_values.append(r65)
-            a, b = slope_by_code.get(code_s, (None, None))
+            a, b = dev_by_code.get(code_s, (None, None))
             if a is not None:
-                slope_a_values.append(a)
+                dev_a_values.append(a)
             if b is not None:
-                slope_b_values.append(b)
+                dev_b_values.append(b)
             members.append({
                 "code_s": code_s,
                 "stock_name": name_map.get(code_s, "") or "",
@@ -3078,26 +3074,21 @@ def build_portfolio_theme_summary(
             -(m["momentum_pt"] or 0),
             m["code_s"],
         ))
-        leaders = [
-            {"code_s": m["code_s"], "stock_name": m["stock_name"],
-             "momentum_pt": m["momentum_pt"]}
-            for m in members if m["momentum_pt"] is not None
-        ][:3]
+        # members は momentum_pt 降順済み。先頭から非 None 上位 3 件がリーダー株
+        leaders = [m for m in members if m["momentum_pt"] is not None][:3]
         result.append({
             "theme": theme,
             "member_count": len(codes),
             "momentum_pt_avg": _avg_or_none(mom_values),
             "momentum_pt_max": max(mom_values) if mom_values else None,
-            "ret_20d_avg": _avg_or_none(ret20_values),
-            "ret_65d_avg": _avg_or_none(ret65_values),
-            "slope_a_avg": _avg_or_none(slope_a_values),
-            "slope_b_avg": _avg_or_none(slope_b_values),
+            "dev_a_avg": _avg_or_none(dev_a_values),
+            "dev_b_avg": _avg_or_none(dev_b_values),
             "leaders": leaders,
             "members": members,
         })
 
     # ソート: sort_key 降順 (None 末尾) → member_count 降順 → テーマ名昇順
-    primary = "slope_a_avg" if sort_key == "slope_a" else "momentum_pt_avg"
+    primary = "dev_a_avg" if sort_key == "dev_a" else "momentum_pt_avg"
     result.sort(key=lambda r: (
         r[primary] is None,
         -(r[primary] or 0),

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -22,6 +22,7 @@ from flask import Blueprint, flash, jsonify, redirect, render_template, request,
 import portfolio
 import portfolio_shelve as ps
 from webapp.helpers import (
+    THEME_SUMMARY_SORT_FIELDS,
     build_portfolio_theme_summary,
     compute_cell_styles,
     get_stock_data,
@@ -671,7 +672,8 @@ def dashboard():
 # 業態テーマ別 RS サマリー (issue #283)
 # ===========================================
 
-THEME_SUMMARY_SORT_KEYS = {"momentum", "dev_a"}
+# 許可 sort_key は helper のマッピング (真実の源) から導出する
+THEME_SUMMARY_SORT_KEYS = set(THEME_SUMMARY_SORT_FIELDS)
 DEFAULT_THEME_SUMMARY_SORT = "momentum"
 
 
@@ -700,7 +702,7 @@ def theme_summary():
 
     sort_urls = {
         k: url_for("portfolio.theme_summary", sort=k)
-        for k in ("momentum", "dev_a")
+        for k in THEME_SUMMARY_SORT_KEYS
     }
     return render_template(
         "portfolio_theme_summary.html",

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -671,7 +671,7 @@ def dashboard():
 # 業態テーマ別 RS サマリー (issue #283)
 # ===========================================
 
-THEME_SUMMARY_SORT_KEYS = {"momentum", "slope_a"}
+THEME_SUMMARY_SORT_KEYS = {"momentum", "dev_a"}
 DEFAULT_THEME_SUMMARY_SORT = "momentum"
 
 
@@ -680,10 +680,10 @@ def theme_summary():
     """業態テーマ別 RS サマリー (閲覧専用、issue #283)。
 
     手動付けした業態テーマ (memo.gyoutai_themes) でユニバースをグルーピングし、
-    momentum_pt (中長期) と rs_line スロープ (短期) を集約表示する。
+    momentum_pt (中長期) と rs_line 移動平均乖離オシレーター (短期の勢い) を集約表示する。
 
     URL クエリ:
-      sort: momentum / slope_a (省略時=momentum)
+      sort: momentum / dev_a (省略時=momentum)
     """
     sort_key = (request.args.get("sort") or "").strip()
     if sort_key not in THEME_SUMMARY_SORT_KEYS:
@@ -700,7 +700,7 @@ def theme_summary():
 
     sort_urls = {
         k: url_for("portfolio.theme_summary", sort=k)
-        for k in ("momentum", "slope_a")
+        for k in ("momentum", "dev_a")
     }
     return render_template(
         "portfolio_theme_summary.html",

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -22,6 +22,7 @@ from flask import Blueprint, flash, jsonify, redirect, render_template, request,
 import portfolio
 import portfolio_shelve as ps
 from webapp.helpers import (
+    build_portfolio_theme_summary,
     compute_cell_styles,
     get_stock_data,
     list_portfolio_with_indicators,
@@ -663,6 +664,51 @@ def dashboard():
         theme_master=theme_master,
         gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
         hold_summary=hold_summary,
+    )
+
+
+# ===========================================
+# 業態テーマ別 RS サマリー (issue #283)
+# ===========================================
+
+THEME_SUMMARY_SORT_KEYS = {"momentum", "slope_a"}
+DEFAULT_THEME_SUMMARY_SORT = "momentum"
+
+
+@portfolio_bp.route("/portfolio/themes/summary", methods=["GET"])
+def theme_summary():
+    """業態テーマ別 RS サマリー (閲覧専用、issue #283)。
+
+    手動付けした業態テーマ (memo.gyoutai_themes) でユニバースをグルーピングし、
+    momentum_pt (中長期) と rs_line スロープ (短期) を集約表示する。
+
+    URL クエリ:
+      sort: momentum / slope_a (省略時=momentum)
+    """
+    sort_key = (request.args.get("sort") or "").strip()
+    if sort_key not in THEME_SUMMARY_SORT_KEYS:
+        sort_key = DEFAULT_THEME_SUMMARY_SORT
+
+    fallback_mode = _is_fallback_mode()
+    # fallback (portfolio_shelve 空) では空テーブル + 案内文。
+    if fallback_mode:
+        themes: list = []
+        total_members = 0
+    else:
+        themes = build_portfolio_theme_summary(sort_key=sort_key)
+        total_members = sum(t["member_count"] for t in themes)
+
+    sort_urls = {
+        k: url_for("portfolio.theme_summary", sort=k)
+        for k in ("momentum", "slope_a")
+    }
+    return render_template(
+        "portfolio_theme_summary.html",
+        themes=themes,
+        total_members=total_members,
+        active_sort=sort_key,
+        sort_urls=sort_urls,
+        fallback_mode=fallback_mode,
     )
 
 

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -170,6 +170,9 @@
   <a href="{{ url_for('portfolio.themes_index') }}"
      style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
      title="テーママスターを編集">✏️ テーマを編集</a>
+  <a href="{{ url_for('portfolio.theme_summary') }}"
+     style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
+     title="業態テーマ別 RS サマリー">📊 テーマサマリー</a>
 </form>
 
 <p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">

--- a/scripts/webapp/templates/portfolio_theme_summary.html
+++ b/scripts/webapp/templates/portfolio_theme_summary.html
@@ -17,8 +17,8 @@
   table.theme-summary .member-list { margin: 0.3em 0 0.3em 1em; font-size: 0.85em; color: #444; }
   .mom-strong { font-weight: 700; color: #060; }
   .mom-weak { color: #c00; }
-  .slope-up { color: #060; }
-  .slope-down { color: #c00; }
+  .dev-up { color: #060; }
+  .dev-down { color: #c00; }
   .sort-bar a { font-size: 0.85em; color: #555; text-decoration: none; padding: 0.2em 0.5em; border: 1px solid #ccc; border-radius: 3px; background: #fff; margin-left: 0.3em; }
   .sort-bar a.active { background: #2c5282; color: #fff; border-color: #2c5282; }
 </style>
@@ -33,13 +33,13 @@
 
 <p style="font-size:0.85em;color:#666;margin:0 0 0.6em 0;">
   手動付けした業態テーマ (memo.gyoutai_themes) を自分の分類軸とした市場ローテーション検知。
-  中長期の強さ (momentum_pt) と短期の値動き傾向 (rs_line スロープ) を併記する。
+  中長期の強さ (momentum_pt) と短期の勢い (rs_line の移動平均乖離) を併記する。
 </p>
 
 <div class="sort-bar" style="margin-bottom:0.6em;">
   <span style="font-size:0.85em;color:#666;">並べ替え:</span>
   <a href="{{ sort_urls['momentum'] }}" class="{% if active_sort == 'momentum' %}active{% endif %}">強さ (momentum)</a>
-  <a href="{{ sort_urls['slope_a'] }}" class="{% if active_sort == 'slope_a' %}active{% endif %}">短期スロープ (A)</a>
+  <a href="{{ sort_urls['dev_a'] }}" class="{% if active_sort == 'dev_a' %}active{% endif %}">短期の勢い (5日乖離)</a>
 </div>
 
 {% if fallback_mode %}
@@ -62,10 +62,8 @@
       <th>構成</th>
       <th title="構成銘柄の momentum_pt 平均 (0〜100)">mom平均</th>
       <th title="構成銘柄の momentum_pt 最大">最大</th>
-      <th title="rs_line (銘柄/TOPIX) の 5日前比の平均">短期スロープ</th>
-      <th title="rs_line (銘柄/TOPIX) の 20日前比の平均">中期スロープ</th>
-      <th title="20 営業日リターンの平均">20日</th>
-      <th title="65 営業日リターンの平均">65日</th>
+      <th title="今日の rs_line (銘柄/TOPIX) と直近5日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)">5日乖離</th>
+      <th title="今日の rs_line (銘柄/TOPIX) と直近20日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)">20日乖離</th>
       <th class="leaders-col" title="momentum_pt 降順 上位3銘柄">リーダー株 (top3)</th>
     </tr>
   </thead>
@@ -94,13 +92,11 @@
       </td>
       <td class="num">{{ fmt_int(t.momentum_pt_max) }}</td>
       <td class="num">
-        {% if t.slope_a_avg is not none %}<span class="{% if t.slope_a_avg >= 0 %}slope-up{% else %}slope-down{% endif %}">{{ fmt_pct(t.slope_a_avg) }}</span>{% else %}—{% endif %}
+        {% if t.dev_a_avg is not none %}<span class="{% if t.dev_a_avg >= 0 %}dev-up{% else %}dev-down{% endif %}">{{ fmt_pct(t.dev_a_avg) }}</span>{% else %}—{% endif %}
       </td>
       <td class="num">
-        {% if t.slope_b_avg is not none %}<span class="{% if t.slope_b_avg >= 0 %}slope-up{% else %}slope-down{% endif %}">{{ fmt_pct(t.slope_b_avg) }}</span>{% else %}—{% endif %}
+        {% if t.dev_b_avg is not none %}<span class="{% if t.dev_b_avg >= 0 %}dev-up{% else %}dev-down{% endif %}">{{ fmt_pct(t.dev_b_avg) }}</span>{% else %}—{% endif %}
       </td>
-      <td class="num">{{ fmt_pct(t.ret_20d_avg) }}</td>
-      <td class="num">{{ fmt_pct(t.ret_65d_avg) }}</td>
       <td class="leaders-cell">
         {% for l in t.leaders %}<a href="{{ url_for('detail.stock_detail', code_s=l.code_s) }}">{{ l.code_s }}</a>({{ l.momentum_pt|round|int }}){% if not loop.last %}, {% endif %}{% else %}—{% endfor %}
       </td>

--- a/scripts/webapp/templates/portfolio_theme_summary.html
+++ b/scripts/webapp/templates/portfolio_theme_summary.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+{% block title %}業態テーマ別 RS サマリー | Shintakane Research{% endblock %}
+
+{% block content %}
+<style>
+  table.theme-summary { width: 100%; font-size: 0.9em; border-collapse: collapse; }
+  table.theme-summary th, table.theme-summary td { padding: 0.4em 0.6em; vertical-align: middle; border-bottom: 1px solid #e2e8f0; }
+  table.theme-summary th { text-align: right; color: #666; font-weight: 600; white-space: nowrap; }
+  table.theme-summary th.theme-col, table.theme-summary th.leaders-col { text-align: left; }
+  table.theme-summary td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.theme-summary td.theme-cell { font-weight: 600; word-break: break-word; max-width: 14em; }
+  table.theme-summary td.leaders-cell { font-size: 0.85em; white-space: nowrap; }
+  table.theme-summary tr.few-members { background: #fafad2; }  /* 少数構成マーカー (薄黄) */
+  table.theme-summary details { margin: 0; }
+  table.theme-summary details summary { cursor: pointer; list-style: none; }
+  table.theme-summary details summary::-webkit-details-marker { display: none; }
+  table.theme-summary .member-list { margin: 0.3em 0 0.3em 1em; font-size: 0.85em; color: #444; }
+  .mom-strong { font-weight: 700; color: #060; }
+  .mom-weak { color: #c00; }
+  .slope-up { color: #060; }
+  .slope-down { color: #c00; }
+  .sort-bar a { font-size: 0.85em; color: #555; text-decoration: none; padding: 0.2em 0.5em; border: 1px solid #ccc; border-radius: 3px; background: #fff; margin-left: 0.3em; }
+  .sort-bar a.active { background: #2c5282; color: #fff; border-color: #2c5282; }
+</style>
+
+{% macro fmt_pct(v) %}{% if v is none %}—{% else %}{{ '%+.1f'|format(v) }}%{% endif %}{% endmacro %}
+{% macro fmt_int(v) %}{% if v is none %}—{% else %}{{ v|round|int }}{% endif %}{% endmacro %}
+
+<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6em;flex-wrap:wrap;gap:0.5em;">
+  <h2 style="margin:0;">業態テーマ別 RS サマリー</h2>
+  <a href="{{ url_for('portfolio.dashboard') }}" style="font-size:0.9em;">← ポートフォリオに戻る</a>
+</div>
+
+<p style="font-size:0.85em;color:#666;margin:0 0 0.6em 0;">
+  手動付けした業態テーマ (memo.gyoutai_themes) を自分の分類軸とした市場ローテーション検知。
+  中長期の強さ (momentum_pt) と短期の値動き傾向 (rs_line スロープ) を併記する。
+</p>
+
+<div class="sort-bar" style="margin-bottom:0.6em;">
+  <span style="font-size:0.85em;color:#666;">並べ替え:</span>
+  <a href="{{ sort_urls['momentum'] }}" class="{% if active_sort == 'momentum' %}active{% endif %}">強さ (momentum)</a>
+  <a href="{{ sort_urls['slope_a'] }}" class="{% if active_sort == 'slope_a' %}active{% endif %}">短期スロープ (A)</a>
+</div>
+
+{% if fallback_mode %}
+<p style="padding:0.8em 1em;background:#f5f7fa;border:1px solid #d8dee6;border-radius:4px;color:#666;">
+  portfolio_shelve が空のためテーマ集計を表示できません。銘柄を登録すると集計対象になります。
+</p>
+{% elif not themes %}
+<p style="padding:0.8em 1em;background:#f5f7fa;border:1px solid #d8dee6;border-radius:4px;color:#666;">
+  業態テーマ (memo.gyoutai_themes) が設定された銘柄がありません。
+</p>
+{% else %}
+<p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">
+  {{ themes|length }} テーマ / {{ total_members }} 銘柄
+</p>
+
+<table class="theme-summary">
+  <thead>
+    <tr>
+      <th class="theme-col">テーマ</th>
+      <th>構成</th>
+      <th title="構成銘柄の momentum_pt 平均 (0〜100)">mom平均</th>
+      <th title="構成銘柄の momentum_pt 最大">最大</th>
+      <th title="rs_line (銘柄/TOPIX) の 5日前比の平均">短期スロープ</th>
+      <th title="rs_line (銘柄/TOPIX) の 20日前比の平均">中期スロープ</th>
+      <th title="20 営業日リターンの平均">20日</th>
+      <th title="65 営業日リターンの平均">65日</th>
+      <th class="leaders-col" title="momentum_pt 降順 上位3銘柄">リーダー株 (top3)</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for t in themes %}
+    <tr class="{% if t.member_count == 1 %}few-members{% endif %}">
+      <td class="theme-cell">
+        <details>
+          <summary title="クリックで構成銘柄を展開">▶ {{ t.theme }}</summary>
+          <div class="member-list">
+            {% for m in t.members %}
+            <div>
+              <a href="{{ url_for('detail.stock_detail', code_s=m.code_s) }}">{{ m.code_s }}</a>
+              {{ m.stock_name }}
+              <span style="color:#888;">({{ m.status }}{% if m.momentum_pt is not none %} / RS {{ m.momentum_pt|round|int }}{% endif %})</span>
+            </div>
+            {% endfor %}
+          </div>
+        </details>
+      </td>
+      <td class="num">{{ t.member_count }}</td>
+      <td class="num">
+        {% if t.momentum_pt_avg is not none and t.momentum_pt_avg >= 70 %}<span class="mom-strong">{{ fmt_int(t.momentum_pt_avg) }}</span>
+        {% elif t.momentum_pt_avg is not none and t.momentum_pt_avg <= 30 %}<span class="mom-weak">{{ fmt_int(t.momentum_pt_avg) }}</span>
+        {% else %}{{ fmt_int(t.momentum_pt_avg) }}{% endif %}
+      </td>
+      <td class="num">{{ fmt_int(t.momentum_pt_max) }}</td>
+      <td class="num">
+        {% if t.slope_a_avg is not none %}<span class="{% if t.slope_a_avg >= 0 %}slope-up{% else %}slope-down{% endif %}">{{ fmt_pct(t.slope_a_avg) }}</span>{% else %}—{% endif %}
+      </td>
+      <td class="num">
+        {% if t.slope_b_avg is not none %}<span class="{% if t.slope_b_avg >= 0 %}slope-up{% else %}slope-down{% endif %}">{{ fmt_pct(t.slope_b_avg) }}</span>{% else %}—{% endif %}
+      </td>
+      <td class="num">{{ fmt_pct(t.ret_20d_avg) }}</td>
+      <td class="num">{{ fmt_pct(t.ret_65d_avg) }}</td>
+      <td class="leaders-cell">
+        {% for l in t.leaders %}<a href="{{ url_for('detail.stock_detail', code_s=l.code_s) }}">{{ l.code_s }}</a>({{ l.momentum_pt|round|int }}){% if not loop.last %}, {% endif %}{% else %}—{% endfor %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/scripts/webapp/templates/portfolio_theme_summary.html
+++ b/scripts/webapp/templates/portfolio_theme_summary.html
@@ -98,7 +98,7 @@
         {% if t.dev_b_avg is not none %}<span class="{% if t.dev_b_avg >= 0 %}dev-up{% else %}dev-down{% endif %}">{{ fmt_pct(t.dev_b_avg) }}</span>{% else %}—{% endif %}
       </td>
       <td class="leaders-cell">
-        {% for l in t.leaders %}<a href="{{ url_for('detail.stock_detail', code_s=l.code_s) }}">{{ l.code_s }}</a>({{ l.momentum_pt|round|int }}){% if not loop.last %}, {% endif %}{% else %}—{% endfor %}
+        {% for l in t.leaders %}{% set nm = l.stock_name or l.code_s %}<a href="{{ url_for('detail.stock_detail', code_s=l.code_s) }}" title="{{ nm }}">{{ nm|truncate(8, true, '..', 0) }}</a>{% if not loop.last %}, {% endif %}{% else %}—{% endfor %}
       </td>
     </tr>
     {% endfor %}

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -663,41 +663,41 @@ class TestComputeRsLineChanges:
         assert a is None and b is None
 
     def test_none_when_too_short_for_short_change(self):
-        """rs_line が 6本未満なら 5日前比 A も計算不能"""
-        stock = {"price_log": _make_log(5, base=2000)}
-        market_db = {"topix": {"price_log": _make_log(5, base=1000)}}
+        """rs_line が 5本未満なら 5日移動平均乖離 A も計算不能"""
+        stock = {"price_log": _make_log(4, base=2000)}
+        market_db = {"topix": {"price_log": _make_log(4, base=1000)}}
         a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is None and b is None
 
     def test_short_only_when_partial_data(self):
-        """rs_line が 6本以上16本未満なら A だけ計算可、B は None (15日前すら届かない)"""
+        """rs_line が 5本以上15本未満なら A だけ計算可、B は None (20日平均に届かず代替も不可)"""
         stock = {"price_log": _make_log(10, base=2000)}
         market_db = {"topix": {"price_log": _make_log(10, base=1000)}}
         a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is None
 
-    def test_fallback_when_16_to_20_bars(self):
-        """rs_line が 16-20本のとき、B は 15-19日前で代替して数値を返す"""
-        # 20本 = index 0..19 → offset 19 で代替可能
-        stock = {"price_log": _make_log(20, base=2000, step=20)}
-        market_db = {"topix": {"price_log": _make_log(20, base=1000, step=2)}}
+    def test_fallback_when_15_to_19_bars(self):
+        """rs_line が 15-19本のとき、B は 15-19本平均で代替して数値を返す"""
+        # 19本 → window 19 で代替可能
+        stock = {"price_log": _make_log(19, base=2000, step=20)}
+        market_db = {"topix": {"price_log": _make_log(19, base=1000, step=2)}}
         a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is not None
-        # 16本 = index 0..15 → offset 15 で代替可能
-        stock = {"price_log": _make_log(16, base=2000, step=20)}
-        market_db = {"topix": {"price_log": _make_log(16, base=1000, step=2)}}
+        # 15本 → window 15 で代替可能
+        stock = {"price_log": _make_log(15, base=2000, step=20)}
+        market_db = {"topix": {"price_log": _make_log(15, base=1000, step=2)}}
         a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is not None
 
-    def test_no_fallback_when_15_bars(self):
-        """rs_line が 15本のとき (index 0..14)、offset 15 にも届かないので B は None"""
-        stock = {"price_log": _make_log(15, base=2000, step=20)}
-        market_db = {"topix": {"price_log": _make_log(15, base=1000, step=2)}}
+    def test_no_fallback_when_14_bars(self):
+        """rs_line が 14本のとき、window 15 にも届かないので B は None"""
+        stock = {"price_log": _make_log(14, base=2000, step=20)}
+        market_db = {"topix": {"price_log": _make_log(14, base=1000, step=2)}}
         a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is None
 
     def test_both_when_full_data(self):
-        """rs_line が 21本以上で A・B 両方計算可"""
+        """rs_line が 20本以上で A・B 両方計算可"""
         stock = {"price_log": _make_log(25, base=2000)}
         market_db = {"topix": {"price_log": _make_log(25, base=1000)}}
         a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
@@ -867,16 +867,16 @@ class TestCalibrateMomentumPt:
 
 
     def test_fallback_marked_with_asterisk(self):
-        """rs_line 16-20本のとき、B 値の末尾に '*' が付く"""
-        stock = {"price_log": _make_log(20, base=2000, step=20)}
-        market_db = {"topix": {"price_log": _make_log(20, base=1000, step=2)}}
+        """rs_line 15-19本のとき、B 値の末尾に '*' が付く (window 20 未満で代替)"""
+        stock = {"price_log": _make_log(19, base=2000, step=20)}
+        market_db = {"topix": {"price_log": _make_log(19, base=1000, step=2)}}
         s = make_stock_db.get_rs_line_changes_expr(stock, market_db)
         parts = s.split("/")
         assert parts[0].endswith("*"), "フォールバック時は B 値末尾に '*' が付くべき"
         assert not parts[1].endswith("*"), "A 値には '*' を付けない"
 
     def test_no_asterisk_when_full_data(self):
-        """rs_line 21本以上 (offset 20 で取れる) のとき、'*' は付かない"""
+        """rs_line 20本以上 (window 20 で取れる) のとき、'*' は付かない"""
         stock = {"price_log": _make_log(25, base=2000, step=20)}
         market_db = {"topix": {"price_log": _make_log(25, base=1000, step=2)}}
         s = make_stock_db.get_rs_line_changes_expr(stock, market_db)
@@ -884,9 +884,9 @@ class TestCalibrateMomentumPt:
         assert not parts[0].endswith("*")
 
     def test_no_asterisk_when_b_uncomputable(self):
-        """rs_line 15本以下 (B 計算不能) のとき、'-' に '*' は付かない"""
-        stock = {"price_log": _make_log(15, base=2000, step=20)}
-        market_db = {"topix": {"price_log": _make_log(15, base=1000, step=2)}}
+        """rs_line 14本以下 (B 計算不能) のとき、'-' に '*' は付かない"""
+        stock = {"price_log": _make_log(14, base=2000, step=20)}
+        market_db = {"topix": {"price_log": _make_log(14, base=1000, step=2)}}
         s = make_stock_db.get_rs_line_changes_expr(stock, market_db)
         parts = s.split("/")
         assert parts[0] == "-"

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2652,3 +2652,142 @@ class TestBuildGyosekiTooltips:
     ])
     def test_tooltip_format(self, expr, expected):
         assert helpers.build_gyoseki_tooltips(expr) == expected
+
+
+class TestBuildPortfolioThemeSummary:
+    """build_portfolio_theme_summary のテスト (issue #283)。
+
+    rs_line 系 (compute_rs_line_changes) と DB バルク取得は monkeypatch で
+    固定値に差し替え、集約ロジック (平均 / 除外 / ソート) を検証する。
+    """
+
+    def _record(self, code_s, themes, status="3監"):
+        return {"code_s": code_s, "status": status,
+                "memo": {"gyoutai_themes": themes}}
+
+    def test_basic_aggregation(self, monkeypatch):
+        """2 テーマ × 3 銘柄で momentum_pt 平均/最大・リターンが期待通り。"""
+        records = [
+            self._record("1111", ["半導体"]),
+            self._record("2222", ["半導体"]),
+            self._record("3333", ["防衛"]),
+        ]
+        stock_data = {
+            "1111": {"stock_name": "A", "momentum_pt": 80,
+                     "price_log": [("d0", 110)] + [("d", 100)] * 70},
+            "2222": {"stock_name": "B", "momentum_pt": 60,
+                     "price_log": [("d0", 90)] + [("d", 100)] * 70},
+            "3333": {"stock_name": "C", "momentum_pt": 50, "price_log": []},
+        }
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: stock_data)
+        monkeypatch.setattr(
+            helpers, "_bulk_resolve_stock_names",
+            lambda codes: {c: stock_data[c]["stock_name"] for c in codes},
+        )
+        import make_market_db
+        monkeypatch.setattr(make_market_db, "get_market_db", lambda: None)  # rs_line スキップ
+
+        out = helpers.build_portfolio_theme_summary(records=records, sort_key="momentum")
+        by_theme = {t["theme"]: t for t in out}
+        assert by_theme["半導体"]["member_count"] == 2
+        assert by_theme["半導体"]["momentum_pt_avg"] == 70.0  # (80+60)/2
+        assert by_theme["半導体"]["momentum_pt_max"] == 80.0
+        assert round(by_theme["半導体"]["ret_20d_avg"], 1) == 0.0  # (+10% + -10%)/2
+        # 半導体 (avg 70) が 防衛 (avg 50) より先 (momentum 降順)
+        assert out[0]["theme"] == "半導体"
+
+    def test_same_code_in_two_themes(self, monkeypatch):
+        """同一銘柄が 2 テーマに属する場合、両テーマで集計される。"""
+        records = [self._record("1111", ["半導体", "AI"])]
+        stock_data = {"1111": {"stock_name": "A", "momentum_pt": 80, "price_log": []}}
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: stock_data)
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names",
+                            lambda codes: {"1111": "A"})
+        import make_market_db
+        monkeypatch.setattr(make_market_db, "get_market_db", lambda: None)
+
+        out = helpers.build_portfolio_theme_summary(records=records)
+        themes = {t["theme"] for t in out}
+        assert themes == {"半導体", "AI"}
+        for t in out:
+            assert t["member_count"] == 1
+            assert t["momentum_pt_avg"] == 80.0
+
+    def test_missing_momentum_excluded_but_counted(self, monkeypatch):
+        """momentum_pt 欠損銘柄は集計から除外されるが member_count には含まれる。"""
+        records = [
+            self._record("1111", ["半導体"]),
+            self._record("2222", ["半導体"]),  # momentum_pt 欠損
+        ]
+        stock_data = {
+            "1111": {"stock_name": "A", "momentum_pt": 80, "price_log": []},
+            "2222": {"stock_name": "B", "price_log": []},  # momentum_pt なし
+        }
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: stock_data)
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names",
+                            lambda codes: {c: stock_data[c]["stock_name"] for c in codes})
+        import make_market_db
+        monkeypatch.setattr(make_market_db, "get_market_db", lambda: None)
+
+        out = helpers.build_portfolio_theme_summary(records=records)
+        t = out[0]
+        assert t["member_count"] == 2          # 欠損も数える
+        assert t["momentum_pt_avg"] == 80.0     # 欠損は平均から除外
+        assert len(t["leaders"]) == 1           # momentum_pt がある銘柄のみ
+
+    def test_slope_aggregation_excludes_none(self, monkeypatch):
+        """短期スロープ: rs_line データ不足銘柄 (None) は平均から除外される。"""
+        records = [
+            self._record("1111", ["半導体"]),
+            self._record("2222", ["半導体"]),
+        ]
+        stock_data = {
+            "1111": {"stock_name": "A", "momentum_pt": 80, "price_log": []},
+            "2222": {"stock_name": "B", "momentum_pt": 60, "price_log": []},
+        }
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: stock_data)
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names",
+                            lambda codes: {c: stock_data[c]["stock_name"] for c in codes})
+        import make_market_db
+        import make_stock_db
+        monkeypatch.setattr(make_market_db, "get_market_db", lambda: {"topix": {}})
+        monkeypatch.setattr(make_stock_db, "_topix_close_map", lambda mdb: {"d": 1.0})
+        # 公開 API compute_rs_line_changes を stock 名から (A, B) を返すよう差し替え。
+        # A=有効/B=None, A=有効/B=有効 を返し分け
+        slope_map = {"A": (2.0, None), "B": (4.0, 8.0)}
+        monkeypatch.setattr(
+            make_stock_db, "compute_rs_line_changes",
+            lambda stock, mdb, topix_map=None: slope_map[stock["stock_name"]],
+        )
+        out = helpers.build_portfolio_theme_summary(records=records)
+        t = out[0]
+        assert t["slope_a_avg"] == 3.0          # (2.0 + 4.0) / 2
+        assert t["slope_b_avg"] == 8.0          # B のみ有効 (A の B は None で除外)
+
+    @pytest.mark.parametrize("sort_key,expected_first", [
+        ("momentum", "強"),    # momentum_pt 平均が高いテーマが先頭
+        ("slope_a", "急"),     # slope_a 平均が高いテーマが先頭
+    ])
+    def test_sort_key_switch(self, monkeypatch, sort_key, expected_first):
+        """sort_key で momentum / slope_a の並び順が切り替わる。"""
+        records = [
+            self._record("1111", ["強"]),   # momentum 高, slope 低
+            self._record("2222", ["急"]),   # momentum 低, slope 高
+        ]
+        stock_data = {
+            "1111": {"stock_name": "S", "momentum_pt": 90, "price_log": []},
+            "2222": {"stock_name": "Q", "momentum_pt": 40, "price_log": []},
+        }
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: stock_data)
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names",
+                            lambda codes: {c: stock_data[c]["stock_name"] for c in codes})
+        import make_market_db
+        import make_stock_db
+        monkeypatch.setattr(make_market_db, "get_market_db", lambda: {"topix": {}})
+        monkeypatch.setattr(make_stock_db, "_topix_close_map", lambda mdb: {"d": 1.0})
+        slope_map = {"S": (1.0, 1.0), "Q": (9.0, 9.0)}
+        monkeypatch.setattr(make_stock_db, "compute_rs_line_changes",
+                            lambda stock, mdb, topix_map=None: slope_map[stock["stock_name"]])
+
+        out = helpers.build_portfolio_theme_summary(records=records, sort_key=sort_key)
+        assert out[0]["theme"] == expected_first

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2096,7 +2096,7 @@ class TestPriceRsSparkline:
         assert "</svg>" in svg
         assert "polyline" in svg
         assert "株価:" in tooltip
-        assert "RSライン:" in tooltip
+        assert "RSライン乖離:" in tooltip
 
     def test_mini_chart_insufficient_data_returns_dash(self):
         svg, _ = helpers.build_price_rs_chart_mini([], [], has_blue_dot=False)
@@ -2131,7 +2131,7 @@ class TestPriceRsSparkline:
         assert svg.count("<polyline") >= 4
         assert "stroke-dasharray" in svg  # RSライン点線
         assert "株価:" in tooltip
-        assert "RSライン:" in tooltip
+        assert "RSライン乖離:" in tooltip
 
     def test_full_chart_includes_date_labels(self):
         price_log = self._make_log(list(range(120, 100, -1)))
@@ -2666,18 +2666,16 @@ class TestBuildPortfolioThemeSummary:
                 "memo": {"gyoutai_themes": themes}}
 
     def test_basic_aggregation(self, monkeypatch):
-        """2 テーマ × 3 銘柄で momentum_pt 平均/最大・リターンが期待通り。"""
+        """2 テーマ × 3 銘柄で momentum_pt 平均/最大が期待通り。"""
         records = [
             self._record("1111", ["半導体"]),
             self._record("2222", ["半導体"]),
             self._record("3333", ["防衛"]),
         ]
         stock_data = {
-            "1111": {"stock_name": "A", "momentum_pt": 80,
-                     "price_log": [("d0", 110)] + [("d", 100)] * 70},
-            "2222": {"stock_name": "B", "momentum_pt": 60,
-                     "price_log": [("d0", 90)] + [("d", 100)] * 70},
-            "3333": {"stock_name": "C", "momentum_pt": 50, "price_log": []},
+            "1111": {"stock_name": "A", "momentum_pt": 80},
+            "2222": {"stock_name": "B", "momentum_pt": 60},
+            "3333": {"stock_name": "C", "momentum_pt": 50},
         }
         monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: stock_data)
         monkeypatch.setattr(
@@ -2692,7 +2690,6 @@ class TestBuildPortfolioThemeSummary:
         assert by_theme["半導体"]["member_count"] == 2
         assert by_theme["半導体"]["momentum_pt_avg"] == 70.0  # (80+60)/2
         assert by_theme["半導体"]["momentum_pt_max"] == 80.0
-        assert round(by_theme["半導体"]["ret_20d_avg"], 1) == 0.0  # (+10% + -10%)/2
         # 半導体 (avg 70) が 防衛 (avg 50) より先 (momentum 降順)
         assert out[0]["theme"] == "半導体"
 
@@ -2735,8 +2732,8 @@ class TestBuildPortfolioThemeSummary:
         assert t["momentum_pt_avg"] == 80.0     # 欠損は平均から除外
         assert len(t["leaders"]) == 1           # momentum_pt がある銘柄のみ
 
-    def test_slope_aggregation_excludes_none(self, monkeypatch):
-        """短期スロープ: rs_line データ不足銘柄 (None) は平均から除外される。"""
+    def test_dev_aggregation_excludes_none(self, monkeypatch):
+        """短期の勢い: rs_line データ不足銘柄 (None) は平均から除外される。"""
         records = [
             self._record("1111", ["半導体"]),
             self._record("2222", ["半導体"]),
@@ -2752,27 +2749,27 @@ class TestBuildPortfolioThemeSummary:
         import make_stock_db
         monkeypatch.setattr(make_market_db, "get_market_db", lambda: {"topix": {}})
         monkeypatch.setattr(make_stock_db, "_topix_close_map", lambda mdb: {"d": 1.0})
-        # 公開 API compute_rs_line_changes を stock 名から (A, B) を返すよう差し替え。
+        # 公開 API compute_rs_line_changes を stock 名から (A, B) 乖離率を返すよう差し替え。
         # A=有効/B=None, A=有効/B=有効 を返し分け
-        slope_map = {"A": (2.0, None), "B": (4.0, 8.0)}
+        dev_map = {"A": (2.0, None), "B": (4.0, 8.0)}
         monkeypatch.setattr(
             make_stock_db, "compute_rs_line_changes",
-            lambda stock, mdb, topix_map=None: slope_map[stock["stock_name"]],
+            lambda stock, mdb, topix_map=None: dev_map[stock["stock_name"]],
         )
         out = helpers.build_portfolio_theme_summary(records=records)
         t = out[0]
-        assert t["slope_a_avg"] == 3.0          # (2.0 + 4.0) / 2
-        assert t["slope_b_avg"] == 8.0          # B のみ有効 (A の B は None で除外)
+        assert t["dev_a_avg"] == 3.0            # (2.0 + 4.0) / 2
+        assert t["dev_b_avg"] == 8.0            # B のみ有効 (A の B は None で除外)
 
     @pytest.mark.parametrize("sort_key,expected_first", [
         ("momentum", "強"),    # momentum_pt 平均が高いテーマが先頭
-        ("slope_a", "急"),     # slope_a 平均が高いテーマが先頭
+        ("dev_a", "急"),       # dev_a (短期の勢い) 平均が高いテーマが先頭
     ])
     def test_sort_key_switch(self, monkeypatch, sort_key, expected_first):
-        """sort_key で momentum / slope_a の並び順が切り替わる。"""
+        """sort_key で momentum / dev_a の並び順が切り替わる。"""
         records = [
-            self._record("1111", ["強"]),   # momentum 高, slope 低
-            self._record("2222", ["急"]),   # momentum 低, slope 高
+            self._record("1111", ["強"]),   # momentum 高, 勢い 低
+            self._record("2222", ["急"]),   # momentum 低, 勢い 高
         ]
         stock_data = {
             "1111": {"stock_name": "S", "momentum_pt": 90, "price_log": []},
@@ -2785,9 +2782,9 @@ class TestBuildPortfolioThemeSummary:
         import make_stock_db
         monkeypatch.setattr(make_market_db, "get_market_db", lambda: {"topix": {}})
         monkeypatch.setattr(make_stock_db, "_topix_close_map", lambda mdb: {"d": 1.0})
-        slope_map = {"S": (1.0, 1.0), "Q": (9.0, 9.0)}
+        dev_map = {"S": (1.0, 1.0), "Q": (9.0, 9.0)}
         monkeypatch.setattr(make_stock_db, "compute_rs_line_changes",
-                            lambda stock, mdb, topix_map=None: slope_map[stock["stock_name"]])
+                            lambda stock, mdb, topix_map=None: dev_map[stock["stock_name"]])
 
         out = helpers.build_portfolio_theme_summary(records=records, sort_key=sort_key)
         assert out[0]["theme"] == expected_first

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1392,7 +1392,7 @@ class TestPortfolioThemeSummary:
 
     @pytest.mark.parametrize("url", [
         "/portfolio/themes/summary",
-        "/portfolio/themes/summary?sort=slope_a",
+        "/portfolio/themes/summary?sort=dev_a",
     ])
     def test_summary_returns_200(self, summary_app, url):
         client = summary_app.test_client()

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1369,3 +1369,35 @@ class TestPortfolioThemes:
         assert resp.status_code == 302
         assert ps.get_theme("半導体", db_path=portfolio_db) is None
         assert ps.get_theme("セミコン", db_path=portfolio_db)["description"] == "renamed"
+
+
+class TestPortfolioThemeSummary:
+    """業態テーマ別 RS サマリー画面の smoke テスト (issue #283)"""
+
+    @pytest.fixture
+    def summary_app(self, db_path, tmp_path, monkeypatch):
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        # 業態テーマ付きで 1 件登録 (集計対象になる)
+        memo = ps.create_memo(gyoutai_themes=["半導体"])
+        ps.add_to_watch("3496", memo=memo, db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        return app
+
+    @pytest.mark.parametrize("url", [
+        "/portfolio/themes/summary",
+        "/portfolio/themes/summary?sort=slope_a",
+    ])
+    def test_summary_returns_200(self, summary_app, url):
+        client = summary_app.test_client()
+        resp = client.get(url)
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "業態テーマ別 RS サマリー" in html
+        assert "半導体" in html


### PR DESCRIPTION
Closes #283

## Summary
- 手動付けの業態テーマ (`memo.gyoutai_themes`) でユニバースをグルーピングし、中長期の強さ (momentum_pt 平均/最大) と短期の勢い (rs_line 移動平均乖離オシレーター) を集約表示する閲覧専用画面を追加
- 用途は「手動業態テーマ (自分の分類軸) による市場ローテーション検知」。株探テーマベースの `theme_rank` (自動分類) を補完する
- あわせて #155 由来の rs_line 指標を**移動平均乖離オシレーター化** (CSV モメンタム列・銘柄詳細 tooltip にも波及)

## 変更点
### 業態テーマサマリー画面 (新規)
- `helpers.build_portfolio_theme_summary`: テーマ別集約。公開 API `compute_rs_line_changes` を流用、`_topix_close_map` 1回構築で N+1 回避、銘柄単位キャッシュ
- ルート `/portfolio/themes/summary` (`?sort=momentum|dev_a` で再ソート切替)
- テンプレート `portfolio_theme_summary.html` (行展開で構成銘柄、少数構成マーカー、条件付き書式)
- `/portfolio` ヘッダに「📊 テーマサマリー」導線リンク追加

### rs_line 指標の移動平均乖離オシレーター化 (#155 系指標の挙動変更)
- `_rs_line_changes_from_line`: 「N日前の1点比」→「今日 vs 直近N日移動平均の乖離率」(A=5日, B=20日, 15本まで代替)
- 1点比較はヒゲ・急変でブレるため、移動平均基準でブレを 1/N に薄め勢い・過熱を安定して捉える
- 波及: code_rank.csv モメンタム列・銘柄詳細 tooltip (RSライン行) も MA 基準に統一。株価 tooltip は期間騰落率のまま据え置き
- 命名は slope→dev に統一 (オシレーターであり傾きではないため)
- **スコアリング・ランキングには非影響** (rs_line changes は表示用途のみ、コードで確認済み)

## 設計判断 (issue #283 追記の反映)
- Blue Dot のグループ集計は不採用 (MarketSmith の Blue Dot は銘柄レベル機能、グループ集計は過剰実装)
- 短期層は永続化不要で即動く rs_line で実装 (案A)。MarketSmith に忠実な momentum_pt 履歴 (案B) は将来の別 issue で再検討
- 詳細: [doc/plan/portfolio_theme_summary.md](doc/plan/portfolio_theme_summary.md)

## Test plan
- [x] pytest test_make_stock_db / test_append_research_snapshots / test_webapp_helpers / test_webapp_routes → 475 passed
- [x] webapp 起動 + `/portfolio/themes/summary` 200、実データ 27テーマで「5日乖離/20日乖離」カラム描画
- [x] `?sort=dev_a` 200、`/portfolio` ヘッダにリンク表示、旧 sort 値はデフォルトにフォールバック
- [x] ブラウザ目視 (サマリー画面・銘柄詳細 tooltip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)