### PR TITLE
feat(webapp): 業態テーマ別RSサマリーにポジション割合ゲージ・ステータスバッジ追加

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -3555,6 +3555,8 @@ def build_portfolio_theme_summary(
 
     # テーマ → [code_s, ...] の逆引き (スロット最大2を両方展開、空は無視)
     theme_to_codes: Dict[str, List[str]] = {}
+    # 銘柄が属するテーマ数 (ポジションの按分用。2テーマ銘柄は 50/50 で各テーマに計上)
+    theme_count_by_code: Dict[str, int] = {}
     for rec in records:
         code_s = rec.get("code_s", "")
         if not code_s:
@@ -3567,6 +3569,7 @@ def build_portfolio_theme_summary(
             if not name:
                 continue
             theme_to_codes.setdefault(name, []).append(code_s)
+            theme_count_by_code[code_s] = theme_count_by_code.get(code_s, 0) + 1
     if not theme_to_codes:
         return []
 
@@ -3574,8 +3577,26 @@ def build_portfolio_theme_summary(
     status_by_code = {r.get("code_s", ""): r.get("status", "") for r in records}
 
     all_codes = sorted({c for codes in theme_to_codes.values() for c in codes})
-    stock_map = _bulk_get_stock_data(all_codes)
+    # ポジション分母 (全保有合計) 計算用に、テーマ未設定の 1保 銘柄も price を引く
+    holding_codes = {
+        r.get("code_s", "") for r in records
+        if r.get("status") == "1保" and (r.get("qty", 0) or 0) > 0 and r.get("code_s")
+    }
+    stock_map = _bulk_get_stock_data(sorted(set(all_codes) | holding_codes))
     name_map = _bulk_resolve_stock_names(all_codes)
+
+    # 銘柄単位の保有ポジション (1保 × qty>0 × price>0 のみ)。
+    # 条件は list_portfolio_with_indicators の position_value と同一。
+    position_value_by_code: Dict[str, float] = {}
+    for rec in records:
+        code_s = rec.get("code_s", "")
+        qty = rec.get("qty", 0) or 0
+        if rec.get("status") != "1保" or not code_s or qty <= 0:
+            continue
+        price = (stock_map.get(code_s) or {}).get("price")
+        if isinstance(price, (int, float)) and price > 0:
+            position_value_by_code[code_s] = float(price) * qty
+    total_position_value = sum(position_value_by_code.values())
 
     # rs_line 計算の共有リソース (issue #283: N+1 回避、再計算回避)
     try:
@@ -3633,6 +3654,10 @@ def build_portfolio_theme_summary(
                 "status": _PORTFOLIO_STATUS_LABEL.get(
                     status_by_code.get(code_s, ""), status_by_code.get(code_s, "")
                 ),
+                # 展開リストのバッジ色分け用 (hold/semi/watch)
+                "status_query": _PORTFOLIO_STATUS_QUERY.get(
+                    status_by_code.get(code_s, ""), ""
+                ),
             })
         # members を momentum_pt 降順 (None 末尾) → code_s 昇順で並べる
         members.sort(key=lambda m: (
@@ -3642,6 +3667,12 @@ def build_portfolio_theme_summary(
         ))
         # members は momentum_pt 降順済み。先頭から非 None 上位 3 件がリーダー株
         leaders = [m for m in members if m["momentum_pt"] is not None][:3]
+        # テーマ内 1保 銘柄の合計ポジション。2テーマ所属銘柄は 50/50 で按分
+        # (テーマ間の pct 合計は 100% を超えない)
+        position_value = sum(
+            position_value_by_code.get(c, 0.0) / (theme_count_by_code.get(c) or 1)
+            for c in codes
+        )
         result.append({
             "theme": theme,
             "member_count": len(codes),
@@ -3652,7 +3683,19 @@ def build_portfolio_theme_summary(
             "dev_b_avg": _avg_or_none(dev_b_values),
             "leaders": leaders,
             "members": members,
+            "position_value": position_value,
+            "position_pct": (
+                position_value / total_position_value * 100.0
+                if total_position_value > 0 else 0.0
+            ),
+            "position_ratio": 0.0,
         })
+
+    # 最大ポジションのテーマ = 100 として塗り幅を正規化 (portfolio 状態列と同方式)
+    max_theme_position = max((r["position_value"] for r in result), default=0.0)
+    if max_theme_position > 0:
+        for r in result:
+            r["position_ratio"] = r["position_value"] / max_theme_position * 100.0
 
     # ソート: sort_key 降順 (None 末尾) → member_count 降順 → テーマ名昇順
     primary = THEME_SUMMARY_SORT_FIELDS.get(sort_key, "momentum_pt_avg")

--- a/scripts/webapp/templates/portfolio_theme_summary.html
+++ b/scripts/webapp/templates/portfolio_theme_summary.html
@@ -7,6 +7,7 @@
   table.theme-summary th, table.theme-summary td { padding: 0.4em 0.6em; vertical-align: middle; border-bottom: 1px solid #e2e8f0; }
   table.theme-summary th { text-align: right; color: #666; font-weight: 600; white-space: nowrap; }
   table.theme-summary th.theme-col, table.theme-summary th.leaders-col { text-align: left; }
+  table.theme-summary th.num-col { width: 5.5em; }  /* 数値列 (構成〜20日乖離) は等幅に揃える */
   table.theme-summary td.num { text-align: right; font-variant-numeric: tabular-nums; }
   table.theme-summary td.theme-cell { font-weight: 600; word-break: break-word; max-width: 14em; }
   table.theme-summary td.leaders-cell { font-size: 0.85em; white-space: nowrap; }
@@ -15,6 +16,12 @@
   table.theme-summary details summary { cursor: pointer; list-style: none; }
   table.theme-summary details summary::-webkit-details-marker { display: none; }
   table.theme-summary .member-list { margin: 0.3em 0 0.3em 1em; font-size: 0.85em; color: #444; }
+  /* 展開リストのステータス区別 (配色は portfolio_list の status-badge と同一) */
+  .member-list .status-badge { display: inline-block; padding: 0 0.4em; border-radius: 3px; font-size: 0.9em; }
+  .member-list .status-hold  { background: #d4ead4; color: #285028; font-weight: 700; }
+  .member-list .status-semi  { background: #fdf0c0; color: #856100; }
+  .member-list .status-watch { background: #e2e2e2; color: #555; }
+  .member-list .member-hold { font-weight: 700; }
   .mom-strong { font-weight: 700; color: #060; }
   .mom-weak { color: #c00; }
   .dev-up { color: #060; }
@@ -53,12 +60,12 @@
   <thead>
     <tr>
       <th class="theme-col">テーマ</th>
-      <th>構成</th>
-      <th class="{% if active_sort == 'momentum' %}sort-active{% endif %}" title="構成銘柄の momentum_pt 平均 (0〜100)。クリックで降順ソート"><a href="{{ sort_urls['momentum'] }}">RS平均</a></th>
-      <th title="構成銘柄の momentum_pt 最大">最大</th>
-      <th class="{% if active_sort == 'dev_1d' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) の前日比 (%) の平均。本日の瞬間的な勢い。クリックで降順ソート"><a href="{{ sort_urls['dev_1d'] }}">1日乖離</a></th>
-      <th class="{% if active_sort == 'dev_a' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) と直近5日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)。クリックで降順ソート"><a href="{{ sort_urls['dev_a'] }}">5日乖離</a></th>
-      <th class="{% if active_sort == 'dev_b' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) と直近20日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)。クリックで降順ソート"><a href="{{ sort_urls['dev_b'] }}">20日乖離</a></th>
+      <th class="num-col">構成</th>
+      <th class="num-col {% if active_sort == 'momentum' %}sort-active{% endif %}" title="構成銘柄の momentum_pt 平均 (0〜100)。クリックで降順ソート"><a href="{{ sort_urls['momentum'] }}">RS平均</a></th>
+      <th class="num-col" title="構成銘柄の momentum_pt 最大">最大</th>
+      <th class="num-col {% if active_sort == 'dev_1d' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) の前日比 (%) の平均。本日の瞬間的な勢い。クリックで降順ソート"><a href="{{ sort_urls['dev_1d'] }}">1日乖離</a></th>
+      <th class="num-col {% if active_sort == 'dev_a' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) と直近5日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)。クリックで降順ソート"><a href="{{ sort_urls['dev_a'] }}">5日乖離</a></th>
+      <th class="num-col {% if active_sort == 'dev_b' %}sort-active{% endif %}" title="今日の rs_line (銘柄/TOPIX) と直近20日移動平均の乖離率の平均。正=直近平均より上振れ(勢い強)。クリックで降順ソート"><a href="{{ sort_urls['dev_b'] }}">20日乖離</a></th>
       <th class="leaders-col" title="momentum_pt 降順 上位3銘柄">リーダー株 (top3)</th>
     </tr>
   </thead>
@@ -72,14 +79,19 @@
             {% for m in t.members %}
             <div>
               <a href="{{ url_for('detail.stock_detail', code_s=m.code_s) }}">{{ m.code_s }}</a>
-              {{ m.stock_name }}
-              <span style="color:#888;">({{ m.status }}{% if m.momentum_pt is not none %} / RS {{ m.momentum_pt|round|int }}{% endif %})</span>
+              <span class="{% if m.status_query == 'hold' %}member-hold{% endif %}">{{ m.stock_name }}</span>
+              <span class="status-badge status-{{ m.status_query }}">{{ m.status }}</span>
+              {% if m.momentum_pt is not none %}<span style="color:#888;">RS {{ m.momentum_pt|round|int }}</span>{% endif %}
             </div>
             {% endfor %}
           </div>
         </details>
       </td>
-      <td class="num">{{ t.member_count }}</td>
+      {# 保有ポジション (1保 現在株価×株数 の合計) を最大テーマ比で背景塗り (portfolio 状態列と同方式) #}
+      <td class="num"
+        {%- if t.position_value > 0 %} title="ポジション: ¥{{ '{:,}'.format(t.position_value|int) }} (全保有の {{ '%.1f'|format(t.position_pct) }}%)"{% endif -%}
+        {%- if t.position_ratio > 0 %} style="background: linear-gradient(to right, rgba(40,80,40,0.18) 0% {{ '%.1f'|format(t.position_ratio) }}%, transparent {{ '%.1f'|format(t.position_ratio) }}% 100%);"{% endif -%}
+      >{{ t.member_count }}</td>
       <td class="num">
         {% if t.momentum_pt_avg is not none and t.momentum_pt_avg >= 70 %}<span class="mom-strong">{{ fmt_int(t.momentum_pt_avg) }}</span>
         {% elif t.momentum_pt_avg is not none and t.momentum_pt_avg <= 30 %}<span class="mom-weak">{{ fmt_int(t.momentum_pt_avg) }}</span>

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2956,6 +2956,44 @@ class TestBuildPortfolioThemeSummary:
         out = helpers.build_portfolio_theme_summary(records=records, sort_key=sort_key)
         assert out[0]["theme"] == expected_first
 
+    def test_position_value_aggregation(self, monkeypatch):
+        """ポジション集計: 1保のみ計上、テーマ無し1保は分母のみ、2テーマは50/50按分、max正規化。"""
+        records = [
+            {"code_s": "1111", "status": "1保", "qty": 100,
+             "memo": {"gyoutai_themes": ["半導体"]}},        # 100,000
+            {"code_s": "2222", "status": "1保", "qty": 10,
+             "memo": {"gyoutai_themes": ["半導体", "AI"]}},   # 50,000 → 両テーマに25,000ずつ按分
+            {"code_s": "3333", "status": "2準", "qty": 100,
+             "memo": {"gyoutai_themes": ["防衛"]}},           # 2準 → 計上しない
+            {"code_s": "4444", "status": "1保", "qty": 50,
+             "memo": {"gyoutai_themes": []}},                 # テーマ無し 100,000 → 分母のみ
+        ]
+        stock_data = {
+            "1111": {"stock_name": "A", "momentum_pt": 80, "price": 1000},
+            "2222": {"stock_name": "B", "momentum_pt": 60, "price": 5000},
+            "3333": {"stock_name": "C", "momentum_pt": 50, "price": 1000},
+            "4444": {"stock_name": "D", "momentum_pt": 40, "price": 2000},
+        }
+        # codes でフィルタ: テーマ無し 1保 (4444) が fetch 対象に入ることも検証する
+        monkeypatch.setattr(helpers, "_bulk_get_stock_data",
+                            lambda codes: {c: stock_data[c] for c in codes if c in stock_data})
+        monkeypatch.setattr(helpers, "_bulk_resolve_stock_names",
+                            lambda codes: {c: stock_data[c]["stock_name"] for c in codes})
+        import make_market_db
+        monkeypatch.setattr(make_market_db, "get_market_db", lambda: None)
+
+        out = helpers.build_portfolio_theme_summary(records=records)
+        by_theme = {t["theme"]: t for t in out}
+        # 分母 = 100,000 + 50,000 + 100,000 (テーマ無し) = 250,000
+        assert by_theme["半導体"]["position_value"] == 125000.0  # 100,000 + 50,000/2
+        assert by_theme["半導体"]["position_pct"] == 50.0
+        assert by_theme["半導体"]["position_ratio"] == 100.0  # 最大テーマ
+        assert by_theme["AI"]["position_value"] == 25000.0      # 50,000/2
+        assert by_theme["AI"]["position_pct"] == 10.0
+        assert by_theme["AI"]["position_ratio"] == 20.0
+        assert by_theme["防衛"]["position_value"] == 0.0
+        assert by_theme["防衛"]["position_ratio"] == 0.0
+
 
 # ==================================================
 # issue #253: signal セル tooltip/背景色・チャートマーカー


### PR DESCRIPTION
## 概要

業態テーマ別 RS サマリー (`/portfolio/themes/summary`) で保有ポジションの状況がわかるようにする。

## 変更内容

### 構成列のポジション割合ゲージ
- テーマごとの保有ポジション (1保銘柄の 現在株価 × qty 合計) を、構成列セルの背景塗り (`linear-gradient` 左→右) で可視化。portfolio 状態列 (issue #269) と同方式
- 塗り幅は最大ポジションのテーマ = 100% に正規化
- ツールチップに実金額と全保有比を表示: `ポジション: ¥4,053,300 (全保有の 14.6%)`
- 分母は全 1保銘柄の合計 (業態テーマ未設定の保有銘柄も含む)
- **2テーマ所属銘柄は 50/50 で按分** → テーマ間の%合計は 100% 以内

### 数値列の幅揃え
- 構成・RS平均・最大・1日乖離・5日乖離・20日乖離 の6列を `width: 5.5em` で等幅化 (テーマ・リーダー株列は対象外)

### テーマ展開リストのステータス区別
- 保有=緑バッジ+銘柄名太字 / 準保有=黄バッジ / 監視=グレーバッジ
- 配色は portfolio ページの `status-badge` と同一でページ間の一貫性を維持

## テスト

- `pytest tests/test_webapp_helpers.py tests/test_html_sanitizer.py` 全パス
- 追加テスト1本 (`test_position_value_aggregation`): 1保のみ計上 / 2準除外 / テーマ無し1保は分母のみ / 2テーマ50/50按分 / max正規化を網羅
- 実データでブラウザ確認済み (ゲージ塗り幅・按分値・ツールチップ・バッジ表示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)