### PR TITLE
[codex] ポートフォリオに評価とチャートパターン列を追加

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1740,6 +1740,26 @@ def _bulk_resolve_stock_name_prevs(code_list: List[str]) -> Dict[str, Optional[s
     return result
 
 
+def _bulk_resolve_overall_ratings(code_list: List[str]) -> Dict[str, str]:
+    """複数 code_s 分の総合評価 (research_shelve.overall_rating) をバルク取得する。"""
+    from db_shelve import RESEARCH_SHELVE  # 遅延 import (循環回避)
+
+    result: Dict[str, str] = {c: "" for c in code_list if c}
+    if not result:
+        return result
+
+    valid_nonempty = VALID_RATINGS - {""}
+    with ShelveDB(RESEARCH_SHELVE) as db:
+        for c in list(result.keys()):
+            rec = db.get(normalize_code_s(c))
+            if not rec:
+                continue
+            rating = rec.get("overall_rating") or ""
+            if rating in valid_nonempty:
+                result[c] = rating
+    return result
+
+
 # issue #178: status 内部値 → URL クエリ / 表示ラベルの対応表 (helpers 内部利用のみ)。
 # routes/portfolio.py の同名定数とは独立に保持し、循環 import を避ける。
 _PORTFOLIO_STATUS_QUERY = {
@@ -1796,6 +1816,7 @@ def list_portfolio_with_indicators(
     stock_map = _bulk_get_stock_data(code_list)
     name_map = _bulk_resolve_stock_names(code_list)
     name_prev_map = _bulk_resolve_stock_name_prevs(code_list)  # issue #183
+    rating_map = _bulk_resolve_overall_ratings(code_list)  # issue #199
     today = date.today()  # 全 row 共通の基準日 (issue #177)
 
     # issue #227: 株価 + RSライン 統合チャート用に market_db を1回だけロード。
@@ -1812,6 +1833,7 @@ def list_portfolio_with_indicators(
         row = dict(rec)
         row["stock_name"] = name_map.get(code_s, "") or rec.get("stock_name", "")  # 旧データ互換
         row["stock_name_prev"] = name_prev_map.get(code_s)  # issue #183
+        row["overall_rating"] = rating_map.get(code_s, "")  # issue #199
         stock = stock_map.get(code_s, {})
         row.update(_extract_indicators_for_portfolio(stock))
         # issue #227: 3点ミニチャート (svg + tooltip)

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -5,12 +5,13 @@
 {% block content %}
 {# 一覧の列数を多く表示するため、main.container のデフォルト max-width を上書きして全幅化 #}
 <style>
-  main.container { max-width: 100% !important; padding-left: 0.8em !important; padding-right: 0.8em !important; }
-  /* 22 列をできるだけ表示するための列幅微調整 (issue #177)。
+  html, body { overflow-x: hidden; }
+  main.container { width: 100vw !important; max-width: none !important; margin-left: 0 !important; margin-right: 0 !important; padding-left: 0 !important; padding-right: 0 !important; }
+  /* 24 列をできるだけ表示するための列幅微調整 (issue #177 / #199 / #314)。
      全体 font-size ダウン + セル padding 圧縮 + ヘッダ折り返し許可。 */
-  table.portfolio-list { font-size: 0.78em; }
+  table.portfolio-list { width: 100%; font-size: 0.76em; }
   table.portfolio-list th, table.portfolio-list td {
-    padding: 0.3em 0.4em;
+    padding: 0.25em 0.35em;
     white-space: normal;  /* ヘッダの折り返しを許可してセル幅を縮める */
   }
   /* 長いヘッダラベル ("RSライン(20,5)" 等) が列幅を引っ張らないよう、
@@ -27,6 +28,26 @@
   }
   /* 数値・短文列は明示的に狭くする */
   table.portfolio-list td.num { text-align: right; }
+  table.portfolio-list td.rating-cell { text-align: center; white-space: nowrap; }
+  table.portfolio-list td.stage-cell {
+    width: 5em;
+    max-width: 5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  table.portfolio-list td.jukyu-cell {
+    max-width: 6em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre-line;
+    line-height: 1.2;
+  }
+  .portfolio-table-wrap {
+    width: 100vw;
+    max-width: 100vw;
+    overflow-x: auto;
+  }
   /* 削除モード時のみチェックボックス列を表示 */
   .bulk-col { display: none; }
   body.delete-mode .bulk-col { display: table-cell; }
@@ -213,7 +234,7 @@
 {% endif %}
 
 {% if rows %}
-<div style="overflow:auto;max-height:80vh;">
+<div class="portfolio-table-wrap">
 <table class="portfolio-list">
   <thead>
     <tr>
@@ -222,6 +243,7 @@
       <th>コード</th>
       <th>銘柄名</th>
       <th><a href="{{ sort_urls.position }}">状態</a></th>
+      <th>評価</th>
       <th><a href="{{ sort_urls.gyoutai }}">業態・テーマ</a></th>
       <th><a href="{{ sort_urls.rank }}">順位</a></th>
       <th>売上成長(%)</th>
@@ -234,6 +256,7 @@
       <th>決算日</th>
       <th>更新日</th>
       <th>ステージ</th>
+      <th>チャートパターン</th>
       <th>RS</th>
       <th title="RSライン (対TOPIX, 青=上昇/オレンジ=下降) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸">RS(20,5)</th>
       <th>トレンド</th>
@@ -290,8 +313,9 @@
                 aria-label="保有ステータスを変更">{{ row.status_label }}</button>
         {% endif %}
       </td>
+      <td class="rating-cell"{% if row.overall_rating in ('S', 'A') %} style="background:#fbbc04"{% endif %}>{{ row.overall_rating or "—" }}</td>
       <td class="gyoutai-themes-cell" data-code="{{ row.code_s }}"
-          style="max-width:11em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
+          style="max-width:10em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
         {% set themes = row.memo.gyoutai_themes or [] %}
         {% set master_names = theme_master | map(attribute='name') | list %}
         {% for i in range(gyoutai_themes_max_slots) %}
@@ -330,8 +354,13 @@
           style="{{ row.styles.last_research_update or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.last_research_update or "—" }}</td>
       <td title="クリックで編集 (ステージ変更時は更新日も自動で当日に) / Ctrl+クリックで株探チャート"
           data-style-field="stage"
-          {% if not fallback_mode %}class="editable" data-code="{{ row.code_s }}" data-field="stage" data-touch-update="1"{% endif %}
+          class="stage-cell{% if not fallback_mode %} editable{% endif %}"
+          {% if not fallback_mode %}data-code="{{ row.code_s }}" data-field="stage" data-touch-update="1"{% endif %}
           style="{{ row.styles.stage or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.stage or "—" }}</td>
+      <td title="{{ ((row.memo.jukyu_chart or '') ~ ' (クリックで編集)') if (not fallback_mode and row.memo.jukyu_chart) else ('クリックで編集' if not fallback_mode else (row.memo.jukyu_chart or '')) }}"
+          data-full="{{ row.memo.jukyu_chart or '' }}"
+          {% if not fallback_mode %}class="editable jukyu-cell" data-code="{{ row.code_s }}" data-field="jukyu_chart" data-multiline="1" data-input-width="8em"{% else %}class="jukyu-cell"{% endif %}
+          style="{% if not fallback_mode %}cursor:pointer{% endif %}">{{ row.memo.jukyu_chart or "—" }}</td>
       <td style="{{ row.styles.rs or '' }}">{{ row.rs }}</td>
       {# issue #227: 株価 + RSライン 3点ミニチャート (旧 RSライン/株価向き 2列を統合) #}
       <td title="{{ row.price_rs_chart.tooltip }}" style="padding:0 2px;line-height:0;">
@@ -346,8 +375,8 @@
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      {# 状態列 1 つ追加 (22→23)、削除モード時はさらに +1 / issue #227 で旧 RSライン+株価向き 2列を1列に統合 → 1 減 / 買い集め+需給バランスを需給バランス1列に統合 → 1 減 #}
-      <td colspan="{% if delete_mode_allowed %}23{% else %}22{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
+      {# 状態列 + 評価/需給列を含む全列に展開行を合わせる #}
+      <td colspan="{% if delete_mode_allowed %}25{% else %}24{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">
@@ -366,7 +395,6 @@
                   ("inago_origin", "イナゴ元"),
                   ("trade_idea", "売買アイデア"),
                   ("takaichi_sensitivity", "高市感応度"),
-                  ("jukyu_chart", "需給チャート"),
               ] %}
               <label style="display:flex;flex-direction:column;gap:0.1em;margin:0;">
                 <span style="color:#666;">{{ label }}</span>
@@ -627,6 +655,12 @@ function excludeFromUniverse(codeS) {
     td.textContent = value || '—';
   }
 
+  function renderJukyu(td, value) {
+    td.dataset.full = value || '';
+    td.title = value ? value + ' (クリックで編集)' : 'クリックで編集';
+    td.textContent = value || '—';
+  }
+
   // PORTFOLIO_COLORS のうち背景色に使われる HEX (compute_cell_styles の bg() / bg_with_white() 出力)。
   // 既存セルの背景色をクリアする際にこの集合を使って判定する。
   var PORTFOLIO_BG_COLORS = [
@@ -701,7 +735,7 @@ function excludeFromUniverse(codeS) {
     if (td.dataset.multiline === '1') {
       input = document.createElement('textarea');
       input.rows = 2;
-      input.style.cssText = 'width:11em;font-size:0.85em;padding:0.2em;font-family:inherit;';
+      input.style.cssText = 'width:' + (td.dataset.inputWidth || '11em') + ';font-size:0.85em;padding:0.2em;font-family:inherit;';
     } else if (td.dataset.inputType === 'date') {
       input = document.createElement('input');
       input.type = 'date';
@@ -718,7 +752,7 @@ function excludeFromUniverse(codeS) {
     } else {
       input = document.createElement('input');
       input.type = 'text';
-      input.style.cssText = 'font-size:0.85em;padding:0.2em;width:6em;';
+      input.style.cssText = 'font-size:0.85em;padding:0.2em;width:' + (td.dataset.inputWidth || '6em') + ';';
     }
     if (input.tagName === 'TEXTAREA' || input.type === 'text') {
       input.value = currentValue;
@@ -782,6 +816,7 @@ function excludeFromUniverse(codeS) {
           alert('保存失敗: ' + (res.body && res.body.error || 'unknown'));
           // 元値で再描画
           if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
+          else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
           else renderPlain(td, currentValue);
           return;
         }
@@ -789,6 +824,7 @@ function excludeFromUniverse(codeS) {
         var disp = (res.body.display) || {};
         var displayValue = (disp[field] !== undefined) ? disp[field] : newValue;
         if (field === 'gyoutai_theme') renderGyoutaiTheme(td, displayValue);
+        else if (field === 'jukyu_chart') renderJukyu(td, displayValue);
         else renderPlain(td, displayValue);
 
         // ステージ編集時は同じ行の last_research_update セルも更新
@@ -808,6 +844,7 @@ function excludeFromUniverse(codeS) {
       }).catch(function(err) {
         alert('保存失敗: ' + err);
         if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
+        else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
         else renderPlain(td, currentValue);
       });
     }
@@ -817,6 +854,7 @@ function excludeFromUniverse(codeS) {
       finished = true;
       td.dataset.editing = '';
       if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
+      else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
       else renderPlain(td, currentValue);
     }
 

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -397,7 +397,8 @@
             <form action="/portfolio/{{ row.code_s }}/memo" method="POST"
                   style="display:grid;grid-template-columns:1fr 1fr;gap:0.6em 1em;margin:0.3em 0 0 0;font-size:0.95em;">
               <input type="hidden" name="return_query" value="{{ return_query }}">
-              {# 業態・テーマ / 更新日 / ステージ は表内 inline 編集に移動 (issue #177) #}
+              {# 業態・テーマ / 更新日 / ステージ は表内 inline 編集に移動 (issue #177)。
+                 需給チャート (チャートパターン列) も表内 inline 編集に移動 (issue #314) #}
               {% for field, label in [
                   ("watch_in_reason", "IN 理由"),
                   ("inago_origin", "イナゴ元"),

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -46,9 +46,15 @@
     white-space: pre-line;
     line-height: 1.2;
   }
+  /* overflow:auto + max-height で縦スクロールコンテナを作る。
+     thead th の position:sticky (列名固定) はこのコンテナを基準に動くため、
+     overflow-y / max-height を欠かすと sticky が壊れる (commit 0bba1b4)。
+     overflow-x:auto 単独だと祖先 containing block を作り sticky を妨げるため、
+     縦横まとめて overflow:auto にする。 */
   .portfolio-table-wrap {
     width: 100%;
-    overflow-x: auto;
+    overflow: auto;
+    max-height: 80vh;
   }
   /* 削除モード時のみチェックボックス列を表示 */
   .bulk-col { display: none; }

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -6,7 +6,10 @@
 {# 一覧の列数を多く表示するため、main.container のデフォルト max-width を上書きして全幅化 #}
 <style>
   html, body { overflow-x: hidden; }
-  main.container { width: 100vw !important; max-width: none !important; margin-left: 0 !important; margin-right: 0 !important; padding-left: 0 !important; padding-right: 0 !important; }
+  /* 全幅化 (max-width 解除) しつつ、左右に余白を確保する (issue #314: 詰まりすぎ解消)。
+     他ページは max-width + 中央寄せで余白を作るが、本ページは全幅のため
+     左右パディングで他ページと同程度の余白を再現する。 */
+  main.container { width: 100%; max-width: none !important; padding-left: var(--pico-spacing) !important; padding-right: var(--pico-spacing) !important; }
   /* 24 列をできるだけ表示するための列幅微調整 (issue #177 / #199 / #314)。
      全体 font-size ダウン + セル padding 圧縮 + ヘッダ折り返し許可。 */
   table.portfolio-list { width: 100%; font-size: 0.76em; }
@@ -44,8 +47,7 @@
     line-height: 1.2;
   }
   .portfolio-table-wrap {
-    width: 100vw;
-    max-width: 100vw;
+    width: 100%;
     overflow-x: auto;
   }
   /* 削除モード時のみチェックボックス列を表示 */

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1889,6 +1889,8 @@ class TestListPortfolioWithIndicators:
         """rank を rec から直接読めるよう _extract_indicators_for_portfolio もスタブ。"""
         monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: {c: {} for c in codes})
         monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: f"name_{c}" for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_name_prevs", lambda codes: {c: None for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_overall_ratings", lambda codes: {c: "" for c in codes})
         monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
         # _extract_indicators_for_portfolio は rec の rank を上書きしないよう空 dict を返す
         monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
@@ -1946,6 +1948,31 @@ class TestListPortfolioWithIndicators:
         assert by_code["0003"]["status_query"] == "watch"
         assert by_code["0003"]["status_label"] == "監視"
 
+    def test_overall_rating_filled_from_research_shelve(self, populated_db, monkeypatch):
+        rec = rs.get_research_record("3496")
+        rec["overall_rating"] = "S"
+        rs.upsert_research_record(rec)
+        rs.upsert_research_record(rs.create_research_record("1234", "空評価"))
+
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data", lambda codes: {c: {} for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: "" for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_name_prevs", lambda codes: {c: None for c in codes})
+        monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
+        monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
+        monkeypatch.setattr(helpers, "build_stock_chart_payload", lambda stock, market_db, mode: {"svg": "", "tooltip": ""})
+
+        records = [
+            self._make("3496", "3監"),
+            self._make("1234", "3監"),
+            self._make("9999", "3監"),
+        ]
+        rows = helpers.list_portfolio_with_indicators(records)
+        by_code = {r["code_s"]: r for r in rows}
+
+        assert by_code["3496"]["overall_rating"] == "S"
+        assert by_code["1234"]["overall_rating"] == ""
+        assert by_code["9999"]["overall_rating"] == ""
+
     @pytest.mark.parametrize(
         "sort_key, expected",
         [
@@ -1962,6 +1989,8 @@ class TestListPortfolioWithIndicators:
             lambda codes: {c: {"price": prices[c]} for c in codes if c in prices},
         )
         monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: "" for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_name_prevs", lambda codes: {c: None for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_overall_ratings", lambda codes: {c: "" for c in codes})
         monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
         monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
 
@@ -2024,6 +2053,8 @@ class TestListPortfolioWithIndicators:
             lambda codes: {c: ({"price": prices.get(c)} if prices.get(c) is not None else {}) for c in codes},
         )
         monkeypatch.setattr(helpers, "_bulk_resolve_stock_names", lambda codes: {c: "" for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_name_prevs", lambda codes: {c: None for c in codes})
+        monkeypatch.setattr(helpers, "_bulk_resolve_overall_ratings", lambda codes: {c: "" for c in codes})
         monkeypatch.setattr(helpers, "compute_cell_styles", lambda row, today: {})
         monkeypatch.setattr(helpers, "_extract_indicators_for_portfolio", lambda stock: {})
 

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -9,6 +9,7 @@ import os
 import pytest
 
 import portfolio_shelve as ps
+import research_shelve as rs
 from db_shelve import ShelveDB, STOCKS_SHELVE
 from webapp import create_app
 
@@ -24,13 +25,18 @@ def stocks_db_path(tmp_path):
 
 
 @pytest.fixture
+def research_db_path(tmp_path):
+    return str(tmp_path / "test_research_shelve")
+
+
+@pytest.fixture
 def txt_path(tmp_path):
     """sync_to_my_watch_list_txt の出力先を tmp_path に逃がす"""
     return str(tmp_path / "my_watch_list.txt")
 
 
 @pytest.fixture
-def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
+def app(portfolio_db_path, stocks_db_path, research_db_path, txt_path, monkeypatch):
     """テスト用 Flask アプリ。"""
     # portfolio_shelve のパス差し替え
     monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db_path)
@@ -38,6 +44,9 @@ def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
     # stocks_shelve のパス差し替え
     monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db_path)
     monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db_path)
+    # research_shelve のパス差し替え (portfolio 一覧の評価/旧名 fallback 用)
+    monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", research_db_path)
+    monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", research_db_path)
     # my_watch_list.txt の出力先を tmp_path に
     monkeypatch.setattr("portfolio_shelve.DATA_DIR", os.path.dirname(txt_path))
 
@@ -87,6 +96,16 @@ def app(portfolio_db_path, stocks_db_path, txt_path, monkeypatch):
             "trend_template": ["不通過1", "不通過2", "不通過3"],
             "stock_rank_log": [("2026-05-03", 200)],
         }
+
+    # portfolio 登録済み銘柄の調査レコード。評価列の表示確認に使う。
+    rs.upsert_research_record(
+        rs.create_research_record("3496", "アズーム", overall_rating="S"),
+        db_path=research_db_path,
+    )
+    rs.upsert_research_record(
+        rs.create_research_record("6324", "ハーモニックドライブシステムズ", overall_rating=""),
+        db_path=research_db_path,
+    )
 
     app = create_app()
     app.config["TESTING"] = True
@@ -161,6 +180,25 @@ class TestDashboardGet:
         # 売上成長%・利益成長% (アズーム fixture の gyoseki_current から計算: 50→100 は +100%)
         # 値の "%" は列ヘッダ側 ("利益成長(%)") に集約 (issue #177)
         assert ">100<" in html
+
+    def test_dashboard_shows_rating_and_jukyu_column(self, client, portfolio_db_path):
+        """評価列とチャートパターン inline 編集列が一覧に出る (issue #199 / #314)"""
+        ps.update_memo(
+            "3496",
+            {"jukyu_chart": "月足低位ブレイク\nCWH"},
+            db_path=portfolio_db_path,
+        )
+
+        resp = client.get("/portfolio?status=hold")
+        html = resp.data.decode()
+
+        assert "<th>評価</th>" in html
+        assert "<th>チャートパターン</th>" in html
+        assert '<td class="rating-cell" style="background:#fbbc04">S</td>' in html
+        assert 'data-field="jukyu_chart"' in html
+        assert 'data-multiline="1"' in html
+        assert "月足低位ブレイク" in html
+        assert 'name="jukyu_chart"' not in html
 
 
 class TestAddPost:
@@ -692,6 +730,20 @@ class TestUpdateMemoAjax:
         # display フィールドに保存後の表示値が入っている
         assert body["display"]["stage"] == "2S"
         assert body["display"]["last_research_update"] == "5/10"
+
+    def test_ajax_updates_jukyu_chart_with_newline(self, client, portfolio_db_path):
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"jukyu_chart": "月足低位ブレイク\nCWH"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["display"]["jukyu_chart"] == "月足低位ブレイク\nCWH"
+
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["jukyu_chart"] == "月足低位ブレイク\nCWH"
 
     def test_ajax_unknown_code_returns_404_json(self, client):
         resp = client.post(


### PR DESCRIPTION
## 概要
- `/portfolio` 一覧に `research_shelve.overall_rating` の評価列を追加しました。
- 手動メモ `jukyu_chart` を「チャートパターン」列としてステージ隣に追加し、一覧から inline 編集できるようにしました。
- 展開行の手動メモフォームから `jukyu_chart` を外し、編集導線を列に一本化しました。

## 表示・レイアウト
- 評価 `S` / `A` は既存パレットのオレンジ (`#fbbc04`) 背景にしました。
- チャートパターン列は改行を表示するため `white-space: pre-line` にしています。
- MacBook Air 想定の 1280px 幅で右端余白が出ないよう、portfolio 画面の main/table wrapper を `100vw` 基準にしました。
- ステージ列は `5em` 幅に調整しました。

## 検証
- `cd scripts && ../.venv/bin/python -m pytest ../tests/test_webapp_helpers.py ../tests/test_webapp_portfolio_routes.py -q`
- Playwright で `http://127.0.0.1:5001/portfolio?status=` を 1280px 幅表示し、以下を確認しました。
  - `screen.width = 1280`
  - テーブル右端 gap: 0px (`table.right = innerWidth = 1280`)
  - ページ/テーブル横スクロールなし
  - `ステージ → チャートパターン → RS` の並び
  - チャートパターン列の改行表示 (`white-space: pre-line`)
  - 需給メモ編集セルが textarea で開くこと

## 補足
- この PR は現在の作業ベース `issue-snapshot-date-semantics` 向けの stacked PR です。`main` に直接向けると PR#312 系の差分も含まれるため、base を明示しています。