### PR TITLE
feat(price): 30日連続10MA判定に porosity(浸透許容)を適用

### DIFF
--- a/doc/plan/ma10_streak_porosity.md
+++ b/doc/plan/ma10_streak_porosity.md
@@ -1,0 +1,189 @@
+# 30日連続10MA上回り判定に porosity(浸透許容)を適用
+
+## 背景
+
+保有銘柄ダッシュボードのトレンド列で、10MA乖離を縦点線で表示し、
+「30営業日連続で終値が10MAを上回り続けた」場合に赤太線へ切替えている
+(利確基準有効の印)。出典は Gil Morales / Chris Kacher
+"Trade Like an O'Neil Disciple" (邦題『株式売買スクール』)。
+
+現状の連続判定 `_above_ma10(i)` は「その日の終値 > その日の10MA」を厳密判定し、
+**1日でも終値が10MAを割れたら即座に連続を切断**している
+(`price.py:461` コメント「一致・下回りで連続を切断(厳密)」)。
+
+これは原典の **violation(違反) 定義より厳しすぎる**。原典では:
+
+> violation = 終値が移動平均線を割り込み、**かつ翌日(以降)にその割り込んだ日の
+> ザラ場安値(intraday low)を下回る**こと
+
+の2条件 AND で初めて「本物の崩れ」と判定し、終値1回の軽い潜り(porosity)は
+ダマシとして救済する。現実装は porosity を許容せず、一時的な潜りで赤太線が
+点きにくくなっている。
+
+## 確定方針 (案A: 原典 violation の否定を継続条件にする)
+
+連続上回り判定を以下に変更する:
+
+- **継続条件**: ある日 i の終値が10MAを割っても、その**翌営業日(時系列で次の日)の
+  安値が「割れ日 i の安値」を下回らなければ**、連続を切断しない(porosity許容)。
+- **切断条件**: 終値が10MAを割り、**かつ翌営業日の安値が割れ日 i の安値を下回った**
+  (= violation成立) 場合に連続を切断する。
+- 終値が10MAを割っていない日は従来どおり連続維持。
+
+### violation の監視窓を「翌営業日のみ」に確定する理由
+
+原典の文言は「終値割れ + **翌日以降**に割れ日安値を下回る」だが、本実装では
+**監視窓を「割れ日 i の翌営業日 (i-1) のみ」に固定する**。理由:
+
+1. violation は「割れた直後にフォロースルー(安値更新)があるか」で本物/ダマシを
+   判定するルール。割れから2日以上経った安値更新は、新しい局面の値動きであり
+   同一 violation の確認とは見なさない (原典でも実務上は割れ直後で判定)。
+2. 「翌日以降・無期限」にすると、割れ日のあと一度でも安値更新があれば過去に遡って
+   切断され、判定が監視窓終端の定義に依存して不安定になる。終端を「翌営業日」に
+   固定することで判定を決定的にする。
+3. 本指標は表示専用 (赤太線の点灯)。porosity の主目的は「1日だけの軽い潜りの救済」
+   であり、それは翌営業日の安値確認で十分達成できる。
+
+この限定は意図的な仕様であり、原典の「翌日以降」を翌営業日に絞ったものである旨を
+コード/テストのコメントに明記する。
+
+STREAK_DAYS は **30 のまま据え置き** (7週=35日化は yfinance `2mo`=41営業日では
+44本必要で不足。`3mo` 化は全銘柄再取得・取得負荷1.5倍を全処理に強いるため、
+表示専用・スコア非連動の本指標には費用対効果が低く今回スコープ外)。
+
+## データ構造
+
+`calc_ma10_kairi_indicators` は現在 `closes` (終値のみ) を受ける。
+porosity判定に**安値が必要**なため、`lows` 引数を追加する。
+
+- 入力元 `_calc_daily_indicators` の `daily_price_list` は
+  `[3]安値, [4]終値` を持つ (price.py:499 docstring)。安値は取得済み。
+- 両リストとも「新しい日が先頭」。closes[i]/lows[i] は同じ日 i を指す。
+- 「翌営業日」= 時系列で i の次の日 = リスト上は **index i-1** (新しい側)。
+  i=0 (最新日) には翌日が無いので、violation判定は i>=1 の割れ日についてのみ行う。
+  最新日 i=0 が終値割れの場合、翌日未到来 → violation未確定 → 連続は切断しない
+  (porosity救済側に倒す。翌日データが来た次回実行で確定判定される)。
+
+## 変更内容
+
+### price.py
+
+`calc_ma10_kairi_indicators(closes)` → `calc_ma10_kairi_indicators(closes, lows)`:
+
+```python
+def calc_ma10_kairi_indicators(closes, lows):
+    res = {}
+    # 乖離率は従来どおり closes のみで計算
+    if len(closes) >= 10:
+        ma10 = sum(closes[:10]) / 10
+        res["price_kairi_ma10"] = (closes[0] - ma10) * 100 / ma10 if ma10 else None
+    else:
+        res["price_kairi_ma10"] = None
+
+    STREAK_DAYS = 30
+
+    def _ma10(i):
+        return sum(closes[i:i + 10]) / 10 if len(closes) >= i + 10 else None
+
+    def _streak_holds(i):
+        """日 i が連続を維持するか (porosity許容)。
+        終値が10ma上なら維持。終値割れでも翌営業日(i-1)の安値が割れ日 i の
+        安値を下回らなければ維持 (violation未成立)。最新日 i=0 の割れは
+        翌日未到来のため未確定 → 維持側に倒す。"""
+        ma = _ma10(i)
+        if ma is None or ma == 0:
+            return False  # 10ma算出不可 = データ不足
+        if closes[i] > ma:
+            return True   # 終値が10ma上 → 維持
+        # 終値が10maを割った日。violation成立(翌日安値 < 割れ日安値)なら切断
+        if i == 0:
+            return True   # 翌日未到来 → 未確定、porosity救済側
+        return lows[i - 1] >= lows[i]  # 翌日安値が割れ日安値を割らなければ維持
+
+    had_streak = False
+    if len(closes) >= STREAK_DAYS + 9:
+        max_start = len(closes) - (STREAK_DAYS + 9)
+        for s in range(max_start + 1):
+            if all(_streak_holds(i) for i in range(s, s + STREAK_DAYS)):
+                had_streak = True
+                break
+    res["ma10_above_streak_30"] = had_streak
+    return res
+```
+
+**呼び出し元は2箇所あり、`price_list` のインデックス体系が異なる**ので
+各々で正しく closes/lows を生成する。
+
+#### 呼び出し元1: `_calc_daily_indicators` (price.py:558-562 付近)
+
+`daily_price_list` = 8要素タプル `[3]安値, [4]終値` (price.py:499):
+
+```python
+    try:
+        closes = [int(float(d[4].replace(",", ""))) for d in daily_price_list]
+        lows = [int(float(d[3].replace(",", ""))) for d in daily_price_list]
+    except (ValueError, IndexError):
+        closes = []
+        lows = []
+    dic.update(calc_ma10_kairi_indicators(closes, lows))
+```
+
+#### 呼び出し元2: `parse_price_text_from_list` (price.py:1766-1769)
+
+ここの `price_list` は**別構造** `(日付[0],始値[1],高値[2],安値[3],終値[6],出来高[5])`
+で、終値が `[6]`・安値が `[3]` (price.py:1717 で `[3]`=安値, `[6]`=終値として使用)。
+既に int 化済みなので `float`/`replace` 不要:
+
+```python
+    closes = [row[6] for row in price_list]
+    lows = [row[3] for row in price_list]
+    price.update(calc_ma10_kairi_indicators(closes, lows))
+```
+
+両呼び出し元とも「新しい日が先頭」である点は共通 (porosity判定の前提)。
+
+コメント (price.py:461-462) を porosity仕様に合わせて更新。
+
+### tests/test_price.py
+
+CLAUDE.md のテスト方針 (1PR5本以下、parametrize集約) に従い、porosity の
+コア挙動と「2つ目の特殊経路」回帰を最小本数でカバーする。
+
+#### 1. `test_ma10_above_streak_30` (既存 parametrize) に porosity ケース追加
+
+`_calc_daily_indicators` (8カラム経路) で:
+- 1日だけ終値割れ + 翌日安値が割れ日安値を上回る → 連続維持 (True)
+- 終値割れ + 翌日安値が割れ日安値を下回る (violation成立) → 切断 (False)
+
+既存ケースは終値を "0"/"1" で割り込ませているが、安値カラムも併せて設定し、
+porosity判定が意図通り効くようにする (安値を割れ日安値より高く/低く作り分ける)。
+
+#### 2. `TestParsePriceTextFromList` (既存クラス) に経路回帰テスト1本追加
+
+第2呼び出し元 `parse_price_text_from_list` は **7カラム系
+(`[3]=安値, [6]=終値`)** の特殊経路で、index取り違え (`[4]`/`[6]`) や lows
+渡し忘れが起きやすい。これを直接叩く porosity 回帰を parametrize 1本で追加:
+- 終値1日割れ + 翌日安値が割れ日安値を上回る → `ma10_above_streak_30` 維持
+- 終値割れ + 翌日安値が割れ日安値を下回る → 切断
+
+(2ケースを1つの parametrize に集約。これにより「経路依存で赤太線判定がズレる」
+回帰を検出できる)
+
+## スコープ外
+
+- STREAK_DAYS の 7週(35日)化 (yfinance `3mo` 化が前提、費用対効果低)
+- スコアリング/ランキングへの組込み (本指標は表示専用、従来どおり非連動)
+- 売りシグナル(violation)そのものの新規列・通知 (別issue候補)
+- violation 監視窓を「翌営業日以降の複数日」へ拡張すること (本実装は翌営業日のみに
+  固定。上記「確定方針」の理由参照)
+- DB マイグレーション (次回スクレイピングで上書き再計算、後方互換不要)
+
+## 検証
+
+```
+pytest tests/test_price.py tests/test_webapp_helpers.py -v
+cd scripts && python make_stock_db.py update <赤太線が出ている保有銘柄>  # 再計算確認
+```
+
+ダッシュボードのトレンド列で、軽い1日割れで赤太線が消えなくなることを目視確認
+(運用しながら確認)。

--- a/doc/plans/issue327_portfolio_2page.md
+++ b/doc/plans/issue327_portfolio_2page.md
@@ -1,0 +1,170 @@
+# issue #327 実装プラン: portfolio一覧の2ページ化と売買アイデア可視化
+
+## ゴール
+
+portfolio一覧を「自動算出データ(ページ1) / 手動入力データ(ページ2)」の2ページに分割し、
+JSトグルで列セットを切り替える。売買アイデアを定型リスト化してページ2に色分けバッジ表示する。
+高市感応度を「売買メモ」にリネームする。
+
+検証可能なゴール:
+- ページ1/2トグルで列セットが切り替わり、データ取得は1回(ページ遷移なし)
+- ページ2に「更新日/ステージ/チャートパターン/売買アイデア(バッジ)/イナゴ元/IN理由(短縮)/売買メモ(短縮)」が出る
+- 売買アイデアは定型リスト単一選択(+未分類)、未分類は警告色
+- 高市感応度のUIラベルが「売買メモ」になる(DBキー takaichi_sensitivity は不変)
+- pytest 緑、`python shintakane.py` 等は不要(HTMLパース無関係)
+
+## スコープ外(issue準拠)
+
+- 戦略ミックスサマリー
+- 売買アイデアの時間軸属性(中期/短期イベント) ← #326連携、本PRでは持たせない
+- ページ2デフォルト表示
+- 過去メモの自動再分類
+
+## 設計判断
+
+### 1. 列のページ切り替え方式: セルに data-page を付与しCSSでtoggle
+- 各 `<th>`/`<td>` に `data-page="1"` または `data-page="2"` を付ける
+- 両ページ共通の列(コード・銘柄名・状態・評価・業態テーマ・順位)は `data-page="both"`
+- `body.portfolio-page-2` クラスの有無で `[data-page="1"]{display:none}` / `[data-page="2"]{display:none}` を切替
+- 既存の sticky thead・inline編集・行展開(details)はDOM構造を変えないため影響なし
+- トグルUIはダッシュボードヘッダ付近にボタン2つ(「指標」「メモ」)を置く
+
+理由: 列セットを2テーブルに分けるとsticky/行展開/モーダルJSのセレクタが二重化し複雑になる。
+セル属性+CSSなら1テーブルのまま、表示/非表示だけで済む(Simplicity First)。
+
+### 2. 売買アイデアの定型リスト: portfolio_shelve.py に定数で定義
+- `TRADE_IDEA_OPTIONS` を `portfolio_shelve.py` に tuple で定義(順序保持)
+  - 初期値(実装時にユーザー確認で確定。暫定): GARP / テーマ / イベント・カタリスト / モメンタム / 底値リバ
+  - 空文字 = 「未分類」(選択肢には出さず、未選択状態を未分類とみなす)
+- gyoutai_themes と違い動的マスターではないので shelve ではなく定数が適切(ETF_code等の
+  外部txtにするほど可変でない)
+- バリデーション: `update_memo()` で trade_idea が `TRADE_IDEA_OPTIONS ∪ {""}` 以外なら ValueError
+  - **既存の自由記述値の救済**: 現行レコードに既に入っている値は、リスト外でも保持を許可
+    (gyoutai_themes の移行漏れ救済と同じパターン)。これにより過去メモが保存拒否で壊れない
+  - **移行層(migrate_portfolio_from_csv)の扱い【確定】**: 移行は `create_record()` で memo を
+    そのまま格納し、`update_memo()` を経由しない(確認済: portfolio_shelve.py create_record は
+    trade_idea を検証しない)。よって**移行は自由記述をそのまま保持する仕様で確定**。定型チェックは
+    かけない。バリデーションは update_memo(=UIからの編集保存)にのみ追加する。
+    過去CSVの `押し目買い` 等はそのまま移行され、UI で「リスト外現行値=⚠️option差し込み +
+    未分類バッジ」として表示し、ユーザーが手動再分類する(issue方針「自動分類しない」と一致)
+
+### 3. 売買アイデアの編集UI: ページ2セル内の select inline編集
+- ページ2の売買アイデア列セルに `<select>` を直接置く(gyoutai_themes と同じ inline 編集系統)
+- change で `/portfolio/<code_s>/memo` に POST(既存AJAX動線を再利用)
+- バッジ色は定型値ごとに固定色をCSSで割当。未分類は警告色(赤系)
+
+**既存の自由記述値の扱い(codex指摘1)**:
+現行 trade_idea は自由記述で `押し目買い` 等の既存値が入っている(test_portfolio_shelve.py:405,
+test_migrate_portfolio_from_csv.py:63 に実在)。issue方針は「過去メモの自動分類はしない=手動再分類」。
+そこで gyoutai_themes と同じ「リスト外の現行値を選択肢に差し込む」方式を採る:
+- select の option を `TRADE_IDEA_OPTIONS` + 空(未分類) で構成
+- **現行値がリスト外なら、先頭に `⚠️ <現行値>` option を selected で差し込む**(gyoutai_themes の
+  未登録name表示と同じパターン: portfolio_list.html:358-360)
+- ユーザーが別の定型値を選べば再分類完了。選ばない限り既存値は保持され消えない
+- これにより事前マイグレーション不要。バッジは未分類(警告色)扱いで表示し、再分類を促す
+
+### 4. IN理由・売買メモの短縮表示: 既存 jukyu_chart パターンを踏襲
+- セルは1行省略表示(`overflow:hidden;text-overflow:ellipsis;white-space:nowrap`)
+- `title`(ホバー)で全文。クリックで既存 `.editable`+`data-multiline="1"` の textarea inline編集
+- jukyu_chart 列が全く同じ実装なので、それを2列(watch_in_reason / takaichi_sensitivity)に展開するだけ
+
+### 5. 高市感応度→売買メモ リネーム
+- UIラベルのみ変更。DBキー `takaichi_sensitivity` は維持(マイグレーション不要)
+- 変更箇所: portfolio_list.html のラベル文字列、detail系に出ていれば同様
+- コメントに「旧:高市感応度」を残し、キー名との対応が追えるようにする
+
+### 6. 展開パネルの扱い
+- IN理由・売買メモ・売買アイデア・イナゴ元はページ2の列に出るため、展開パネル内の
+  該当フォームは**不要**になる。展開パネル(手動メモフォーム)は削除する
+- ただし行展開(details)の仕組み自体は他に使っていなければ撤去。要確認: 展開パネルが
+  手動メモ表示専用なら、行頭の ▸ ボタンごと削除する
+  - フォールバックモードの読み取り専用 ul も整理(売買メモへのラベル変更のみ反映)
+
+## 変更ファイルと具体的変更
+
+### A. `scripts/portfolio_shelve.py`
+1. `TRADE_IDEA_OPTIONS` 定数を追加(tuple)
+2. `update_memo()` の trade_idea バリデーション追加
+   - リスト外かつ現行レコードに無い値 → ValueError
+   - リスト外だが現行レコードに既存 → 許容(救済)
+
+### B. `scripts/webapp/routes/portfolio.py`
+1. `update_memo()` の保存 → 行再構築は既存だが、AJAX応答の `display` は現状
+   `last_research_update`/`stage`/`jukyu_chart`/`gyoutai_*` のみ(portfolio.py:447付近)。
+   今回 inline編集する `trade_idea`/`watch_in_reason`/`inago_origin`/`takaichi_sensitivity`
+   を **`display` に追加**しないと保存後にクライアントが正しい表示値・バッジを同期できない
+   (codex指摘2)。これら4フィールドを display に含める
+   - trade_idea は再分類後のバッジ色判定に必要なので display 値で `data-trade-idea` 属性 or
+     バッジ class をクライアントが付け替える。JS側で再描画する
+2. ValueError(リスト外新規値)を AJAX エラーJSON `{ok:false, error:...}` として返す既存
+   ハンドリングを確認・流用
+
+### C. `scripts/webapp/templates/portfolio_list.html`
+1. ヘッダにページトグルボタン(指標/メモ)を追加
+2. `<style>` に:
+   - `body.portfolio-page-2 [data-page="1"]{display:none}` / 既定で `[data-page="2"]{display:none}`
+   - 売買アイデアバッジ色(定型値ごと + 未分類警告色)
+3. thead の各 `<th>` に `data-page` 属性を付与し、更新日/ステージ/チャートパターンを page2 に
+4. tbody の対応する各 `<td>` に同じ `data-page` を付与
+5. ページ2列を追加:
+   - 売買アイデア(select inline編集 + バッジ表示)
+   - イナゴ元(短縮表示 + inline編集)
+   - IN理由(短縮表示 + inline編集、jukyu_chart パターン)
+   - 売買メモ(短縮表示 + inline編集、jukyu_chart パターン)
+6. 展開パネル(手動メモフォーム)を削除。行頭 ▸ もメモ専用なら削除
+7. フォールバック表示の「高市感応度」→「売買メモ」
+8. `<script>` にページトグルのJS(body class付け外し)を追加
+9. colspan(展開行)を削除 or 調整
+
+### D. `scripts/webapp/helpers.py`
+- 売買アイデアバッジ・未分類判定に必要なら row に値を載せる(memo.trade_idea は既に row.memo にある)
+- compute_cell_styles で trade_idea の未分類警告色を返すか、テンプレ側CSSで処理するか決める
+  → テンプレ側CSS(セレクタ)で処理しstyles関数は触らない方が surgical
+
+### E. detail.html(該当あれば)
+- 高市感応度ラベルが出ていれば「売買メモ」に変更
+
+## テスト(5本以下、parametrize集約)
+
+`tests/test_portfolio_shelve.py` に(shelve層のバリデーション):
+1. `update_memo` で trade_idea にリスト内の値 → 保存成功 / リスト外新規値 → ValueError
+   / リスト外でも現行レコードに既存なら保持(救済) を parametrize で1関数に集約
+
+`tests/test_webapp_portfolio_routes.py` に(route層の契約。codex指摘3 — 最も壊れやすい):
+2. `/portfolio/<code>/memo` AJAX応答の `display` に
+   trade_idea/watch_in_reason/inago_origin/takaichi_sensitivity が含まれる
+3. 既存テスト(:185付近の一覧列・inline編集)が列再編で壊れていないか確認・必要なら更新
+   (列の data-page 化で参照セレクタがズレる可能性。回帰を吸収)
+
+**既存テストの一括更新(codex指摘 — pytest緑の必須条件)**:
+trade_idea を定型値制限すると、自由記述値を保存している既存テストが ValueError で落ちる。
+新規保存値は「現行レコードに無い新規値」なので救済対象外=直撃する。該当箇所を定型値
+(TRADE_IDEA_OPTIONS のいずれか)へ一括置換する:
+- test_webapp_portfolio_routes.py:592, 602, 680, 824 付近(`trade_idea="X"` 等)
+- test_portfolio_shelve.py:414, 443 付近(`"X"`/`"X2"`/`"val_trade_idea"` 等)
+- test_migrate_portfolio_from_csv.py:63 付近: **変更不要**。移行は自由記述を保持する仕様で
+  確定(create_record は trade_idea を検証しない)ため、既存の `押し目買い` テストはそのまま
+  維持する。むしろ「リスト外値が移行後も保持される」回帰防止として残す価値がある
+これは「テストを5本以下」の新規追加方針とは別枠の既存修正(回帰吸収)。
+
+テンプレート(HTML/JS/CSS)のページトグル・短縮表示・バッジ色はブラウザ目視確認(Playwright)。
+
+実行: `pytest tests/test_portfolio_shelve.py tests/test_webapp_portfolio_routes.py tests/test_migrate_portfolio_from_csv.py -v`
+
+## 検証手順
+
+1. pytest 上記
+2. `python -m webapp.app` 起動 → /portfolio
+3. ページトグル(指標/メモ)で列セットが切り替わるか
+4. ページ2で売買アイデア select 変更 → 即保存・バッジ色反映
+5. 未分類銘柄が警告色か
+6. IN理由・売買メモが短縮表示+ホバー全文+クリック編集できるか
+7. 高市感応度ラベルが「売買メモ」になっているか
+8. Playwright スクショ(.playwright-mcp/issue327-*.png)
+
+## 確定事項(ユーザー確認済み)
+
+- 売買アイデアの定型リスト内容: **暫定値で進める**
+  (GARP / テーマ / イベント・カタリスト / モメンタム / 底値リバ)
+- トグルボタンのラベル文言: **「指標 / メモ」**
+- 行展開(▸): **完全撤去する**(手動メモがページ2列に出るため不要)

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -436,14 +436,15 @@ def add_stalling_days(dic, daily_price_list, high52_weekly):
     return dic
 
 
-def calc_ma10_kairi_indicators(closes):
-    """終値リスト (新しい日が先頭) から 10日MA乖離率と30日連続上回り判定を計算する。
+def calc_ma10_kairi_indicators(closes, lows):
+    """終値・安値リスト (新しい日が先頭) から 10日MA乖離率と30日連続上回り判定を計算する。
 
     Kabutan/yfinance 両系統で共通利用する。トレンド列の点線マーカー用。
     30日連続で終値が10maを上回る期間が保持データ窓内にあると赤実線に切替える。
 
     Args:
         closes: 終値 (int/float) のリスト、新しい日が先頭
+        lows: 安値 (int/float) のリスト、新しい日が先頭 (closes と同じ日付並び)
     Returns:
         dict: price_kairi_ma10 (float or None) / ma10_above_streak_30 (bool)
     """
@@ -454,24 +455,49 @@ def calc_ma10_kairi_indicators(closes):
         res["price_kairi_ma10"] = (closes[0] - ma10) * 100 / ma10 if ma10 else None
     else:
         res["price_kairi_ma10"] = None
-    # 保持している価格データ (日足~40日) の範囲内に「30営業日連続で終値 > その日の
-    # 10ma」の期間があるか。利確基準 (10maを30日上回り続けた) がこの窓内で一度でも
-    # 成立していれば、その後10maを割って売りシグナルが出ても True のまま → トレンド列で
-    # 赤太点線として表示する (達成期間が保持データ窓の外に流れたら False に戻る = 現状仕様)。
-    # 各日 i の10ma = closes[i:i+10] の平均 (要 i+10 本)。一致・下回りで連続を切断 (厳密)。
+    # 保持している価格データ (日足~40日) の範囲内に「30営業日連続で 10ma を維持した」
+    # 期間があるか。利確基準 (10maを30日上回り続けた) がこの窓内で一度でも成立していれば、
+    # その後10maを割って売りシグナルが出ても True のまま → トレンド列で赤太点線として表示
+    # する (達成期間が保持データ窓の外に流れたら False に戻る = 現状仕様)。
+    #
+    # 連続維持の判定は Morales/Kacher の violation (浸透許容=porosity) に準拠する:
+    #   - 終値 > 10ma なら維持。
+    #   - 終値が10maを割っても、翌営業日の安値が「割れた日の安値」を下回らなければ維持
+    #     (一時的な潜りは shakeout として救済)。
+    #   - 終値が10maを割り、かつ翌営業日の安値が割れた日の安値を下回ったら violation 成立
+    #     として切断。
+    # 原典は「翌日以降」に安値を下回ることを violation とするが、本実装は監視窓を
+    # 「割れ日の翌営業日のみ」に固定する (割れ直後のフォロースルー有無で本物/ダマシを
+    # 判定する趣旨。窓終端を確定させ判定を決定的にするため)。
+    # 各日 i の10ma = closes[i:i+10] の平均 (要 i+10 本)。リスト先頭が最新日なので、
+    # 日 i の「翌営業日」は index i-1。
     # (原典は7週=35日だが日足取得が period="2mo"≒40日のため取得範囲で収まる30日に調整)
     STREAK_DAYS = 30
 
-    def _above_ma10(i):
-        ma = sum(closes[i:i + 10]) / 10 if len(closes) >= i + 10 else None
-        return ma is not None and ma != 0 and closes[i] > ma
+    def _ma10(i):
+        return sum(closes[i:i + 10]) / 10 if len(closes) >= i + 10 else None
 
-    # 各起点 s から STREAK_DAYS 連続で _above_ma10 が成立する s があれば True
+    def _streak_holds(i):
+        ma = _ma10(i)
+        if ma is None or ma == 0:
+            return False  # 10ma 算出不可 = データ不足
+        if closes[i] > ma:
+            return True  # 終値が10ma上 → 維持
+        # 終値が10maを割った日。翌営業日 (i-1) の安値が割れ日 i の安値を下回れば
+        # violation 成立 → 切断。下回らなければ porosity 救済で維持。
+        if i == 0:
+            # 最新日の割れは翌営業日が未到来で violation 未確定。ここを維持側に倒すと
+            # 当日 streak=True を立てた翌日に violation 確定で False へひっくり返る
+            # (前日分の先取り誤判定)。確定情報のみで判定するため未確定は不成立とする。
+            return False
+        return lows[i - 1] >= lows[i]
+
+    # 各起点 s から STREAK_DAYS 連続で維持が成立する s があれば True
     had_streak = False
     if len(closes) >= STREAK_DAYS + 9:
         max_start = len(closes) - (STREAK_DAYS + 9)  # s+STREAK_DAYS+9 が範囲内に収まる上限
         for s in range(max_start + 1):
-            if all(_above_ma10(i) for i in range(s, s + STREAK_DAYS)):
+            if all(_streak_holds(i) for i in range(s, s + STREAK_DAYS)):
                 had_streak = True
                 break
     res["ma10_above_streak_30"] = had_streak  # データ不足時も False
@@ -557,9 +583,11 @@ def _calc_daily_indicators(daily_price_list):
     # トレンド列の点線マーカー用。daily_price_list は終値が d[4]。
     try:
         closes = [int(float(d[4].replace(",", ""))) for d in daily_price_list]
+        lows = [int(float(d[3].replace(",", ""))) for d in daily_price_list]
     except (ValueError, IndexError):
         closes = []
-    dic.update(calc_ma10_kairi_indicators(closes))
+        lows = []
+    dic.update(calc_ma10_kairi_indicators(closes, lows))
     log_debug("10日MA乖離率:", dic["price_kairi_ma10"], "30日連続上回り期間あり:", dic["ma10_above_streak_30"])
 
     # direction_signal は make_market_db.py が market_state を計算してから上書きする。
@@ -1764,9 +1792,11 @@ def parse_price_text_from_list(price_current, price_list):
     # TODO: 週次でやっている20MA押しをやりたい
 
     # ---- 10日MA乖離率 + 30日連続上回り判定 (トレンド列の点線マーカー用)
-    # price_list は終値が [6]。_calc_daily_indicators と同一ロジックを共通化。
+    # この price_list は終値が [6]・安値が [3] (int 済み)。_calc_daily_indicators とは
+    # カラム体系が異なる点に注意。calc_ma10_kairi_indicators のロジックを共通化。
     closes = [row[6] for row in price_list]
-    price.update(calc_ma10_kairi_indicators(closes))
+    lows = [row[3] for row in price_list]
+    price.update(calc_ma10_kairi_indicators(closes, lows))
 
     return price, [price_list[0][6], price_list[0][2], price_list[0][3]]
 

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -457,8 +457,8 @@ def calc_ma10_kairi_indicators(closes, lows):
         res["price_kairi_ma10"] = (closes[0] - ma10) * 100 / ma10 if ma10 else None
     else:
         res["price_kairi_ma10"] = None
-    # streak 判定は lows を porosity 判定で参照する。安値欠損で closes と長さが
-    # ずれると lows[i] が別日を指すため、不一致なら streak は判定不能として False。
+    # streak 判定は lows を porosity 判定で参照する。closes と日付整列できない
+    # 場合だけ判定不能とする。各要素の None は「その日の安値だけ欠損」を表す。
     if len(lows) != len(closes):
         res["ma10_above_streak_30"] = False
         return res
@@ -497,6 +497,8 @@ def calc_ma10_kairi_indicators(closes, lows):
             # 当日 streak=True を立てた翌日に violation 確定で False へひっくり返る
             # (前日分の先取り誤判定)。確定情報のみで判定するため未確定は不成立とする。
             return False
+        if lows[i] is None or lows[i - 1] is None:
+            return False  # porosity 判定に必要な安値欠損日は未確定扱い
         return lows[i - 1] >= lows[i]
 
     # 各起点 s から STREAK_DAYS 連続で維持が成立する s があれば True
@@ -594,10 +596,12 @@ def _calc_daily_indicators(daily_price_list):
         closes = [int(float(d[4].replace(",", ""))) for d in daily_price_list]
     except (ValueError, IndexError):
         closes = []
-    try:
-        lows = [int(float(d[3].replace(",", ""))) for d in daily_price_list]
-    except (ValueError, IndexError):
-        lows = []
+    lows = []
+    for d in daily_price_list:
+        try:
+            lows.append(int(float(d[3].replace(",", ""))))
+        except (ValueError, IndexError):
+            lows.append(None)
     dic.update(calc_ma10_kairi_indicators(closes, lows))
     log_debug("10日MA乖離率:", dic["price_kairi_ma10"], "30日連続上回り期間あり:", dic["ma10_above_streak_30"])
 

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -444,17 +444,24 @@ def calc_ma10_kairi_indicators(closes, lows):
 
     Args:
         closes: 終値 (int/float) のリスト、新しい日が先頭
-        lows: 安値 (int/float) のリスト、新しい日が先頭 (closes と同じ日付並び)
+        lows: 安値 (int/float) のリスト、新しい日が先頭 (closes と同じ日付並び)。
+            安値が欠損して closes と長さが揃わない場合は streak 判定のみ無効化し、
+            乖離率は closes だけで計算する (安値欠損が乖離率まで巻き込まないため)。
     Returns:
         dict: price_kairi_ma10 (float or None) / ma10_above_streak_30 (bool)
     """
     res = {}
-    # 直近10本平均からの乖離率
+    # 乖離率は closes のみで計算する (安値の欠損に影響されない)
     if len(closes) >= 10:
         ma10 = sum(closes[:10]) / 10
         res["price_kairi_ma10"] = (closes[0] - ma10) * 100 / ma10 if ma10 else None
     else:
         res["price_kairi_ma10"] = None
+    # streak 判定は lows を porosity 判定で参照する。安値欠損で closes と長さが
+    # ずれると lows[i] が別日を指すため、不一致なら streak は判定不能として False。
+    if len(lows) != len(closes):
+        res["ma10_above_streak_30"] = False
+        return res
     # 保持している価格データ (日足~40日) の範囲内に「30営業日連続で 10ma を維持した」
     # 期間があるか。利確基準 (10maを30日上回り続けた) がこの窓内で一度でも成立していれば、
     # その後10maを割って売りシグナルが出ても True のまま → トレンド列で赤太点線として表示
@@ -580,12 +587,16 @@ def _calc_daily_indicators(daily_price_list):
     log_debug("フォロースルー候補:", followthrough_day)
 
     # ---- 10日MA乖離率 + 30日連続10ma上回り判定 (短期ブレイク上昇時の利確基準)
-    # トレンド列の点線マーカー用。daily_price_list は終値が d[4]。
+    # トレンド列の点線マーカー用。daily_price_list は終値が d[4]・安値が d[3]。
+    # closes と lows は別々に読む。安値の欠損 (株探 "－" 等) で lows が落ちても
+    # 終値ベースの乖離率は計算できるようにする (calc 側で長さ不一致は streak 無効化)。
     try:
         closes = [int(float(d[4].replace(",", ""))) for d in daily_price_list]
-        lows = [int(float(d[3].replace(",", ""))) for d in daily_price_list]
     except (ValueError, IndexError):
         closes = []
+    try:
+        lows = [int(float(d[3].replace(",", ""))) for d in daily_price_list]
+    except (ValueError, IndexError):
         lows = []
     dic.update(calc_ma10_kairi_indicators(closes, lows))
     log_debug("10日MA乖離率:", dic["price_kairi_ma10"], "30日連続上回り期間あり:", dic["ma10_above_streak_30"])

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -597,7 +597,7 @@ class TestCalcDailyIndicators:
 
         従来は終値さえ読めれば乖離率を出せていた。porosity 用に安値を読む変更で、
         安値欠損が乖離率まで巻き込んで全滅する回帰が起きないことを確認する
-        (streak 判定は lows 不整合のため False に倒れるが、乖離率は生きる)。
+        (安値が不要な日なら streak まで巻き込まず、乖離率も生きる)。
         """
         rows = self._make_price_list(39)  # 全日 終値>10ma
         d, o, h, _l, c, r5, r6, v = rows[7]
@@ -605,7 +605,15 @@ class TestCalcDailyIndicators:
         result = price._calc_daily_indicators(rows)
         # 乖離率は終値だけで計算できる → None にならない
         assert isinstance(result["price_kairi_ma10"], float)
-        # 安値欠損で lows が落ちる → streak は判定不能として False
+        assert result["ma10_above_streak_30"] is True
+
+    def test_ma10_streak_missing_low_break_day_is_false(self):
+        """porosity 判定が必要な割れ日に安値欠損があると streak は未確定扱い。"""
+        rows = self._make_price_list(39)
+        d, o, h, _l, _c, r5, r6, v = rows[5]
+        rows[5] = (d, o, h, "－", "1", r5, r6, v)  # 終値割れ + 安値欠損
+        result = price._calc_daily_indicators(rows)
+        assert isinstance(result["price_kairi_ma10"], float)
         assert result["ma10_above_streak_30"] is False
 
     def test_price_log_tuple_format(self):

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -592,6 +592,22 @@ class TestCalcDailyIndicators:
         result = price._calc_daily_indicators(rows)
         assert result["ma10_above_streak_30"] is expected
 
+    def test_ma10_kairi_survives_missing_low(self):
+        """安値1件が非数値 (株探 "－" 等) でも、終値ベースの乖離率は計算される。
+
+        従来は終値さえ読めれば乖離率を出せていた。porosity 用に安値を読む変更で、
+        安値欠損が乖離率まで巻き込んで全滅する回帰が起きないことを確認する
+        (streak 判定は lows 不整合のため False に倒れるが、乖離率は生きる)。
+        """
+        rows = self._make_price_list(39)  # 全日 終値>10ma
+        d, o, h, _l, c, r5, r6, v = rows[7]
+        rows[7] = (d, o, h, "－", c, r5, r6, v)  # 安値だけ非数値に欠損
+        result = price._calc_daily_indicators(rows)
+        # 乖離率は終値だけで計算できる → None にならない
+        assert isinstance(result["price_kairi_ma10"], float)
+        # 安値欠損で lows が落ちる → streak は判定不能として False
+        assert result["ma10_above_streak_30"] is False
+
     def test_price_log_tuple_format(self):
         """price_log の各要素は (date, int) タプル"""
         rows = self._make_price_list_with_real_dates(30)

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -548,19 +548,49 @@ class TestCalcDailyIndicators:
     @pytest.mark.parametrize("n,break_days,expected", [
         (45, [], True),               # 全日 終値>10ma → 30日連続窓が存在
         (50, [0, 1, 2], True),        # 直近を割り込み (売りシグナル中) でも古い側に達成窓あり → 残る
-        (45, list(range(0, 45, 5)), False),  # 5日おきに割り込み → どの30日窓も成立しない
+        # 単発の飛び石割れは porosity (翌日安値が割れ日安値を上回る) で全て救済され連続維持。
+        # break日の安値を 0 にしても翌営業日は通常の高い安値なので violation 不成立 → True。
+        (45, list(range(0, 45, 5)), True),
         (30, [], False),              # 終値39本未満 (データ不足) → 未達成扱い
     ])
     def test_ma10_above_streak_30(self, n, break_days, expected):
-        """保持データ内に30日連続10ma上回り期間があるか。break_days はその日を急落させる。"""
+        """保持データ内に30日連続10ma維持期間があるか。break_days はその日を急落させる。
+
+        break日は終値・安値とも極端に下げる。porosity 仕様では「終値割れ + 翌営業日の安値が
+        割れ日安値を下回る」で初めて連続切断 (violation)。単発の飛び石割れは翌日安値で救済され
+        維持される (連続 violation を起こさない限り streak は壊れない)。
+        """
         rows = self._make_price_list(n)  # 先頭=最新、単調増加 (新しいほど高い)
         for bd in break_days:
             d, o, h, _l, _c, r5, r6, v = rows[bd]
-            rows[bd] = (d, o, h, "0", "1", r5, r6, v)  # 終値1で10maを確実に割り込む
+            rows[bd] = (d, o, h, "0", "1", r5, r6, v)  # 終値1・安値0で10maを確実に割り込む
         result = price._calc_daily_indicators(rows)
         assert result["ma10_above_streak_30"] is expected
         # price_kairi_ma10 は数値 (10本以上あるため)
         assert isinstance(result["price_kairi_ma10"], float)
+
+    @pytest.mark.parametrize("bd,next_low,expected", [
+        # 30連続窓の途中 (bd=5) で終値だけ10maを割る単発割れ。
+        # 翌営業日 (index bd-1) の安値が割れ日安値を下回るか否かで維持/切断が変わる。
+        (5, 9999, True),   # 翌日安値 >= 割れ日安値 → porosity 救済 → 30連続維持
+        (5, 1, False),     # 翌日安値 < 割れ日安値 → violation 成立 → 切断
+        # 最新日 (bd=0) の割れは翌営業日が未到来 = violation 未確定。先取り誤判定を
+        # 避けるため不成立 (False) に倒す。next_low は無関係 (翌日が存在しない)。
+        (0, None, False),
+    ])
+    def test_ma10_streak_porosity(self, bd, next_low, expected):
+        """終値割れ時の porosity 救済/violation 切断、および最新日の未確定扱いを検証する。"""
+        # 39本ちょうどにして30連続窓を1つ (s=0, i=0..29) に絞り、bd を必ず含める。
+        rows = self._make_price_list(39)  # 先頭=最新、単調増加
+        # 割れ日 bd: 終値だけ10maを割り込ませ、安値は基準値 (500) を置く
+        d, o, h, _l, _c, r5, r6, v = rows[bd]
+        rows[bd] = (d, o, h, "500", "1", r5, r6, v)
+        # bd>0 のときのみ翌営業日 bd-1 の安値を可変 (割れ日安値500 との大小で violation 判定)
+        if bd > 0:
+            d2, o2, h2, _l2, c2, r52, r62, v2 = rows[bd - 1]
+            rows[bd - 1] = (d2, o2, h2, str(next_low), c2, r52, r62, v2)
+        result = price._calc_daily_indicators(rows)
+        assert result["ma10_above_streak_30"] is expected
 
     def test_price_log_tuple_format(self):
         """price_log の各要素は (date, int) タプル"""
@@ -1031,6 +1061,40 @@ class TestParsePriceTextFromList:
             assert per >= 0
         else:
             assert len(breaks) == 0
+
+    @pytest.mark.parametrize("bd,next_low,expected", [
+        # 7カラム経路 (close=adj_close=[6], low=[3]) の porosity 回帰。割れ日 (bd) で
+        # adj_close だけ10maを割り、翌営業日 (bd-1) の安値で維持/切断が分岐することを検証。
+        (5, 9999, True),   # 翌日安値 >= 割れ日安値 → porosity 救済 → 30連続維持
+        (5, 1, False),     # 翌日安値 < 割れ日安値 → violation 成立 → 切断
+        # 最新日 (bd=0) の割れは翌営業日が未到来 = violation 未確定 → 不成立 (False)。
+        (0, None, False),
+    ])
+    def test_ma10_streak_porosity_7col(self, bd, next_low, expected):
+        """parse_price_text_from_list (7カラム経路) でも porosity 判定が効くことの回帰。
+
+        全日 adj_close>10ma を確実に満たすよう刻みを大きく取り、39本で30連続窓を
+        1つ (i=0..29) に絞る。bd をその窓に含め violation 成立時のみ False になる構成。
+        """
+        from datetime import date as _date, timedelta
+        d0 = _date(2025, 12, 31)
+        price_list = []
+        # i 小 (新しい) ほど高値になる急上昇データ → 全日 adj_close>10ma
+        for i in range(39):
+            dt = d0 - timedelta(days=i)
+            date_str = "%d年%d月%d日" % (dt.year, dt.month, dt.day)
+            close = 1000 + (38 - i) * 50  # 最新ほど高い
+            price_list.append([date_str, close, close + 20, close - 10,
+                               close, 100000 + i * 1000, close])
+        d, o, h, _l, c, v, _adj = price_list[bd]
+        # 割れ日 bd: adj_close ([6]) だけ10maを割り込ませ、安値 ([3]) は基準値 500
+        price_list[bd] = [d, o, h, 500, c, v, 1]
+        # bd>0 のときのみ翌営業日 bd-1 の安値 ([3]) を可変 (割れ日安値 500 との大小で判定)
+        if bd > 0:
+            d2, o2, h2, _l2, c2, v2, adj2 = price_list[bd - 1]
+            price_list[bd - 1] = [d2, o2, h2, next_low, c2, v2, adj2]
+        result_dict, _ = price.parse_price_text_from_list(1050, price_list)
+        assert result_dict["ma10_above_streak_30"] is expected
 
 
 # ==================================================


### PR DESCRIPTION
## 概要

保有銘柄ダッシュボードのトレンド列の「赤太線」(30日連続で株価が10MAを上回り続けた = 利確基準有効の印) の判定に、Gil Morales / Chris Kacher *"Trade Like an O'Neil Disciple"* (邦題『株式売買スクール』) の **violation (浸透許容 = porosity)** 概念を適用する。

## 背景

従来の連続判定は「終値が1日でも10MAを割れたら即連続切断 (厳密)」だった。だが原典の violation 定義は2条件の AND:

> 終値が移動平均線を割り込み、**かつ翌営業日にその割り込んだ日のザラ場安値を下回る**

一時的な軽い潜り (porosity) はダマシとして救済すべきで、終値1回の割れだけで切断するのは原典より厳しすぎ、本来10MAに従順な銘柄でも赤太線が点きにくくなっていた。

## 変更内容

- `calc_ma10_kairi_indicators(closes)` → `(closes, lows)` にシグネチャ拡張
- 連続維持判定を porosity 版に変更:
  - 終値 > 10ma → 維持
  - 終値割れでも翌営業日の安値が割れ日の安値を下回らなければ維持 (shakeout 救済)
  - 終値割れ + 翌営業日の安値が割れ日安値を下回る → violation 成立 → 切断
- **最新日 (i=0) の割れは翌営業日が未到来 = violation 未確定のため不成立扱い** (当日点灯→翌日消灯の先取り誤判定を防ぐ)
- 呼び出し元2箇所を修正 (8カラム経路 `close[4]/low[3]`、7カラム経路 `adj_close[6]/low[3]` でカラム体系が異なる)

## スコープ外 (確定)

- **7週 (35日) 化**: yfinance `2mo`=41営業日では44本必要で不足。`3mo` 化は全銘柄再取得・取得負荷1.5倍を全処理に強いるため、表示専用・スコア非連動の本指標には費用対効果が低い。`421A` で検証した結果、4月末の本物 violation が直近清浄区間を28日に制限しており、`3mo` 化しても点灯しない (= 7週化は本件の論拠にならない) ことを実データで確認済み
- スコアリング/ランキングへの組込み (本指標は従来どおり非連動)
- 売りシグナル (violation) 自体の新規列・通知 (別issue候補)

## 検証

- `pytest tests/test_price.py tests/test_webapp_helpers.py` → **406 passed**
  - porosity 救済 / violation 切断 / 最新日未確定 を 8カラム・7カラム両経路で parametrize 検証
- 実データ `421A` (ムービン・ストラテジック・キャリア) で実スクレイピングパス完走・DB保存値正常を確認。現状 `streak_30=False` (あと2営業日清浄に上回れば点灯する状態 = 想定通り)
- codex (gpt-5.4) レビュー済み: プラン3往復 + 実装2往復、最終「重大な問題なし」。`i==0` の先取り誤判定指摘を反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)
