### PR TITLE
portfolio: 業態テーマを事業内容から LLM 自動提案 (#297)

### DIFF
--- a/doc/plan/issue297_gyoutai_theme_suggest.md
+++ b/doc/plan/issue297_gyoutai_theme_suggest.md
@@ -1,0 +1,193 @@
+# issue #297 実装プラン: 業態テーマを事業内容から LLM で自動提案
+
+## ゴール
+
+銘柄詳細画面で、業態テーマ未設定の銘柄に「🤖 提案」ボタンを出し、
+事業内容テキスト (四季報特色・四季報コメント・株探概要) を軽量 LLM (`claude -p` Haiku) に渡して、
+既定の業態テーママスターから 1〜2 件を提案する。提案は `<select>` にプリセットするだけで、
+保存はユーザーが既存の保存ボタンで手動確定する。
+
+検証可能なゴール:
+- (A) 業態テーマ未設定 & 事業テキストありの銘柄で「🤖 提案」ボタンが表示される
+- (B) ボタン押下 → API が事業テキストを LLM に渡し、マスター内テーマ 1〜2 件を JSON で返す
+- (C) 返ったテーマが `<select>` に selected 反映される (保存は走らない)
+- (D) 業態テーマ設定済み or 事業テキスト空の銘柄ではボタンが出ない
+- (E) マスターに無いテーマを LLM が返しても無視される (ハルシネーション防止)
+
+## スコープ外 (やらないこと)
+
+- 提案の自動保存 (手動確定のみ)
+- ポートフォリオ一覧画面への提案ボタン追加 (詳細画面のみ)
+- テーママスター自体の自動生成・追加
+- Anthropic SDK / API キー方式 (CLI 経由のみ)
+
+## 運用前提 (設計判断の土台)
+
+本 WebApp は `http://localhost:5001` で動く**単一ユーザーの調査ツール**。
+起動は `python -m webapp.app` = **Flask 開発サーバの単一プロセス運用** (`app.run`、
+gunicorn/uWSGI のマルチワーカーは使っていない。webapp/app.py 確認済み)。
+`debug=True` 既定で threaded=True のため同一プロセス内のスレッド並行はあり得るが、
+プロセスは 1 つなので `threading.Lock` が同時実行ガードとして機能する (codex 指摘1 への回答)。
+
+公開サービスではないため、認証・マルチユーザー・本格的な DoS 対策・ジョブキュー化・
+プロセス間 file lock は overcomplicated と判断 (CLAUDE.md: Simplicity First)。
+ただし「誤操作・多重押下・直接 API 叩き」による LLM コスト暴発とワーカースレッド枯渇は
+軽量ガードで防ぐ (下記 §2 のサーバー側検証 + プロセス内 同時実行 1 件制限)。
+※ 将来マルチプロセス運用 (gunicorn 等) に切り替える場合は file lock 等への置換が必要、
+  と §2 のコメントに残す。
+
+## 前提となる既存実装 (確認済み)
+
+- 詳細画面のテーマ select: `detail.html:57-80` (`portfolio_status_query and not portfolio_fallback_mode` の時のみ表示)
+- テーママスター: `ps.list_themes()` → `[{"name", "description", "created_at"}, ...]` (`portfolio_shelve.py:940`)
+- 現状テーマ: `detail.py:89` の `gyoutai_themes` (list[str])
+- 事業テキスト 3 ソース:
+  - research overview: `get_research_record(code_s)["overview"]` (四季報特色)
+  - shikiho_comments: `get_research_record(code_s)["shikiho_comments"]` → `[{"period","comment"}, ...]`
+  - stocks overview: `get_stock_data(code_s)["overview"]` (株探 1 行)
+- LLM 起動の前例: `run_theme_news.py:67-90` (`subprocess.run(["claude", "-p", ...], timeout=, capture_output=True)`)
+- detail route の context 注入: `detail.py:108-124`
+
+## 実装
+
+### 1. LLM 呼び出しヘルパー (新規モジュール)
+
+`scripts/theme_suggest.py` を新規作成。
+
+```
+def build_business_text(research_overview, shikiho_comments, stocks_overview) -> str
+    # 3 ソースを結合して 1 つの事業説明テキストにする。
+    # 各ソースに見出しを付けて結合。全ソース空なら "" を返す。
+
+def suggest_gyoutai_themes(business_text, theme_names, *, max_suggest=2, timeout_sec=45) -> list[str]
+    # claude -p を subprocess 起動し、theme_names の中から business_text に最も合う
+    # テーマを最大 max_suggest 件、JSON 配列で返させる。
+    # - business_text が空なら [] を即返す (LLM 起動しない)
+    # - theme_names が空なら [] を即返す
+    # - プロンプトで「以下のリストからのみ選べ。リスト外は出力するな」と制約
+    # - --output-format json で claude -p を起動、result フィールドから JSON 配列を抽出
+    # - 返り値は theme_names に含まれるものだけにフィルタ (ハルシネーション防止 = ゴールE)
+    # - 重複除去・max_suggest 件で打ち切り
+    # - タイムアウト/異常終了/パース失敗時は [] を返す (UI 側でエラー表示)
+```
+
+claude -p の呼び出し方 (`run_theme_news.py` 踏襲):
+```
+cmd = ["claude", "-p", <prompt>, "--model", "haiku", "--output-format", "json"]
+result = subprocess.run(cmd, cwd=PROJECT_ROOT, timeout=timeout_sec,
+                        check=False, capture_output=True, text=True)
+```
+- プロンプトはテーマ一覧と事業テキストを埋め込んだ単一文字列。ツール不要なので `--allowed-tools` は付けない (Web 検索等させない)。
+- `--output-format json` の stdout 末尾 JSON から `result` を取り出し、その中の JSON 配列をパース。
+  - LLM 出力が ```json フェンス付きの可能性に備え、配列部分 `[...]` を正規表現で抽出してから json.loads。
+
+ログ: `log_print`/`log_warning`/`log_error` を使用 (print 不可)。
+個別銘柄の中間値・プロンプト全文は `log_debug`。
+
+### 2. API エンドポイント (memo.py に追加)
+
+`POST /stock/<code_s>/suggest_themes` を `memo_bp` に追加 (AJAX, JSON 応答)。
+
+```
+@memo_bp.route("/stock/<code_s>/suggest_themes", methods=["POST"])
+def post_suggest_themes(code_s):
+    # 0. 同時実行ガード: モジュールレベルの threading.Lock を acquire(blocking=False)。
+    #    既に実行中なら 429 {"ok": False, "error": "他の提案処理を実行中です"} を返す
+    #    (try/finally で必ず release)。単一ユーザー前提なので「同時 1 件」で十分。
+    # 1. record = get_research_record(code_s); stock = get_stock_data(code_s)
+    #    どちらも無ければ 404 {"ok": False, "error": "銘柄が見つかりません"}
+    # 2. サーバー側ガード (codex 指摘1): ボタン表示条件を API でも再検証する。
+    #    - 業態テーマが既に設定済み (gyoutai_themes に非空値あり) → 409
+    #      {"ok": False, "error": "業態テーマが既に設定済みです"}
+    #      (portfolio_record.memo.gyoutai_themes を detail.py:86-89 と同じ方法で取得)
+    # 3. business_text = build_business_text(record.overview, record.shikiho_comments,
+    #                                        stock.overview)
+    #    business_text 空 → 200 {"ok": True, "themes": [], "reason": "no_business_text"}
+    # 4. theme_names = [t["name"] for t in ps.list_themes()]
+    #    theme_names 空 → 200 {"ok": True, "themes": [], "reason": "no_master"}
+    # 5. themes = suggest_gyoutai_themes(business_text, theme_names)
+    # 6. 200 {"ok": True, "themes": themes}
+    # 例外時 → 500 {"ok": False, "error": str(e)}
+```
+- サーバー側ガード (codex 指摘1 対応): クライアントの表示条件に依存せず、API 側で
+  「業態テーマ未設定」「事業テキストあり」を再検証する。直接 API を叩いても
+  設定済み銘柄では LLM を起動しない (コスト暴発の入口を塞ぐ)。
+- 同時実行 1 件制限 (codex 指摘2 対応): `threading.Lock` で多重押下・並行リクエストを弾く。
+  単一プロセス (app.run) 運用なのでプロセス内 Lock で同時実行をプロセス全体に対して
+  1 件に制限できる。単一ユーザーなのでジョブキュー化は不要と判断。
+  ※ コメントに「マルチプロセス運用へ移行する場合は file lock 等に置換が必要」と明記する。
+- タイムアウト (codex 指摘2 対応): `suggest_gyoutai_themes` の `timeout_sec` は 60→**45** に短縮。
+  ワーカーが過度に長くブロックされないようにする (Haiku の分類は通常数秒で返る)。
+- 既存 memo.py の import に `get_research_record`, `get_stock_data` (helpers 経由), `portfolio_shelve`,
+  theme_suggest を追加。helpers 経由で取れるものは helpers から import (既存スタイルに合わせる)。
+
+### 3. detail route の context (detail.py)
+
+ボタン表示条件をテンプレートに渡すため、context に下記を追加:
+```
+gyoutai_themes_unset = (not any(gyoutai_themes))   # 全スロット未設定か
+has_business_text = bool(build_business_text(...))  # 事業テキストが 1 つでもあるか
+```
+- `build_business_text` は theme_suggest から import。
+- research overview / shikiho_comments は `record` (= get_research_detail の戻り) から、
+  stocks overview は `stock` から取得。
+- ボタン表示判定はテンプレート側で `gyoutai_themes_unset and has_business_text` を見る。
+
+### 4. テンプレート (detail.html)
+
+`detail.html:76-78` の ✏️ リンクの隣 (テーマ select 群の後) に提案ボタンを追加:
+```
+{% if gyoutai_themes_unset and has_business_text %}
+<button type="button" class="gyoutai-suggest-btn" data-code="{{ record.code_s }}"
+        title="事業内容から業態テーマを LLM 提案">🤖 提案</button>
+{% endif %}
+```
+JS (既存の inline script ブロックに追記、または detail.html 末尾の script 内):
+```
+- ボタン click → fetch POST /stock/<code>/suggest_themes (X-Requested-With ヘッダ)
+- ボタンを「提案中...」に変えて disable (二重実行防止)
+- 応答 themes[] を gyoutai-input-detail の select に順に selected 設定
+  (既存値が無い前提だが、空きスロットに前から詰める)
+- themes 空なら「候補なし」を一時表示
+- 失敗時はアラート or ボタン脇に「提案失敗」表示
+- 保存はしない (ユーザーが既存の保存フローで確定)
+```
+- select への反映方法: `gyoutai-input-detail` クラスの select を順に取得し、
+  themes[i] を value に持つ option を selected にする。
+  value が option に無い場合 (マスター未登録) はスキップ — ただし API 側でフィルタ済みなので基本発生しない。
+
+## 検証
+
+CLAUDE.md / testing.md のマッピングに従う。
+
+- 新規 `theme_suggest.py` のユニットテスト (`tests/test_theme_suggest.py`, 5 本以下 parametrize):
+  - `build_business_text`: 全空→""、一部あり→結合される (parametrize で数ケース)
+  - `suggest_gyoutai_themes`: business_text 空→[]、theme_names 空→[]、
+    LLM 返り値のフィルタ (マスター外除去・重複除去・max 件打ち切り) を subprocess mock で検証
+  - subprocess は monkeypatch でモック (実際の claude -p は呼ばない)
+- WebApp ルート: `pytest tests/test_webapp_routes.py -v` (memo.py 変更のため)
+  - suggest_themes エンドポイントの 200/空応答パスを 1〜2 ケース追加 (theme_suggest をモック)
+- テンプレート変更はブラウザ目視 (testing.md: HTML/JS のみはブラウザ確認):
+  - 未設定 & 事業テキストあり銘柄でボタン表示 → 押下 → select に反映を確認
+  - 設定済み銘柄 / 事業テキスト空銘柄でボタン非表示を確認
+  - スクリーンショットは `.playwright-mcp/` 配下に保存
+
+## 影響範囲・互換性
+
+- 新規ファイル 1 (theme_suggest.py) + テスト 1
+- 既存変更: memo.py (route 追加), detail.py (context 2 つ追加), detail.html (ボタン + JS)
+- 既存の保存フロー・テーママスター・DB スキーマは一切変更しない (読み取りのみ)
+- claude -p は read-only 用途 (ツール無し)。DB 書き込みなし。
+- LLM 失敗は [] フォールバックで UI が壊れない (ゴール E と整合)
+
+## コスト注記 (疎通確認で判明)
+
+- `claude -p` は CLAUDE.md 等のシステムコンテキストを毎回ロードするため、
+  1 回あたり cacheCreation 込みで概算 ~$0.06 (実測: input 3 / output 13 tokens でも
+  cache_creation 51,612 tokens)。純粋な API 呼び出しより割高。
+- 単一ユーザーが「迷ったときだけ」押す用途なので許容範囲。多重押下は §2 の Lock で抑止済み。
+- モデルは `--model haiku` で有効 (実体 `claude-haiku-4-5-20251001`) を疎通確認済み。
+
+## 解決済みの確認事項
+
+- `claude -p --model haiku` のモデル指定は現環境で**有効** (疎通確認済み、実体 claude-haiku-4-5-20251001)。

--- a/scripts/theme_suggest.py
+++ b/scripts/theme_suggest.py
@@ -1,0 +1,191 @@
+"""業態テーマ自動提案 (issue #297)。
+
+銘柄の事業内容テキスト (四季報特色・四季報コメント・株探概要) を軽量 LLM
+(`claude -p` Haiku) に渡し、既定の業態テーママスターから最も合うテーマを
+1〜2 件提案する。
+
+- LLM は「マスターのリストから選ぶ分類」のみを行う。リスト外のテーマを返しても
+  呼び出し側でフィルタ除去する (ハルシネーション防止)。
+- `claude -p` の起動方法は run_theme_news.py を踏襲 (新規依存・API キー不要)。
+- LLM の失敗 (タイムアウト・異常終了・パース失敗) は空リストにフォールバックする。
+"""
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ks_util import log_debug, log_print, log_warning, log_error
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# claude -p のタイムアウト (秒)。Haiku の分類は通常数秒で返る。
+# Flask ワーカースレッドを過度にブロックしないよう短めに設定。
+DEFAULT_TIMEOUT_SEC = 45
+
+# 提案するテーマの最大件数 (業態テーマのスロット数に合わせる)。
+DEFAULT_MAX_SUGGEST = 2
+
+
+def build_business_text(
+    research_overview: Optional[str],
+    shikiho_comments: Optional[List[Dict[str, Any]]],
+    stocks_overview: Optional[str],
+) -> str:
+    """3 ソースを結合して 1 つの事業説明テキストにする。
+
+    - research_overview: 四季報の特色・企業概要 (research_shelve.overview)
+    - shikiho_comments: 四季報コメント [{"period", "comment"}, ...]
+    - stocks_overview: 株探の概要 1 行 (stocks_shelve.overview)
+
+    全ソースが空なら "" を返す (呼び出し側で LLM を起動しない判定に使う)。
+    """
+    parts: List[str] = []
+
+    ro = (research_overview or "").strip()
+    if ro:
+        parts.append(f"【企業概要(四季報特色)】\n{ro}")
+
+    comments = shikiho_comments or []
+    comment_lines: List[str] = []
+    for item in comments:
+        if not isinstance(item, dict):
+            continue
+        text = (item.get("comment") or "").strip()
+        if not text:
+            continue
+        period = (item.get("period") or "").strip()
+        comment_lines.append(f"({period}) {text}" if period else text)
+    if comment_lines:
+        parts.append("【四季報コメント】\n" + "\n".join(comment_lines))
+
+    so = (stocks_overview or "").strip()
+    if so:
+        parts.append(f"【概要(株探)】\n{so}")
+
+    return "\n\n".join(parts)
+
+
+def _build_prompt(business_text: str, theme_names: List[str], max_suggest: int) -> str:
+    """LLM へ渡すプロンプトを組み立てる。
+
+    マスターのテーマ一覧から「のみ」選ばせ、JSON 配列で返させる。
+    """
+    theme_list = "\n".join(f"- {name}" for name in theme_names)
+    return (
+        "あなたは日本株の業態分類アシスタントです。"
+        "以下の事業内容に最も合致する「業態テーマ」を、後述のテーマ一覧の中から"
+        f"最大{max_suggest}件選んでください。\n\n"
+        "厳守事項:\n"
+        "- 必ずテーマ一覧に存在する文字列だけを、一字一句そのまま出力すること。\n"
+        "- 一覧に無いテーマを新しく作ってはいけない。\n"
+        "- 合致するものが無ければ空配列を返すこと。\n"
+        '- 出力は JSON 配列のみ。例: ["半導体", "AI"]。説明文は不要。\n\n'
+        f"# テーマ一覧\n{theme_list}\n\n"
+        f"# 事業内容\n{business_text}\n"
+    )
+
+
+def _extract_json_array(text: str) -> List[str]:
+    """LLM 出力テキストから最初の JSON 配列を抽出して list[str] にする。
+
+    ```json フェンスや前後の説明文が付いていても配列部分だけを拾う。
+    パース失敗時は [] を返す。
+    """
+    if not text:
+        return []
+    m = re.search(r"\[.*?\]", text, re.DOTALL)
+    if not m:
+        return []
+    try:
+        arr = json.loads(m.group(0))
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(arr, list):
+        return []
+    return [str(x).strip() for x in arr if str(x).strip()]
+
+
+def _run_claude(prompt: str, timeout_sec: int) -> str:
+    """claude -p (Haiku) を起動し、result テキストを返す。
+
+    失敗時は "" を返す。ツールは使わせない (分類のみ、Web 検索等は不要)。
+    """
+    cmd = [
+        "claude",
+        "-p",
+        prompt,
+        "--model",
+        "haiku",
+        "--output-format",
+        "json",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(PROJECT_ROOT),
+            timeout=timeout_sec,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        log_error(f"[theme-suggest] claude -p タイムアウト ({timeout_sec}s)")
+        return ""
+    except FileNotFoundError:
+        log_error("[theme-suggest] claude CLI が見つかりません")
+        return ""
+
+    if result.returncode != 0:
+        log_warning(f"[theme-suggest] claude -p 異常終了: rc={result.returncode}")
+        log_warning(f"stderr: {(result.stderr or '')[-500:]}")
+        return ""
+
+    # --output-format json の stdout は {"result": "...", "usage": {...}, ...}
+    try:
+        payload = json.loads(result.stdout)
+    except (ValueError, TypeError):
+        log_warning("[theme-suggest] claude -p の出力が JSON としてパースできない")
+        log_debug(f"stdout 末尾: {(result.stdout or '')[-300:]!r}")
+        return ""
+    return str(payload.get("result", ""))
+
+
+def suggest_gyoutai_themes(
+    business_text: str,
+    theme_names: List[str],
+    *,
+    max_suggest: int = DEFAULT_MAX_SUGGEST,
+    timeout_sec: int = DEFAULT_TIMEOUT_SEC,
+) -> List[str]:
+    """事業内容テキストから業態テーマを最大 max_suggest 件提案する。
+
+    theme_names (マスター登録テーマ) の中からのみ選ぶ。LLM がリスト外を返しても
+    フィルタ除去する。空入力や LLM 失敗時は [] を返す。
+    """
+    business_text = (business_text or "").strip()
+    if not business_text:
+        return []
+    if not theme_names:
+        return []
+
+    prompt = _build_prompt(business_text, theme_names, max_suggest)
+    log_debug(f"[theme-suggest] prompt:\n{prompt}")
+
+    raw = _run_claude(prompt, timeout_sec)
+    candidates = _extract_json_array(raw)
+    log_debug(f"[theme-suggest] LLM 候補: {candidates}")
+
+    # マスター内のみ・重複除去・順序保持・max_suggest 件で打ち切り
+    valid = set(theme_names)
+    seen: set = set()
+    result: List[str] = []
+    for name in candidates:
+        if name in valid and name not in seen:
+            seen.add(name)
+            result.append(name)
+        if len(result) >= max_suggest:
+            break
+
+    log_print(f"[theme-suggest] 提案テーマ: {result}")
+    return result

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -90,6 +90,19 @@ def stock_detail(code_s: str):
     # issue #282: テーママスターから候補を取得
     theme_master = [] if portfolio_fallback_mode else ps.list_themes()
 
+    # issue #297: 業態テーマ自動提案ボタンの表示条件。
+    # 未設定 (全スロット空) かつ事業テキスト (四季報特色・コメント・株探概要) が
+    # 1 つでもある銘柄にのみ「🤖 提案」ボタンを出す。
+    from theme_suggest import build_business_text  # 遅延 import
+    gyoutai_themes_unset = not any((t or "").strip() for t in gyoutai_themes)
+    has_business_text = bool(
+        build_business_text(
+            record.get("overview"),
+            record.get("shikiho_comments"),
+            stock.get("overview") if stock else None,
+        )
+    )
+
     # issue #227: 株価 + RSライン 統合チャート (フル版)
     # market_db のロード失敗時は RS 無しの株価のみで描画 (500 にしない)
     from webapp.helpers import build_stock_chart_payload  # 遅延 import
@@ -121,4 +134,6 @@ def stock_detail(code_s: str):
         gyoutai_themes=gyoutai_themes,
         theme_master=theme_master,
         gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
+        gyoutai_themes_unset=gyoutai_themes_unset,
+        has_business_text=has_business_text,
     )

--- a/scripts/webapp/routes/memo.py
+++ b/scripts/webapp/routes/memo.py
@@ -8,17 +8,29 @@ POST /stock/<code_s>/corporate_url    : 会社HP URL 上書き保存/クリア (
 POST /stock/<code_s>/stock_name_prev  : 旧名/エイリアス 保存/クリア (issue #236, AJAX)
 """
 
+import threading
+
 from flask import Blueprint, flash, jsonify, request, redirect, url_for
 
+import portfolio_shelve as ps
+import theme_suggest
 from webapp.helpers import (
     save_memo,
     save_shikiho,
     save_ir_comments,
     save_corporate_url_override,
     save_stock_name_prev,
+    get_research_detail,
+    get_stock_data,
 )
 
 memo_bp = Blueprint("memo", __name__)
+
+# 業態テーマ提案 (issue #297) の同時実行ガード。
+# 単一プロセス運用 (app.run) 前提のプロセス内ロック。多重押下・並行リクエストで
+# claude -p が同時に複数走りワーカースレッドが枯渇するのを防ぐ。
+# ※ 将来マルチプロセス運用 (gunicorn 等) に切り替える場合は file lock 等に置換が必要。
+_suggest_themes_lock = threading.Lock()
 
 
 @memo_bp.route("/stock/<code_s>/memo", methods=["POST"])
@@ -85,3 +97,52 @@ def post_stock_name_prev(code_s: str):
     except (ValueError, TypeError) as e:
         return jsonify({"ok": False, "error": str(e)}), 400
     return ("", 204)
+
+
+@memo_bp.route("/stock/<code_s>/suggest_themes", methods=["POST"])
+def post_suggest_themes(code_s: str):
+    """業態テーマを事業内容から LLM 提案する (issue #297, AJAX/JSON)。
+
+    事業テキスト (四季報特色・四季報コメント・株探概要) をマスター登録テーマと
+    ともに claude -p (Haiku) に渡し、最も合うテーマを最大2件返す。
+    提案は保存せず、クライアントが select にプリセットするだけ。
+
+    サーバー側でもボタン表示条件 (テーマ未設定・事業テキストあり) を再検証し、
+    直接 API を叩いても設定済み銘柄では LLM を起動しない (コスト暴発防止)。
+    """
+    # 同時実行ガード: 既に提案処理中なら 429 を返す (二重起動防止)。
+    if not _suggest_themes_lock.acquire(blocking=False):
+        return jsonify({"ok": False, "error": "他の提案処理を実行中です"}), 429
+    try:
+        record = get_research_detail(code_s)
+        stock = get_stock_data(code_s)
+        if record is None and not stock:
+            return jsonify({"ok": False, "error": "銘柄が見つかりません"}), 404
+
+        # サーバー側ガード: 業態テーマが既に設定済みなら起動しない。
+        portfolio_record = ps.get_record(code_s)
+        memo = (portfolio_record or {}).get("memo")
+        if not isinstance(memo, dict):
+            memo = {}
+        existing_themes = memo.get("gyoutai_themes") or []
+        if any((t or "").strip() for t in existing_themes):
+            return jsonify({"ok": False, "error": "業態テーマが既に設定済みです"}), 409
+
+        business_text = theme_suggest.build_business_text(
+            (record or {}).get("overview"),
+            (record or {}).get("shikiho_comments"),
+            stock.get("overview"),
+        )
+        if not business_text:
+            return jsonify({"ok": True, "themes": [], "reason": "no_business_text"})
+
+        theme_names = [t["name"] for t in ps.list_themes()]
+        if not theme_names:
+            return jsonify({"ok": True, "themes": [], "reason": "no_master"})
+
+        themes = theme_suggest.suggest_gyoutai_themes(business_text, theme_names)
+        return jsonify({"ok": True, "themes": themes})
+    except Exception as e:  # noqa: BLE001
+        return jsonify({"ok": False, "error": str(e)}), 500
+    finally:
+        _suggest_themes_lock.release()

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -76,6 +76,13 @@
         <a href="{{ url_for('portfolio.themes_index') }}"
            style="font-size:0.85em;color:#555;text-decoration:none;padding:0 0.3em;"
            title="テーママスターを編集">✏️</a>
+        {# issue #297: 業態テーマ未設定 & 事業テキストありの銘柄に LLM 提案ボタン #}
+        {% if gyoutai_themes_unset and has_business_text %}
+        <button type="button" class="gyoutai-suggest-btn" data-code="{{ record.code_s }}"
+                title="事業内容 (四季報・概要) から業態テーマを LLM 提案"
+                style="font-size:0.85em;padding:0.1em 0.5em;margin-left:0.2em;background:transparent;border:1px solid #ccc;color:#666;border-radius:3px;cursor:pointer;">🤖 提案</button>
+        <span class="gyoutai-suggest-msg" style="font-size:0.8em;color:#888;margin-left:0.3em;"></span>
+        {% endif %}
       </span>
       {% endif %}
       <form method="POST" action="/stock/{{ record.code_s }}/refresh" style="display:inline;margin-left:0.5em;">
@@ -704,6 +711,49 @@ function excludeFromUniverse(codeS) {
       window.open('/portfolio?gyoutai_theme=' + encodeURIComponent(v), '_blank', 'noopener');
     });
   });
+
+  // issue #297: 業態テーマ LLM 提案ボタン。
+  // 提案を select にプリセットするだけ (保存はユーザーが change で確定)。
+  var suggestBtn = wrap.querySelector('.gyoutai-suggest-btn');
+  var suggestMsg = wrap.querySelector('.gyoutai-suggest-msg');
+  if (suggestBtn) {
+    suggestBtn.addEventListener('click', function() {
+      suggestBtn.disabled = true;
+      suggestBtn.textContent = '提案中...';
+      if (suggestMsg) suggestMsg.textContent = '';
+      fetch('/stock/' + encodeURIComponent(code) + '/suggest_themes', {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      }).then(function(r) {
+        return r.json().then(function(json) { return { ok: r.ok, json: json }; });
+      }).then(function(res) {
+        suggestBtn.disabled = false;
+        suggestBtn.textContent = '🤖 提案';
+        if (!res.ok || !res.json || res.json.ok !== true) {
+          if (suggestMsg) suggestMsg.textContent = (res.json && res.json.error) || '提案に失敗しました';
+          return;
+        }
+        var themes = res.json.themes || [];
+        if (themes.length === 0) {
+          if (suggestMsg) suggestMsg.textContent = '候補なし';
+          return;
+        }
+        // 提案テーマを前のスロットから順に select へ反映 (value に持つ option を選択)。
+        // 既存値は無い前提 (未設定銘柄のみボタン表示)。保存は走らせない。
+        themes.forEach(function(name, i) {
+          var inp = inputs[i];
+          if (!inp) return;
+          var hasOpt = Array.prototype.some.call(inp.options, function(o) { return o.value === name; });
+          if (hasOpt) inp.value = name;
+        });
+        if (suggestMsg) suggestMsg.textContent = '提案を反映 (保存は select 変更で確定)';
+      }).catch(function(err) {
+        suggestBtn.disabled = false;
+        suggestBtn.textContent = '🤖 提案';
+        if (suggestMsg) suggestMsg.textContent = '通信エラー: ' + err;
+      });
+    });
+  }
 })();
 </script>
 {% endif %}

--- a/tests/test_theme_suggest.py
+++ b/tests/test_theme_suggest.py
@@ -1,0 +1,70 @@
+"""theme_suggest.py のテスト (issue #297)。
+
+claude -p は実際に呼ばず、_run_claude を monkeypatch でモックする。
+"""
+import pytest
+
+import theme_suggest as ts
+
+
+# ==================================================
+# build_business_text
+# ==================================================
+@pytest.mark.parametrize(
+    "ro, comments, so, expected_contains, expected_empty",
+    [
+        # 全空 → ""
+        (None, None, None, [], True),
+        ("", [], "", [], True),
+        # research overview のみ
+        ("半導体製造装置の専業", None, None, ["企業概要", "半導体製造装置"], False),
+        # 四季報コメント (period 有り/無り混在、空コメントはスキップ)
+        (
+            None,
+            [{"period": "26.1", "comment": "増益"}, {"period": "", "comment": "新工場"}, {"comment": ""}],
+            None,
+            ["四季報コメント", "(26.1) 増益", "新工場"],
+            False,
+        ),
+        # 3 ソース全部
+        ("特色テキスト", [{"period": "25.11", "comment": "好調"}], "株探概要", ["特色テキスト", "好調", "株探概要"], False),
+    ],
+)
+def test_build_business_text(ro, comments, so, expected_contains, expected_empty):
+    result = ts.build_business_text(ro, comments, so)
+    if expected_empty:
+        assert result == ""
+    else:
+        for token in expected_contains:
+            assert token in result
+
+
+# ==================================================
+# suggest_gyoutai_themes
+# ==================================================
+@pytest.mark.parametrize(
+    "business_text, theme_names, llm_result, expected",
+    [
+        # business_text 空 → LLM 呼ばず []
+        ("", ["AI", "半導体"], '["AI"]', []),
+        # theme_names 空 → []
+        ("半導体の会社", [], '["半導体"]', []),
+        # マスター外を除去 (防衛 はマスターに無い)
+        ("AIと防衛の会社", ["AI", "半導体"], '["AI", "防衛"]', ["AI"]),
+        # 重複除去 + max_suggest=2 で打ち切り
+        (
+            "色々な事業",
+            ["AI", "半導体", "EV"],
+            '["AI", "AI", "半導体", "EV"]',
+            ["AI", "半導体"],
+        ),
+        # フェンス付き・説明文付きでも配列を抽出
+        ("半導体の会社", ["AI", "半導体"], 'おすすめ: ```json\n["半導体"]\n```', ["半導体"]),
+        # パース不能 → []
+        ("半導体の会社", ["AI", "半導体"], "JSONじゃない応答", []),
+    ],
+)
+def test_suggest_gyoutai_themes(monkeypatch, business_text, theme_names, llm_result, expected):
+    monkeypatch.setattr(ts, "_run_claude", lambda prompt, timeout_sec: llm_result)
+    result = ts.suggest_gyoutai_themes(business_text, theme_names)
+    assert result == expected

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1401,3 +1401,63 @@ class TestPortfolioThemeSummary:
         html = resp.data.decode()
         assert "業態テーマ別 RS サマリー" in html
         assert "半導体" in html
+
+
+class TestSuggestThemes:
+    """issue #297: POST /stock/<code_s>/suggest_themes (LLM 業態テーマ提案)。
+
+    claude -p は呼ばず theme_suggest.suggest_gyoutai_themes をモックして、
+    エンドポイントのガード分岐 (設定済み409・事業テキスト空・正常提案) を検証する。
+    """
+
+    @pytest.fixture
+    def suggest_app(self, db_path, tmp_path, monkeypatch):
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+
+        # 事業テキストあり銘柄 (overview + shikiho_comments)
+        rec = rs.create_research_record(
+            "3496", "アズーム", overall_rating="A",
+            overview="駐車場サブリース", shikiho_comments=["最高益"],
+        )
+        rs.upsert_research_record(rec, db_path=db_path)
+        # 事業テキスト空銘柄
+        rec_empty = rs.create_research_record("1234", "空テスト", overall_rating="B")
+        rs.upsert_research_record(rec_empty, db_path=db_path)
+        # テーママスター登録
+        ps.create_theme("不動産", db_path=portfolio_db)
+        ps.create_theme("AI", db_path=portfolio_db)
+        # 3496 を 3監 で登録 (テーマ未設定)
+        ps.add_to_watch("3496", reason="テスト", db_path=portfolio_db)
+        ps.add_to_watch("1234", reason="テスト", db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        return app
+
+    def test_suggest_returns_filtered_themes(self, suggest_app, monkeypatch):
+        """事業テキスト・マスターありで提案テーマが JSON で返る"""
+        monkeypatch.setattr(
+            "webapp.routes.memo.theme_suggest.suggest_gyoutai_themes",
+            lambda business_text, theme_names: ["不動産"],
+        )
+        resp = suggest_app.test_client().post("/stock/3496/suggest_themes")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"ok": True, "themes": ["不動産"]}
+
+    def test_suggest_empty_business_text(self, suggest_app):
+        """事業テキスト空銘柄は LLM を呼ばず空配列 + reason を返す"""
+        resp = suggest_app.test_client().post("/stock/1234/suggest_themes")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"ok": True, "themes": [], "reason": "no_business_text"}
+
+    def test_suggest_rejects_already_set(self, suggest_app):
+        """業態テーマ設定済み銘柄は 409 で拒否 (サーバー側ガード)"""
+        import portfolio_shelve as ps
+        ps.update_memo("3496", {"gyoutai_themes": ["不動産"]})
+        resp = suggest_app.test_client().post("/stock/3496/suggest_themes")
+        assert resp.status_code == 409


### PR DESCRIPTION
Closes #297

## 概要
銘柄詳細画面で業態テーマ**未設定**かつ事業テキストありの銘柄に「🤖 提案」ボタンを表示し、事業内容を軽量 LLM (`claude -p` Haiku) に渡してテーママスターから 1〜2 件を提案する。手動でテーマを選ぶ際の「どれにするか迷う」を軽減する。

## 仕様
- **対象**: 業態テーマ未設定 & 事業テキストありの銘柄のみ (条件外はボタン非表示)
- **入力**: research `overview` (四季報特色) + `shikiho_comments` (四季報コメント) + stocks `overview` (株探概要) の3ソースを結合
- **LLM**: `claude -p --model haiku` を subprocess 起動 (`run_theme_news.py` 踏襲、新規依存・APIキー管理なし)
- **選択肢**: テーママスター `list_themes()` の登録テーマのみ。リスト外は呼び出し側でフィルタ除去 (ハルシネーション防止)
- **適用**: 候補を `<select>` にプリセットするのみ。**保存はユーザーが手動確定** (誤提案を自動保存しない)

## codex レビュー反映 (実装プラン段階)
- **サーバー側ガード**: クライアント表示条件に依存せず API でも「未設定」を再検証。設定済み銘柄は 409 で拒否しコスト暴発を防ぐ
- **同時実行 1 件制限**: `threading.Lock` で多重押下・並行リクエストを弾く (単一プロセス `app.run` 運用前提、将来マルチプロセス化時は file lock へ)
- **タイムアウト 45 秒**: ワーカースレッドの過度なブロックを防止

## 変更ファイル
- `scripts/theme_suggest.py` (新規): `build_business_text` + `suggest_gyoutai_themes`
- `scripts/webapp/routes/memo.py`: `POST /stock/<code_s>/suggest_themes`
- `scripts/webapp/routes/detail.py`: 表示条件 context 追加
- `scripts/webapp/templates/detail.html`: 提案ボタン + fetch JS
- `tests/test_theme_suggest.py` (新規) / `tests/test_webapp_routes.py`: テスト
- `doc/plan/issue297_gyoutai_theme_suggest.md`: 実装プラン

## テスト・検証
- `pytest tests/test_theme_suggest.py tests/test_webapp_routes.py` → **103 passed** (回帰なし)
- 実銘柄 E2E (135A VRAIN Solution = 製造業AI外観検査): 提案 \`フィジカルAI\` / \`SIコンサル\` を的確にプリセット
- 設定済み銘柄 (1436) でボタン非表示・直接 API 叩き → 409 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)