### PR TITLE
テーマモーダルに監視銘柄をインライン列挙で追加表示 (#307)

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -242,9 +242,9 @@ def build_theme_portfolio_links(portfolio_records, stock_map):
     """保有/準保有銘柄をテーマ名から逆引きできる形にする。
 
     Returns:
-        dict: {theme_name: {"hold": [(code_s, stock_name)], "semi": [...]}}
+        dict: {theme_name: {"hold": [(code_s, stock_name)], "semi": [...], "watch": [...]}}
     """
-    status_key = {"1保": "hold", "2準": "semi"}
+    status_key = {"1保": "hold", "2準": "semi", "3監": "watch"}
     links = {}
     for rec in portfolio_records or []:
         status = rec.get("status")
@@ -256,12 +256,13 @@ def build_theme_portfolio_links(portfolio_records, stock_map):
         stock_name = stock.get("stock_name") or code_s
         item = (code_s, stock_name)
         for theme in _split_theme_names(stock.get("themes", "")):
-            theme_links = links.setdefault(theme, {"hold": [], "semi": []})
+            theme_links = links.setdefault(theme, {"hold": [], "semi": [], "watch": []})
             if item not in theme_links[key]:
                 theme_links[key].append(item)
     for theme_links in links.values():
         theme_links["hold"].sort(key=lambda item: item[0])
         theme_links["semi"].sort(key=lambda item: item[0])
+        theme_links["watch"].sort(key=lambda item: item[0])
     return links
 
 
@@ -277,6 +278,7 @@ def collect_theme_portfolio_links():
         records = (
             portfolio_shelve.list_records(status="1保")
             + portfolio_shelve.list_records(status="2準")
+            + portfolio_shelve.list_records(status="3監")
         )
         if not records:
             return {}
@@ -931,6 +933,7 @@ tr:hover { background: #f5f5f5; }
 .theme-modal-section h4 { margin: 0 0 0.3em 0; font-size: 0.9em; color: #555; }
 .theme-modal-section ul { list-style: none; padding: 0; margin: 0; }
 .theme-modal-section li { margin-bottom: 0.3em; font-size: 0.9em; list-style: none; }
+.theme-modal-inline { margin: 0; font-size: 0.9em; line-height: 1.6; }
 .theme-modal-section a { color: #1976d2; text-decoration: none; }
 .theme-modal-section a:hover { text-decoration: underline; }
 
@@ -1095,7 +1098,9 @@ def _html_theme_rank(market_db, theme_rank_data=None):
         link_info = theme_portfolio_links.get(theme, {}) or {}
         hold_items = link_info.get("hold", []) or []
         semi_items = link_info.get("semi", []) or []
-        has_links = bool(hold_items or semi_items)
+        watch_items = link_info.get("watch", []) or []
+        has_links = bool(hold_items or semi_items or watch_items)
+        # カードの強調色は保有 > 準保有の優先順 (監視は強調色を付けない)
         portfolio_class = " theme-hold" if hold_items else (
             " theme-semi" if semi_items else ""
         )
@@ -1107,11 +1112,14 @@ def _html_theme_rank(market_db, theme_rank_data=None):
             semi_json = html_mod.escape(
                 json.dumps(semi_items, ensure_ascii=False), quote=True,
             )
+            watch_json = html_mod.escape(
+                json.dumps(watch_items, ensure_ascii=False), quote=True,
+            )
             theme_attr = html_mod.escape(theme, quote=True)
             click_attrs = (
-                ' data-theme="%s" data-hold="%s" data-semi="%s"'
+                ' data-theme="%s" data-hold="%s" data-semi="%s" data-watch="%s"'
                 ' onclick="openThemeModal(this)"'
-            ) % (theme_attr, hold_json, semi_json)
+            ) % (theme_attr, hold_json, semi_json, watch_json)
         else:
             click_attrs = ""
         theme_escaped = html_mod.escape(theme)
@@ -1158,8 +1166,10 @@ def _html_theme_rank(market_db, theme_rank_data=None):
         '  var theme = card.dataset.theme || "";\n'
         '  var hold = [];\n'
         '  var semi = [];\n'
+        '  var watch = [];\n'
         '  try { hold = JSON.parse(card.dataset.hold || "[]"); } catch (e) {}\n'
         '  try { semi = JSON.parse(card.dataset.semi || "[]"); } catch (e) {}\n'
+        '  try { watch = JSON.parse(card.dataset.watch || "[]"); } catch (e) {}\n'
         '  document.getElementById("theme-modal-title").textContent = theme;\n'
         '  var body = document.getElementById("theme-modal-body");\n'
         '  body.innerHTML = "";\n'
@@ -1184,8 +1194,30 @@ def _html_theme_rank(market_db, theme_rank_data=None):
         '    div.appendChild(ul);\n'
         '    body.appendChild(div);\n'
         '  }\n'
+        '  function inlineSection(label, items) {\n'
+        '    if (!items.length) return;\n'
+        '    var div = document.createElement("div");\n'
+        '    div.className = "theme-modal-section";\n'
+        '    var h4 = document.createElement("h4");\n'
+        '    h4.textContent = label;\n'
+        '    div.appendChild(h4);\n'
+        '    var p = document.createElement("p");\n'
+        '    p.className = "theme-modal-inline";\n'
+        '    items.forEach(function(item, idx) {\n'
+        '      if (idx > 0) p.appendChild(document.createTextNode(", "));\n'
+        '      var a = document.createElement("a");\n'
+        '      a.href = "/stock/" + encodeURIComponent(item[0]);\n'
+        '      a.target = "_blank";\n'
+        '      a.rel = "noopener";\n'
+        '      a.textContent = item[0] + (item[1] ? " " + item[1] : "");\n'
+        '      p.appendChild(a);\n'
+        '    });\n'
+        '    div.appendChild(p);\n'
+        '    body.appendChild(div);\n'
+        '  }\n'
         '  section("保有", hold);\n'
         '  section("準保有", semi);\n'
+        '  inlineSection("監視", watch);\n'
         '  document.getElementById("theme-modal").style.display = "flex";\n'
         '}\n'
         'function closeThemeModal() {\n'

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -1398,24 +1398,29 @@ class TestThemeRankHistory:
 
 
 class TestThemePortfolioLinks:
-    """テーマカードの保有/準保有リンク作成テスト"""
+    """テーマカードの保有/準保有/監視リンク作成テスト"""
 
     def test_build_links_exact_theme_match(self):
         records = [
             {"code_s": "3496", "status": "1保"},
             {"code_s": "6324", "status": "2準"},
             {"code_s": "7203", "status": "3監"},
+            {"code_s": "9999", "status": "9other"},
         ]
         stock_map = {
             "3496": {"stock_name": "アズーム", "themes": "AI,半導体"},
             "6324": {"stock_name": "ハーモニック", "themes": "半導体,ロボット"},
             "7203": {"stock_name": "トヨタ", "themes": "自動車"},
+            "9999": {"stock_name": "対象外", "themes": "圏外"},
         }
         result = make_market_db.build_theme_portfolio_links(records, stock_map)
         assert result["AI"]["hold"] == [("3496", "アズーム")]
         assert result["半導体"]["hold"] == [("3496", "アズーム")]
         assert result["半導体"]["semi"] == [("6324", "ハーモニック")]
-        assert "自動車" not in result
+        # 監視 (3監) もテーマに紐付く (issue #307)
+        assert result["自動車"]["watch"] == [("7203", "トヨタ")]
+        # 未対応 status はどのテーマにも紐付かない
+        assert "圏外" not in result
 
     def test_collect_links_dbm_error_returns_empty(self):
         """DBアクセス系エラーは警告だけ出して空dictにする"""


### PR DESCRIPTION
## 概要

Closes #307

market ページのテーマランクでテーマカードをクリックすると表示されるモーダルに、
従来の「保有・準保有」に加えて**監視 (3監) 銘柄**を表示する。

監視は銘柄数が多くなりがち（実データで1テーマ最大55件）なので、保有・準保有の
1銘柄1行リストとは別に、**カンマ区切りのインライン列挙**（改行せず折り返し）で表示する。

## 変更内容

`scripts/make_market_db.py`
- `build_theme_portfolio_links`: `status_key` に `"3監": "watch"` を追加、watch もソート
- `collect_theme_portfolio_links`: `list_records(status="3監")` を追加
- テーマカードに `data-watch` 属性（監視銘柄JSON）を追加。`has_links` 判定に watch を含める
  （カードの強調色は従来どおり保有>準保有のみ。監視は色を付けない）
- モーダル JS に `inlineSection()` を新設し、監視はカンマ区切りで描画
- CSS `.theme-modal-inline` を追加

`tests/test_make_market_db.py`
- `3監` 銘柄が watch に紐付くこと + 未対応 status が除外されることを検証
  （旧テストは「3監は除外」前提だったため新仕様に合わせて更新）

## テスト

- `pytest tests/test_make_market_db.py tests/test_functional_market.py` 全パス
- ブラウザ確認: 「人工知能」テーマで保有・準保有が従来の1行リスト、監視35件が
  カンマ区切りのインライン列挙で折り返し表示されることを目視確認

<img width="600" alt="theme-modal-watch-inline" src="https://github.com/user-attachments/assets/placeholder" />

（スクショ: 監視セクションがカンマ区切りで「135A VRAIN Solution, 1980 ダイダン, ...」と列挙）

## 運用反映

`market_data.html` は静的生成物のため、本番では次回の market DB 更新時に
`create_market_html` が走れば自動で新仕様になる（コード変更のみで反映される）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)