### PR TITLE
webapp: 銘柄詳細に外部チャット (ChatGPT/Claude) リンク登録を追加 (#265)

### DIFF
--- a/doc/plan/issue265_chat_links.md
+++ b/doc/plan/issue265_chat_links.md
@@ -1,0 +1,128 @@
+# issue #265: 銘柄詳細ページに外部チャット (ChatGPT/Claude) リンクを手動登録
+
+## 目的
+
+銘柄ごとの ChatGPT/Claude チャットスレッド URL を ResearchDB に手動登録し、
+銘柄詳細ページ (`/stock/<code_s>`) から即座に開ける導線を作る。
+
+**最小機能に限定** — 外部 LLM からの DB 参照、内蔵チャット UI、URL 自動取得は別 issue。
+
+## データモデル
+
+`chat_links` は **ラベル付きリスト**: `[{"label": str, "url": str}, ...]`
+
+- `label`: 自由入力 (例「ChatGPT 事業分析」「Claude IR読み」)
+- `url`: `http://` / `https://` で始まる文字列のみ許容
+- 既存レコードに欠損していたら空リスト `[]` 扱い (後方互換)
+
+## 設計判断 (ユーザー確認済み)
+
+1. **編集 UI**: 行ごとフォーム + AJAX。各リンクを「ラベル / URL」行で表示し、追加・編集・削除を fetch でサーバ送信 → 再描画。
+2. **URL 検証**: `http://` / `https://` 始まりのみ許可 (corporate_url と同基準)。ラベルは自由入力。
+
+## 変更ファイル
+
+### 1. `scripts/research_shelve.py` — スキーマ + 後方互換
+
+- `RECORD_FIELDS` に `"chat_links"` を追加。
+- `create_research_record()` に `chat_links: Optional[List[Dict[str, Any]]] = None` 引数を追加し、
+  返却 dict に `"chat_links": list(chat_links) if chat_links else []` を含める。
+- `get_research_record()` の後方互換ブロック (L508-526) に
+  `if not isinstance(record.get("chat_links"), list): record["chat_links"] = []` を追加。
+- 各要素の正規化ヘルパー `_normalize_chat_links(links)` を新設:
+  - list でなければ `[]`
+  - 各要素は dict かつ `label`/`url` が str のもののみ採用 (壊れたエントリは捨てる)
+  - `url` が http/https 始まりでないエントリは捨てる
+  - `get_research_record()` で呼んで正規化 (shikiho_comments と同じ箇所・同じ流儀)
+
+  → **検証ポイント**: chat_links 未設定の旧レコードを読んで `[]` が返る / 壊れたエントリが除去される。
+
+### 2. `scripts/webapp/helpers.py` — 保存ロジック (CRUD)
+
+`corporate_url_override` の `save_corporate_url_override()` (L428) に倣い、
+**`_flock()` で read-modify-write を排他** した3関数を新設:
+
+```python
+def add_chat_link(code_s, label, url) -> List[dict]   # 末尾に追加、保存後の全リストを返す
+def update_chat_link(code_s, index, label, url) -> List[dict]  # index 行を上書き
+def delete_chat_link(code_s, index) -> List[dict]     # index 行を削除
+```
+
+- URL 検証 (`http://`/`https://` 始まり) は **ルート側** で行い (corporate_url と同じ層分担)、
+  helpers は index 範囲チェック・レコード未登録チェックのみ。
+- index は範囲外なら `IndexError` / `ValueError` を送出 → ルートが 400 にマップ。
+- `label` は `strip()` のみ (空ラベルは許容: URL だけ登録したいケースもある)。
+
+  → **検証ポイント**: add → update → delete の一連操作後に get_research_record で永続化を確認。
+     並行 index ずれ (同時削除) は flock で直列化される範囲で保証。
+
+### 3. `scripts/webapp/routes/memo.py` — AJAX ルート
+
+`post_stock_name_prev` (L85, AJAX/JSON 204 パターン) に倣い、JSON を返す3ルート:
+
+```
+POST /stock/<code_s>/chat_link            label, url           → 201 {ok, links}
+POST /stock/<code_s>/chat_link/<int:idx>  label, url           → 200 {ok, links}
+POST /stock/<code_s>/chat_link/<int:idx>/delete                → 200 {ok, links}
+```
+
+- URL バリデーション: 空 or `http(s)://` 始まり以外は 400 `{ok:false, error}`。
+- レコード未登録は 404、index 範囲外は 400。
+- 成功時は最新の `links` 配列を JSON で返し、クライアントがその場で再描画
+  (リロード不要。stock_name_prev はリロードだが links は配列を返せるので DOM 差し替えにする)。
+
+  → **検証ポイント**: 各ルートに正常系 + 400 (不正URL) + 404 (未登録) のテスト。
+
+### 4. `scripts/webapp/templates/detail.html` — UI (手動メモセクション内)
+
+**「5. 手動メモ」セクション内、「メモ・総括」の `memo-field` (L315-319) の直後**
+(「機関投資家」フィールドの前) に「外部チャット」の `memo-field` を挿入する (ユーザー指定)。
+
+⚠️ **重要な制約**: 手動メモセクションは単一 `<form action="/stock/<code_s>/memo">` で
+全フィールドを一括 POST する。chat_links は AJAX で個別保存するため、
+**chat_links の入力要素にはこの memo フォーム送信対象になる `name` を付けない**
+(リンク表示・編集ボタンは form 内に置いてよいが、保存は独立 fetch 経路にする。
+`name` 付き input を置かなければ memo POST に混入しない)。
+
+- `record.chat_links` を `{% for link in record.chat_links %}` で行表示。
+  各行: `<a href="{{ link.url }}" target="_blank" rel="noopener noreferrer">{{ link.label or link.url }}</a>`
+  + ✎ 編集ボタン + 🗑 削除ボタン (data-index 付き)。
+- 末尾に「+ 追加」ボタン → ラベル/URL の prompt() 2連 or インライン入力欄。
+  **AJAX 方針なので**: 追加・編集はインラインの `<input>` 2つ + 保存ボタンを JS で生成 or
+  シンプルに `window.prompt` 2回 (label, url) で取得 → fetch。
+  → 既存 editCorpUrl が prompt 方式なので、**追加/編集は prompt 2連 + fetch**、削除は confirm + fetch に統一
+    (JS 量を抑えつつ AJAX 化。完全インライン編集フォームは過剰)。
+- fetch 成功で返ってきた `links` 配列から行を再構築する小さな JS 関数 `renderChatLinks(codeS, links)`。
+- `rel="noopener noreferrer"` 必須 (既存リンクと同様)。
+
+  → **検証ポイント**: ブラウザで追加→表示→編集→削除→リロードで永続化を目視確認 (.playwright-mcp/ にスクショ)。
+
+## やらないこと (issue 準拠)
+
+- 外部 LLM からの DB 参照、内蔵チャット UI、LLM API 連携
+- URL 妥当性検査 (http/https チェック以上)、スクレイピング、自動タイトル取得
+- 複数銘柄への同一リンク紐付け
+
+## テスト方針 (CLAUDE.md: 1 PR 5本以下, parametrize 集約)
+
+- `tests/test_research_shelve.py`: `_normalize_chat_links` + 後方互換 (旧レコード→`[]`, 壊れエントリ除去) を parametrize で 1本。
+- `tests/test_webapp_routes.py`: chat_link の add/update/delete 正常系 + 不正URL(400) + 未登録(404) を parametrize で 2本程度。
+- テンプレートのみの表示は目視 (CLAUDE.md: HTML/JS のみはブラウザ確認)。
+
+合計 ≦ 5本。
+
+## 検証手順
+
+1. `pytest tests/test_research_shelve.py tests/test_webapp_routes.py -v`
+2. `cd scripts && python -m webapp.app` → `/stock/<既存銘柄>` で追加/編集/削除/リロード永続化を目視
+3. chat_links 未設定の既存銘柄ページが壊れず開けることを確認 (DoD 最終項目)
+
+## DoD 対応表
+
+| DoD | 対応 |
+|---|---|
+| RECORD_FIELDS に chat_links 追加 + 補完ロジック | 変更1 |
+| 外部チャット表示 (手動メモ内・総括の直後) | 変更4 |
+| ラベル+URL 追加・編集・削除 | 変更2,3,4 |
+| 再読込で永続化 | 変更2 (upsert) |
+| chat_links 未設定でも壊れない | 変更1 (後方互換) |

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -87,6 +87,7 @@ RECORD_FIELDS = frozenset(
         "analysis_date_raw",
         "kessan_date_raw",
         "corporate_url_override",
+        "chat_links",
     }
 )
 
@@ -258,6 +259,7 @@ def create_research_record(
     analysis_date_raw: str = "",
     kessan_date_raw: str = "",
     corporate_url_override: str = "",
+    chat_links: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """銘柄調査レコードのひな型 dict を生成する。
 
@@ -306,6 +308,7 @@ def create_research_record(
         "analysis_date_raw": analysis_date_raw,
         "kessan_date_raw": kessan_date_raw,
         "corporate_url_override": corporate_url_override,
+        "chat_links": _normalize_chat_links(chat_links),
     }
 
 
@@ -439,6 +442,31 @@ def _normalize_shikiho_comments(comments):
     return result
 
 
+def _normalize_chat_links(links):
+    """外部チャットリンクを List[{"label", "url"}] に正規化する（後方互換, issue #265）。
+
+    - list でなければ空リスト
+    - 各要素は dict かつ url が http://・https:// 始まりの str のもののみ採用
+    - label は str 化して strip。壊れたエントリ・不正 URL は捨てる
+    """
+    if not isinstance(links, list):
+        return []
+    result = []
+    for item in links:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("url")
+        if not isinstance(url, str):
+            continue
+        url = url.strip()
+        if not (url.startswith("http://") or url.startswith("https://")):
+            continue
+        label = item.get("label")
+        label = label.strip() if isinstance(label, str) else ""
+        result.append({"label": label, "url": url})
+    return result
+
+
 def sort_shikiho_comments_desc(
     comments: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
@@ -499,6 +527,7 @@ def get_research_record(
     held_after_kessan が無ければ False で補完する（後方互換）。
     post_price_changes が無く旧 post_price_change のみがある場合、
     {"1d": <旧値>, "5d": ""} に正規化する（後方互換）。
+    chat_links は未設定/壊れたエントリを除去して List[{"label","url"}] に正規化する。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
@@ -524,6 +553,7 @@ def get_research_record(
             record["corporate_url_override"] = ""
         if "stock_name_prev" not in record:
             record["stock_name_prev"] = None
+        record["chat_links"] = _normalize_chat_links(record.get("chat_links"))
     return record
 
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -25,6 +25,7 @@ from research_shelve import (
     normalize_code_s,
     validate_rating,
     _flock,
+    _normalize_chat_links,
     normalize_kessan_post_price_changes,
     VALID_RATINGS,
     VALID_EXPECTATIONS,
@@ -454,6 +455,68 @@ def save_corporate_url_override(code_s: str, url: str) -> str:
         record["corporate_url_override"] = cleaned
         upsert_research_record(record)
     return cleaned
+
+
+# =======================================================
+# 外部チャットリンク (chat_links) の CRUD (issue #265)
+# =======================================================
+# URL の http/https バリデーションはルート側で実施する
+# (save_corporate_url_override と同じ層分担)。helpers は index 範囲・
+# レコード存在チェックのみ行い、_flock で read-modify-write を直列化する。
+
+def _get_record_for_chat_link(normalized: str) -> Dict[str, Any]:
+    """chat_link 操作用にレコードを取得する。未登録は ValueError。"""
+    record = get_research_record(normalized)
+    if record is None:
+        raise ValueError(f"レコード未登録: {normalized}")
+    return record
+
+
+def add_chat_link(code_s: str, label: str, url: str) -> List[Dict[str, str]]:
+    """外部チャットリンクを末尾に追加し、保存後の全リストを返す。"""
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    entry = {"label": (label or "").strip(), "url": (url or "").strip()}
+    with _flock():
+        record = _get_record_for_chat_link(normalized)
+        links = _normalize_chat_links(record.get("chat_links"))
+        links.append(entry)
+        record["chat_links"] = links
+        upsert_research_record(record)
+    return links
+
+
+def update_chat_link(
+    code_s: str, index: int, label: str, url: str
+) -> List[Dict[str, str]]:
+    """index 行を上書きし、保存後の全リストを返す。範囲外は IndexError。"""
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    entry = {"label": (label or "").strip(), "url": (url or "").strip()}
+    with _flock():
+        record = _get_record_for_chat_link(normalized)
+        links = _normalize_chat_links(record.get("chat_links"))
+        if not 0 <= index < len(links):
+            raise IndexError(f"chat_links の index 範囲外: {index}")
+        links[index] = entry
+        record["chat_links"] = links
+        upsert_research_record(record)
+    return links
+
+
+def delete_chat_link(code_s: str, index: int) -> List[Dict[str, str]]:
+    """index 行を削除し、保存後の全リストを返す。範囲外は IndexError。"""
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    with _flock():
+        record = _get_record_for_chat_link(normalized)
+        links = _normalize_chat_links(record.get("chat_links"))
+        if not 0 <= index < len(links):
+            raise IndexError(f"chat_links の index 範囲外: {index}")
+        del links[index]
+        record["chat_links"] = links
+        upsert_research_record(record)
+    return links
 
 
 # =======================================================

--- a/scripts/webapp/routes/memo.py
+++ b/scripts/webapp/routes/memo.py
@@ -6,6 +6,9 @@ POST /stock/<code_s>/shikiho          : 四季報保存
 POST /stock/<code_s>/ir_comment       : IR分析コメント一括保存
 POST /stock/<code_s>/corporate_url    : 会社HP URL 上書き保存/クリア (issue #208)
 POST /stock/<code_s>/stock_name_prev  : 旧名/エイリアス 保存/クリア (issue #236, AJAX)
+POST /stock/<code_s>/chat_link            : 外部チャットリンク追加 (issue #265, AJAX)
+POST /stock/<code_s>/chat_link/<idx>      : 外部チャットリンク更新 (issue #265, AJAX)
+POST /stock/<code_s>/chat_link/<idx>/delete : 外部チャットリンク削除 (issue #265, AJAX)
 """
 
 from flask import Blueprint, flash, jsonify, request, redirect, url_for
@@ -16,6 +19,9 @@ from webapp.helpers import (
     save_ir_comments,
     save_corporate_url_override,
     save_stock_name_prev,
+    add_chat_link,
+    update_chat_link,
+    delete_chat_link,
 )
 
 memo_bp = Blueprint("memo", __name__)
@@ -85,3 +91,60 @@ def post_stock_name_prev(code_s: str):
     except (ValueError, TypeError) as e:
         return jsonify({"ok": False, "error": str(e)}), 400
     return ("", 204)
+
+
+# =======================================================
+# 外部チャットリンク (chat_links) ルート (issue #265, AJAX/JSON)
+# =======================================================
+
+def _validate_chat_url(url: str):
+    """chat_link の URL を検証する。不正なら (error_message) を返し、正常なら None。"""
+    if not url:
+        return "URL を入力してください"
+    if not (url.startswith("http://") or url.startswith("https://")):
+        return "URL は http:// または https:// で始めてください"
+    return None
+
+
+@memo_bp.route("/stock/<code_s>/chat_link", methods=["POST"])
+def post_chat_link_add(code_s: str):
+    """外部チャットリンク追加 -> JSON {ok, links}。"""
+    label = request.form.get("label", "")
+    url = request.form.get("url", "").strip()
+    err = _validate_chat_url(url)
+    if err:
+        return jsonify({"ok": False, "error": err}), 400
+    try:
+        links = add_chat_link(code_s, label, url)
+    except (ValueError, TypeError) as e:
+        return jsonify({"ok": False, "error": str(e)}), 404
+    return jsonify({"ok": True, "links": links}), 201
+
+
+@memo_bp.route("/stock/<code_s>/chat_link/<int:idx>", methods=["POST"])
+def post_chat_link_update(code_s: str, idx: int):
+    """外部チャットリンク更新 -> JSON {ok, links}。範囲外 idx は 400。"""
+    label = request.form.get("label", "")
+    url = request.form.get("url", "").strip()
+    err = _validate_chat_url(url)
+    if err:
+        return jsonify({"ok": False, "error": err}), 400
+    try:
+        links = update_chat_link(code_s, idx, label, url)
+    except IndexError as e:
+        return jsonify({"ok": False, "error": str(e)}), 400
+    except (ValueError, TypeError) as e:
+        return jsonify({"ok": False, "error": str(e)}), 404
+    return jsonify({"ok": True, "links": links})
+
+
+@memo_bp.route("/stock/<code_s>/chat_link/<int:idx>/delete", methods=["POST"])
+def post_chat_link_delete(code_s: str, idx: int):
+    """外部チャットリンク削除 -> JSON {ok, links}。範囲外 idx は 400。"""
+    try:
+        links = delete_chat_link(code_s, idx)
+    except IndexError as e:
+        return jsonify({"ok": False, "error": str(e)}), 400
+    except (ValueError, TypeError) as e:
+        return jsonify({"ok": False, "error": str(e)}), 404
+    return jsonify({"ok": True, "links": links})

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -318,6 +318,16 @@
       <textarea class="editable-field rich-edit" name="memo" rows="6" data-form="memo" style="display:none;">{{ record.memo or '' }}</textarea>
     </div>
 
+    {# issue #265: 外部チャット (ChatGPT/Claude) リンク。AJAX で個別保存するため
+       memo フォーム送信対象になる name 付き input は置かない。 #}
+    <div class="memo-field">
+      <label>外部チャット</label>
+      <div id="chat-links-list" data-code="{{ record.code_s }}"></div>
+      <button type="button" onclick="addChatLink(this)" data-code="{{ record.code_s }}"
+              title="ChatGPT/Claude のチャット URL を登録"
+              style="display:inline-block;width:auto !important;padding:0.05em 0.5em;font-size:0.8em;margin:0.2em 0 0 0;background:transparent;border:1px solid #ccc;color:#666;border-radius:3px;cursor:pointer;">+ 追加</button>
+    </div>
+
     <div class="memo-field">
       <label>機関投資家</label>
       <div class="rich-display" onclick="switchToEdit(this)" style="min-height:3em;">{{ record.institutional_comment or '' }}</div>
@@ -337,6 +347,109 @@
 
   </form>
 </div>
+
+{# issue #265: 外部チャットリンクの描画・追加・編集・削除 (AJAX) #}
+<script>
+  // サーバから渡される初期リンク配列 (label/url の dict 列)
+  var CHAT_LINKS = {{ (record.chat_links or [])|tojson }};
+
+  // links 配列から #chat-links-list を再構築する。
+  // label/url は createElement + textContent / setAttribute で挿入し XSS を防ぐ。
+  function renderChatLinks(links) {
+    var container = document.getElementById('chat-links-list');
+    container.innerHTML = '';
+    if (!links.length) {
+      var empty = document.createElement('span');
+      empty.style.color = '#999';
+      empty.style.fontSize = '0.85em';
+      empty.textContent = '未登録';
+      container.appendChild(empty);
+      return;
+    }
+    links.forEach(function (link, idx) {
+      var row = document.createElement('div');
+      row.style.cssText = 'display:flex;align-items:center;gap:0.3em;margin-bottom:0.2em;';
+
+      var a = document.createElement('a');
+      a.href = link.url;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.textContent = link.label || link.url;
+      row.appendChild(a);
+
+      var edit = document.createElement('button');
+      edit.type = 'button';
+      edit.textContent = '✎';
+      edit.title = '編集';
+      edit.style.cssText = 'width:auto !important;padding:0 0.3em;font-size:0.8em;background:transparent;border:1px solid #ccc;color:#666;border-radius:3px;cursor:pointer;';
+      edit.onclick = function () { editChatLink(idx, link); };
+      row.appendChild(edit);
+
+      var del = document.createElement('button');
+      del.type = 'button';
+      del.textContent = '🗑';
+      del.title = '削除';
+      del.style.cssText = 'width:auto !important;padding:0 0.3em;font-size:0.8em;background:transparent;border:1px solid #ccc;color:#666;border-radius:3px;cursor:pointer;';
+      del.onclick = function () { deleteChatLink(idx, link); };
+      row.appendChild(del);
+
+      container.appendChild(row);
+    });
+  }
+
+  function _chatCode() {
+    return document.getElementById('chat-links-list').dataset.code;
+  }
+
+  // fetch 共通処理。成功で links を再描画、失敗で alert。
+  function _postChatLink(path, formData) {
+    fetch('/stock/' + encodeURIComponent(_chatCode()) + path, {
+      method: 'POST',
+      headers: {'X-Requested-With': 'XMLHttpRequest'},
+      body: formData,
+    }).then(function (r) {
+      return r.json().then(function (j) {
+        if (!r.ok || !j.ok) {
+          alert('失敗: ' + (j.error || r.status));
+          return;
+        }
+        CHAT_LINKS = j.links;
+        renderChatLinks(CHAT_LINKS);
+      });
+    }).catch(function (err) {
+      alert('通信エラー: ' + err);
+    });
+  }
+
+  function addChatLink() {
+    var label = window.prompt('ラベル (例: ChatGPT 事業分析)', '');
+    if (label === null) return;  // Cancel
+    var url = window.prompt('URL (http:// または https://)', '');
+    if (url === null) return;
+    var fd = new FormData();
+    fd.append('label', label);
+    fd.append('url', url);
+    _postChatLink('/chat_link', fd);
+  }
+
+  function editChatLink(idx, link) {
+    var label = window.prompt('ラベル', link.label || '');
+    if (label === null) return;
+    var url = window.prompt('URL (http:// または https://)', link.url || '');
+    if (url === null) return;
+    var fd = new FormData();
+    fd.append('label', label);
+    fd.append('url', url);
+    _postChatLink('/chat_link/' + idx, fd);
+  }
+
+  function deleteChatLink(idx, link) {
+    if (!window.confirm('削除しますか?\n' + (link.label || link.url))) return;
+    _postChatLink('/chat_link/' + idx + '/delete', new FormData());
+  }
+
+  renderChatLinks(CHAT_LINKS);
+</script>
 
 {# ===== 6. 四季報（click-to-edit） ===== #}
 <div class="memo-section" id="shikiho-section">

--- a/tests/test_research_shelve.py
+++ b/tests/test_research_shelve.py
@@ -1010,3 +1010,33 @@ class TestStockNamePrev:
         assert rs.clear_stock_name_prev_field("1436", db_path=db_path) is False
         # 未登録 → False
         assert rs.clear_stock_name_prev_field("9999", db_path=db_path) is False
+
+
+class TestChatLinks:
+    """issue #265: chat_links の正規化と後方互換"""
+
+    @pytest.mark.parametrize("raw, expected", [
+        # 未設定 (旧レコード) / 非リスト → 空リスト
+        (None, []),
+        ("not-a-list", []),
+        ([], []),
+        # 正常エントリ (label/url が保持される)
+        ([{"label": "ChatGPT", "url": "https://chat.example/a"}],
+         [{"label": "ChatGPT", "url": "https://chat.example/a"}]),
+        # label 欠損は空文字で補完、url の前後空白は strip
+        ([{"url": "  https://x.example  "}], [{"label": "", "url": "https://x.example"}]),
+        # 壊れたエントリ (dict でない / url 非str / http以外) は除去
+        (["str", {"label": "no url"}, {"url": 123},
+          {"url": "ftp://x"}, {"label": "ok", "url": "http://ok.example"}],
+         [{"label": "ok", "url": "http://ok.example"}]),
+    ])
+    def test_normalize_chat_links(self, raw, expected):
+        assert rs._normalize_chat_links(raw) == expected
+
+    def test_get_record_backfills_chat_links(self, db_path):
+        """旧レコード (chat_links 欠損) を読むと空リストで補完される"""
+        rec = rs.create_research_record("3496", "アズーム")
+        del rec["chat_links"]  # 旧スキーマを再現
+        rs.upsert_research_record(rec, db_path=db_path)
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        assert loaded["chat_links"] == []

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1401,3 +1401,48 @@ class TestPortfolioThemeSummary:
         html = resp.data.decode()
         assert "業態テーマ別 RS サマリー" in html
         assert "半導体" in html
+
+
+class TestChatLinkRoutes:
+    """issue #265: 外部チャットリンク AJAX ルート"""
+
+    def test_add_update_delete_flow(self, client, db_path):
+        """追加 → 更新 → 削除の一連と永続化を検証"""
+        # 追加 (201, links に1件)
+        resp = client.post("/stock/3496/chat_link",
+                           data={"label": "ChatGPT", "url": "https://chat.example/a"})
+        assert resp.status_code == 201
+        assert resp.get_json()["links"] == [
+            {"label": "ChatGPT", "url": "https://chat.example/a"}
+        ]
+        # 永続化確認
+        assert rs.get_research_record("3496", db_path=db_path)["chat_links"] == [
+            {"label": "ChatGPT", "url": "https://chat.example/a"}
+        ]
+        # 更新 (200, index 0 を上書き)
+        resp = client.post("/stock/3496/chat_link/0",
+                           data={"label": "Claude", "url": "https://claude.example/b"})
+        assert resp.status_code == 200
+        assert resp.get_json()["links"] == [
+            {"label": "Claude", "url": "https://claude.example/b"}
+        ]
+        # 削除 (200, 空に戻る)
+        resp = client.post("/stock/3496/chat_link/0/delete")
+        assert resp.status_code == 200
+        assert resp.get_json()["links"] == []
+        assert rs.get_research_record("3496", db_path=db_path)["chat_links"] == []
+
+    @pytest.mark.parametrize("path, data, status", [
+        # 不正 URL (http/https 以外) → 400
+        ("/stock/3496/chat_link", {"label": "x", "url": "ftp://x"}, 400),
+        ("/stock/3496/chat_link", {"label": "x", "url": ""}, 400),
+        # 未登録銘柄 → 404
+        ("/stock/9999/chat_link", {"label": "x", "url": "https://x.example"}, 404),
+        # index 範囲外 (chat_links 空なので 0 も範囲外) → 400
+        ("/stock/3496/chat_link/5", {"label": "x", "url": "https://x.example"}, 400),
+        ("/stock/3496/chat_link/5/delete", {}, 400),
+    ])
+    def test_error_cases(self, client, path, data, status):
+        resp = client.post(path, data=data)
+        assert resp.status_code == status
+        assert resp.get_json()["ok"] is False


### PR DESCRIPTION
## 概要

銘柄ごとの ChatGPT/Claude チャットスレッド URL を ResearchDB に手動登録し、銘柄詳細ページ (`/stock/<code_s>`) の**手動メモ内・「メモ・総括」の直後**から即座に開ける導線を追加 (issue #265)。

最小機能に限定 — 外部 LLM からの DB 参照・内蔵チャット UI・URL 自動取得は別 issue。

## データモデル

`chat_links` = `[{"label": str, "url": str}, ...]`
- `label`: 自由入力（例「ChatGPT 事業分析」「Claude IR読み」）
- `url`: `http://` / `https://` 始まりのみ許容
- 既存レコードに欠損していたら空リスト扱い（後方互換）

## 変更内容

| ファイル | 変更 |
|---|---|
| `research_shelve.py` | `RECORD_FIELDS` に `chat_links` 追加、`_normalize_chat_links` で後方互換補完（未設定/壊れエントリ/非http URL を除去） |
| `webapp/helpers.py` | `add/update/delete_chat_link` を `_flock` 排他で実装 |
| `webapp/routes/memo.py` | AJAX 3ルート、URL は http/https のみ許可（範囲外idx→400, 未登録→404） |
| `detail.html` | リンク表示＋追加/編集（prompt）/削除（confirm）を fetch 化。memo 一括 POST に混入しないよう `name` なし。XSS 防止のため `textContent`/`setAttribute` で挿入 |

## 検証

- 新規テスト 13件（research_shelve 7 + routes 6）+ マッピング対象 483件 **全パス**
- E2E（実DB で curl）: 追加→更新→削除→**再読込で永続化**を確認、不正URL(`javascript:`)は400で拒否、本番DBは空に戻してクリーンアップ済み
- chat_links 未設定の旧レコードでもセクションが壊れず `[]` で表示

## DoD

- [x] `RECORD_FIELDS` に `chat_links` 追加 + 補完ロジック
- [x] 外部チャットセクション表示（手動メモ内・総括の直後）
- [x] 任意のラベル＋URL を追加・編集・削除
- [x] 再読込で永続化
- [x] chat_links 未設定でも壊れない

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)