### PR TITLE
[codex] issue309対応

### DIFF
--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -889,6 +889,24 @@ def get_stock_db(code):
         return db.get(str(code), {})
 
 
+def persist_stock_fields(stock_data_list):
+    """指定銘柄の任意フィールドを shelve へ直接永続化する。
+
+    update_db_rows の戻り値(export_to_dict した通常 dict)に update_db を
+    かけてもメモリ上のコピーが変わるだけで shelve に保存されないため、
+    永続化が必要な軽量フィールド更新はこの関数を経由する。
+
+    Args:
+        stock_data_list: list<dict> 各要素は code_s と更新カラムを持つ
+    """
+    if not stock_data_list:
+        return
+    with _get_stock_shelve_db() as db:
+        for stock_data in stock_data_list:
+            update_db(db, stock_data)
+        db.sync()
+
+
 @contextmanager
 def print_to():
     output = io.StringIO()

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1092,6 +1092,17 @@ def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
             dt = get_price_day(dt)
             if (date.today() - dt).days <= 30:
                 tags.append("".join(new_high))
+    # 株探リスト掲載（本日のみ）
+    kabutan_origin = stock.get("kabutan_origin", "")
+    if kabutan_origin and stock.get("kabutan_origin_date"):
+        dt = get_price_day(stock.get("kabutan_origin_date"))
+        if (date.today() - dt).days <= 1:
+            if "高" in kabutan_origin:
+                tags.append("高")
+            if "出" in kabutan_origin:
+                tags.append("出")
+            if "P" in kabutan_origin:
+                tags.append("P")
     # 20MA押し
     pb20 = stock.get("pullback_20", "")
     if pb20:
@@ -1118,8 +1129,6 @@ def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
             try:
                 delta_day = get_recent_signal_delta(spl[0])
                 # mark = "★"  if delta_day < 3 else ""
-                if delta_day is not None and delta_day <= 7 and delta_day >= 0 and "ポ" not in tags:
-                    tags.append("ポ")
             except ValueError:
                 log_warning("ポケットピポット日付エラー", spl[0])
             if i == 0:
@@ -1132,8 +1141,6 @@ def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
         try:
             delta_day = get_recent_signal_delta(brkspl[0])
             # mark = "★"  if delta_day < 3 else ""
-            if delta_day is not None and delta_day <= 7 and delta_day >= 0:
-                tags.append("ブ")
         except ValueError:
             log_warning("ブレイクアウト日付エラー", brkspl[0])
         signal += "[ブ]"

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -236,6 +236,18 @@ def get_latest_pts_fname():
     return today_csv, today
 
 
+def _origin_to_mark(origin):
+    """origin文字列を表示用記号へ変換する。"""
+    mark = ""
+    if str(origin).find("shintakane") >= 0:
+        mark += "高"
+    if str(origin).find("dekidakaup") >= 0:
+        mark += "出"
+    if str(origin).find("pts") >= 0:
+        mark += "P"
+    return mark
+
+
 def todays_shintakane(upd=UPD_INTERVAL):
     """本日の新高値銘柄データを解析して結果を表示する"""
     log_print("=" * 30)
@@ -422,6 +434,37 @@ def todays_shintakane(upd=UPD_INTERVAL):
     # 調査不要なものを除く(stocksが必要なのでここで)
     today_list = filter_today_list(today_list)
     already_list = filter_today_list(already_list)
+
+    def save_kabutan_origin():
+        """本日リスト掲載の株探由来記号をDBへ保存する。"""
+        base_day = get_price_day(datetime.today())
+        active_sources = {
+            "shintakane": bool(latest_csv_dt) and get_price_day(latest_csv_dt) == base_day,
+            "dekidakaup": bool(latest_csv_dt_d) and get_price_day(latest_csv_dt_d) == base_day,
+            "pts": bool(latest_csv_dt_p) and get_price_day(latest_csv_dt_p) == base_day,
+        }
+        saved_at = datetime.today()
+        for item in today_list:
+            origin = item.get("origin", "")
+            mark = ""
+            if active_sources["shintakane"] and origin.find("shintakane") >= 0:
+                mark += "高"
+            if active_sources["dekidakaup"] and origin.find("dekidakaup") >= 0:
+                mark += "出"
+            if active_sources["pts"] and origin.find("pts") >= 0:
+                mark += "P"
+            if not mark:
+                continue
+            stock_db.update_db(
+                stocks,
+                {
+                    "code_s": item["code_s"],
+                    "kabutan_origin": mark,
+                    "kabutan_origin_date": saved_at,
+                },
+            )
+
+    save_kabutan_origin()
     already_list_code = [a["code_s"] for a in already_list]
     today_list_code = [a["code_s"] for a in today_list]
     # 未調査フィルタ
@@ -576,13 +619,7 @@ def todays_shintakane(upd=UPD_INTERVAL):
         funda_pt = stock.get("funda_pt", 0)
         overview = stock.get("overview", "")
         purchase_money = int(stock.get("lowest_purchase_money", 0)) / 10000
-        origin = ""
-        if d["origin"].find("shintakane") >= 0:
-            origin += "新"
-        if d["origin"].find("pts") >= 0:
-            origin += "P"
-        if d["origin"].find("dekidakaup") >= 0:
-            origin += "出"
+        origin = _origin_to_mark(d["origin"])
         major_theme = make_market_db.get_major_theme(stock.get("themes", ""))
         if TO_CSV:
             row = [

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -444,6 +444,7 @@ def todays_shintakane(upd=UPD_INTERVAL):
             "pts": bool(latest_csv_dt_p) and get_price_day(latest_csv_dt_p) == base_day,
         }
         saved_at = datetime.today()
+        updates = []
         for item in today_list:
             origin = item.get("origin", "")
             mark = ""
@@ -455,14 +456,15 @@ def todays_shintakane(upd=UPD_INTERVAL):
                 mark += "P"
             if not mark:
                 continue
-            stock_db.update_db(
-                stocks,
+            updates.append(
                 {
                     "code_s": item["code_s"],
                     "kabutan_origin": mark,
                     "kabutan_origin_date": saved_at,
-                },
+                }
             )
+        # shelve へ直接永続化する(stocks は export 済み dict のため保存されない)
+        stock_db.persist_stock_fields(updates)
 
     save_kabutan_origin()
     already_list_code = [a["code_s"] for a in already_list]

--- a/scripts/shintakane.py
+++ b/scripts/shintakane.py
@@ -236,6 +236,16 @@ def get_latest_pts_fname():
     return today_csv, today
 
 
+def _is_csv_active(latest_csv_dt, base_day):
+    """CSVファイル日付が当日営業日(base_day)と一致するか判定する。
+
+    latest_csv_dt は get_latest_*_fname() が返すファイル日付で時刻は現在時刻のまま。
+    get_price_day() を再適用すると 17時前に前日へ二重補正されるため、日付部分
+    (.date()) と base_day を直接比較する。
+    """
+    return bool(latest_csv_dt) and latest_csv_dt.date() == base_day
+
+
 def _origin_to_mark(origin):
     """origin文字列を表示用記号へ変換する。"""
     mark = ""
@@ -437,11 +447,12 @@ def todays_shintakane(upd=UPD_INTERVAL):
 
     def save_kabutan_origin():
         """本日リスト掲載の株探由来記号をDBへ保存する。"""
+        # base_day は「当日とみなす営業日」(17時前は前日)。
         base_day = get_price_day(datetime.today())
         active_sources = {
-            "shintakane": bool(latest_csv_dt) and get_price_day(latest_csv_dt) == base_day,
-            "dekidakaup": bool(latest_csv_dt_d) and get_price_day(latest_csv_dt_d) == base_day,
-            "pts": bool(latest_csv_dt_p) and get_price_day(latest_csv_dt_p) == base_day,
+            "shintakane": _is_csv_active(latest_csv_dt, base_day),
+            "dekidakaup": _is_csv_active(latest_csv_dt_d, base_day),
+            "pts": _is_csv_active(latest_csv_dt_p, base_day),
         }
         saved_at = datetime.today()
         updates = []

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1910,6 +1910,24 @@ def _format_tags(stock: Dict[str, Any], tags=None) -> str:
     return "/".join(tags) if tags else "—"
 
 
+def _format_signal(stock: Dict[str, Any]) -> Tuple[str, str]:
+    """portfolio 一覧のシグナル列用に (表示記号, tooltip全文) を返す。"""
+    if not stock:
+        return ("—", "")
+    try:
+        from make_stock_db import extract_signals, make_signal  # 遅延 import
+        signal_full, _tags = make_signal(stock)
+        signals = extract_signals(stock)
+    except Exception:  # noqa: BLE001
+        return ("—", "")
+    marks = []
+    for sig in signals:
+        kind = sig.get("kind")
+        if kind and kind not in marks:
+            marks.append(kind)
+    return ("/".join(marks) if marks else "—", signal_full or "")
+
+
 # ポ/ブシグナルの鮮度係数 (issue #253)。経過日数→不透明度の乗数。
 # tooltip 背景色 (_build_signal_display) とチャートマーカー (項目3) で共有する。
 def _signal_freshness_alpha(delta: int) -> float:
@@ -3120,6 +3138,8 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
             "trend_template_tooltip": "—",
             "kairi_gauge_svg": "",
             "tags": "—",
+            "signal_mark": "—",
+            "signal_full": "",
             "spr_gauge": {"svg": "—", "tooltip": ""},
             "theoretical_diff": "—",
             "theoretical_diff_raw": None,
@@ -3154,6 +3174,7 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         _signal, _tags = make_signal(stock)
     except Exception:  # noqa: BLE001
         _tags = None
+    signal_mark, signal_full = _format_signal(stock)
 
     return {
         "rank": rank if isinstance(rank, int) else None,
@@ -3181,6 +3202,8 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "trend_template_tooltip": trend_info["tooltip"],
         "kairi_gauge_svg": trend_info["kairi_gauge_svg"],
         "tags": _format_tags(stock, _tags),
+        "signal_mark": signal_mark,
+        "signal_full": signal_full,
         "signal_display": _build_signal_display(stock),  # issue #253: tooltip+背景色
         "spr_gauge": _build_spr_gauge_for_stock(stock),
         "theoretical_diff": _format_theoretical_diff(stock),
@@ -3365,15 +3388,16 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
 
     # --- シグナル (ルール 2-7): 強い色から順に評価
     tags = row.get("tags") or ""
-    if any(c in tags for c in ("ポ", "ブ", "最")):
-        # issue #253: ポ/ブは強度×鮮度の赤系濃淡を優先 (signal_display.style)。
-        # 算出不可・「最」のみの場合は従来の一律赤にフォールバック。
-        sig_style = (row.get("signal_display") or {}).get("style")
-        styles["tags"] = sig_style or bg_with_white("赤")
+    if "最" in tags:
+        styles["tags"] = bg_with_white("赤")
     elif any(c in tags for c in ("警", "売")):
         styles["tags"] = bg_with_white("青")
     elif "押" in tags:
         styles["tags"] = f"color:{PORTFOLIO_COLORS['青']}"
+    signal_mark = row.get("signal_mark") or ""
+    if signal_mark and signal_mark != "—":
+        sig_style = (row.get("signal_display") or {}).get("style")
+        styles["signal"] = sig_style or bg_with_white("赤")
 
     # --- 時価総額 (ルール 29, 30): カテゴリ "中" / "大" → 薄黄 (極小/小/特大は色なし)
     cat = row.get("market_cap_category")

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -269,6 +269,7 @@
       <th title="RSライン (対TOPIX, 青=上昇/オレンジ=下降) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸">RS(20,5)</th>
       <th>トレンド</th>
       <th>タグ</th>
+      <th title="ポ/ブ記号。ホバーで signal 全文 (発生日付含む)">シグナル</th>
       <th title="バー背景の濃淡で買い集め評価 (A=濃 / E=薄、左=緑 / 右=赤)">需給バランス</th>
       <th>時価総額</th>
     </tr>
@@ -377,14 +378,16 @@
       <td title="{{ row.trend_template_tooltip }}" style="width:40px;padding:0;line-height:0;text-align:center;{{ row.styles.trend_template or '' }}">
         {% if row.kairi_gauge_svg %}{{ row.kairi_gauge_svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
       </td>
-      <td title="{{ row.signal_display.tooltip or row.tags }}"
+      <td title="{{ row.tags if row.tags != '—' else '' }}"
           style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
+      <td title="{{ row.signal_full or '' }}"
+          style="max-width:3em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.signal or '' }}">{{ row.signal_mark }}</td>
       <td class="spr-gauge-cell" title="{{ row.spr_gauge.tooltip }}">{{ row.spr_gauge.svg|safe }}</td>
       <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
     </tr>
     <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
       {# 状態列 + 評価/需給列を含む全列に展開行を合わせる #}
-      <td colspan="{% if delete_mode_allowed %}25{% else %}24{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
+      <td colspan="{% if delete_mode_allowed %}26{% else %}25{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
         <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
           {% if row.gyoseki.isKonki %}
           <div style="flex:0 0 auto;">

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -152,7 +152,7 @@ class TestMakeSignal:
     # ---- issue #110: ポケットピポット改善 ----
 
     @pytest.mark.parametrize(
-        "trend_template, expect_tag",
+        "trend_template, expect_signal",
         [
             ([], True),  # 全通過(◎) → タグ付与
             (None, True),  # legacy None → 空扱い
@@ -163,7 +163,7 @@ class TestMakeSignal:
             ("__missing__", True),  # trend_template キー欠落 → タグ付与
         ],
     )
-    def test_pocket_pivot_stage4_filter(self, trend_template, expect_tag):
+    def test_pocket_pivot_stage4_filter(self, trend_template, expect_signal):
         """項目1: Stage 4 崩壊銘柄ではポケットピポットを除外する"""
         today = datetime.today()
         recent = (today - timedelta(days=2)).strftime("%m/%d")
@@ -173,8 +173,9 @@ class TestMakeSignal:
         }
         if trend_template != "__missing__":
             stock["trend_template"] = trend_template
-        _, tags = make_stock_db.make_signal(stock)
-        assert ("ポ" in tags) is expect_tag
+        signal, tags = make_stock_db.make_signal(stock)
+        assert ("[ポ]" in signal) is expect_signal
+        assert "ポ" not in tags
 
     def test_pocket_pivot_year_boundary(self, monkeypatch):
         """項目3: 年初に年末シグナルを処理しても delta_day が正で「ポ」が付く"""
@@ -191,25 +192,27 @@ class TestMakeSignal:
             "trend_template": [],
             "access_date_price": datetime(2026, 1, 3, 18, 0),
         }
-        _, tags = make_stock_db.make_signal(stock)
-        assert "ポ" in tags
+        signal, tags = make_stock_db.make_signal(stock)
+        assert "[ポ]" in signal
+        assert "ポ" not in tags
         # ブレイクアウト側も同じ年跨ぎ修正
         stock_b = {
             "breakout": ["12/31,50"],
             "trend_template": [],
             "access_date_price": datetime(2026, 1, 3, 18, 0),
         }
-        _, tags_b = make_stock_db.make_signal(stock_b)
-        assert "ブ" in tags_b
+        signal_b, tags_b = make_stock_db.make_signal(stock_b)
+        assert "[ブ]" in signal_b
+        assert "ブ" not in tags_b
 
     @pytest.mark.parametrize(
-        "today_dt, expect_tag",
+        "today_dt, expect_visible",
         [
             (datetime(2026, 6, 13), True),   # 金曜更新の8日後(翌週末): anchor基準でdelta=0→残る
             (datetime(2026, 7, 7), False),   # 32日後: 銘柄データstale(>30日)→消える
         ],
     )
-    def test_pocket_pivot_anchor_based_freshness(self, monkeypatch, today_dt, expect_tag):
+    def test_pocket_pivot_anchor_based_freshness(self, monkeypatch, today_dt, expect_visible):
         """鮮度は anchor_day 基準。週末・数日の更新停止では当日シグナルが残り、
         30日超の更新停止では stale として消える (PR320 レビュー対応)。"""
 
@@ -225,8 +228,10 @@ class TestMakeSignal:
             "trend_template": [],
             "access_date_price": datetime(2026, 6, 5, 18, 0),
         }
-        _, tags = make_stock_db.make_signal(stock)
-        assert ("ポ" in tags) is expect_tag
+        signal, tags = make_stock_db.make_signal(stock)
+        visible = any(s["kind"] == "ポ" for s in make_stock_db.extract_signals(stock))
+        assert visible is expect_visible
+        assert "ポ" not in tags
 
     def test_pocket_pivot_stale_prior_year_not_reactivated(self, monkeypatch):
         """前年以前の stale シグナルを年初に再点灯しない"""
@@ -242,11 +247,12 @@ class TestMakeSignal:
             "trend_template": [],
             "access_date_price": datetime(2024, 12, 31, 18, 0),
         }
-        _, tags = make_stock_db.make_signal(stock)
+        signal, tags = make_stock_db.make_signal(stock)
+        assert "[ポ]" in signal
         assert "ポ" not in tags
 
     def test_pocket_pivot_consecutive(self):
-        """項目4: 連続ポケットピポットは最大3件・「ポ」タグは1個"""
+        """項目4: 連続ポケットピポットは最大3件。タグ列にはポを出さない"""
         today = datetime.today()
         days = [(today - timedelta(days=n)).strftime("%m/%d") for n in (1, 2, 3, 4)]
         stock = {
@@ -255,10 +261,35 @@ class TestMakeSignal:
             "access_date_price": today,
         }
         signal, tags = make_stock_db.make_signal(stock)
-        assert tags.count("ポ") == 1
+        assert "ポ" not in tags
         # 先頭3件のみ signal に出力、4件目は出ない
         assert days[2] in signal
         assert days[3] not in signal
+
+    @pytest.mark.parametrize(
+        "origin, days_ago, expected",
+        [
+            ("高出P", 0, ["高", "出", "P"]),
+            ("高", 1, ["高"]),
+            ("出P", 2, []),
+        ],
+    )
+    def test_kabutan_origin_tags(self, monkeypatch, origin, days_ago, expected):
+        """株探リスト由来タグは当日分のみ高/出/Pを付与する"""
+        base = datetime(2026, 6, 9, 18, 0)
+
+        class FakeDate(date):
+            @classmethod
+            def today(cls):
+                return base.date()
+
+        monkeypatch.setattr(make_stock_db, "date", FakeDate)
+        stock = {
+            "kabutan_origin": origin,
+            "kabutan_origin_date": base - timedelta(days=days_ago),
+        }
+        _signal, tags = make_stock_db.make_signal(stock)
+        assert tags == expected
 
 
 # ==================================================

--- a/tests/test_shintakane.py
+++ b/tests/test_shintakane.py
@@ -735,3 +735,18 @@ class Test_recent_weekday:
     ])
     def test_期待最新営業日(self, dt, expected):
         assert shintakane._recent_weekday(dt) == expected
+
+
+class TestOriginToMark:
+    @pytest.mark.parametrize(
+        "origin, expected",
+        [
+            ("shintakane", "高"),
+            ("dekidakaup", "出"),
+            ("pts", "P"),
+            ("shintakanedekidakauppts", "高出P"),
+            ("", ""),
+        ],
+    )
+    def test_origin_to_mark(self, origin, expected):
+        assert shintakane._origin_to_mark(origin) == expected

--- a/tests/test_shintakane.py
+++ b/tests/test_shintakane.py
@@ -1,6 +1,6 @@
 """shintakane.py のHTMLパース関数テスト"""
 
-from datetime import datetime
+from datetime import date, datetime
 
 import pytest
 
@@ -750,3 +750,25 @@ class TestOriginToMark:
     )
     def test_origin_to_mark(self, origin, expected):
         assert shintakane._origin_to_mark(origin) == expected
+
+
+class TestIsCsvActive:
+    """CSVファイル日付と当日営業日の一致判定 (二重補正リグレッション防止)"""
+
+    @pytest.mark.parametrize(
+        "latest_csv_dt, base_day, expected",
+        [
+            # 17時前に当日CSVが無く前日CSVを掴むケース。
+            # latest_csv_dt の時刻は現在時刻(16時)のままだが、日付が base_day と
+            # 一致するため active=True (get_price_day 二重適用なら False になり退行)
+            (datetime(2026, 6, 10, 16), date(2026, 6, 10), True),
+            # 17時後に当日CSVを掴む通常ケース
+            (datetime(2026, 6, 11, 18), date(2026, 6, 11), True),
+            # 古い前々日CSVしかない場合は inactive
+            (datetime(2026, 6, 9, 18), date(2026, 6, 11), False),
+            # CSV未取得 (空) は inactive
+            (None, date(2026, 6, 11), False),
+        ],
+    )
+    def test_is_csv_active(self, latest_csv_dt, base_day, expected):
+        assert shintakane._is_csv_active(latest_csv_dt, base_day) is expected

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1653,13 +1653,10 @@ class TestComputeCellStyles:
     @pytest.mark.parametrize(
         "tags, expected",
         [
-            ("ポ", f"background:{C['赤']};color:#fff"),
-            ("ブ", f"background:{C['赤']};color:#fff"),
             ("最", f"background:{C['赤']};color:#fff"),
             ("警", f"background:{C['青']};color:#fff"),
             ("売", f"background:{C['青']};color:#fff"),
             ("押", f"color:{C['青']}"),
-            ("警/ポ", f"background:{C['赤']};color:#fff"),     # 赤 > 青
             ("警/押", f"background:{C['青']};color:#fff"),     # 青背景 > 青文字
             ("", None),
         ],
@@ -1670,6 +1667,16 @@ class TestComputeCellStyles:
             assert "tags" not in styles
         else:
             assert styles["tags"] == expected
+
+    def test_signal_cell_uses_signal_display_style(self):
+        """ポ/ブの赤背景は新シグナル列に移す"""
+        style = "background:rgba(234,67,53,0.85);color:#fff"
+        styles = helpers.compute_cell_styles(
+            {"tags": "高", "signal_mark": "ポ/ブ", "signal_display": {"style": style}},
+            today=TODAY,
+        )
+        assert "tags" not in styles
+        assert styles["signal"] == style
 
     # ----- 進捗率乖離: <C3>=赤(注目) 単独 / eiri≧20 = 濃黄 単独 / 両該当=左右分割 -----
     def test_progress_diff_c3_only(self):
@@ -2996,6 +3003,24 @@ class TestSignalDisplay:
         assert m is not None
         alpha = float(m.group(1))
         assert (alpha >= 0.8) is alpha_high
+
+    def test_format_signal_uses_recent_marks_only_but_keeps_full_title(self):
+        """表示記号は直近ポ/ブのみ、title用全文は make_signal の signal を保持する"""
+        from datetime import timedelta
+        anchor_now, anchor_day = self._anchor()
+        stock = {
+            "pocket_pivot": ["%s,0" % (anchor_day - timedelta(days=1)).strftime("%m/%d")],
+            "breakout": ["%s,180" % (anchor_day - timedelta(days=10)).strftime("%m/%d")],
+            "trend_template": [],
+            "access_date_price": anchor_now,
+            "sell_pressure_ratio": [50, 80, 40, 2.5, 1.8],
+            "rs_raw": 0.5,
+        }
+        mark, full = helpers._format_signal(stock)
+        assert mark == "ポ"
+        assert "[ポ]" in full
+        assert "[ブ]" in full
+        assert "[買過]" in full
 
     def test_resolve_markers_x_interp_and_drop(self):
         """発生日を週バー間で日割り按分 (同週内の日付差がXに出る)・窓外はdrop"""


### PR DESCRIPTION
## 概要
issue309 に対応し、code_rank / portfolio のタグ・シグナル表示を整理しました。

## 変更内容
- 株探リスト由来を DB に保存し、当日分のみ `高` / `出` / `P` タグとして表示
- `make_signal()` の tags から `ポ` / `ブ` を除外し、signal 本文は維持
- portfolio 一覧にシグナル列を追加し、`ポ` / `ブ` 記号と signal 全文 tooltip を表示
- 赤背景をタグ列からシグナル列へ移し、タグ列は `最` のみ赤背景に変更
- 関連ユニットテストを更新・追加

## 目的
- 株探リスト掲載シグナルが code_rank / webapp に出ない問題の解消
- タグ列とシグナル列で `ポ` / `ブ` が重複していた表示の整理

## 検証
- `../.venv/bin/python -m pytest ../tests/test_make_stock_db.py ../tests/test_webapp_helpers.py ../tests/test_shintakane.py -q`
