### PR TITLE
業績/指標スナップショットの日付セマンティクスを分離・統一する

### DIFF
--- a/.claude/rules/codex-plan-review.md
+++ b/.claude/rules/codex-plan-review.md
@@ -20,10 +20,10 @@
 
 ### 初回レビュー
 
-※ モデルは `-m` で必ず指定（gpt-5.3-codex 推奨）
+※ モデルは `-m` で必ず指定（gpt-5.4 推奨）
 
 ```bash
-codex exec -m gpt-5.3-codex "Review this plan. Don't nitpick trivial things. Only point out critical issues: {plan_full_path} (ref: {CLAUDE.md full_path})"
+codex exec -m gpt-5.4 "Review this plan. Don't nitpick trivial things. Only point out critical issues: {plan_full_path} (ref: {CLAUDE.md full_path})"
 ```
 
 ### 修正後の再レビュー
@@ -31,5 +31,5 @@ codex exec -m gpt-5.3-codex "Review this plan. Don't nitpick trivial things. Onl
 ※ 初回レビューのコンテキストを保持するため `resume --last` が必須
 
 ```bash
-codex exec resume --last -m gpt-5.3-codex "I've updated the plan, please review again. Don't nitpick trivial things. Only point out critical issues: {plan_full_path} (ref: {CLAUDE.md full_path})"
+codex exec resume --last -m gpt-5.4 "I've updated the plan, please review again. Don't nitpick trivial things. Only point out critical issues: {plan_full_path} (ref: {CLAUDE.md full_path})"
 ```

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -112,7 +112,7 @@ stocks_shelve（日次更新の揮発性キャッシュ）とは別に、銘柄�
 
 - **識別・評価**: 銘柄名、旧銘柄名（`stock_name_prev`, issue #183）、総合評価（S〜E）、企業概要、機関投資家コメント
 - **手動メモ**: OpenWork、ジムクレイマー、四季報コメント、メモ・総括
-- **スナップショット** (list): 決算タイミングごとの IR定量データ・クォリティ指標・理論株価乖離（`date_yy_m` 降順）
+- **スナップショット** (list): 決算タイミングごとの IR定量データ・クォリティ指標・理論株価乖離（`date_yy_m` 降順）。日付は2軸で保持する: 業績(IR定量)は株価非依存なので `date_yy_m`=**決算日/修正日**、株価依存の指標・理論株価乖離は `acquired_date`=**取得日**。WebApp の業績テーブルは `date_yy_m`、指標テーブルは `acquired_date` を表示
 
 ### 銘柄名変更の追従（issue #183）
 
@@ -127,9 +127,14 @@ stocks_shelve（日次更新の揮発性キャッシュ）とは別に、銘柄�
 
 `make_stock_db.py` の `update_research_snapshots()` が `list_all_db()` 末尾で実行:
 
-- research_shelve管理銘柄のうち、決算発表日/修正通知日から14日以内（`KESSAN_WINDOW_DAYS`）の銘柄が対象
+- research_shelve管理銘柄のうち、決算イベント日から14日以内（`KESSAN_WINDOW_DAYS`）の銘柄が対象。トリガー日は `kessan_jisseki_date`（決算発表実績日）・`kessanbi`（発表日/次回予定日）・`kessan_mod_date`（決算修正日）を**独立に窓判定**し、窓内のものを全て採用（`_collect_trigger_dates`）。未来の次回予定日は自動的に窓外
+- 決算発表と業績修正は**別イベント**として別スナップショット行に記録する（発表行・修正行を `date_yy_m` で分けて残す）。同日のトリガーは1件に集約
+- 業績(IR定量)の `date_yy_m` は決算イベント日、株価依存の指標・理論株価乖離の `acquired_date` は取得日（本日）を付与
 - `gyoseki`・`shihyou`・`rironkabuka` から自動抽出、`data_source: "auto"` で記録
-- 同一 `date_yy_m` のスナップショットは冪等上書き
+- 同一 `date_yy_m` の auto 行は冪等上書き（指標・`acquired_date` を更新）。manual/migration 行は保護され不変
+- 直近決算実績日 `kessan_jisseki_date` は `shintakane.py` の決算発表パース時に保存（`kessanbi` は次回予定日に上書きされ実績日が残らないため別フィールドで保持）
+
+> 新規監視追加（WebApp `add_stock`）も同じ日付ルール（業績=直近決算イベント日、指標=取得日）でスナップショットを1件作る。
 
 ### モジュール構成
 

--- a/doc/requirements/phase1_requirements.md
+++ b/doc/requirements/phase1_requirements.md
@@ -97,10 +97,11 @@ research_shelve + stocks_shelve → 統合ビュー（Phase 2）
 - `shikiho_comments` (list[str]): 四季報コメント（最新が先頭。スプシは最大5件だが件数上限は設けない）
 
 **時系列スナップショットブロック**:
-- `snapshots` (list[dict]): 1決算=1スナップショット、最新が先頭（`date_yy_m` 降順ソート）
+- `snapshots` (list[dict]): 1決算イベント=1スナップショット、最新が先頭（`date_yy_m` 降順ソート）。決算発表と業績修正は別イベントとして別スナップショットに記録する
 
-各スナップショットは1つの決算タイミングに対応し、以下のフィールドを持つ:
-- `date_yy_m` (str): `"26.1"` のような `YY.M` 表記。**内部も同形式で保持**（スプシ原文準拠、決算月までしか情報がないため ISO 化しない）
+各スナップショットは1つの決算イベント（発表または修正）に対応し、以下のフィールドを持つ:
+- `date_yy_m` (str): 業績(`ir_quant`)の**決算日/修正日**。`"26.1"`（`YY.M` 月精度、移行データ）または `"26.4.15"`（`YY.M.D` 日精度、自動追記）。**内部も同形式で保持**（ISO 化しない）
+- `acquired_date` (str): 株価依存の指標・理論株価乖離の**取得日**（`"YY.M.D"`、空可）。業績は株価非依存なので決算日、指標は株価依存なので取得日、と日付を二軸で持つ。移行データは空（表示時は `date_yy_m` にフォールバック）
 - `ir_quant` (str): IR 分析の定量部分を原文保持（例: `"[A]26%,21%[Q]25%,25%[P]1Q21%(22%),20%(19%)"`)
 - `ir_comment` (str): IR 分析の手動コメント（`・` 箇条書き行を改行区切りで連結）
 - `quality_indicators` (str): クォリティ指標を原文保持（改行含む。例: `"555億 PER27 PBR9.3\n配当2.8 ROE36"`)
@@ -141,6 +142,14 @@ CLAUDE.md の当該規約は **`stocks_shelve` に対するスクレイピング
 - **追記タイミング**: `list_all_db()` の処理末尾（CSV 出力後）
 - **データソース区分**: `data_source="auto"` として記録
 - **呼び出しパターン**: レコード非存在時はまず `upsert_research_record(create_research_record(...))` で最低限の土台を作ってから `upsert_snapshot` を呼ぶ（`upsert_snapshot` は自動作成しない）
+
+#### 日付セマンティクスの分離（PR #312）
+
+- **業績=決算日 / 指標=取得日**: `ir_quant`（株価非依存）は `date_yy_m`=決算日/修正日、`quality_indicators`・`rironkabuka_kairi`（株価依存）は `acquired_date`=取得日（本日）を持つ。全経路（決算自動追記・新規監視追加 `add_stock`）で一貫適用
+- **発表と修正は別行**: `_collect_trigger_dates()` が `kessan_jisseki_date`（発表実績日）・`kessanbi`（発表日/次回予定日）・`kessan_mod_date`（修正日）を独立に14日窓判定し、窓内のものを全てトリガーにする。発表行・修正行は別スナップショットとして残す（同日は集約）
+- **直近決算実績日の保持**: `kessanbi` は次回予定日に上書きされ実績日が残らないため、`shintakane.py` の決算発表パース時に `kessan_jisseki_date` へ実績日を保存
+- **冪等更新の保護**: 同一 `date_yy_m` の再実行では auto 行のみ指標・`acquired_date` を更新。manual/migration 行は保護され不変
+- **移行データ**: 過去 migration 分（`date_yy_m`=YY.M 月精度、`acquired_date` 空）は再変換せず据え置き
 
 ---
 

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1785,26 +1785,28 @@ KESSAN_WINDOW_DAYS = 14
 
 
 def _collect_trigger_dates(stock, today):
-    """stock の kessanbi / kessan_mod_date から KESSAN_WINDOW_DAYS 以内のトリガー日を返す。
+    """stock の決算実績日/修正日から KESSAN_WINDOW_DAYS 以内のトリガー日を返す。
 
-    両方が窓内の場合は新しい方のみ採用 (stocks データが最新イベント時点の値しか
-    保持しないため、古い方に書くと履歴捏造になる)。
+    - kessan_jisseki_date (決算発表実績日) と kessan_mod_date (決算修正日) を候補にする。
+      両者は別フィールドで保持される実イベントの日付なので、両方窓内なら両方返す
+      (発表行・修正行を別スナップショットとして残すため)。
+    - kessan_jisseki_date 未設定の銘柄 (次回 fetch で入るまでの繋ぎ) は kessanbi を
+      フォールバック候補にする。kessanbi は次回予定日に上書きされ得るため実績日を優先。
+    - 同日 (発表日==修正日 等) は1件に集約。
     """
+    jisseki = stock.get("kessan_jisseki_date", "") or stock.get("kessanbi", "")
     candidates = []
-    for date_field in ("kessanbi", "kessan_mod_date"):
-        date_str = stock.get(date_field, "")
+    for date_str in (jisseki, stock.get("kessan_mod_date", "")):
         if not date_str:
             continue
         try:
             dt = datetime.strptime(date_str, "%Y/%m/%d").date()
-            if 0 <= (today - dt).days <= KESSAN_WINDOW_DAYS:
-                candidates.append((dt, date_str))
         except ValueError:
-            pass
-    if len(candidates) >= 2:
-        candidates.sort(reverse=True)
-        return [candidates[0][1]]
-    return [c[1] for c in candidates]
+            continue
+        if 0 <= (today - dt).days <= KESSAN_WINDOW_DAYS:
+            candidates.append(date_str)
+    # 同日 (発表日==修正日) を集約しつつ順序は保持
+    return list(dict.fromkeys(candidates))
 
 
 def update_research_snapshots(*, db_path=None, code_filter=None):
@@ -1889,10 +1891,13 @@ def update_research_snapshots(*, db_path=None, code_filter=None):
         for s in record.get("snapshots", []):
             existing_by_date.setdefault(s["date_yy_m"], []).append(s)
 
+        # 指標/理論株価は株価依存のため取得日 (today) をラベルにする
+        acquired_date = research_shelve.to_date_yy_m(today)
+
         for trigger_date_str in trigger_dates:
             try:
-                dt = datetime.strptime(trigger_date_str, "%Y/%m/%d")
-                date_yy_m = f"{dt.year % 100}.{dt.month}.{dt.day}"
+                dt = datetime.strptime(trigger_date_str, "%Y/%m/%d").date()
+                date_yy_m = research_shelve.to_date_yy_m(dt)
 
                 # 同日に1件でも非auto (manual/migration等) があれば、
                 # 後段の upsert_snapshot(overwrite_same_date=True) で消えてしまうため
@@ -1912,6 +1917,7 @@ def update_research_snapshots(*, db_path=None, code_filter=None):
 
                 snapshot = research_shelve.create_snapshot(
                     date_yy_m,
+                    acquired_date=acquired_date,
                     ir_quant=ir_quant,
                     quality_indicators=quality_indicators,
                     rironkabuka_kairi=rironkabuka_kairi,

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1787,16 +1787,19 @@ KESSAN_WINDOW_DAYS = 14
 def _collect_trigger_dates(stock, today):
     """stock の決算実績日/修正日から KESSAN_WINDOW_DAYS 以内のトリガー日を返す。
 
-    - kessan_jisseki_date (決算発表実績日) と kessan_mod_date (決算修正日) を候補にする。
-      両者は別フィールドで保持される実イベントの日付なので、両方窓内なら両方返す
+    - kessan_jisseki_date (決算発表実績日)、kessanbi (決算発表日/次回予定日)、
+      kessan_mod_date (決算修正日) を独立に窓判定し、窓内のものを候補にする。
+      いずれも実イベントの日付なので、複数窓内なら複数返す
       (発表行・修正行を別スナップショットとして残すため)。
-    - kessan_jisseki_date 未設定の銘柄 (次回 fetch で入るまでの繋ぎ) は kessanbi を
-      フォールバック候補にする。kessanbi は次回予定日に上書きされ得るため実績日を優先。
-    - 同日 (発表日==修正日 等) は1件に集約。
+    - kessanbi も候補に残すのは、master 更新が shintakane.update_todays_kessan より
+      先に走ると kessan_jisseki_date が前回分のまま (窓外) で kessanbi だけ今回決算日
+      (窓内) になるケースがあり、これを取りこぼさないため。未来の次回予定日は
+      days<0 で自動的に窓外になる。
+    - 同日 (発表日==予定日==修正日 等) は1件に集約。
     """
-    jisseki = stock.get("kessan_jisseki_date", "") or stock.get("kessanbi", "")
     candidates = []
-    for date_str in (jisseki, stock.get("kessan_mod_date", "")):
+    for field in ("kessan_jisseki_date", "kessanbi", "kessan_mod_date"):
+        date_str = stock.get(field, "")
         if not date_str:
             continue
         try:
@@ -1805,7 +1808,7 @@ def _collect_trigger_dates(stock, today):
             continue
         if 0 <= (today - dt).days <= KESSAN_WINDOW_DAYS:
             candidates.append(date_str)
-    # 同日 (発表日==修正日) を集約しつつ順序は保持
+    # 同日 (発表日==予定日==修正日 等) を集約しつつ順序は保持
     return list(dict.fromkeys(candidates))
 
 

--- a/scripts/research_shelve.py
+++ b/scripts/research_shelve.py
@@ -146,6 +146,7 @@ MAX_KESSAN_COMMENTS = 12
 SNAPSHOT_FIELDS = frozenset(
     {
         "date_yy_m",
+        "acquired_date",
         "ir_quant",
         "ir_comment",
         "quality_indicators",
@@ -205,6 +206,14 @@ def validate_date_yy_m(date_yy_m: Any) -> None:
             raise ValueError(
                 f"invalid date_yy_m day: {date_yy_m!r} (日は1-31の範囲)"
             )
+
+
+def to_date_yy_m(d) -> str:
+    """date/datetime を "YY.M.D" 形式の date_yy_m 文字列に変換する。
+
+    例: date(2026, 4, 15) -> "26.4.15"。validate_date_yy_m が受理する形式。
+    """
+    return f"{d.year % 100}.{d.month}.{d.day}"
 
 
 def validate_rating(rating: Any) -> None:
@@ -315,6 +324,7 @@ def create_research_record(
 def create_snapshot(
     date_yy_m: str,
     *,
+    acquired_date: str = "",
     ir_quant: str = "",
     ir_comment: str = "",
     quality_indicators: str = "",
@@ -323,15 +333,19 @@ def create_snapshot(
 ) -> Dict[str, Any]:
     """決算スナップショット1件の dict を生成する。
 
-    - date_yy_m は validate_date_yy_m で検証
+    - date_yy_m は業績(ir_quant)の決算日/修正日。validate_date_yy_m で検証
+    - acquired_date は指標/理論株価(株価依存)の取得日 ("YY.M.D")。空可
     - data_source は manual/migration/auto のみ許容 (デフォルト manual)
     - 他フィールドは空文字をデフォルト (原文保持用)
     """
     validate_date_yy_m(date_yy_m)
+    if acquired_date:
+        validate_date_yy_m(acquired_date)
     validate_data_source(data_source)
 
     return {
         "date_yy_m": date_yy_m,
+        "acquired_date": acquired_date,
         "ir_quant": ir_quant,
         "ir_comment": ir_comment,
         "quality_indicators": quality_indicators,

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -1492,6 +1492,9 @@ def update_todays_kessan():
             if kessanbi and kessanbi != announce_date:
                 stocks[code_s]["kessanbi"] = announce_date
                 log_print("決算発表日更新", code_s, announce_date)
+            # kessanbi は次回予定日に上書きされ得るため、直近決算実績日は
+            # 別フィールドで確実に保持する (スナップショットの決算日ラベルに使う)
+            stocks[code_s]["kessan_jisseki_date"] = announce_date
             stocks[code_s]["kessan_announce"] = "発表," + item[2] + "," + item[3]
         except KeyError:
             log_print(code_s, "はDBにありません")

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -19,6 +19,7 @@ from research_shelve import (
     upsert_research_record,
     create_research_record,
     create_snapshot,
+    to_date_yy_m,
     list_research_records,
     sort_shikiho_comments_desc,
     validate_code_s,
@@ -133,6 +134,32 @@ def get_stock_data(code_s: str) -> Dict[str, Any]:
         return db.get(normalized) or {}
 
 
+def _latest_kessan_date_yy_m(stock: Dict[str, Any]) -> str:
+    """stock の直近決算イベント日 (実績日/修正日のうち新しい方) を "YY.M.D" で返す。
+
+    kessan_jisseki_date (発表実績日) と kessan_mod_date (修正日) を比較し、
+    新しい方を採用する。どちらも無い/不正なら空文字を返す。
+    kessanbi (次回予定日に上書きされ得る) は使わない。新規追加は手動操作で
+    「今の業績」を撮る用途なので、実績日が無ければ呼び出し側が取得日に
+    フォールバックする (決算ウィンドウ判定を行う B経路の _collect_trigger_dates
+    とはフォールバック方針が異なる)。
+    """
+    latest = None
+    for date_field in ("kessan_jisseki_date", "kessan_mod_date"):
+        date_str = stock.get(date_field, "")
+        if not date_str:
+            continue
+        try:
+            dt = datetime.strptime(date_str, "%Y/%m/%d").date()
+        except ValueError:
+            continue
+        if latest is None or dt > latest:
+            latest = dt
+    if latest is None:
+        return ""
+    return to_date_yy_m(latest)
+
+
 def add_stock(code_s: str) -> str:
     """銘柄を research_shelve に追加する。
 
@@ -167,10 +194,15 @@ def add_stock(code_s: str) -> str:
         ir_quant = growth_expr + progress_expr
 
         today = get_price_day(datetime.today())
-        date_yy_m = f"{today.year % 100}.{today.month}.{today.day}"
+        acquired_date = to_date_yy_m(today)
+
+        # 業績 date_yy_m は直近の決算イベント日 (実績日/修正日のうち新しい方)。
+        # 取得できなければ取得日にフォールバック (dedup キーが必要なため)。
+        date_yy_m = _latest_kessan_date_yy_m(stock) or acquired_date
 
         snapshot = create_snapshot(
             date_yy_m,
+            acquired_date=acquired_date,
             ir_quant=ir_quant,
             quality_indicators=shihyou.get_shihyo_expr(stock),
             rironkabuka_kairi=rironkabuka.get_rironkabuka_expr(stock),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1740,6 +1740,26 @@ def _bulk_resolve_stock_name_prevs(code_list: List[str]) -> Dict[str, Optional[s
     return result
 
 
+def _bulk_resolve_overall_ratings(code_list: List[str]) -> Dict[str, str]:
+    """複数 code_s 分の総合評価 (research_shelve.overall_rating) をバルク取得する。"""
+    from db_shelve import RESEARCH_SHELVE  # 遅延 import (循環回避)
+
+    result: Dict[str, str] = {c: "" for c in code_list if c}
+    if not result:
+        return result
+
+    valid_nonempty = VALID_RATINGS - {""}
+    with ShelveDB(RESEARCH_SHELVE) as db:
+        for c in list(result.keys()):
+            rec = db.get(normalize_code_s(c))
+            if not rec:
+                continue
+            rating = rec.get("overall_rating") or ""
+            if rating in valid_nonempty:
+                result[c] = rating
+    return result
+
+
 # issue #178: status 内部値 → URL クエリ / 表示ラベルの対応表 (helpers 内部利用のみ)。
 # routes/portfolio.py の同名定数とは独立に保持し、循環 import を避ける。
 _PORTFOLIO_STATUS_QUERY = {
@@ -1796,6 +1816,7 @@ def list_portfolio_with_indicators(
     stock_map = _bulk_get_stock_data(code_list)
     name_map = _bulk_resolve_stock_names(code_list)
     name_prev_map = _bulk_resolve_stock_name_prevs(code_list)  # issue #183
+    rating_map = _bulk_resolve_overall_ratings(code_list)  # issue #199
     today = date.today()  # 全 row 共通の基準日 (issue #177)
 
     # issue #227: 株価 + RSライン 統合チャート用に market_db を1回だけロード。
@@ -1812,6 +1833,7 @@ def list_portfolio_with_indicators(
         row = dict(rec)
         row["stock_name"] = name_map.get(code_s, "") or rec.get("stock_name", "")  # 旧データ互換
         row["stock_name_prev"] = name_prev_map.get(code_s)  # issue #183
+        row["overall_rating"] = rating_map.get(code_s, "")  # issue #199
         stock = stock_map.get(code_s, {})
         row.update(_extract_indicators_for_portfolio(stock))
         # issue #227: 3点ミニチャート (svg + tooltip)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -139,10 +139,10 @@ def _latest_kessan_date_yy_m(stock: Dict[str, Any]) -> str:
 
     kessan_jisseki_date (発表実績日) と kessan_mod_date (修正日) を比較し、
     新しい方を採用する。どちらも無い/不正なら空文字を返す。
-    kessanbi (次回予定日に上書きされ得る) は使わない。新規追加は手動操作で
-    「今の業績」を撮る用途なので、実績日が無ければ呼び出し側が取得日に
-    フォールバックする (決算ウィンドウ判定を行う B経路の _collect_trigger_dates
-    とはフォールバック方針が異なる)。
+    新規追加は手動操作で「今の業績」を撮る用途のため、kessanbi (次回予定日に
+    上書きされ得る) は使わず、実績日が無ければ呼び出し側が取得日にフォール
+    バックする。決算ウィンドウ判定を行う B経路 (_collect_trigger_dates) とは
+    別の用途・別ロジック。
     """
     latest = None
     for date_field in ("kessan_jisseki_date", "kessan_mod_date"):

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -297,7 +297,7 @@
     <table class="snapshot-table">
       <thead>
         <tr>
-          <th>日付</th>
+          <th>取得日</th>
           <th>クォリティ指標</th>
           <th>理論株価乖離</th>
         </tr>
@@ -305,7 +305,7 @@
       <tbody>
         {% for snap in indicator_snaps[:5] %}
         <tr>
-          <td>{{ snap.date_yy_m }}</td>
+          <td>{{ snap.acquired_date or snap.date_yy_m }}</td>
           <td>{{ snap.quality_indicators|replace('\n', ' ') if snap.quality_indicators else '' }}</td>
           <td>{{ snap.rironkabuka_kairi if snap.rironkabuka_kairi else '' }}</td>
         </tr>
@@ -319,7 +319,7 @@
         <tbody>
           {% for snap in indicator_snaps[5:] %}
           <tr>
-            <td>{{ snap.date_yy_m }}</td>
+            <td>{{ snap.acquired_date or snap.date_yy_m }}</td>
             <td>{{ snap.quality_indicators|replace('\n', ' ') if snap.quality_indicators else '' }}</td>
             <td>{{ snap.rironkabuka_kairi if snap.rironkabuka_kairi else '' }}</td>
           </tr>

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -5,12 +5,16 @@
 {% block content %}
 {# 一覧の列数を多く表示するため、main.container のデフォルト max-width を上書きして全幅化 #}
 <style>
-  main.container { max-width: 100% !important; padding-left: 0.8em !important; padding-right: 0.8em !important; }
-  /* 22 列をできるだけ表示するための列幅微調整 (issue #177)。
+  html, body { overflow-x: hidden; }
+  /* 全幅化 (max-width 解除) しつつ、左右に余白を確保する (issue #314: 詰まりすぎ解消)。
+     他ページは max-width + 中央寄せで余白を作るが、本ページは全幅のため
+     左右パディングで他ページと同程度の余白を再現する。 */
+  main.container { width: 100%; max-width: none !important; padding-left: var(--pico-spacing) !important; padding-right: var(--pico-spacing) !important; }
+  /* 24 列をできるだけ表示するための列幅微調整 (issue #177 / #199 / #314)。
      全体 font-size ダウン + セル padding 圧縮 + ヘッダ折り返し許可。 */
-  table.portfolio-list { font-size: 0.78em; }
+  table.portfolio-list { width: 100%; font-size: 0.76em; }
   table.portfolio-list th, table.portfolio-list td {
-    padding: 0.3em 0.4em;
+    padding: 0.25em 0.35em;
     white-space: normal;  /* ヘッダの折り返しを許可してセル幅を縮める */
   }
   /* 長いヘッダラベル ("RSライン(20,5)" 等) が列幅を引っ張らないよう、
@@ -27,6 +31,31 @@
   }
   /* 数値・短文列は明示的に狭くする */
   table.portfolio-list td.num { text-align: right; }
+  table.portfolio-list td.rating-cell { text-align: center; white-space: nowrap; }
+  table.portfolio-list td.stage-cell {
+    width: 5em;
+    max-width: 5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  table.portfolio-list td.jukyu-cell {
+    max-width: 6em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre-line;
+    line-height: 1.2;
+  }
+  /* overflow:auto + max-height で縦スクロールコンテナを作る。
+     thead th の position:sticky (列名固定) はこのコンテナを基準に動くため、
+     overflow-y / max-height を欠かすと sticky が壊れる (commit 0bba1b4)。
+     overflow-x:auto 単独だと祖先 containing block を作り sticky を妨げるため、
+     縦横まとめて overflow:auto にする。 */
+  .portfolio-table-wrap {
+    width: 100%;
+    overflow: auto;
+    max-height: 80vh;
+  }
   /* 削除モード時のみチェックボックス列を表示 */
   .bulk-col { display: none; }
   body.delete-mode .bulk-col { display: table-cell; }
@@ -213,7 +242,7 @@
 {% endif %}
 
 {% if rows %}
-<div style="overflow:auto;max-height:80vh;">
+<div class="portfolio-table-wrap">
 <table class="portfolio-list">
   <thead>
     <tr>
@@ -222,6 +251,7 @@
       <th>コード</th>
       <th>銘柄名</th>
       <th><a href="{{ sort_urls.position }}">状態</a></th>
+      <th>評価</th>
       <th><a href="{{ sort_urls.gyoutai }}">業態・テーマ</a></th>
       <th><a href="{{ sort_urls.rank }}">順位</a></th>
       <th>売上成長(%)</th>
@@ -234,6 +264,7 @@
       <th>決算日</th>
       <th>更新日</th>
       <th>ステージ</th>
+      <th>チャートパターン</th>
       <th>RS</th>
       <th title="RSライン (対TOPIX, 青=上昇/オレンジ=下降) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸">RS(20,5)</th>
       <th>トレンド</th>
@@ -290,8 +321,9 @@
                 aria-label="保有ステータスを変更">{{ row.status_label }}</button>
         {% endif %}
       </td>
+      <td class="rating-cell"{% if row.overall_rating in ('S', 'A') %} style="background:#fbbc04"{% endif %}>{{ row.overall_rating or "—" }}</td>
       <td class="gyoutai-themes-cell" data-code="{{ row.code_s }}"
-          style="max-width:11em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
+          style="max-width:10em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
         {% set themes = row.memo.gyoutai_themes or [] %}
         {% set master_names = theme_master | map(attribute='name') | list %}
         {% for i in range(gyoutai_themes_max_slots) %}
@@ -330,8 +362,13 @@
           style="{{ row.styles.last_research_update or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.last_research_update or "—" }}</td>
       <td title="クリックで編集 (ステージ変更時は更新日も自動で当日に) / Ctrl+クリックで株探チャート"
           data-style-field="stage"
-          {% if not fallback_mode %}class="editable" data-code="{{ row.code_s }}" data-field="stage" data-touch-update="1"{% endif %}
+          class="stage-cell{% if not fallback_mode %} editable{% endif %}"
+          {% if not fallback_mode %}data-code="{{ row.code_s }}" data-field="stage" data-touch-update="1"{% endif %}
           style="{{ row.styles.stage or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.stage or "—" }}</td>
+      <td title="{{ ((row.memo.jukyu_chart or '') ~ ' (クリックで編集)') if (not fallback_mode and row.memo.jukyu_chart) else ('クリックで編集' if not fallback_mode else (row.memo.jukyu_chart or '')) }}"
+          data-full="{{ row.memo.jukyu_chart or '' }}"
+          {% if not fallback_mode %}class="editable jukyu-cell" data-code="{{ row.code_s }}" data-field="jukyu_chart" data-multiline="1" data-input-width="8em"{% else %}class="jukyu-cell"{% endif %}
+          style="{% if not fallback_mode %}cursor:pointer{% endif %}">{{ row.memo.jukyu_chart or "—" }}</td>
       <td style="{{ row.styles.rs or '' }}">{{ row.rs }}</td>
       {# issue #227: 株価 + RSライン 3点ミニチャート (旧 RSライン/株価向き 2列を統合) #}
       <td title="{{ row.price_rs_chart.tooltip }}" style="padding:0 2px;line-height:0;">
@@ -346,8 +383,8 @@
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 / issue #227 で旧 RSライン+株価向き 2列を1列に統合 → 1 減 / 買い集め+需給バランスを需給バランス1列に統合 → 1 減 #}
-      <td colspan="{% if delete_mode_allowed %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
+      {# 状態列 + 評価/需給列を含む全列に展開行を合わせる #}
+      <td colspan="{% if delete_mode_allowed %}25{% else %}24{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">
@@ -360,13 +397,13 @@
             <form action="/portfolio/{{ row.code_s }}/memo" method="POST"
                   style="display:grid;grid-template-columns:1fr 1fr;gap:0.6em 1em;margin:0.3em 0 0 0;font-size:0.95em;">
               <input type="hidden" name="return_query" value="{{ return_query }}">
-              {# 業態・テーマ / 更新日 / ステージ は表内 inline 編集に移動 (issue #177) #}
+              {# 業態・テーマ / 更新日 / ステージ は表内 inline 編集に移動 (issue #177)。
+                 需給チャート (チャートパターン列) も表内 inline 編集に移動 (issue #314) #}
               {% for field, label in [
                   ("watch_in_reason", "IN 理由"),
                   ("inago_origin", "イナゴ元"),
                   ("trade_idea", "売買アイデア"),
                   ("takaichi_sensitivity", "高市感応度"),
-                  ("jukyu_chart", "需給チャート"),
               ] %}
               <label style="display:flex;flex-direction:column;gap:0.1em;margin:0;">
                 <span style="color:#666;">{{ label }}</span>
@@ -627,6 +664,12 @@ function excludeFromUniverse(codeS) {
     td.textContent = value || '—';
   }
 
+  function renderJukyu(td, value) {
+    td.dataset.full = value || '';
+    td.title = value ? value + ' (クリックで編集)' : 'クリックで編集';
+    td.textContent = value || '—';
+  }
+
   // PORTFOLIO_COLORS のうち背景色に使われる HEX (compute_cell_styles の bg() / bg_with_white() 出力)。
   // 既存セルの背景色をクリアする際にこの集合を使って判定する。
   var PORTFOLIO_BG_COLORS = [
@@ -701,7 +744,7 @@ function excludeFromUniverse(codeS) {
     if (td.dataset.multiline === '1') {
       input = document.createElement('textarea');
       input.rows = 2;
-      input.style.cssText = 'width:11em;font-size:0.85em;padding:0.2em;font-family:inherit;';
+      input.style.cssText = 'width:' + (td.dataset.inputWidth || '11em') + ';font-size:0.85em;padding:0.2em;font-family:inherit;';
     } else if (td.dataset.inputType === 'date') {
       input = document.createElement('input');
       input.type = 'date';
@@ -718,7 +761,7 @@ function excludeFromUniverse(codeS) {
     } else {
       input = document.createElement('input');
       input.type = 'text';
-      input.style.cssText = 'font-size:0.85em;padding:0.2em;width:6em;';
+      input.style.cssText = 'font-size:0.85em;padding:0.2em;width:' + (td.dataset.inputWidth || '6em') + ';';
     }
     if (input.tagName === 'TEXTAREA' || input.type === 'text') {
       input.value = currentValue;
@@ -782,6 +825,7 @@ function excludeFromUniverse(codeS) {
           alert('保存失敗: ' + (res.body && res.body.error || 'unknown'));
           // 元値で再描画
           if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
+          else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
           else renderPlain(td, currentValue);
           return;
         }
@@ -789,6 +833,7 @@ function excludeFromUniverse(codeS) {
         var disp = (res.body.display) || {};
         var displayValue = (disp[field] !== undefined) ? disp[field] : newValue;
         if (field === 'gyoutai_theme') renderGyoutaiTheme(td, displayValue);
+        else if (field === 'jukyu_chart') renderJukyu(td, displayValue);
         else renderPlain(td, displayValue);
 
         // ステージ編集時は同じ行の last_research_update セルも更新
@@ -808,6 +853,7 @@ function excludeFromUniverse(codeS) {
       }).catch(function(err) {
         alert('保存失敗: ' + err);
         if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
+        else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
         else renderPlain(td, currentValue);
       });
     }
@@ -817,6 +863,7 @@ function excludeFromUniverse(codeS) {
       finished = true;
       td.dataset.editing = '';
       if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
+      else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
       else renderPlain(td, currentValue);
     }
 

--- a/tests/test_append_research_snapshots.py
+++ b/tests/test_append_research_snapshots.py
@@ -28,13 +28,17 @@ def _today_yy_m_d(offset_days=0):
     return f"{dt.year % 100}.{dt.month}.{dt.day}"
 
 
-def _make_stock(code_s, kessanbi="", kessan_mod_date="", stock_name="テスト銘柄"):
+def _make_stock(
+    code_s, kessanbi="", kessan_mod_date="", kessan_jisseki_date="",
+    stock_name="テスト銘柄",
+):
     """最小限の stock dict を生成する"""
     return {
         "code_s": code_s,
         "stock_name": stock_name,
         "kessanbi": kessanbi,
         "kessan_mod_date": kessan_mod_date,
+        "kessan_jisseki_date": kessan_jisseki_date,
         "score_gyoseki": "0",
         "shihyo_pt": 0,
         "shihyo": {},
@@ -270,11 +274,30 @@ class TestUpdateResearchSnapshots:
         assert len(manuals) == 1
         assert manuals[0]["ir_quant"] == "手動値"
 
-    def test_newer_date_wins_when_both_in_window(self, db_path, monkeypatch):
-        """両方が窓内の場合、新しい方の日付のみ採用される"""
-        ann_date = _today_str(-3)
-        mod_date = _today_str()
-        stock = _make_stock("3496", kessanbi=ann_date, kessan_mod_date=mod_date)
+    @pytest.mark.parametrize(
+        "jisseki_delta, mod_delta, expected_deltas",
+        [
+            # 発表日・修正日が両方窓内 → 別行で2件 (発表行+修正行)
+            (-3, 0, [-3, 0]),
+            (-1, -5, [-1, -5]),
+            # 発表日==修正日 (同日) → 1件に集約
+            (-2, -2, [-2]),
+            # 修正日が窓外 → 発表行のみ1件
+            (-3, -20, [-3]),
+        ],
+    )
+    def test_announce_and_mod_dates_become_separate_rows(
+        self, db_path, monkeypatch, jisseki_delta, mod_delta, expected_deltas,
+    ):
+        """発表日と修正日が両方窓内なら別行で残す。同日は集約、窓外は除外。
+
+        各 auto 行の acquired_date は取得日 (本日) になる。
+        """
+        stock = _make_stock(
+            "3496",
+            kessan_jisseki_date=_today_str(jisseki_delta),
+            kessan_mod_date=_today_str(mod_delta),
+        )
         monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
 
         rec = rs.create_research_record("3496", "アズーム")
@@ -283,30 +306,16 @@ class TestUpdateResearchSnapshots:
         make_stock_db.update_research_snapshots(db_path=db_path)
 
         loaded = rs.get_research_record("3496", db_path=db_path)
-        assert len(loaded["snapshots"]) == 1
-        assert loaded["snapshots"][0]["date_yy_m"] == _today_yy_m_d()
+        snaps = loaded["snapshots"]
+        assert len(snaps) == len(expected_deltas)
+        actual_dates = {s["date_yy_m"] for s in snaps}
+        assert actual_dates == {_today_yy_m_d(d) for d in expected_deltas}
+        # 株価依存指標の取得日は本日
+        assert all(s["acquired_date"] == _today_yy_m_d() for s in snaps)
 
-    def test_newer_kessanbi_wins_over_old_mod_date(self, db_path, monkeypatch):
-        """kessanbi が修正日より新しい場合、kessanbi が採用される"""
-        old_mod_date = _today_str(-5)
-        ann_date = _today_str(-1)
-        stock = _make_stock("3496", kessanbi=ann_date, kessan_mod_date=old_mod_date)
-        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
-
-        rec = rs.create_research_record("3496", "アズーム")
-        rs.upsert_research_record(rec, db_path=db_path)
-
-        make_stock_db.update_research_snapshots(db_path=db_path)
-
-        loaded = rs.get_research_record("3496", db_path=db_path)
-        assert len(loaded["snapshots"]) == 1
-        assert loaded["snapshots"][0]["date_yy_m"] == _today_yy_m_d(-1)
-
-    def test_only_kessanbi_when_mod_date_outside_window(self, db_path, monkeypatch):
-        """修正日が窓外なら kessanbi のみ使われる"""
-        ann_date = _today_str(-3)
-        old_mod_date = _today_str(-20)  # 窓外
-        stock = _make_stock("3496", kessanbi=ann_date, kessan_mod_date=old_mod_date)
+    def test_kessanbi_fallback_when_jisseki_unset(self, db_path, monkeypatch):
+        """kessan_jisseki_date 未設定なら kessanbi をフォールバック候補にする"""
+        stock = _make_stock("3496", kessanbi=_today_str(-3))  # jisseki 未設定
         monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
 
         rec = rs.create_research_record("3496", "アズーム")

--- a/tests/test_append_research_snapshots.py
+++ b/tests/test_append_research_snapshots.py
@@ -314,7 +314,7 @@ class TestUpdateResearchSnapshots:
         assert all(s["acquired_date"] == _today_yy_m_d() for s in snaps)
 
     def test_kessanbi_fallback_when_jisseki_unset(self, db_path, monkeypatch):
-        """kessan_jisseki_date 未設定なら kessanbi をフォールバック候補にする"""
+        """kessan_jisseki_date 未設定なら kessanbi を候補にする"""
         stock = _make_stock("3496", kessanbi=_today_str(-3))  # jisseki 未設定
         monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
 
@@ -326,6 +326,29 @@ class TestUpdateResearchSnapshots:
         loaded = rs.get_research_record("3496", db_path=db_path)
         assert len(loaded["snapshots"]) == 1
         assert loaded["snapshots"][0]["date_yy_m"] == _today_yy_m_d(-3)
+
+    def test_kessanbi_in_window_not_dropped_by_old_jisseki(self, db_path, monkeypatch):
+        """前回 jisseki が窓外でも、今回決算日 kessanbi が窓内なら拾う (PR#312 codex P2)。
+
+        master 更新が shintakane.update_todays_kessan より先に走り、
+        kessan_jisseki_date が前回分 (窓外) のまま kessanbi だけ今回決算日 (窓内)
+        になるケースで、今回決算の auto スナップショットを取りこぼさないこと。
+        """
+        stock = _make_stock(
+            "3496",
+            kessan_jisseki_date=_today_str(-90),  # 前回決算 (窓外)
+            kessanbi=_today_str(-2),              # 今回決算日 (窓内)
+        )
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {"3496": stock})
+
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=db_path)
+
+        make_stock_db.update_research_snapshots(db_path=db_path)
+
+        loaded = rs.get_research_record("3496", db_path=db_path)
+        dates = {s["date_yy_m"] for s in loaded["snapshots"]}
+        assert _today_yy_m_d(-2) in dates  # kessanbi (今回決算) が拾われる
 
     def test_migration_not_affected_by_auto(self, db_path, monkeypatch):
         """既存の migration (月精度) があっても auto (日精度) は追記される"""

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1889,6 +1889,8 @@ class TestListPortfolioWithIndicators:
         """rank を rec から直接読めるよう _extract_indicators_for_portfolio もスタブ。"""
         monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: {c: {} for c in codes})
         monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: f"name_{c}" for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_name_prevs", lambda codes: {c: None for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_overall_ratings", lambda codes: {c: "" for c in codes})
         monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
         # _extract_indicators_for_portfolio は rec の rank を上書きしないよう空 dict を返す
         monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
@@ -1946,6 +1948,31 @@ class TestListPortfolioWithIndicators:
         assert by_code["0003"]["status_query"] == "watch"
         assert by_code["0003"]["status_label"] == "監視"
 
+    def test_overall_rating_filled_from_research_shelve(self, populated_db, monkeypatch):
+        rec = rs.get_research_record("3496")
+        rec["overall_rating"] = "S"
+        rs.upsert_research_record(rec)
+        rs.upsert_research_record(rs.create_research_record("1234", "空評価"))
+
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: {c: {} for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: "" for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_name_prevs", lambda codes: {c: None for c in codes})
+        monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
+        monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
+        monkeypatch.setattr(helpers, "build_stock_chart_payload", lambda stock, market_db, mode: {"svg": "", "tooltip": ""})
+
+        records = [
+            self._make("3496", "3監"),
+            self._make("1234", "3監"),
+            self._make("9999", "3監"),
+        ]
+        rows = helpers.list_portfolio_with_indicators(records)
+        by_code = {r["code_s"]: r for r in rows}
+
+        assert by_code["3496"]["overall_rating"] == "S"
+        assert by_code["1234"]["overall_rating"] == ""
+        assert by_code["9999"]["overall_rating"] == ""
+
     @pytest.mark.parametrize(
         "sort_key, expected",
         [
@@ -1962,6 +1989,8 @@ class TestListPortfolioWithIndicators:
             lambda codes: {c: {"price": prices[c]} for c in codes if c in prices},
         )
         monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: "" for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_name_prevs", lambda codes: {c: None for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_overall_ratings", lambda codes: {c: "" for c in codes})
         monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
         monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
 
@@ -2024,6 +2053,8 @@ class TestListPortfolioWithIndicators:
             lambda codes: {c: ({"price": prices.get(c)} if prices.get(c) is not None else {}) for c in codes},
         )
         monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: "" for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_name_prevs", lambda codes: {c: None for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_overall_ratings", lambda codes: {c: "" for c in codes})
         monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
         monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
 

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -9,6 +9,7 @@ import os
 import pytest
 
 import portfolio_shelve as ps
+import research_shelve as rs
 from db_shelve import ShelveDB, STOCKS_SHELVE
 from webapp import create_app
 
@@ -24,13 +25,18 @@ def stocks_db_path(tmp_path):
 
 
 @pytest.fixture
+def research_db_path(tmp_path):
+    return str(tmp_path / "test_research_shelve")
+
+
+@pytest.fixture
 def txt_path(tmp_path):
     """sync_to_my_watch_list_txt の出力先を tmp_path に逃がす"""
     return str(tmp_path / "my_watch_list.txt")
 
 
 @pytest.fixture
-def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
+def app(portfolio_db_path, stocks_db_path, research_db_path, txt_path, monkeypatch):
     """テスト用 Flask アプリ。"""
     # portfolio_shelve のパス差し替え
     monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db_path)
@@ -38,6 +44,9 @@ def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
     # stocks_shelve のパス差し替え
     monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db_path)
     monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db_path)
+    # research_shelve のパス差し替え (portfolio 一覧の評価/旧名 fallback 用)
+    monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", research_db_path)
+    monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", research_db_path)
     # my_watch_list.txt の出力先を tmp_path に
     monkeypatch.setattr("portfolio_shelve.DATA_DIR", os.path.dirname(txt_path))
 
@@ -87,6 +96,16 @@ def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
             "trend_template": ["不通過1", "不通過2", "不通過3"],
             "stock_rank_log": [("2026-05-03", 200)],
         }
+
+    # portfolio 登録済み銘柄の調査レコード。評価列の表示確認に使う。
+    rs.upsert_research_record(
+        rs.create_research_record("3496", "アズーム", overall_rating="S"),
+        db_path=research_db_path,
+    )
+    rs.upsert_research_record(
+        rs.create_research_record("6324", "ハーモニックドライブシステムズ", overall_rating=""),
+        db_path=research_db_path,
+    )
 
     app = create_app()
     app.config["TESTING"] = True
@@ -161,6 +180,25 @@ class TestDashboardGet:
         # 売上成長%・利益成長% (アズーム fixture の gyoseki_current から計算: 50→100 は +100%)
         # 値の "%" は列ヘッダ側 ("利益成長(%)") に集約 (issue #177)
         assert ">100<" in html
+
+    def test_dashboard_shows_rating_and_jukyu_column(self, client, portfolio_db_path):
+        """評価列とチャートパターン inline 編集列が一覧に出る (issue #199 / #314)"""
+        ps.update_memo(
+            "3496",
+            {"jukyu_chart": "月足低位ブレイク\nCWH"},
+            db_path=portfolio_db_path,
+        )
+
+        resp = client.get("/portfolio?status=hold")
+        html = resp.data.decode()
+
+        assert "<th>評価</th>" in html
+        assert "<th>チャートパターン</th>" in html
+        assert '<td class="rating-cell" style="background:#fbbc04">S</td>' in html
+        assert 'data-field="jukyu_chart"' in html
+        assert 'data-multiline="1"' in html
+        assert "月足低位ブレイク" in html
+        assert 'name="jukyu_chart"' not in html
 
 
 class TestAddPost:
@@ -692,6 +730,20 @@ class TestUpdateMemoAjax:
         # display フィールドに保存後の表示値が入っている
         assert body["display"]["stage"] == "2S"
         assert body["display"]["last_research_update"] == "5/10"
+
+    def test_ajax_updates_jukyu_chart_with_newline(self, client, portfolio_db_path):
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"jukyu_chart": "月足低位ブレイク\nCWH"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["display"]["jukyu_chart"] == "月足低位ブレイク\nCWH"
+
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["jukyu_chart"] == "月足低位ブレイク\nCWH"
 
     def test_ajax_unknown_code_returns_404_json(self, client):
         resp = client.post(


### PR DESCRIPTION
## Summary
- 業績スナップショット(`ir_quant`)は株価非依存なので**決算日/修正日**、指標・理論株価(`quality_indicators`/`rironkabuka_kairi`)は株価依存なので**取得日**をラベルにするよう分離。
- これを新規監視追加(`add_stock`)・決算自動追記(`update_research_snapshots`)の両経路で一貫適用。
- 決算修正があった場合は、発表行と修正行を**別スナップショット**として残す。

## 背景
スナップショットの日付(`date_yy_m`)の意味が経路ごとにバラバラ(新規追加=取得日、決算自動追記=決算日)だった。また直近決算実績日を構造化保持するフィールドが無く、`kessanbi` が次回予定日に上書きされるため実績日を取りこぼしていた。

## 主な変更
- **research_shelve**: snapshot に `acquired_date` フィールド追加。`to_date_yy_m()` ヘルパ新設(日付→"YY.M.D")。
- **shintakane**: 決算発表パース時に実績日を `kessan_jisseki_date` へ保存。
- **make_stock_db**: `_collect_trigger_dates` が発表日・修正日を両方トリガーとして返し別行で記録。各 auto 行に `acquired_date`(取得日)を付与。
- **webapp helpers**: `add_stock` も同ルールで追記。
- **detail.html**: 指標テーブルの日付列を `acquired_date`(取得日)表示に。
- **codex-plan-review.md**: レビューモデルを gpt-5.4 に更新。

過去 migration スナップショットの再変換は対象外。

## Test plan
- [x] `pytest tests/test_make_stock_db.py tests/test_append_research_snapshots.py tests/test_research_shelve.py tests/test_webapp_helpers.py tests/test_webapp_routes.py tests/test_shintakane.py` → 629 passed
- [x] 隔離DBで発表日/修正日/取得日を全てズラした E2E 検証 → 発表行(`date_yy_m`=発表日) / 修正行(`date_yy_m`=修正日) が別行で記録され、両行とも `acquired_date`=取得日 になることを確認
- [x] webapp 起動 + 7095 detail ページで指標テーブルのヘッダ「取得日」表示・レイアウト確認(Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)