### PR TITLE
test(webapp): シグナルマーカーテストの anchor を直近平日に正規化 (CI UTC 対応)

### DIFF
--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2961,11 +2961,20 @@ class TestSignalDisplay:
     """_build_signal_display の強度/色・_resolve_signal_markers の週マップ"""
 
     def _anchor(self):
-        # extract_signals は access_date_price を get_price_day() で anchor 化する。
-        # テストは anchor を基準に mmdd を作り delta を安定させる。
-        from datetime import datetime
+        # extract_signals は access_date_price を get_price_day() で anchor 化し、
+        # かつ (today - anchor_day) で stale 判定する。テストは anchor を基準に
+        # mmdd を作り delta を安定させる。
+        # 素の datetime.now() だと CI(UTC) の午前実行で get_price_day の17時
+        # カットオーバーにより anchor_day が前日(日曜)になり、曜日依存の按分
+        # テストが崩れる。そこで「今日付近の直近平日 20:00」に正規化して
+        # 実行時刻・TZ に依存させない (stale 判定も today-anchor が小さく通る)。
+        from datetime import datetime, timedelta
         from ks_util import get_price_day
-        now = datetime.now()
+        today = datetime.now().date()
+        wd = today.weekday()
+        if wd >= 5:  # 土(5)/日(6) は直近金曜へ
+            today -= timedelta(days=wd - 4)
+        now = datetime(today.year, today.month, today.day, 20, 0)  # 平日20:00
         return now, get_price_day(now)
 
     def _stock_with_signal(self, kind, num, days_ago):


### PR DESCRIPTION
## 背景

PR #322 のマージ時に発覚。`tests/test_webapp_helpers.py::TestSignalDisplay::test_resolve_markers_x_interp_and_drop` が CI で恒常的に失敗しており、**main を含む直近の CI が全て赤い**状態だった。

## 原因

`TestSignalDisplay._anchor()` が `datetime.now()` をそのまま `get_price_day()` に渡していた。

- CI ランナーは **UTC**。UTC 午前(JST 午前〜夕方)に実行されると `get_price_day` の **17時カットオーバー**で `anchor_day` が前日になる
- その前日が**日曜**だと、テスト内の「今週月曜」計算 (`anchor_day - anchor_day.weekday()`) が前週基準にズレ、`po_day`(先週金曜)が window 範囲外になって「ポ」マーカーが drop → `assert "ポ" in kinds` で失敗

ローカル(JST 夜)では `anchor_day` が当日(平日)になるため再現しなかった。`097ca51`(#317)でこのテストが追加されて以降、CI が赤いまま見過ごされていた。

## 修正

`_anchor()` で基準時刻を「**今日付近の直近平日 20:00**」に正規化:
- 土日なら直近金曜へ寄せる
- 時刻を 20:00 固定にして `get_price_day` が当日(平日)を返すようにする
- `_signal_recent_delta` の stale 判定 `(today - anchor_day)` も小さく保たれるため通る

これで実行時刻・TZ に依存しなくなる。

## 検証

- `pytest tests/test_webapp_helpers.py::TestSignalDisplay` → JST/UTC 両方で 6件パス
- CI 同一コマンド `pytest tests/ -m "not local_db and not live_html"` を `TZ=UTC` で全体実行 → 1763 passed(回帰なし、当該テスト解消)

## スコープ

PR #322(日次キャッシュ判定)とは別件。helpers 本体のロジックは変更せず、テストの基準日生成のみ修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)