### PR TITLE
feat(webapp): 業態テーマ別RSサマリーに1日乖離列追加・ヘッダクリックソート化

### DIFF
--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -286,22 +286,24 @@ def compute_rs_line(stock, market_db, topix_map=None):
 
 
 def compute_rs_line_changes(stock, market_db, topix_map=None):
-    """rs_line の「今日 vs 直近 N 日移動平均」乖離率 A・B を%値で計算する (issue #283)。
+    """rs_line の「今日 vs 直近 N 日移動平均」乖離率 A・B と前日比 D を%値で計算する (issue #283)。
 
     A = 直近 5 日平均乖離率、B = 直近 20 日平均乖離率。20 本に満たない場合は
     19,18,17,16,15 本平均で B を代替 (近似値)。
+    D = 前日比 (1点比較)。当日の瞬間的な強さの把握用。
 
     Returns:
-        tuple[float|None, float|None]: (短期A%, 中期B%)
-            - rs_line が 5本未満 → (None, None)
-            - rs_line が 5本以上15本未満 → (A, None)
-            - rs_line が 15本以上20本未満 → (A, B_approx) ※15-19本平均で代替
-            - rs_line が 20本以上 → (A, B)
-            移動平均が0の場合も None
+        tuple[float|None, float|None, float|None]: (短期A%, 中期B%, 前日比D%)
+            - rs_line が 5本未満 → A=None
+            - rs_line が 5本以上15本未満 → (A, None, D)
+            - rs_line が 15本以上20本未満 → (A, B_approx, D) ※15-19本平均で代替
+            - rs_line が 20本以上 → (A, B, D)
+            - rs_line が 2本未満 → D=None
+            移動平均 (D は前日値) が0の場合も None
     """
     rs_line = compute_rs_line(stock, market_db, topix_map=topix_map)
-    a, b, _ = _rs_line_changes_from_line(rs_line)
-    return (a, b)
+    a, b, _, d = _rs_line_changes_from_line(rs_line)
+    return (a, b, d)
 
 
 def _fmt_rs_change(v):
@@ -322,7 +324,7 @@ def get_rs_line_changes_expr(stock, market_db, topix_map=None, rs_line=None):
     """
     if rs_line is None:
         rs_line = compute_rs_line(stock, market_db, topix_map=topix_map)
-    a, b, b_is_approx = _rs_line_changes_from_line(rs_line)
+    a, b, b_is_approx, _ = _rs_line_changes_from_line(rs_line)
     if a is None and b is None:
         return ""
     b_str = _fmt_rs_change(b)
@@ -332,21 +334,24 @@ def get_rs_line_changes_expr(stock, market_db, topix_map=None, rs_line=None):
 
 
 def _rs_line_changes_from_line(rs_line):
-    """rs_line 系列から「今日 vs 直近 N 日移動平均」の乖離率 A・B を計算する内部関数。
+    """rs_line 系列から「今日 vs 直近 N 日移動平均」の乖離率 A・B と前日比 D を計算する内部関数。
 
     A = 直近 5 日平均乖離率、B = 直近 20 日平均乖離率 (いずれも今日 rs_line[0] を含む)。
     1 点比較 (旧: N 日前の 1 点との比) ではヒゲ・急変でブレるため、基準を移動平均にして
     ブレを 1/N に薄め、勢い・過熱の度合いを安定して捉える (issue #283)。
+    D = 前日比。window=1 の MA 乖離は恒等的に 0 になるため、D だけは
+    rs_line[1] との 1 点比較とする (当日の瞬間的な強さの把握用)。
 
     Returns:
-        tuple[float|None, float|None, bool]: (A, B, B が代替値か)
+        tuple[float|None, float|None, bool, float|None]: (A, B, B が代替値か, D)
             乖離率 = (rs_line[0] - mean(直近 window 本)) / mean(直近 window 本) * 100。
             A は window=5 (5 本未満は None)。
             B は window=20、20 本未満なら 19,18,17,16,15 本平均で代替 (b_is_approx=True)。
-            平均が 0 の場合も None。
+            D = (rs_line[0] - rs_line[1]) / rs_line[1] * 100 (2 本未満は None)。
+            平均 (D は前日値) が 0 の場合も None。
     """
     if not rs_line:
-        return (None, None, False)
+        return (None, None, False, None)
     current = rs_line[0][1]
 
     def _deviation(window):
@@ -358,16 +363,20 @@ def _rs_line_changes_from_line(rs_line):
             return None
         return (current - ma) / ma * 100
 
+    d = None
+    if len(rs_line) >= 2 and rs_line[1][1] != 0:
+        d = (current - rs_line[1][1]) / rs_line[1][1] * 100
+
     a = _deviation(5)
     b = _deviation(20)
     if b is not None:
-        return (a, b, False)
+        return (a, b, False, d)
     # 20 本に満たないときは、データ長に収まる最大 window (15-19 本) の平均で代替する。
     # MA 版では _deviation(window) が None になるのは len < window のときだけなので、
     # 試すべき window は min(len, 19) の 1 つに定まる (15 本未満なら代替不可)。
     if len(rs_line) >= 15:
-        return (a, _deviation(min(len(rs_line), 19)), True)
-    return (a, None, False)
+        return (a, _deviation(min(len(rs_line), 19)), True, d)
+    return (a, None, False, d)
 
 
 def compute_rs_line_new_high(stock, market_db, topix_map=None, lookback=20, rs_line=None):

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -3521,7 +3521,9 @@ def get_current_research_data(code_s, stock_data=None, portfolio_status=None):
 # ルート側の allowlist もこの keys() を参照する (二重定義を避ける)。
 THEME_SUMMARY_SORT_FIELDS = {
     "momentum": "momentum_pt_avg",
+    "dev_1d": "dev_1d_avg",
     "dev_a": "dev_a_avg",
+    "dev_b": "dev_b_avg",
 }
 
 
@@ -3541,7 +3543,7 @@ def build_portfolio_theme_summary(
     Args:
         records: portfolio_shelve.list_records(include_excluded=False) の戻り値。
             None なら関数内で取得する (テスト時に注入できるよう引数化)。
-        sort_key: "momentum" | "dev_a"。並べ替えキー。
+        sort_key: "momentum" | "dev_1d" | "dev_a" | "dev_b"。並べ替えキー。
 
     Returns:
         list[dict]: 各テーマの集約 dict。並び順は sort_key に従う
@@ -3589,20 +3591,21 @@ def build_portfolio_theme_summary(
         except Exception:  # noqa: BLE001
             topix_map = None
 
-    # 銘柄ごとの rs_line スロープ (A, B) を 1 回だけ計算してキャッシュ。
+    # 銘柄ごとの rs_line スロープ (A, B, D) を 1 回だけ計算してキャッシュ。
     # 公開 API compute_rs_line_changes を使う (private 関数には依存しない)。
     # topix_map を渡すことで内部 compute_rs_line の TOPIX マップ再構築を避ける。
     # (a, b) = 今日 vs 直近5日/20日移動平均の乖離率 = 勢いオシレーター。
+    # d = 前日比 = 当日の瞬間的な強さ。
     dev_by_code: Dict[str, tuple] = {}
     if market_db is not None and topix_map:
         from make_stock_db import compute_rs_line_changes  # 遅延 import
         for code_s in all_codes:
             stock = stock_map.get(code_s) or {}
             try:
-                a, b = compute_rs_line_changes(stock, market_db, topix_map=topix_map)
+                a, b, d = compute_rs_line_changes(stock, market_db, topix_map=topix_map)
             except Exception:  # noqa: BLE001
-                a, b = None, None
-            dev_by_code[code_s] = (a, b)
+                a, b, d = None, None, None
+            dev_by_code[code_s] = (a, b, d)
 
     result: List[Dict[str, Any]] = []
     for theme, codes in theme_to_codes.items():
@@ -3610,16 +3613,19 @@ def build_portfolio_theme_summary(
         mom_values: List[float] = []
         dev_a_values: List[float] = []
         dev_b_values: List[float] = []
+        dev_1d_values: List[float] = []
         for code_s in codes:
             stock = stock_map.get(code_s) or {}
             mom = stock.get("momentum_pt")
             if isinstance(mom, (int, float)):
                 mom_values.append(float(mom))
-            a, b = dev_by_code.get(code_s, (None, None))
+            a, b, d = dev_by_code.get(code_s, (None, None, None))
             if a is not None:
                 dev_a_values.append(a)
             if b is not None:
                 dev_b_values.append(b)
+            if d is not None:
+                dev_1d_values.append(d)
             members.append({
                 "code_s": code_s,
                 "stock_name": name_map.get(code_s, "") or "",
@@ -3641,6 +3647,7 @@ def build_portfolio_theme_summary(
             "member_count": len(codes),
             "momentum_pt_avg": _avg_or_none(mom_values),
             "momentum_pt_max": max(mom_values) if mom_values else None,
+            "dev_1d_avg": _avg_or_none(dev_1d_values),
             "dev_a_avg": _avg_or_none(dev_a_values),
             "dev_b_avg": _avg_or_none(dev_b_values),
             "leaders": leaders,

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -743,7 +743,7 @@ def theme_summary():
     momentum_pt (中長期) と rs_line 移動平均乖離オシレーター (短期の勢い) を集約表示する。
 
     URL クエリ:
-      sort: momentum / dev_a (省略時=momentum)
+      sort: momentum / dev_1d / dev_a / dev_b (省略時=momentum)
     """
     sort_key = (request.args.get("sort") or "").strip()
     if sort_key not in THEME_SUMMARY_SORT_KEYS:

--- a/scripts/webapp/templates/portfolio_theme_summary.html
+++ b/scripts/webapp/templates/portfolio_theme_summary.html
@@ -19,8 +19,8 @@
   .mom-weak { color: #c00; }
   .dev-up { color: #060; }
   .dev-down { color: #c00; }
-  .sort-bar a { font-size: 0.85em; color: #555; text-decoration: none; padding: 0.2em 0.5em; border: 1px solid #ccc; border-radius: 3px; background: #fff; margin-left: 0.3em; }
-  .sort-bar a.active { background: #2c5282; color: #fff; border-color: #2c5282; }
+  table.theme-summary th a { color: inherit; }
+  table.theme-summary th.sort-active a { color: #2c5282; }
 </style>
 
 {% macro fmt_pct(v) %}{% if v is none %}—{% else %}{{ '%+.1f'|format(v) }}%{% endif %}{% endmacro %}
@@ -35,12 +35,6 @@
   手動付けした業態テーマ (memo.gyoutai_themes) を自分の分類軸とした市場ローテーション検知。
   中長期の強さ (momentum_pt) と短期の勢い (rs_line の移動平均乖離) を併記する。
 </p>
-
-<div class="sort-bar" style="margin-bottom:0.6em;">
-  <span style="font-size:0.85em;color:#666;">並べ替え:</span>
-  <a href="{{ sort_urls['momentum'] }}" class="{% if active_sort == 'momentum' %}active{% endif %}">強さ (momentum)</a>
-  <a href="{{ sort_urls['dev_a'] }}" class="{% if active_sort == 'dev_a' %}active{% endif %}">短期の勢い (5日乖離)</a>
-</div>
 
 {% if fallback_mode %}
 <p style="padding:0.8em 1em;background:#f5f7fa;border:1px solid #d8dee6;border-radius:4px;color:#666;">
@@ -60,10 +54,11 @@
     <tr>
       <th class="theme-col">テーマ</th>
       <th>構成</th>
-      <th title="構成銘柄の momentum_pt 平均 (0〜100)">mom平均</th>
+      <th class="{% if active_sort == 'momentum' %}sort-active{% endif %}" title="構成銘柄の momentum_pt 平均 (0〜100)。クリックで降順ソート"><a href="{{ sort_urls['momentum'] }}">RS平均</a></th>
       <th title="構成銘柄の momentum_pt 最大">最大</th>
-      <th title="今日の rs_line (銘柄/TOPIX) と直近5日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)">5日乖離</th>
-      <th title="今日の rs_line (銘柄/TOPIX) と直近20日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)">20日乖離</th>
+      <th class="{% if active_sort == 'dev_1d' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) の前日比 (%) の平均。本日の瞬間的な勢い。クリックで降順ソート"><a href="{{ sort_urls['dev_1d'] }}">1日乖離</a></th>
+      <th class="{% if active_sort == 'dev_a' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) と直近5日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)。クリックで降順ソート"><a href="{{ sort_urls['dev_a'] }}">5日乖離</a></th>
+      <th class="{% if active_sort == 'dev_b' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) と直近20日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)。クリックで降順ソート"><a href="{{ sort_urls['dev_b'] }}">20日乖離</a></th>
       <th class="leaders-col" title="momentum_pt 降順 上位3銘柄">リーダー株 (top3)</th>
     </tr>
   </thead>
@@ -91,6 +86,9 @@
         {% else %}{{ fmt_int(t.momentum_pt_avg) }}{% endif %}
       </td>
       <td class="num">{{ fmt_int(t.momentum_pt_max) }}</td>
+      <td class="num">
+        {% if t.dev_1d_avg is not none %}<span class="{% if t.dev_1d_avg >= 0 %}dev-up{% else %}dev-down{% endif %}">{{ fmt_pct(t.dev_1d_avg) }}</span>{% else %}—{% endif %}
+      </td>
       <td class="num">
         {% if t.dev_a_avg is not none %}<span class="{% if t.dev_a_avg >= 0 %}dev-up{% else %}dev-down{% endif %}">{{ fmt_pct(t.dev_a_avg) }}</span>{% else %}—{% endif %}
       </td>

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -810,24 +810,31 @@ class TestComputeRsLineWeeklyNewHigh5d:
 # compute_rs_line_changes
 # ==================================================
 class TestComputeRsLineChanges:
-    """rs_line 騰落率 (5日前比 A / 20日前比 B) の単体テスト"""
+    """rs_line 騰落率 (5日MA乖離 A / 20日MA乖離 B / 前日比 D) の単体テスト"""
 
     def test_none_when_rs_line_empty(self):
-        a, b = make_stock_db.compute_rs_line_changes({}, {"topix": {}})
-        assert a is None and b is None
+        a, b, d = make_stock_db.compute_rs_line_changes({}, {"topix": {}})
+        assert a is None and b is None and d is None
 
     def test_none_when_too_short_for_short_change(self):
-        """rs_line が 5本未満なら 5日移動平均乖離 A も計算不能"""
+        """rs_line が 5本未満なら 5日移動平均乖離 A は計算不能 (前日比 D は2本あれば計算可)"""
         stock = {"price_log": _make_log(4, base=2000)}
         market_db = {"topix": {"price_log": _make_log(4, base=1000)}}
-        a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
-        assert a is None and b is None
+        a, b, d = make_stock_db.compute_rs_line_changes(stock, market_db)
+        assert a is None and b is None and d is not None
+
+    def test_day_change_none_when_single_bar(self):
+        """rs_line が 1本のみなら前日比 D も計算不能"""
+        stock = {"price_log": _make_log(1, base=2000)}
+        market_db = {"topix": {"price_log": _make_log(1, base=1000)}}
+        a, b, d = make_stock_db.compute_rs_line_changes(stock, market_db)
+        assert a is None and b is None and d is None
 
     def test_short_only_when_partial_data(self):
         """rs_line が 5本以上15本未満なら A だけ計算可、B は None (20日平均に届かず代替も不可)"""
         stock = {"price_log": _make_log(10, base=2000)}
         market_db = {"topix": {"price_log": _make_log(10, base=1000)}}
-        a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
+        a, b, _ = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is None
 
     def test_fallback_when_15_to_19_bars(self):
@@ -835,43 +842,43 @@ class TestComputeRsLineChanges:
         # 19本 → window 19 で代替可能
         stock = {"price_log": _make_log(19, base=2000, step=20)}
         market_db = {"topix": {"price_log": _make_log(19, base=1000, step=2)}}
-        a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
+        a, b, _ = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is not None
         # 15本 → window 15 で代替可能
         stock = {"price_log": _make_log(15, base=2000, step=20)}
         market_db = {"topix": {"price_log": _make_log(15, base=1000, step=2)}}
-        a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
+        a, b, _ = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is not None
 
     def test_no_fallback_when_14_bars(self):
         """rs_line が 14本のとき、window 15 にも届かないので B は None"""
         stock = {"price_log": _make_log(14, base=2000, step=20)}
         market_db = {"topix": {"price_log": _make_log(14, base=1000, step=2)}}
-        a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
+        a, b, _ = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is None
 
     def test_both_when_full_data(self):
         """rs_line が 20本以上で A・B 両方計算可"""
         stock = {"price_log": _make_log(25, base=2000)}
         market_db = {"topix": {"price_log": _make_log(25, base=1000)}}
-        a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
+        a, b, _ = make_stock_db.compute_rs_line_changes(stock, market_db)
         assert a is not None and b is not None
 
     def test_uptrend_positive_signs(self):
-        """rs_line が上昇トレンド (TOPIX より速く上昇) なら A・B プラス"""
+        """rs_line が上昇トレンド (TOPIX より速く上昇) なら A・B・D プラス"""
         # 銘柄: 速く上昇 (step=20), TOPIX: 緩やか (step=2) → ratio は単調増加
         stock = {"price_log": _make_log(25, base=2000, step=20)}
         market_db = {"topix": {"price_log": _make_log(25, base=1000, step=2)}}
-        a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
-        assert a > 0 and b > 0
+        a, b, d = make_stock_db.compute_rs_line_changes(stock, market_db)
+        assert a > 0 and b > 0 and d > 0
 
     def test_downtrend_negative_signs(self):
-        """rs_line 下降トレンド (TOPIX より遅い) なら A・B マイナス"""
+        """rs_line 下降トレンド (TOPIX より遅い) なら A・B・D マイナス"""
         # 銘柄: 緩やか上昇 (step=2), TOPIX: 速く上昇 (step=20)
         stock = {"price_log": _make_log(25, base=2000, step=2)}
         market_db = {"topix": {"price_log": _make_log(25, base=1000, step=20)}}
-        a, b = make_stock_db.compute_rs_line_changes(stock, market_db)
-        assert a < 0 and b < 0
+        a, b, d = make_stock_db.compute_rs_line_changes(stock, market_db)
+        assert a < 0 and b < 0 and d < 0
 
 
 # ==================================================

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2913,9 +2913,9 @@ class TestBuildPortfolioThemeSummary:
         import make_stock_db
         monkeypatch.setattr(make_market_db, "get_market_db", lambda: {"topix": {}})
         monkeypatch.setattr(make_stock_db, "_topix_close_map", lambda mdb: {"d": 1.0})
-        # 公開 API compute_rs_line_changes を stock 名から (A, B) 乖離率を返すよう差し替え。
-        # A=有効/B=None, A=有効/B=有効 を返し分け
-        dev_map = {"A": (2.0, None), "B": (4.0, 8.0)}
+        # 公開 API compute_rs_line_changes を stock 名から (A, B, D) 乖離率を返すよう差し替え。
+        # A=有効/B=None/D=None, A=有効/B=有効/D=有効 を返し分け
+        dev_map = {"A": (2.0, None, None), "B": (4.0, 8.0, 1.0)}
         monkeypatch.setattr(
             make_stock_db, "compute_rs_line_changes",
             lambda stock, mdb, topix_map=None: dev_map[stock["stock_name"]],
@@ -2924,13 +2924,16 @@ class TestBuildPortfolioThemeSummary:
         t = out[0]
         assert t["dev_a_avg"] == 3.0            # (2.0 + 4.0) / 2
         assert t["dev_b_avg"] == 8.0            # B のみ有効 (A の B は None で除外)
+        assert t["dev_1d_avg"] == 1.0           # B のみ有効 (A の D は None で除外)
 
     @pytest.mark.parametrize("sort_key,expected_first", [
         ("momentum", "強"),    # momentum_pt 平均が高いテーマが先頭
+        ("dev_1d", "急"),      # dev_1d (前日比) 平均が高いテーマが先頭
         ("dev_a", "急"),       # dev_a (短期の勢い) 平均が高いテーマが先頭
+        ("dev_b", "急"),       # dev_b (20日乖離) 平均が高いテーマが先頭
     ])
     def test_sort_key_switch(self, monkeypatch, sort_key, expected_first):
-        """sort_key で momentum / dev_a の並び順が切り替わる。"""
+        """sort_key で momentum / dev_1d / dev_a / dev_b の並び順が切り替わる。"""
         records = [
             self._record("1111", ["強"]),   # momentum 高, 勢い 低
             self._record("2222", ["急"]),   # momentum 低, 勢い 高
@@ -2946,7 +2949,7 @@ class TestBuildPortfolioThemeSummary:
         import make_stock_db
         monkeypatch.setattr(make_market_db, "get_market_db", lambda: {"topix": {}})
         monkeypatch.setattr(make_stock_db, "_topix_close_map", lambda mdb: {"d": 1.0})
-        dev_map = {"S": (1.0, 1.0), "Q": (9.0, 9.0)}
+        dev_map = {"S": (1.0, 1.0, 0.5), "Q": (9.0, 9.0, 3.0)}
         monkeypatch.setattr(make_stock_db, "compute_rs_line_changes",
                             lambda stock, mdb, topix_map=None: dev_map[stock["stock_name"]])
 

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1415,7 +1415,9 @@ class TestPortfolioThemeSummary:
 
     @pytest.mark.parametrize("url", [
         "/portfolio/themes/summary",
+        "/portfolio/themes/summary?sort=dev_1d",
         "/portfolio/themes/summary?sort=dev_a",
+        "/portfolio/themes/summary?sort=dev_b",
     ])
     def test_summary_returns_200(self, summary_app, url):
         client = summary_app.test_client()


### PR DESCRIPTION
## 概要

業態テーマ別 RS サマリー (`/portfolio/themes/summary`) の改修。

- **1日乖離列の追加**: 本日の瞬間的な強さを認識できるよう、rs_line の前日比列を新設
- **ヘッダクリックソート化**: 「並べ替え:」バーを廃止し、列ヘッダのリンククリックで降順ソートに変更 (保有銘柄ダッシュボードと同じサーバーサイド `?sort=` 方式)
- **列名リネーム**: 「mom平均」→「RS平均」(表示ラベルのみ、内部キーは不変)

## 変更内容

- `make_stock_db.py`: `compute_rs_line_changes()` / `_rs_line_changes_from_line()` に前日比 D を追加。window=1 の MA 乖離は恒等的に 0 になるため、D だけは `(rs_line[0] - rs_line[1]) / rs_line[1] * 100` の 1 点比較。2 本未満・前日値 0 は None
- `webapp/helpers.py`: テーマ集約に `dev_1d_avg` を追加、`THEME_SUMMARY_SORT_FIELDS` に `dev_1d` / `dev_b` を追加 (ルートの allowlist は keys() から自動追従)
- `portfolio_theme_summary.html`: 並び替えバー削除、RS平均/1日/5日/20日乖離の `<th>` をリンク化、ソート中の列ヘッダを青色強調

## 検証

- `pytest tests/test_make_stock_db.py tests/test_append_research_snapshots.py` 151 passed
- `pytest tests/test_webapp_helpers.py tests/test_html_sanitizer.py tests/test_webapp_routes.py` 403 passed
- 実データで `?sort=dev_1d` / `?sort=dev_b` の降順をブラウザ + curl パースで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)