### PR TITLE
feat(market): 日本市場版 Fear & Greed Index を構築し /market に表示 (#212)

### DIFF
--- a/scripts/fear_greed_jp.py
+++ b/scripts/fear_greed_jp.py
@@ -81,11 +81,15 @@ def compute_component_momentum(breadth_history):
     if not hist:
         return None
     latest = hist[-1]
-    return normalize_min_max(latest, hist[:-1][-_NORM_WINDOW:])
+    score = normalize_min_max(latest, hist[:-1][-_NORM_WINDOW:])
+    return score, latest  # raw = 125日MA乖離率(%)
 
 
 def compute_component_strength(breadth_history):
-    """Stock Price Strength: 新高値 - 新安値 を 0-100 化 (高い=Greed)。"""
+    """Stock Price Strength: 新高値 - 新安値 を 0-100 化 (高い=Greed)。
+
+    Returns: (score 0-100, raw=新高値-新安値) または None。
+    """
     diffs = [
         r["new_high"] - r["new_low"]
         for r in breadth_history
@@ -93,11 +97,14 @@ def compute_component_strength(breadth_history):
     ]
     if len(diffs) < 2:
         return None
-    return normalize_min_max(diffs[-1], diffs[:-1][-_NORM_WINDOW:])
+    return normalize_min_max(diffs[-1], diffs[:-1][-_NORM_WINDOW:]), diffs[-1]
 
 
 def compute_component_breadth(breadth_history):
-    """Stock Price Breadth: 値上がり - 値下がり を 0-100 化 (高い=Greed)。"""
+    """Stock Price Breadth: 値上がり - 値下がり を 0-100 化 (高い=Greed)。
+
+    Returns: (score 0-100, raw=値上がり-値下がり) または None。
+    """
     diffs = [
         r["advances"] - r["declines"]
         for r in breadth_history
@@ -105,19 +112,20 @@ def compute_component_breadth(breadth_history):
     ]
     if len(diffs) < 2:
         return None
-    return normalize_min_max(diffs[-1], diffs[:-1][-_NORM_WINDOW:])
+    return normalize_min_max(diffs[-1], diffs[:-1][-_NORM_WINDOW:]), diffs[-1]
 
 
 def compute_component_volatility(vi_history):
     """Market Volatility: 日経VI を 0-100 化し方向反転 (VI が高い=Fear)。
 
     vi_history: [{date, nikkei_vi}, ...] 日付昇順。
+    Returns: (score 0-100=反転後, raw=日経VI) または None。
     """
     vis = [r["nikkei_vi"] for r in vi_history if r.get("nikkei_vi") is not None]
     if len(vis) < 2:
         return None
-    raw = normalize_min_max(vis[-1], vis[:-1][-_NORM_WINDOW:])
-    return 100.0 - raw  # VI は高いほど Fear なので反転
+    raw_score = normalize_min_max(vis[-1], vis[:-1][-_NORM_WINDOW:])
+    return 100.0 - raw_score, vis[-1]  # VI は高いほど Fear なので反転、raw=VI実値
 
 
 def _rating(score):
@@ -140,21 +148,31 @@ def compute_fear_greed_jp(breadth_history, vi_history):
     全成分 None なら None を返す。
 
     Returns:
-        dict|None: {"score": float, "rating": str, "components": {name: 0-100|None}}
+        dict|None: {
+            "score": float, "rating": str,
+            "components": {name: {"score": 0-100, "raw": float} | None},
+        }
+        components の各成分は score(0-100) と raw(元データ値) を持つ。
+        未取得成分は None。
     """
-    components = {
+    raw_components = {
         "momentum": compute_component_momentum(breadth_history),
         "strength": compute_component_strength(breadth_history),
         "breadth": compute_component_breadth(breadth_history),
         "volatility": compute_component_volatility(vi_history),
     }
-    valid = [v for v in components.values() if v is not None]
+    valid = [c[0] for c in raw_components.values() if c is not None]
     if not valid:
         return None
     score = sum(valid) / len(valid)
+    components = {}
+    for k, c in raw_components.items():
+        if c is None:
+            components[k] = None
+        else:
+            components[k] = {"score": round(c[0], 1), "raw": round(c[1], 2)}
     return {
         "score": round(score, 1),
         "rating": _rating(score),
-        "components": {k: (round(v, 1) if v is not None else None)
-                       for k, v in components.items()},
+        "components": components,
     }

--- a/scripts/fear_greed_jp.py
+++ b/scripts/fear_greed_jp.py
@@ -1,7 +1,7 @@
 """日本市場版 Fear & Greed Index (issue #212)。
 
 CNN Fear & Greed Index の構造 (成分構成・等ウェイト平均・5段階 rating) に準拠しつつ、
-各成分の正規化は独自実装 (直近2年 min-max) する日本市場版センチメント指数。
+各成分の正規化は独自実装 (直近2年の percentile rank) する日本市場版センチメント指数。
 
 CNN 原典との差分 (運用上の限界は issue #212 参照):
   1. 成分数 6→4 (第1弾)。Junk Bond Demand は日本市場に対応物が無く除外。
@@ -9,7 +9,8 @@ CNN 原典との差分 (運用上の限界は issue #212 参照):
      データが揃い次第 components に追加する (取れない成分は平均から除外)。
   2. Stock Price Strength が「52週」ではなく「年初来」基準 (データ源の都合)。
   3. Stock Price Breadth が出来高ベースではなく銘柄数ベース。
-  4. 正規化レンジは CNN 非公開のため独自 (直近2年 min-max)。
+  4. 正規化は CNN 非公開のため独自。外れ値1点でレンジが圧縮される min-max を避け、
+     直近2年の percentile rank を採用 (単一の極値に頑健)。
 
 第1弾の4成分 (いずれも nikkei225jp.com 由来、新規データ源不要):
   - Market Momentum     : 日経225 vs 125日移動平均の乖離率
@@ -24,8 +25,24 @@ _NORM_WINDOW = 490
 _MA_DAYS = 125
 
 
+def normalize_percentile(value, history):
+    """直近履歴に対する value の percentile rank を 0-100 で返す (issue #212)。
+
+    「history 中で value 以下の割合」(中央順位法) を百分率にする。
+    min-max と違い単一の外れ値に頑健で、レンジが極端な値1点に圧縮されない。
+    history が空なら中立 50。同値が多いケースも中央順位で滑らかに扱う。
+    """
+    if not history:
+        return 50.0
+    below = sum(1 for h in history if h < value)
+    equal = sum(1 for h in history if h == value)
+    # 中央順位法: 同値は半分が下とみなす (value 自身を含めないため +0.5*equal)
+    rank = (below + 0.5 * equal) / len(history)
+    return max(0.0, min(100.0, rank * 100.0))
+
+
 def normalize_min_max(value, history):
-    """直近の min-max で 0-100 にスケールする。
+    """直近の min-max で 0-100 にスケールする (旧方式、参考用に残置)。
 
     history は正規化の基準となる過去値リスト (最新値 value は含めない想定)。
     履歴が空・最大最小が一致なら中立 50 を返す。0-100 にクリップする。
@@ -81,7 +98,7 @@ def compute_component_momentum(breadth_history):
     if not hist:
         return None
     latest = hist[-1]
-    score = normalize_min_max(latest, hist[:-1][-_NORM_WINDOW:])
+    score = normalize_percentile(latest, hist[:-1][-_NORM_WINDOW:])
     return score, latest  # raw = 125日MA乖離率(%)
 
 
@@ -97,7 +114,7 @@ def compute_component_strength(breadth_history):
     ]
     if len(diffs) < 2:
         return None
-    return normalize_min_max(diffs[-1], diffs[:-1][-_NORM_WINDOW:]), diffs[-1]
+    return normalize_percentile(diffs[-1], diffs[:-1][-_NORM_WINDOW:]), diffs[-1]
 
 
 def compute_component_breadth(breadth_history):
@@ -112,7 +129,7 @@ def compute_component_breadth(breadth_history):
     ]
     if len(diffs) < 2:
         return None
-    return normalize_min_max(diffs[-1], diffs[:-1][-_NORM_WINDOW:]), diffs[-1]
+    return normalize_percentile(diffs[-1], diffs[:-1][-_NORM_WINDOW:]), diffs[-1]
 
 
 def compute_component_volatility(vi_history):
@@ -124,7 +141,7 @@ def compute_component_volatility(vi_history):
     vis = [r["nikkei_vi"] for r in vi_history if r.get("nikkei_vi") is not None]
     if len(vis) < 2:
         return None
-    raw_score = normalize_min_max(vis[-1], vis[:-1][-_NORM_WINDOW:])
+    raw_score = normalize_percentile(vis[-1], vis[:-1][-_NORM_WINDOW:])
     return 100.0 - raw_score, vis[-1]  # VI は高いほど Fear なので反転、raw=VI実値
 
 
@@ -155,6 +172,14 @@ def compute_fear_greed_jp(breadth_history, vi_history):
         components の各成分は score(0-100) と raw(元データ値) を持つ。
         未取得成分は None。
     """
+    # VI履歴を breadth の最新日以前に揃える。
+    # 揃えないと過去日の一括再計算時に VI 成分だけ最新 VI で正規化されてしまい、
+    # 時系列スコア (history の前日比/5日前比) が不正になる (issue #212 セルフレビュー指摘)。
+    if breadth_history and vi_history:
+        as_of = breadth_history[-1].get("date")
+        if as_of:
+            vi_history = [v for v in vi_history if v.get("date", "") <= as_of] or vi_history
+
     raw_components = {
         "momentum": compute_component_momentum(breadth_history),
         "strength": compute_component_strength(breadth_history),

--- a/scripts/fear_greed_jp.py
+++ b/scripts/fear_greed_jp.py
@@ -1,0 +1,160 @@
+"""日本市場版 Fear & Greed Index (issue #212)。
+
+CNN Fear & Greed Index の構造 (成分構成・等ウェイト平均・5段階 rating) に準拠しつつ、
+各成分の正規化は独自実装 (直近2年 min-max) する日本市場版センチメント指数。
+
+CNN 原典との差分 (運用上の限界は issue #212 参照):
+  1. 成分数 6→4 (第1弾)。Junk Bond Demand は日本市場に対応物が無く除外。
+     PCR / Safe Haven(JGB10年) はデータ源未確定のため第1弾では除外し、
+     データが揃い次第 components に追加する (取れない成分は平均から除外)。
+  2. Stock Price Strength が「52週」ではなく「年初来」基準 (データ源の都合)。
+  3. Stock Price Breadth が出来高ベースではなく銘柄数ベース。
+  4. 正規化レンジは CNN 非公開のため独自 (直近2年 min-max)。
+
+第1弾の4成分 (いずれも nikkei225jp.com 由来、新規データ源不要):
+  - Market Momentum     : 日経225 vs 125日移動平均の乖離率
+  - Stock Price Strength: 東証プライム 新高値数 - 新安値数
+  - Stock Price Breadth : 東証プライム 値上がり数 - 値下がり数
+  - Market Volatility   : 日経VI (高いほど Fear なので方向反転)
+"""
+
+# 直近2年 min-max 正規化に使う履歴本数 (約2年 = 約490営業日)。
+_NORM_WINDOW = 490
+# モメンタムの移動平均日数 (CNN は 125日)。
+_MA_DAYS = 125
+
+
+def normalize_min_max(value, history):
+    """直近の min-max で 0-100 にスケールする。
+
+    history は正規化の基準となる過去値リスト (最新値 value は含めない想定)。
+    履歴が空・最大最小が一致なら中立 50 を返す。0-100 にクリップする。
+    """
+    if not history:
+        return 50.0
+    lo, hi = min(history), max(history)
+    if hi == lo:
+        return 50.0
+    score = (value - lo) / (hi - lo) * 100.0
+    return max(0.0, min(100.0, score))
+
+
+def _ma(values):
+    """末尾 _MA_DAYS 本の単純移動平均。データ不足なら全件平均。"""
+    window = values[-_MA_DAYS:] if len(values) >= _MA_DAYS else values
+    return sum(window) / len(window) if window else 0.0
+
+
+def _series_to_scores(series, value_fn):
+    """時系列 (日付昇順) から「各時点の指標値」を計算した数値リストを返す。
+
+    value_fn(rows_up_to_i) -> float|None。None の行は除外。
+    モメンタムのように過去に依存する指標を min-max 履歴化するために使う。
+    """
+    out = []
+    for i in range(len(series)):
+        v = value_fn(series[: i + 1])
+        if v is not None:
+            out.append(v)
+    return out
+
+
+def compute_component_momentum(breadth_history):
+    """Market Momentum: 日経225 vs 125日MA の乖離率を 0-100 化 (高い=Greed)。
+
+    breadth_history: [{date, nikkei_close, ...}, ...] 日付昇順。
+    乖離率 = (終値 - 125日MA) / 125日MA * 100 を直近2年で min-max 正規化。
+    """
+    closes = [r["nikkei_close"] for r in breadth_history if r.get("nikkei_close") is not None]
+    if len(closes) < 2:
+        return None
+
+    def kairi(window):
+        if len(window) < 1:
+            return None
+        ma = _ma(window)
+        if ma == 0:
+            return None
+        return (window[-1] - ma) / ma * 100.0
+
+    hist = _series_to_scores([c for c in closes], lambda w: kairi(w))
+    if not hist:
+        return None
+    latest = hist[-1]
+    return normalize_min_max(latest, hist[:-1][-_NORM_WINDOW:])
+
+
+def compute_component_strength(breadth_history):
+    """Stock Price Strength: 新高値 - 新安値 を 0-100 化 (高い=Greed)。"""
+    diffs = [
+        r["new_high"] - r["new_low"]
+        for r in breadth_history
+        if r.get("new_high") is not None and r.get("new_low") is not None
+    ]
+    if len(diffs) < 2:
+        return None
+    return normalize_min_max(diffs[-1], diffs[:-1][-_NORM_WINDOW:])
+
+
+def compute_component_breadth(breadth_history):
+    """Stock Price Breadth: 値上がり - 値下がり を 0-100 化 (高い=Greed)。"""
+    diffs = [
+        r["advances"] - r["declines"]
+        for r in breadth_history
+        if r.get("advances") is not None and r.get("declines") is not None
+    ]
+    if len(diffs) < 2:
+        return None
+    return normalize_min_max(diffs[-1], diffs[:-1][-_NORM_WINDOW:])
+
+
+def compute_component_volatility(vi_history):
+    """Market Volatility: 日経VI を 0-100 化し方向反転 (VI が高い=Fear)。
+
+    vi_history: [{date, nikkei_vi}, ...] 日付昇順。
+    """
+    vis = [r["nikkei_vi"] for r in vi_history if r.get("nikkei_vi") is not None]
+    if len(vis) < 2:
+        return None
+    raw = normalize_min_max(vis[-1], vis[:-1][-_NORM_WINDOW:])
+    return 100.0 - raw  # VI は高いほど Fear なので反転
+
+
+def _rating(score):
+    """0-100 スコアを CNN 準拠の 5 段階 rating に変換する。"""
+    if score < 25:
+        return "Extreme Fear"
+    if score < 45:
+        return "Fear"
+    if score < 55:
+        return "Neutral"
+    if score < 75:
+        return "Greed"
+    return "Extreme Greed"
+
+
+def compute_fear_greed_jp(breadth_history, vi_history):
+    """4成分から日本市場版 Fear & Greed の合成スコアを計算する。
+
+    取得できなかった成分は None として平均から除外する (フォールバック)。
+    全成分 None なら None を返す。
+
+    Returns:
+        dict|None: {"score": float, "rating": str, "components": {name: 0-100|None}}
+    """
+    components = {
+        "momentum": compute_component_momentum(breadth_history),
+        "strength": compute_component_strength(breadth_history),
+        "breadth": compute_component_breadth(breadth_history),
+        "volatility": compute_component_volatility(vi_history),
+    }
+    valid = [v for v in components.values() if v is not None]
+    if not valid:
+        return None
+    score = sum(valid) / len(valid)
+    return {
+        "score": round(score, 1),
+        "rating": _rating(score),
+        "components": {k: (round(v, 1) if v is not None else None)
+                       for k, v in components.items()},
+    }

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -1784,8 +1784,11 @@ def _html_market_indicators(market_db):
     取得できる行が 1 つもなければ空文字。
     """
     # F&G (米CNN) / 日本版F&G (成分はアコーディオン展開) / 信用評価損益率 の順。
-    # 日経VI・新高値新安値は日本版F&Gの成分と重複するため独立行をやめ、
-    # F&G のアコーディオン内訳に統合する (issue #212)。
+    # 日経VI・新高値新安値は日本版F&Gの成分と重複するため、F&G が出せる日は
+    # アコーディオン内訳に統合し独立行を出さない (issue #212)。
+    # ただし fear_greed_jp.json が無い/壊れている日は F&G を出せないので、
+    # 従来どおり日経VI・新高値新安値を独立行でフォールバック表示する
+    # (nikkei_vi.json / new_high_low.json が残っていれば情報を失わない)。
     body = []
     fng = _fng_row(market_db)
     if fng is not None:
@@ -1796,6 +1799,14 @@ def _html_market_indicators(market_db):
         body.append(fgjp_html)
     for credit in _credit_rows(market_db):
         body.append(_render_indicator_tr(credit))
+    if not fgjp_html:
+        # F&G が出せない日のみ: 日経VI・新高値新安値を独立行で表示 (退行防止)
+        vi = _vi_row(market_db)
+        if vi is not None:
+            body.append(_render_indicator_tr(vi))
+        breadth = _breadth_row(market_db)
+        if breadth is not None:
+            body.append(_render_indicator_tr(breadth))
     if not body:
         return ""
 

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -978,6 +978,17 @@ tr:hover { background: #f5f5f5; }
 .market-indicators td.mi-delta { text-align: right; }
 .market-indicators td.mi-date { text-align: right; color: #888; font-size: 0.85em; }
 .market-indicators .mi-unit { color: #888; font-size: 0.85em; margin-right: 2px; }
+/* 日本版F&G アコーディオン (issue #212) */
+.market-indicators tr.mi-fgjp-parent { cursor: pointer; }
+.market-indicators tr.mi-fgjp-parent:hover { background: #f7fbff; }
+.market-indicators .mi-fgjp-toggle { color: #888; font-size: 0.8em; display: inline-block; transition: transform 0.1s; }
+.market-indicators tr.mi-fgjp-parent.open .mi-fgjp-toggle { transform: rotate(90deg); }
+.market-indicators tr.mi-fgjp-child { display: none; background: #fbfcfd; }
+.market-indicators tr.mi-fgjp-child.open { display: table-row; }
+.market-indicators tr.mi-fgjp-child th.mi-label { font-weight: normal; color: #555; padding-left: 18px; }
+.market-indicators tr.mi-fgjp-child a.mi-fgjp-childlabel { color: #555; text-decoration: none; }
+.market-indicators tr.mi-fgjp-child a.mi-fgjp-childlabel:hover { color: #1976d2; text-decoration: underline; }
+.market-indicators td.mi-fgjp-raw { text-align: right; color: #666; font-size: 0.9em; }
 .fng-rating { padding: 1px 6px; border-radius: 999px; font-size: 0.85em; font-weight: bold; color: #fff; }
 .fng-rating-extreme-fear { background: #a93226; }
 .fng-rating-fear { background: #e67e22; }
@@ -1552,20 +1563,65 @@ def _fng_row(market_db):
     return label_html, value_html, rating_html, d1_html, d4_html, date_text, title
 
 
-def _fgjp_row(market_db):
-    """日本市場版 Fear & Greed の表 1 行分タプルを返す。取得失敗時は None (issue #212)。
+def _render_indicator_tr(row, extra_class="", extra_attr=""):
+    """指標表の 1 行 (label,value,rating,d1,d4,date,title) を <tr> HTML 化する。"""
+    label, value, rating, d1, d4, date_text, title = row
+    title_attr = (' title="%s"' % html_mod.escape(title)) if title else ''
+    cls_attr = (' class="%s"' % extra_class) if extra_class else ''
+    return (
+        '<tr%s%s%s>'
+        '<th class="mi-label">%s</th>'
+        '<td class="mi-value">%s</td>'
+        '<td class="mi-rating">%s</td>'
+        '<td class="mi-delta">%s</td>'
+        '<td class="mi-delta">%s</td>'
+        '<td class="mi-date">%s</td>'
+        '</tr>' % (cls_attr, title_attr, extra_attr, label, value, rating,
+                  d1, d4, html_mod.escape(date_text))
+    )
 
-    値=合成スコア(0-100)、評価=5段階rating、直近=5日前比、中期=20日前比。
-    market_db は使わず、$KS_DATA_DIR/code_rank_data/fear_greed_jp.json を読む。
-    tooltip に成分数と原典差分の注記を入れる。
+
+# 日本版 F&G の成分: (キー, 表示名, tooltip説明, 元データ整形関数, 参照リンクURL)。
+# バッジは 0-100 スコアを F&G 本体と同じ 5 段階 rating に変換して統一表示する。
+def _fmt_signed_int(raw):
+    return "%+d" % int(round(raw))
+
+
+def _fmt_pct(raw):
+    return "%+.1f%%" % raw
+
+
+def _fmt_vi(raw):
+    return "%.2f" % raw
+
+
+_FGJP_COMPONENTS = [
+    ("momentum", "モメンタム", "日経225 vs 125日移動平均の乖離率。高いほど Greed。",
+     _fmt_pct, "https://nikkei225jp.com/nikkei/"),
+    ("strength", "新高値強さ", "東証プライム 新高値数 - 新安値数。高いほど Greed。",
+     _fmt_signed_int, "https://nikkei225jp.com/data/new.php"),
+    ("breadth", "騰落ブレッドス", "東証プライム 値上がり - 値下がり銘柄数。高いほど Greed。",
+     _fmt_signed_int, "https://nikkei225jp.com/data/touraku.php"),
+    ("volatility", "ボラティリティ", "日経VI (恐怖指数)。高いほど Fear なので反転してスコア化。",
+     _fmt_vi, "https://nikkei225jp.com/data/vix.php"),
+]
+
+
+def _fgjp_accordion_html(market_db):
+    """日本版 F&G の親行 + 成分の展開行 (アコーディオン) HTML を返す。取得失敗時は空文字。
+
+    親行クリックで成分行 (mi-fgjp-child) の表示/非表示をトグルする (issue #212)。
+    成分行は各成分の 0-100 スコア (値列) と元データ実値 (評価列) を併記する。
+    日経VI・新高値新安値はこの内訳に統合され独立行を持たない。
+    market_db は使わず fear_greed_jp.json を読む。
     """
     history = _load_breadth_json("fear_greed_jp.json")
     if not history:
-        return None
+        return ""
     latest = history[-1]
     score = latest.get("score")
     if score is None:
-        return None
+        return ""
     components = latest.get("components") or {}
     n_valid = sum(1 for v in components.values() if v is not None)
     rating = str(_fgjp_rating(score)).strip()
@@ -1579,32 +1635,76 @@ def _fgjp_row(market_db):
     d5, d5_cls = _format_fng_delta(score, _prev(5))
     d20, d20_cls = _format_fng_delta(score, _prev(20))
     label = (
+        '<span class="mi-fgjp-toggle">▸ </span>'
         '<span title="CNN Fear &amp; Greed の構造に準拠した日本市場版 (独自実装)。'
-        '%d 成分の等ウェイト平均。両端で信頼度が高く中間域はノイズが多い。'
+        '%d 成分の等ウェイト平均。クリックで成分内訳を展開。'
+        '両端で信頼度が高く中間域はノイズが多い。'
         '差分: Junk Bond除外・52週→年初来・出来高→銘柄数・正規化は独自(直近2年min-max)。">'
         '日本版Fear &amp; Greed</span>' % n_valid
     )
-    # tooltip に4成分の 0-100 スコアを併記 (各成分とも高いほど Greed 寄与。
-    # volatility は日経VI を反転済みなので高い=低ボラ=Greed)。未取得成分は "—"。
-    _COMP_LABELS = [
-        ("momentum", "モメンタム"), ("strength", "新高値強さ"),
-        ("breadth", "騰落ブレッドス"), ("volatility", "ボラ(反転)"),
-    ]
-    comp_parts = []
-    for key, jp in _COMP_LABELS:
-        v = components.get(key)
-        comp_parts.append("%s %s" % (jp, ("%.0f" % v) if v is not None else "—"))
-    title = "直近=5日前比 / 中期=20日前比 ｜ 成分: " + " / ".join(comp_parts)
-    return (
-        label,
-        '%.1f' % score,
-        '<span class="fng-rating %s">%s</span>' % (
-            html_mod.escape(rating_class), html_mod.escape(rating)),
-        '<span class="%s">%s</span>' % (html_mod.escape(d5_cls), html_mod.escape(d5)),
-        '<span class="%s">%s</span>' % (html_mod.escape(d20_cls), html_mod.escape(d20)),
-        _format_short_date(latest.get("date", "")),
-        title,
+    parent = _render_indicator_tr(
+        (
+            label,
+            '%.1f' % score,
+            '<span class="fng-rating %s">%s</span>' % (
+                html_mod.escape(rating_class), html_mod.escape(rating)),
+            '<span class="%s">%s</span>' % (
+                html_mod.escape(d5_cls), html_mod.escape(d5)),
+            '<span class="%s">%s</span>' % (
+                html_mod.escape(d20_cls), html_mod.escape(d20)),
+            _format_short_date(latest.get("date", "")),
+            "直近=5日前比 / 中期=20日前比 ｜ クリックで成分内訳",
+        ),
+        extra_class="mi-fgjp-parent",
     )
+
+    children = []
+    for key, jp, desc, fmt, url in _FGJP_COMPONENTS:
+        comp = components.get(key)
+        if comp is None:
+            value_html, raw_html, rating_html = "—", "", ""
+        else:
+            cscore = comp.get("score")
+            craw = comp.get("raw")
+            value_html = ("%.0f" % cscore) if cscore is not None else "—"
+            raw_html = fmt(craw) if craw is not None else ""
+            # バッジは 0-100 スコアを F&G 本体と同じ 5 段階 rating で統一表示
+            if cscore is not None:
+                crate = _fgjp_rating(cscore)
+                crate_cls = "fng-rating-" + crate.lower().replace(" ", "-")
+                rating_html = '<span class="fng-rating %s">%s</span>' % (
+                    html_mod.escape(crate_cls), html_mod.escape(crate))
+            else:
+                rating_html = ""
+        # ラベルは参照リンク付き (統合前の独立行のリンクを踏襲)
+        child_label = (
+            '└ <a href="%s" title="%s" target="_blank" rel="noopener"'
+            ' class="mi-fgjp-childlabel">%s</a>'
+            % (html_mod.escape(url), html_mod.escape(desc), html_mod.escape(jp))
+        )
+        children.append(
+            '<tr class="mi-fgjp-child">'
+            '<th class="mi-label">%s</th>'
+            '<td class="mi-value">%s</td>'
+            '<td class="mi-rating">%s</td>'
+            '<td class="mi-delta mi-fgjp-raw" colspan="2">%s</td>'
+            '<td class="mi-date"></td>'
+            '</tr>' % (child_label, value_html, rating_html, raw_html)
+        )
+    return parent + "\n" + "\n".join(children)
+
+
+def _fgjp_rating(score):
+    """日本版 Fear & Greed の 0-100 スコアを 5 段階 rating に変換 (CNN準拠)。"""
+    if score < 25:
+        return "Extreme Fear"
+    if score < 45:
+        return "Fear"
+    if score < 55:
+        return "Neutral"
+    if score < 75:
+        return "Greed"
+    return "Extreme Greed"
 
 
 def _fgjp_rating(score):
@@ -1683,37 +1783,22 @@ def _html_market_indicators(market_db):
 
     取得できる行が 1 つもなければ空文字。
     """
-    rows = []
+    # F&G (米CNN) / 日本版F&G (成分はアコーディオン展開) / 信用評価損益率 の順。
+    # 日経VI・新高値新安値は日本版F&Gの成分と重複するため独立行をやめ、
+    # F&G のアコーディオン内訳に統合する (issue #212)。
+    body = []
     fng = _fng_row(market_db)
     if fng is not None:
-        rows.append(fng)
-    fgjp = _fgjp_row(market_db)  # CNN本体の直後に置き日米センチメント差を視認可能に (issue #212)
-    if fgjp is not None:
-        rows.append(fgjp)
-    rows.extend(_credit_rows(market_db))
-    vi = _vi_row(market_db)
-    if vi is not None:
-        rows.append(vi)
-    breadth = _breadth_row(market_db)
-    if breadth is not None:
-        rows.append(breadth)
-    if not rows:
+        body.append(_render_indicator_tr(fng))
+    # 日本版F&G: 親行 (クリックで成分展開) + 成分の展開行
+    fgjp_html = _fgjp_accordion_html(market_db)
+    if fgjp_html:
+        body.append(fgjp_html)
+    for credit in _credit_rows(market_db):
+        body.append(_render_indicator_tr(credit))
+    if not body:
         return ""
 
-    body = []
-    for label, value, rating, d1, d4, date_text, title in rows:
-        title_attr = (' title="%s"' % html_mod.escape(title)) if title else ''
-        body.append(
-            '<tr%s>'
-            '<th class="mi-label">%s</th>'
-            '<td class="mi-value">%s</td>'
-            '<td class="mi-rating">%s</td>'
-            '<td class="mi-delta">%s</td>'
-            '<td class="mi-delta">%s</td>'
-            '<td class="mi-date">%s</td>'
-            '</tr>' % (title_attr, label, value, rating, d1, d4,
-                      html_mod.escape(date_text))
-        )
     header = (
         '<thead><tr>'
         '<th class="mi-label">指標</th>'
@@ -1724,11 +1809,29 @@ def _html_market_indicators(market_db):
         '<th class="mi-date">更新日</th>'
         '</tr></thead>\n'
     )
+    # 親行クリックで成分行 (mi-fgjp-child) をトグル。click ハンドラは一度だけ束縛する。
+    toggle_js = (
+        '<script>\n'
+        '(function(){\n'
+        '  var p = document.querySelector(".market-indicators tr.mi-fgjp-parent");\n'
+        '  if (!p || p.dataset.bound) return;\n'
+        '  p.dataset.bound = "1";\n'
+        '  p.addEventListener("click", function(){\n'
+        '    p.classList.toggle("open");\n'
+        '    var n = p.nextElementSibling;\n'
+        '    while (n && n.classList.contains("mi-fgjp-child")) {\n'
+        '      n.classList.toggle("open"); n = n.nextElementSibling;\n'
+        '    }\n'
+        '  });\n'
+        '})();\n'
+        '</script>\n'
+    )
     return (
         '<table class="market-indicators">\n'
         + header +
         '<tbody>\n' + '\n'.join(body) + '\n</tbody>\n'
         '</table>\n'
+        + toggle_js
     )
 
 

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -1552,6 +1552,74 @@ def _fng_row(market_db):
     return label_html, value_html, rating_html, d1_html, d4_html, date_text, title
 
 
+def _fgjp_row(market_db):
+    """日本市場版 Fear & Greed の表 1 行分タプルを返す。取得失敗時は None (issue #212)。
+
+    値=合成スコア(0-100)、評価=5段階rating、直近=5日前比、中期=20日前比。
+    market_db は使わず、$KS_DATA_DIR/code_rank_data/fear_greed_jp.json を読む。
+    tooltip に成分数と原典差分の注記を入れる。
+    """
+    history = _load_breadth_json("fear_greed_jp.json")
+    if not history:
+        return None
+    latest = history[-1]
+    score = latest.get("score")
+    if score is None:
+        return None
+    components = latest.get("components") or {}
+    n_valid = sum(1 for v in components.values() if v is not None)
+    rating = str(_fgjp_rating(score)).strip()
+    rating_class = "fng-rating-" + rating.lower().replace(" ", "-")
+
+    def _prev(n):
+        if len(history) < n + 1:
+            return None
+        return history[-(n + 1)].get("score")
+
+    d5, d5_cls = _format_fng_delta(score, _prev(5))
+    d20, d20_cls = _format_fng_delta(score, _prev(20))
+    label = (
+        '<span title="CNN Fear &amp; Greed の構造に準拠した日本市場版 (独自実装)。'
+        '%d 成分の等ウェイト平均。両端で信頼度が高く中間域はノイズが多い。'
+        '差分: Junk Bond除外・52週→年初来・出来高→銘柄数・正規化は独自(直近2年min-max)。">'
+        '日本版Fear &amp; Greed</span>' % n_valid
+    )
+    # tooltip に4成分の 0-100 スコアを併記 (各成分とも高いほど Greed 寄与。
+    # volatility は日経VI を反転済みなので高い=低ボラ=Greed)。未取得成分は "—"。
+    _COMP_LABELS = [
+        ("momentum", "モメンタム"), ("strength", "新高値強さ"),
+        ("breadth", "騰落ブレッドス"), ("volatility", "ボラ(反転)"),
+    ]
+    comp_parts = []
+    for key, jp in _COMP_LABELS:
+        v = components.get(key)
+        comp_parts.append("%s %s" % (jp, ("%.0f" % v) if v is not None else "—"))
+    title = "直近=5日前比 / 中期=20日前比 ｜ 成分: " + " / ".join(comp_parts)
+    return (
+        label,
+        '%.1f' % score,
+        '<span class="fng-rating %s">%s</span>' % (
+            html_mod.escape(rating_class), html_mod.escape(rating)),
+        '<span class="%s">%s</span>' % (html_mod.escape(d5_cls), html_mod.escape(d5)),
+        '<span class="%s">%s</span>' % (html_mod.escape(d20_cls), html_mod.escape(d20)),
+        _format_short_date(latest.get("date", "")),
+        title,
+    )
+
+
+def _fgjp_rating(score):
+    """日本版 Fear & Greed の 0-100 スコアを 5 段階 rating に変換 (CNN準拠)。"""
+    if score < 25:
+        return "Extreme Fear"
+    if score < 45:
+        return "Fear"
+    if score < 55:
+        return "Neutral"
+    if score < 75:
+        return "Greed"
+    return "Extreme Greed"
+
+
 def _credit_rows(market_db):
     """信用評価損益率の表行リストを返す ([(label,value,rating,d1,d4,title)])。
     取得失敗時は []。
@@ -1611,7 +1679,7 @@ def _credit_rows(market_db):
 
 
 def _html_market_indicators(market_db):
-    """Fear & Greed / 信用評価損益率 / 日経VI / 新高値-新安値 を 1 つの表に統合した HTML を返す。
+    """Fear & Greed (米CNN/日本版) / 信用評価損益率 / 日経VI / 新高値-新安値 を 1 つの表に統合した HTML を返す。
 
     取得できる行が 1 つもなければ空文字。
     """
@@ -1619,6 +1687,9 @@ def _html_market_indicators(market_db):
     fng = _fng_row(market_db)
     if fng is not None:
         rows.append(fng)
+    fgjp = _fgjp_row(market_db)  # CNN本体の直後に置き日米センチメント差を視認可能に (issue #212)
+    if fgjp is not None:
+        rows.append(fgjp)
     rows.extend(_credit_rows(market_db))
     vi = _vi_row(market_db)
     if vi is not None:

--- a/scripts/market_breadth.py
+++ b/scripts/market_breadth.py
@@ -135,6 +135,39 @@ def fetch_new_high_low():
     return out
 
 
+def fetch_market_breadth_daily():
+    """daily2year.json から日本市場版 Fear & Greed 用の日次時系列をまとめて返す (issue #212)。
+
+    fetch_new_high_low と同じファイル・同じ取得経路を使い、合成スコアに必要な列を
+    1 回の HTTP で抽出する。列構成 (2026-06 時点で実データ突き合わせ確認済):
+      [0] unix timestamp(ms), [1] 日経225終値, [5] 値上がり銘柄数,
+      [6] 値下がり銘柄数, [8] 新高値数, [9] 新安値数 (いずれも東証プライム)。
+
+    Returns:
+        list of dict: [{date, nikkei_close, advances, declines, new_high, new_low}, ...]
+                      日付昇順。必要列が数値でない行 (最新の未確定行など) はスキップ。
+    """
+    text = _fetch_nikkei_json(NEW_HIGH_LOW_URL, NEW_HIGH_LOW_REFERER)
+    rows = _parse_js_rows(text, "DAILY")
+    out = []
+    for r in rows:
+        if len(r) <= 9 or not isinstance(r[0], (int, float)):
+            continue
+        close, adv, dec, high, low = r[1], r[5], r[6], r[8], r[9]
+        if not all(isinstance(v, (int, float)) for v in (close, adv, dec, high, low)):
+            continue
+        d = datetime.fromtimestamp(r[0] / 1000, tz=JST).date().isoformat()
+        out.append({
+            "date": d,
+            "nikkei_close": float(close),
+            "advances": int(adv),
+            "declines": int(dec),
+            "new_high": int(high),
+            "new_low": int(low),
+        })
+    return out
+
+
 def fetch_nikkei_vi():
     """SL621_1990.json から 日経VI (恐怖指数) の時系列を返す。
 

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -1651,6 +1651,77 @@ def update_nikkei_vi():
     )
 
 
+def update_fear_greed_jp():
+    """日本市場版 Fear & Greed Index を計算して JSON 保存 (issue #212)。
+
+    breadth (日経終値・値上がり/値下がり・新高値/安値) は daily2year.json から取得し、
+    日経VI は update_nikkei_vi が保存した nikkei_vi.json を読む (本関数は VI 更新後に呼ぶ)。
+    取得できない成分は除外して残り成分で合成する。
+    キャッシュ・失敗時の扱いは他の update_* と同じ (デイリー全体は止めない)。
+    """
+    import market_breadth
+    import fear_greed_jp
+
+    out_path = os.path.join(DATA_DIR, "code_rank_data", "fear_greed_jp.json")
+    today = get_price_day(datetime.today())
+    if _credit_cache_is_fresh(out_path, today):
+        log_print(f"---- 日本版Fear&Greed キャッシュ有効のためスキップ (generated_at={today.isoformat()})")
+        return
+
+    log_print("----> 日本版Fear&Greed 更新")
+    try:
+        breadth_history = market_breadth.fetch_market_breadth_daily()
+    except Exception as e:
+        log_warning(f"[fear_greed_jp] breadth 取得失敗のためスキップ: {e}")
+        return
+    if not breadth_history:
+        log_warning("[fear_greed_jp] breadth 取得結果が空")
+        return
+
+    # 日経VI はフル履歴を取得して正規化に使う。
+    # nikkei_vi.json は30日分しか保持せず min-max レンジが狭すぎる (直近2年で正規化したい)
+    # ため、breadth と同様にここで生データを直接取得する。取得失敗時は VI 成分のみ除外。
+    vi_history = []
+    try:
+        vi_history = market_breadth.fetch_nikkei_vi()
+    except Exception as e:
+        log_warning(f"[fear_greed_jp] 日経VI取得失敗 (VI成分を除外): {e}")
+
+    result = fear_greed_jp.compute_fear_greed_jp(breadth_history, vi_history)
+    if result is None:
+        log_warning("[fear_greed_jp] 全成分が None のためスキップ")
+        return
+
+    # history は date + score + components を 30 営業日分保持 (前日比/5日前比表示用)
+    latest_date = breadth_history[-1]["date"]
+    prev_history = []
+    if os.path.exists(out_path):
+        try:
+            with open(out_path, "r", encoding="utf-8") as f:
+                prev_history = (json.load(f).get("history") or [])
+        except (OSError, ValueError):
+            prev_history = []
+    entry = {"date": latest_date, "score": result["score"],
+             "components": result["components"]}
+    history = [h for h in prev_history if h.get("date") != latest_date]
+    history.append(entry)
+    history = history[-30:]
+
+    payload = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "source": "nikkei225jp.com (daily2year.json / vix.php) より独自合成 (CNN構造準拠)",
+        "latest": {"date": latest_date, **result},
+        "history": history,
+    }
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    log_print(
+        f"<---- 日本版Fear&Greed 更新完了 latest={latest_date} "
+        f"score={result['score']} ({result['rating']})"
+    )
+
+
 def main(force=False):
     """メイン関数"""
     # TODO: 新高値更新タイミングをタグで
@@ -1673,6 +1744,7 @@ def main(force=False):
         update_credit_balance()
         update_new_high_low()
         update_nikkei_vi()
+        update_fear_greed_jp()  # VI 更新後に呼ぶ (nikkei_vi.json を参照するため)
     # 新高値銘柄の各種解析
     if "analyze" in args:
         todays_shintakane(UPD_INTERVAL)  # UPD_FORCE/UPD_INTERVAL/UPD_CACHE/UPD_REEVAL

--- a/tests/test_fear_greed_jp.py
+++ b/tests/test_fear_greed_jp.py
@@ -1,0 +1,69 @@
+"""日本市場版 Fear & Greed Index のテスト (issue #212)。"""
+
+import pytest
+
+import fear_greed_jp as fg
+
+
+# --- normalize_min_max: 境界 ---------------------------------------------
+@pytest.mark.parametrize("value,history,expected", [
+    (50, [], 50.0),            # 履歴空 → 中立
+    (5, [5, 5, 5], 50.0),      # 最大最小一致 → 中立
+    (100, [0, 100], 100.0),    # 上限
+    (0, [0, 100], 0.0),        # 下限
+    (50, [0, 100], 50.0),      # 中央
+    (200, [0, 100], 100.0),    # 上方クリップ
+    (-50, [0, 100], 0.0),      # 下方クリップ
+])
+def test_normalize_min_max(value, history, expected):
+    assert fg.normalize_min_max(value, history) == expected
+
+
+# --- rating 境界 ----------------------------------------------------------
+@pytest.mark.parametrize("score,rating", [
+    (24, "Extreme Fear"), (25, "Fear"), (44, "Fear"), (45, "Neutral"),
+    (54, "Neutral"), (55, "Greed"), (74, "Greed"), (75, "Extreme Greed"),
+    (100, "Extreme Greed"),
+])
+def test_rating_boundaries(score, rating):
+    assert fg._rating(score) == rating
+
+
+# --- volatility 方向反転 (VI 高い=Fear=低スコア) --------------------------
+def test_volatility_inverted():
+    # VI 最大値(最新)→ 反転で 0 付近、最小値→ 100 付近
+    hist_high = [{"nikkei_vi": v} for v in [10, 20, 40]]   # 最新=最大
+    hist_low = [{"nikkei_vi": v} for v in [40, 20, 10]]    # 最新=最小
+    assert fg.compute_component_volatility(hist_high) == 0.0
+    assert fg.compute_component_volatility(hist_low) == 100.0
+
+
+# --- 合成: None 成分は除外して残りで平均 ---------------------------------
+@pytest.mark.parametrize("breadth,vi,expect_components,expect_score", [
+    # 全成分そろう (momentum はデータ不足で None になりうるので strength/breadth/vol で検証)
+    (
+        # strength: 新高値-新安値, breadth: 値上がり-値下がり
+        [{"nikkei_close": 100, "new_high": 0, "new_low": 10, "advances": 0, "declines": 10},
+         {"nikkei_close": 100, "new_high": 10, "new_low": 0, "advances": 10, "declines": 0}],
+        [{"nikkei_vi": 30}, {"nikkei_vi": 10}],  # VI 最新=最小 → vol=100
+        {"strength", "breadth", "volatility"},   # momentum は close 一定で None になりうる
+        None,  # score は計算可能であればよい (個別値は別アサート)
+    ),
+])
+def test_compose_excludes_none(breadth, vi, expect_components, expect_score):
+    result = fg.compute_fear_greed_jp(breadth, vi)
+    assert result is not None
+    # None でない成分が平均に使われている
+    valid = {k for k, v in result["components"].items() if v is not None}
+    assert expect_components <= valid
+    assert 0.0 <= result["score"] <= 100.0
+    assert result["rating"] in (
+        "Extreme Fear", "Fear", "Neutral", "Greed", "Extreme Greed")
+
+
+def test_compose_all_none_returns_none():
+    # データ1点ずつ (len<2) で全成分 None → None
+    assert fg.compute_fear_greed_jp(
+        [{"nikkei_close": 100, "new_high": 1, "new_low": 1, "advances": 1, "declines": 1}],
+        [{"nikkei_vi": 20}],
+    ) is None

--- a/tests/test_fear_greed_jp.py
+++ b/tests/test_fear_greed_jp.py
@@ -29,13 +29,15 @@ def test_rating_boundaries(score, rating):
     assert fg._rating(score) == rating
 
 
-# --- volatility 方向反転 (VI 高い=Fear=低スコア) --------------------------
+# --- volatility 方向反転 (VI 高い=Fear=低スコア) + raw 値 ------------------
 def test_volatility_inverted():
-    # VI 最大値(最新)→ 反転で 0 付近、最小値→ 100 付近
+    # VI 最大値(最新)→ 反転で score 0、最小値→ score 100。raw は VI 実値。
     hist_high = [{"nikkei_vi": v} for v in [10, 20, 40]]   # 最新=最大
     hist_low = [{"nikkei_vi": v} for v in [40, 20, 10]]    # 最新=最小
-    assert fg.compute_component_volatility(hist_high) == 0.0
-    assert fg.compute_component_volatility(hist_low) == 100.0
+    score_h, raw_h = fg.compute_component_volatility(hist_high)
+    score_l, raw_l = fg.compute_component_volatility(hist_low)
+    assert (score_h, raw_h) == (0.0, 40)
+    assert (score_l, raw_l) == (100.0, 10)
 
 
 # --- 合成: None 成分は除外して残りで平均 ---------------------------------
@@ -53,9 +55,12 @@ def test_volatility_inverted():
 def test_compose_excludes_none(breadth, vi, expect_components, expect_score):
     result = fg.compute_fear_greed_jp(breadth, vi)
     assert result is not None
-    # None でない成分が平均に使われている
+    # None でない成分が平均に使われている。各成分は {"score","raw"} dict。
     valid = {k for k, v in result["components"].items() if v is not None}
     assert expect_components <= valid
+    for k in valid:
+        assert "score" in result["components"][k]
+        assert "raw" in result["components"][k]
     assert 0.0 <= result["score"] <= 100.0
     assert result["rating"] in (
         "Extreme Fear", "Fear", "Neutral", "Greed", "Extreme Greed")

--- a/tests/test_fear_greed_jp.py
+++ b/tests/test_fear_greed_jp.py
@@ -5,7 +5,22 @@ import pytest
 import fear_greed_jp as fg
 
 
-# --- normalize_min_max: 境界 ---------------------------------------------
+# --- normalize_percentile: 境界・外れ値頑健性 (現行の主正規化) -------------
+@pytest.mark.parametrize("value,history,expected", [
+    (50, [], 50.0),                       # 履歴空 → 中立
+    (5, [10, 20, 30, 40], 0.0),           # 全要素より小 → 0
+    (50, [10, 20, 30, 40], 100.0),        # 全要素より大 → 100
+    (25, [10, 20, 30, 40], 50.0),         # 中央 (2件が下) → 50
+    (20, [10, 20, 30, 40], 37.5),         # 中央順位: below1 + equal0.5 = 1.5/4
+    # 外れ値頑健性: 極端な1点があっても percentile は圧縮されない
+    # (min-max なら value=11 は (11-10)/(1000-10)≈0.1 だが percentile は 75)
+    (11, [10, 12, 13, 1000], 25.0),       # 11 より下は 10 のみ → 1/4 = 25
+])
+def test_normalize_percentile(value, history, expected):
+    assert fg.normalize_percentile(value, history) == expected
+
+
+# --- normalize_min_max: 境界 (旧方式、参考用に残置) -----------------------
 @pytest.mark.parametrize("value,history,expected", [
     (50, [], 50.0),            # 履歴空 → 中立
     (5, [5, 5, 5], 50.0),      # 最大最小一致 → 中立

--- a/tests/test_market_breadth.py
+++ b/tests/test_market_breadth.py
@@ -289,3 +289,32 @@ def test_fgjp_accordion_components_in_indicators(tmp_path, monkeypatch):
     # 各成分に参照リンク (統合前の独立行のリンクを踏襲)
     assert 'href="https://nikkei225jp.com/data/vix.php"' in html
     assert 'href="https://nikkei225jp.com/data/new.php"' in html
+
+
+def test_fgjp_absent_falls_back_to_vi_and_breadth_rows(tmp_path, monkeypatch):
+    """fear_greed_jp.json が無い日は 日経VI・新高値新安値を独立行で表示する (退行防止)。
+
+    F&G アコーディオンに統合したことで、F&G を出せない日に従来表示が消えるのを防ぐ。
+    """
+    code_rank = tmp_path / "code_rank_data"
+    code_rank.mkdir(parents=True)
+    # fear_greed_jp.json は作らない (取得失敗日を再現)
+    vi_hist = _build_history(
+        {0: {"nikkei_vi": 16.77}, 5: {"nikkei_vi": 16.5}, 20: {"nikkei_vi": 17.0}},
+        20, lambda i: {"nikkei_vi": 16.0})
+    (code_rank / "nikkei_vi.json").write_text(
+        json.dumps({"history": vi_hist}), encoding="utf-8")
+    nhl_hist = _build_history(
+        {0: {"new_high": 88, "new_low": 131}},
+        20, lambda i: {"new_high": 50, "new_low": 50})
+    (code_rank / "new_high_low.json").write_text(
+        json.dumps({"history": nhl_hist}), encoding="utf-8")
+    monkeypatch.setattr(make_market_db, "DATA_DIR", str(tmp_path))
+
+    html = make_market_db._html_market_indicators({})
+    # F&G アコーディオンの親行は出ない (トグルJSのセレクタ文字列とは区別して tr で判定)
+    assert 'class="mi-fgjp-parent"' not in html
+    assert "日本版Fear" not in html
+    # 日経VI・新高値新安値が独立行でフォールバック表示される
+    assert "日経VI" in html and "16.77" in html
+    assert "新高値-新安値" in html

--- a/tests/test_market_breadth.py
+++ b/tests/test_market_breadth.py
@@ -249,37 +249,43 @@ def _build_history(records, n, key_fn):
     return hist
 
 
-def test_vi_and_breadth_rows_in_indicators(tmp_path, monkeypatch):
-    """日経VI と 新高値-新安値 が変化量付きで統合表に出る (issue #292)。
+def test_fgjp_accordion_components_in_indicators(tmp_path, monkeypatch):
+    """日本版 F&G の成分がアコーディオン展開行に出る (issue #212)。
 
-    index -1=最新 / -6=5日前 / -21=20日前 を基準に直近/中期の変化量を検証する。
+    日経VI・新高値新安値は独立行をやめ、F&G 成分の内訳 (score + 元データ実値) に統合。
     """
     code_rank = tmp_path / "code_rank_data"
     code_rank.mkdir(parents=True)
-    # 日経VI: 最新 16.77 / 5日前 16.5 (直近 +0.3) / 20日前 17.0 (中期 -0.2)
-    vi_hist = _build_history(
-        {0: {"nikkei_vi": 16.77}, 5: {"nikkei_vi": 16.5}, 20: {"nikkei_vi": 17.0}},
-        20, lambda i: {"nikkei_vi": 16.0})
-    (code_rank / "nikkei_vi.json").write_text(
-        json.dumps({"history": vi_hist}), encoding="utf-8")
-    # 新高値-新安値: 最新 -43 (88-131) / 5日前 -80 (直近 +37) / 20日前 -140 (中期 +97)
-    nhl_hist = _build_history(
-        {0: {"new_high": 88, "new_low": 131},
-         5: {"new_high": 70, "new_low": 150},
-         20: {"new_high": 60, "new_low": 200}},
-        20, lambda i: {"new_high": 50, "new_low": 50})
-    (code_rank / "new_high_low.json").write_text(
-        json.dumps({"history": nhl_hist}), encoding="utf-8")
+    fgjp = {
+        "history": [{
+            "date": "2026-06-05",
+            "score": 78.4,
+            "components": {
+                "momentum": {"score": 87.0, "raw": 19.24},
+                "strength": {"score": 72.4, "raw": 39},
+                "breadth": {"score": 76.6, "raw": 856},
+                "volatility": {"score": 77.9, "raw": 21.51},
+            },
+        }],
+    }
+    (code_rank / "fear_greed_jp.json").write_text(
+        json.dumps(fgjp), encoding="utf-8")
     monkeypatch.setattr(make_market_db, "DATA_DIR", str(tmp_path))
 
     html = make_market_db._html_market_indicators({})
-    # 日経VI 行: 値 + バッジ + 直近 +0.3 / 中期 -0.2
-    assert "日経VI" in html
-    assert "16.77" in html
-    assert "安穏" in html
-    assert "+0.3" in html and "-0.2" in html
-    # 新高値-新安値 行: 値 -43、直近 +37 / 中期 +97、内訳は tooltip
-    assert "新高値-新安値" in html
-    assert "-43" in html
-    assert "+37" in html and "+97" in html
-    assert "新高値 88 / 新安値 131" in html
+    # 親行: 日本版F&G + 合成スコア + アコーディオン toggle
+    assert "日本版Fear" in html
+    assert "78.4" in html
+    assert "mi-fgjp-parent" in html and "mi-fgjp-child" in html
+    # 成分の展開行: 各成分名 + 0-100スコア + 元データ実値
+    assert "モメンタム" in html and "新高値強さ" in html
+    assert "騰落ブレッドス" in html and "ボラティリティ" in html
+    assert "21.51" in html          # 日経VI 実値
+    assert "+39" in html            # 新高値-新安値 実値
+    assert "+19.2%" in html         # モメンタム乖離率
+    # 各成分に 0-100 スコア基準のバッジ (score 87/72/77/78 はいずれも Greed〜Extreme Greed)
+    assert "fng-rating-extreme-greed" in html   # momentum 87
+    assert "fng-rating-greed" in html           # strength 72 等
+    # 各成分に参照リンク (統合前の独立行のリンクを踏襲)
+    assert 'href="https://nikkei225jp.com/data/vix.php"' in html
+    assert 'href="https://nikkei225jp.com/data/new.php"' in html


### PR DESCRIPTION
## 概要

CNN Fear & Greed Index の構造（成分構成・等ウェイト平均・5段階rating）に準拠した**日本市場版センチメント指数**を構築し、`/market` の市場指標サマリ表に表示する (issue #212)。

第1弾はデータ源が確定済みの**4成分**（いずれも nikkei225jp.com 由来、新規データ源不要）:

| 成分 | 内容 | 方向 |
|---|---|---|
| Market Momentum | 日経225 vs 125日MA 乖離率 | 高い=Greed |
| Stock Price Strength | 新高値数 - 新安値数 | 高い=Greed |
| Stock Price Breadth | 値上がり - 値下がり銘柄数 | 高い=Greed |
| Market Volatility | 日経VI（高いほどFearなので反転） | 低ボラ=Greed |

## 表示

市場指標表の CNN本体の直後に置き、**日米センチメント差**を一目で視認できる（米42.1=Fear / 日78.4=Extreme Greed など）。行の tooltip に4成分の0-100スコアと原典差分注記を併記。

![market](https://github.com/nasumiso/KSKInvestSystem/blob/worktree-fear-greed-jp-issue212/.claude/worktrees/fear-greed-jp-issue212/.playwright-mcp/issue212-fear-greed-jp-market.png)

（スクショはローカル `.playwright-mcp/issue212-fear-greed-jp-market.png`）

## 変更点

- **`fear_greed_jp.py`(新規)**: min-max正規化（直近2年）・成分計算・等ウェイト合成。取れない成分は除外して残りで平均（フォールバック）。VIは方向反転。
- **`market_breadth.py`**: `fetch_market_breadth_daily()` 追加。daily2year.json の [1]終値/[5]値上がり/[6]値下がり/[8][9]新高値安値を1取得で抽出（既存 `fetch_new_high_low` は不変）。
- **`shintakane.py`**: `update_fear_greed_jp()` をデイリーに追加（VI更新後）。VI正規化は30日では狭いためフル履歴を取得。
- **`make_market_db.py`**: `_fgjp_row()` を市場指標表に追加。tooltipに4成分併記。
- **`test_fear_greed_jp.py`(新規)**: min-max境界 / rating境界 / 方向反転 / None合成（parametrize集約）。

## CNN原典との差分（コードコメント・tooltipにも明記）

1. 成分数 7→4（Junk Bond除外、PCR・JGB10年は後続）
2. Strength が52週ではなく年初来基準
3. Breadth が出来高ベースではなく銘柄数ベース
4. 正規化レンジは独自（直近2年 min-max）

## テスト

- 新規+回帰 **177件パス**（fear_greed_jp / market_breadth / make_market_db / functional_market）
- 実データで4成分すべて計算成功（momentum 87 / strength 72 / breadth 77 / volatility 78 → 合成 78.4 Extreme Greed）
- /market ブラウザ確認・tooltip表示確認済み

## 補足

- 「直近/中期」は初回は履歴1件のため `—`。デイリー運用で蓄積され前日比/5日前比が出る。
- **残課題（別段階）**: PCR・JGB10年(Safe Haven)のデータ源確保で5〜6成分化。issue #212 は段階実装のため本PRでは Closes せず参照に留める。

ref #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
