### PR TITLE
fix: get_major_theme で theme_rank 未設定時の KeyError を防ぐ

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -359,7 +359,7 @@ def get_major_theme(themes):
     @themes 銘柄のテーマ: stock_dbの'themes'キー
     """
     market_db = get_market_db()
-    theme_rank = market_db["theme_rank"]  # 現在のランキング
+    theme_rank = market_db.get("theme_rank", [])  # 現在のランキング (未生成なら空)
     theme_rank_dict = {v: i + 1 for (i, v) in enumerate(theme_rank)}
     if not themes:
         return ""


### PR DESCRIPTION
## 概要

\`get_major_theme()\` が \`market_db[\"theme_rank\"]\` を直接添字参照しており、\`theme_rank\` キーが無い \`market_db\` で \`KeyError\` を起こしていた。\`market_db.get(\"theme_rank\", [])\` に変更し、未設定時は「ランク情報なし(全テーマ同順)」として安全に処理する。

## 背景

CI のフルスイート実行で、テスト実行順序に依存して \`TestBuildCodeRankRow\` (3件) が \`KeyError: 'theme_rank'\` で落ちていた。原因は \`tests/test_make_market_db.py\` が \`make_market_db._market_db_cache\` を \`theme_rank\` キーの無い dict で汚染し、後続の \`build_code_rank_row\` → \`get_major_theme\` → \`get_market_db()\`(キャッシュ) が落ちるテスト分離不備。

本修正は実コード側を防御的にすることで、テスト分離問題と「未生成 DB で theme_rank が無い」実運用ケースの両方を解消する。

## 変更

- \`scripts/make_market_db.py\`: \`get_major_theme\` の theme_rank 参照を \`.get(\"theme_rank\", [])\` に (1行)

## 検証

- \`test_make_market_db.py\` + \`test_functional_market.py\`: 137 passed
- 汚染再現シナリオ(\`test_make_market_db\` → \`TestBuildCodeRankRow\`): 140 passed (以前は2 failed)
- フルスイート(\`--ignore=test_live_html\`): 1691 passed, 1 skipped (theme_rank 失敗 0件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)