### PR TITLE
fix: 決算反応 5d/20d を backfill 時に確定保存する

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -55,13 +55,35 @@ def get_research_detail(code_s: str) -> Optional[Dict[str, Any]]:
     return record
 
 
+def _backfill_entry_reactions(
+    entry: Dict[str, Any],
+    log: List,
+    dt: date,
+) -> Dict[str, str]:
+    """1エントリの post_price_changes の空き期間を price_log から補完する。
+
+    entry["post_price_changes"] を in-place で埋め、今回新たに埋まった期間だけを
+    {key: 値} で返す (永続化ターゲット用)。何も埋まらなければ空 dict。
+    """
+    existing = entry.get("post_price_changes") or {}
+    calculated = _price_reactions_from_log(log, dt)
+    newly_filled: Dict[str, str] = {}
+    for key, _ in KESSAN_REACTION_PERIODS:
+        if not existing.get(key) and calculated.get(key):
+            existing[key] = calculated[key]
+            newly_filled[key] = calculated[key]
+    entry["post_price_changes"] = existing
+    return newly_filled
+
+
 def _backfill_post_price_changes_for_entries(
     code_s: str,
     entries: List[Dict[str, Any]],
 ) -> None:
     """過去エントリの post_price_changes に欠損期間があれば price_log から補完する。
 
-    永続化はせず、entry dict を in-place で更新する。
+    entry dict を in-place で更新し、新たに埋まった反応率は 1d と同じく確定値として
+    shelve に永続化する (price_log の30日ウィンドウから決算日が外れても消えないように)。
     決算日が未来 (今日以降) のエントリは補完対象外。
     """
     if not entries:
@@ -81,16 +103,22 @@ def _backfill_post_price_changes_for_entries(
     if not targets:
         return
 
-    log = _bulk_price_logs([code_s]).get(normalize_code_s(code_s), [])
+    normalized = normalize_code_s(code_s)
+    log = _bulk_price_logs([code_s]).get(normalized, [])
     if not log:
         return
+    ppc_persist_targets: List[Tuple[str, str, int, Dict[str, str]]] = []
     for entry, dt in targets:
-        existing = entry.get("post_price_changes") or {}
-        calculated = _price_reactions_from_log(log, dt)
-        for key, _ in KESSAN_REACTION_PERIODS:
-            if not existing.get(key) and calculated.get(key):
-                existing[key] = calculated[key]
-        entry["post_price_changes"] = existing
+        newly_filled = _backfill_entry_reactions(entry, log, dt)
+        if newly_filled:
+            ppc_persist_targets.append((
+                normalized,
+                entry.get("kessanbi", ""),
+                int(entry.get("quarter", 0) or 0),
+                newly_filled,
+            ))
+    if ppc_persist_targets:
+        _persist_kessan_post_price_changes(ppc_persist_targets)
 
 
 def get_stock_data(code_s: str) -> Dict[str, Any]:
@@ -914,6 +942,57 @@ def _persist_kessan_held_flags(
             log_warning(f"[kessan_matagi] 永続化失敗 code={code_s}: {e}")
 
 
+def _persist_kessan_post_price_changes(
+    targets: List[Tuple[str, str, int, Dict[str, str]]],
+) -> None:
+    """指定 (code_s, kessanbi, quarter) の post_price_changes の空き期間を確定保存する。
+
+    targets の各 updates dict は {"5d": "+5.1", "20d": "+30"} のような
+    「backfill 計算で新たに埋まった非空値」のみ。
+
+    決算反応 (1d/5d/20d) は本来コメント記入時にスナップショット保存されるが、
+    記入時にはまだ経過していない期間は空のまま残る。表示時の backfill で計算
+    できたものを 1d と同じく確定値として永続化し、price_log の30日ウィンドウから
+    決算日が外れても消えないようにする。
+
+    並行書き込み安全対応 (_persist_kessan_held_flags と同じ):
+      - ロック下で get_research_record() による再取得を行い stale record を使わない
+      - 既存 dict の **空き期間にのみ** 書き込む (非空既存値・"pts" 等の未知キーは温存)
+    """
+    grouped: Dict[str, List[Tuple[str, int, Dict[str, str]]]] = {}
+    for code_s, kessanbi, quarter, updates in targets:
+        grouped.setdefault(code_s, []).append((kessanbi, quarter, updates))
+
+    for code_s, items in grouped.items():
+        try:
+            with _flock():
+                record = get_research_record(code_s)
+                if record is None:
+                    continue
+                comments = list(record.get("kessan_comments") or [])
+                changed = False
+                for kessanbi, quarter, updates in items:
+                    for existing in comments:
+                        if (
+                            existing.get("kessanbi") == kessanbi
+                            and int(existing.get("quarter", 0) or 0) == quarter
+                        ):
+                            # 既存 dict をベースに正規化 ("pts" 等の未知キーは温存)
+                            ppc = normalize_kessan_post_price_changes(existing)
+                            for key, new_val in updates.items():
+                                # 空き期間にのみ書き込む (非空既存値は上書きしない)
+                                if new_val and not ppc.get(key):
+                                    ppc[key] = new_val
+                                    changed = True
+                            existing["post_price_changes"] = ppc
+                            break
+                if changed:
+                    record["kessan_comments"] = comments
+                    upsert_research_record(record)
+        except Exception as e:
+            log_warning(f"[post_price_changes] 永続化失敗 code={code_s}: {e}")
+
+
 def _parse_form_tristate_bool(raw: Any) -> Optional[bool]:
     """フォーム値を bool / None (=未指定) に正規化する。
 
@@ -1426,6 +1505,9 @@ def get_market_kessan_data() -> Dict[str, Any]:
     # (stale rec を直接 upsert すると並行編集を上書きするため、lock 下で再取得する)
     # targets: [(code_s, kessanbi, quarter, {"held_before_kessan": True, ...}), ...]
     persist_targets: List[Tuple[str, str, int, Dict[str, bool]]] = []
+    # backfill で新たに埋まった反応率を確定保存するターゲット
+    # targets: [(code_s, kessanbi, quarter, {"5d": "+5.1", ...}), ...]
+    ppc_persist_targets: List[Tuple[str, str, int, Dict[str, str]]] = []
     for entry in merged.values():
         kessanbi = entry["kessanbi"]
         dt = _parse_kessanbi(kessanbi)
@@ -1437,11 +1519,14 @@ def get_market_kessan_data() -> Dict[str, Any]:
             existing_changes = entry.get("post_price_changes") or {}
             if any(not existing_changes.get(key) for key, _ in KESSAN_REACTION_PERIODS):
                 log = price_logs_cache.get(entry["code_s"], [])
-                calculated = _price_reactions_from_log(log, dt)
-                for key, _ in KESSAN_REACTION_PERIODS:
-                    if not existing_changes.get(key) and calculated.get(key):
-                        existing_changes[key] = calculated[key]
-                entry["post_price_changes"] = existing_changes
+                newly_filled = _backfill_entry_reactions(entry, log, dt)
+                if newly_filled:
+                    ppc_persist_targets.append((
+                        entry["code_s"],
+                        entry["kessanbi"],
+                        int(entry.get("quarter", 0) or 0),
+                        newly_filled,
+                    ))
 
         # 前後保有フラグのスナップショット化
         # - 未来エントリ (dt >= base_day): is_possess=True なら held_before_kessan=True
@@ -1490,6 +1575,8 @@ def get_market_kessan_data() -> Dict[str, Any]:
 
     if persist_targets:
         _persist_kessan_held_flags(persist_targets)
+    if ppc_persist_targets:
+        _persist_kessan_post_price_changes(ppc_persist_targets)
 
     # 銘柄コード順にカード内ソート
     for d in (

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -131,6 +131,86 @@ class TestGetResearchDetail:
         assert entry["post_price_changes"] == {"1d": "", "5d": "", "20d": ""}
 
 
+class TestBackfillPersistence:
+    """backfill で補完した反応率が shelve に確定保存される (price_log の
+    30日ウィンドウから決算日が外れても消えないように)"""
+
+    def _setup_entry(self, monkeypatch, post_price_changes, log):
+        """過去決算エントリ1件を挿入し、price_log と today を固定する"""
+        from datetime import date as _date
+        monkeypatch.setattr(
+            helpers,
+            "_bulk_price_logs",
+            lambda codes: {"3496": log} if "3496" in codes else {},
+        )
+        monkeypatch.setattr(
+            helpers, "get_price_day", lambda _: _date(2026, 4, 25)
+        )
+        rec = rs.get_research_record("3496")
+        rec["kessan_comments"] = [{
+            "kessanbi": "2026/04/01",
+            "quarter": 4,
+            "pre_expectation": "○",
+            "pre_outlook": "テスト",
+            "post_price_changes": dict(post_price_changes),
+            "post_comment": "",
+            "kessan_matagi": False,
+            "held_before_kessan": False,
+            "held_after_kessan": False,
+        }]
+        rs.upsert_research_record(rec)
+
+    @staticmethod
+    def _log_with_after_prices():
+        """決算日前営業日終値 + 5営業日後までの終値 (5d まで計算可能)"""
+        from datetime import date as _date, timedelta as _td
+        kessan = _date(2026, 4, 1)
+        log = [(kessan - _td(days=1), 1000)]
+        for i, pr in enumerate([1032, 1040, 1045, 1048, 1051], start=1):
+            log.append((kessan + _td(days=i), pr))
+        return log
+
+    def test_backfilled_5d_is_persisted(self, populated_db, monkeypatch):
+        """補完した 5d が再読込 (= 別呼び出し) でも残る = 永続化されている"""
+        self._setup_entry(
+            monkeypatch,
+            {"1d": "+3.2", "5d": ""},
+            self._log_with_after_prices(),
+        )
+        # 1回目: get_research_detail 内 backfill が走り永続化される
+        helpers.get_research_detail("3496")
+        # 別ルートで生の shelve を再読込し、永続化されたか確認
+        rec = rs.get_research_record("3496")
+        assert rec["kessan_comments"][0]["post_price_changes"]["5d"] == "+5.1"
+
+    def test_existing_nonempty_and_pts_not_overwritten(
+        self, populated_db, monkeypatch
+    ):
+        """既存の非空値・pts キーは backfill 永続化で上書きされない"""
+        self._setup_entry(
+            monkeypatch,
+            # 5d は手動入力済み (+99)、pts も入っている → どちらも温存される
+            {"pts": "+2.5", "1d": "+3.2", "5d": "+99"},
+            self._log_with_after_prices(),
+        )
+        helpers.get_research_detail("3496")
+        ppc = rs.get_research_record("3496")["kessan_comments"][0]["post_price_changes"]
+        assert ppc["5d"] == "+99"   # 既存値温存
+        assert ppc["pts"] == "+2.5"  # 未知キー温存
+
+    def test_uncomputable_period_not_persisted(
+        self, populated_db, monkeypatch
+    ):
+        """price_log に決算日付近が無く計算不能なら何も永続化されない (冪等)"""
+        from datetime import date as _date, timedelta as _td
+        # 決算日 (2026/04/01) より後だけの log → before_price が取れず計算不能
+        log = [(_date(2026, 4, 20) + _td(days=i), 1000 + i) for i in range(5)]
+        self._setup_entry(monkeypatch, {"1d": "+3.2", "5d": ""}, log)
+        helpers.get_research_detail("3496")
+        ppc = rs.get_research_record("3496")["kessan_comments"][0]["post_price_changes"]
+        assert ppc["5d"] == ""  # 計算不能なので空のまま
+
+
 class TestGetMarketKessanData:
     """get_market_kessan_data の振り分けロジックテスト"""
 


### PR DESCRIPTION
## Summary
- disclosure 決算日セクションで 5日後・20日後反応が表示されない問題を修正
- 根本原因: `post_price_changes` は決算コメント記入時（決算直後）にスナップショット保存されるが、未経過の 5d/20d は空のまま。後からの表示時 backfill は in-memory のみで永続化していなかった。`price_log` は `LOG_DAY=30` のローリングウィンドウのため、決算日が約30営業日より古くなると前営業日終値が消えて計算不能になり、5d/20d が永久欠損していた（例: 135A 2026/04/14、5578 2026/04/13）
- 対応: 表示時 backfill で新たに計算できた値を、1d と同じく確定値として shelve に永続化する `_persist_kessan_post_price_changes` を追加。既存 `_persist_kessan_held_flags` と同じ flock 下再取得パターンで、空き期間のみ書込・既存非空値/`pts` は温存。一度埋まれば冪等にスキップ
- 30日ウィンドウ外の過去分は計算不能なため対象外（空のまま温存、誤った値で埋めない）

## 変更点
- `_persist_kessan_post_price_changes()` 新設（並行安全な確定保存）
- `_backfill_entry_reactions()` ヘルパに backfill 計算を集約（market 経路 / 個別詳細経路の重複解消）
- `get_market_kessan_data` / `_backfill_post_price_changes_for_entries` で計算成功値を永続化

## Test plan
- [x] `pytest tests/test_webapp_helpers.py tests/test_html_sanitizer.py` 294 passed（新規3件: 永続化される / 既存値・pts上書きしない / 計算不能時は冪等）
- [x] `pytest tests/test_webapp_routes.py` 98 passed
- [x] webapp 起動 → `/disclosure` 200、5d/20d がレンダリング（2585: `+20.6% | +19%`）
- [x] 実データで 5d 234件・20d 28件が永続化、2回目呼び出しは更新ゼロ（冪等性確認）
- [x] 30日ウィンドウ外の 135A/5578 は空のまま温存・誤値なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)