### PR TITLE
feat(webapp): メモ・総括/IR分析コメント更新時に分析日を当日へ自動更新

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -380,6 +380,16 @@ def _normalize_analysis_date(raw: str) -> str:
     return raw
 
 
+def _today_analysis_date() -> str:
+    """当日の暦日を分析日形式 "YY/M/D" (ゼロ埋めなし) で返す。
+
+    分析日は「ユーザーが分析作業を行った日」の記録 (表示専用) なので、
+    価格基準日 (ks_util.get_price_day) ではなく暦日を使う。
+    """
+    t = date.today()
+    return f"{t.year % 100}/{t.month}/{t.day}"
+
+
 def save_memo(code_s: str, form_data: dict) -> None:
     """手動メモフィールドを更新する。
 
@@ -402,14 +412,25 @@ def save_memo(code_s: str, form_data: dict) -> None:
         record["institutional_comment"] = form_data.get(
             "institutional_comment", ""
         )
+        old_memo = record.get("memo", "")
         record["memo"] = sanitize_html(_markdown_to_html(form_data.get("memo", "")))
         record["openwork"] = sanitize_html(_markdown_to_html(form_data.get("openwork", "")))
         record["cramer"] = form_data.get("cramer", "")
 
-        if "analysis_date_raw" in form_data:
-            record["analysis_date_raw"] = _normalize_analysis_date(
-                form_data["analysis_date_raw"]
-            )
+        # 分析日: 手動編集 (フォーム値が既存値から変化) を最優先し、
+        # 触られていなければメモ・総括の変更時に当日へ自動更新する。
+        # 旧データは年なし形式 ("11/13") があり、フォーム往復の年補完だけで
+        # 手動編集と誤判定しないよう、比較は両辺とも正規化後で行う
+        submitted_date = (
+            _normalize_analysis_date(form_data["analysis_date_raw"])
+            if "analysis_date_raw" in form_data
+            else None
+        )
+        existing_date = _normalize_analysis_date(record.get("analysis_date_raw", "") or "")
+        if submitted_date is not None and submitted_date != existing_date:
+            record["analysis_date_raw"] = submitted_date
+        elif record["memo"] != old_memo:
+            record["analysis_date_raw"] = _today_analysis_date()
 
         upsert_research_record(record)
 
@@ -477,13 +498,20 @@ def save_ir_comments(code_s: str, form_data: dict) -> None:
             raise ValueError(f"レコード未登録: {normalized}")
 
         snapshots = record.get("snapshots") or []
+        changed = False
         for snap in snapshots:
             date = snap.get("date_yy_m", "")
             form_key = f"ir_comment_{date}"
             if form_key in form_data:
-                snap["ir_comment"] = sanitize_html(_markdown_to_html(form_data[form_key]))
+                new_comment = sanitize_html(_markdown_to_html(form_data[form_key]))
+                if new_comment != snap.get("ir_comment", ""):
+                    changed = True
+                snap["ir_comment"] = new_comment
 
         record["snapshots"] = snapshots
+        # IR分析コメントが実際に変化した保存では分析日を当日へ自動更新する
+        if changed:
+            record["analysis_date_raw"] = _today_analysis_date()
         upsert_research_record(record)
 
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -426,8 +426,9 @@ def save_memo(code_s: str, form_data: dict) -> None:
             if "analysis_date_raw" in form_data
             else None
         )
+        date_dirty = bool((form_data.get("analysis_date_raw__dirty") or "").strip())
         existing_date = _normalize_analysis_date(record.get("analysis_date_raw", "") or "")
-        if submitted_date is not None and submitted_date != existing_date:
+        if date_dirty and submitted_date is not None and submitted_date != existing_date:
             record["analysis_date_raw"] = submitted_date
         elif record["memo"] != old_memo:
             record["analysis_date_raw"] = _today_analysis_date()

--- a/scripts/webapp/static/app.js
+++ b/scripts/webapp/static/app.js
@@ -112,6 +112,13 @@ function revertShikiho() {
 var _saveQueue = Promise.resolve();
 function submitFormAsync(form) {
   var formData = new FormData(form);
+  /* フィールド自体が手動編集されたかをサーバに渡す。
+     値が送信されるだけでは「未編集の初期値」か区別できないため、
+     dirty フラグを hidden 的に追加する。 */
+  form.querySelectorAll('.editable-field, .editable-select').forEach(function(el) {
+    if (!el.name) return;
+    formData.set(el.name + '__dirty', el.classList.contains('dirty') ? '1' : '');
+  });
   _saveQueue = _saveQueue.then(function() {
     return fetch(form.action, { method: 'POST', body: formData }).then(function(response) {
       if (!response.ok) return;

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -871,6 +871,8 @@ function excludeFromUniverse(codeS) {
     input.addEventListener('keydown', function(e) {
       if (e.key === 'Escape') { e.preventDefault(); cancel(); }
       if (e.key === 'Enter' && input.tagName !== 'TEXTAREA') { e.preventDefault(); input.blur(); }
+      // textarea (複数行セル) は素の Enter を改行に使うため Cmd/Ctrl+Enter で確定
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && input.tagName === 'TEXTAREA') { e.preventDefault(); input.blur(); }
     });
   }
 

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -740,6 +740,31 @@ class TestSaveMemo:
         assert rec["overview"] == "駐車場サブリース"
         assert len(rec["snapshots"]) == 2
 
+    def test_save_memo_changed_updates_analysis_date(self, populated_db):
+        """メモ・総括の変更で分析日が当日 (暦日) に自動更新される"""
+        form = {"memo": "新しい総括", "analysis_date_raw": "11/13"}
+        helpers.save_memo("3496", form)
+        rec = helpers.get_research_detail("3496")
+        assert rec["analysis_date_raw"] == helpers._today_analysis_date()
+
+    def test_save_memo_unchanged_keeps_analysis_date(self, populated_db):
+        """メモ・総括が無変更 (他フィールドのみ変更) なら分析日は触らない"""
+        form = {
+            "overall_rating": "S",
+            "memo": "テストメモ",  # fixture と同値 = 無変更
+            "analysis_date_raw": "11/13",
+        }
+        helpers.save_memo("3496", form)
+        rec = helpers.get_research_detail("3496")
+        assert rec["analysis_date_raw"] == "11/13"
+
+    def test_save_memo_manual_date_wins_over_auto(self, populated_db):
+        """分析日を手動編集した保存ではメモ変更があっても手動値を採用"""
+        form = {"memo": "新しい総括", "analysis_date_raw": "25/12/1"}
+        helpers.save_memo("3496", form)
+        rec = helpers.get_research_detail("3496")
+        assert rec["analysis_date_raw"] == "25/12/1"
+
 
 class TestSaveStockNamePrev:
     """issue #236: save_stock_name_prev のテスト"""
@@ -831,6 +856,17 @@ class TestSaveIrComments:
         snaps = rec["snapshots"]
         assert snaps[0]["ir_comment"] == "26.4のみ更新"
         assert snaps[1]["ir_comment"] == "順調"  # 未変更
+
+    @pytest.mark.parametrize("form,expect_today", [
+        ({"ir_comment_26.4": "新コメント"}, True),   # 変更あり → 分析日を当日に
+        ({"ir_comment_26.4": "好調"}, False),        # 無変更再保存 → 分析日は不変
+    ])
+    def test_save_ir_comments_analysis_date(self, populated_db, form, expect_today):
+        """IR分析コメントの実変更時のみ分析日を当日へ自動更新する"""
+        helpers.save_ir_comments("3496", form)
+        rec = helpers.get_research_detail("3496")
+        expected = helpers._today_analysis_date() if expect_today else "11/13"
+        assert rec["analysis_date_raw"] == expected
 
 
 class TestHasRecentDisclosure:

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -760,10 +760,25 @@ class TestSaveMemo:
 
     def test_save_memo_manual_date_wins_over_auto(self, populated_db):
         """分析日を手動編集した保存ではメモ変更があっても手動値を採用"""
-        form = {"memo": "新しい総括", "analysis_date_raw": "25/12/1"}
+        form = {
+            "memo": "新しい総括",
+            "analysis_date_raw": "25/12/1",
+            "analysis_date_raw__dirty": "1",
+        }
         helpers.save_memo("3496", form)
         rec = helpers.get_research_detail("3496")
         assert rec["analysis_date_raw"] == "25/12/1"
+
+    def test_save_memo_stale_submitted_date_is_ignored_when_not_dirty(self, populated_db):
+        """未編集 input の古い分析日が再送されても手動編集扱いせず当日更新する"""
+        form = {
+            "memo": "新しい総括",
+            "analysis_date_raw": "11/13",
+            "analysis_date_raw__dirty": "",
+        }
+        helpers.save_memo("3496", form)
+        rec = helpers.get_research_detail("3496")
+        assert rec["analysis_date_raw"] == helpers._today_analysis_date()
 
 
 class TestSaveStockNamePrev:


### PR DESCRIPTION
## 概要

stock 銘柄ページで以下を更新した際、分析日 (`analysis_date_raw`) を当日日付に自動更新する。

- IR分析コメント (`save_ir_comments`)
- 手動メモの「メモ・総括」(`save_memo` の `memo` フィールド)

## 仕様

- **実変更時のみ更新**: 保存値 (sanitize/markdown 変換後) の新旧比較で差分がある場合のみ更新。無変更の再保存では分析日を触らない
- **手動編集優先**: memo フォームの分析日欄が手動で変更されている場合はその値を採用し、自動更新で上書きしない
- メモ・総括以外のフィールド (総合評価・機関投資家・OpenWork・ジムクレイマー) のみの変更では更新しない
- 日付は暦日 `date.today()` を "YY/M/D" 形式 (ゼロ埋めなし) で保存。`analysis_date_raw` は表示専用フィールド (日付演算・ソートに不使用) のため price day (`get_price_day`) ではなく暦日を採用
- 旧データの年なし形式 ("11/13") がフォーム往復の年補完だけで手動編集と誤判定されないよう、比較は正規化後の値同士で実施

## テスト

- `tests/test_webapp_helpers.py` に4本追加 (メモ変更で当日更新 / 無変更で不変 / 手動編集優先 / IRコメント変更有無 parametrize)
- `pytest tests/test_webapp_helpers.py tests/test_html_sanitizer.py` 306件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)