### PR TITLE
feat(portfolio): 一覧を指標/メモの2ページ構成にし売買アイデアを定型バッジ化 (issue #327)

### DIFF
--- a/doc/plans/issue327_portfolio_2page.md
+++ b/doc/plans/issue327_portfolio_2page.md
@@ -1,0 +1,170 @@
+# issue #327 実装プラン: portfolio一覧の2ページ化と売買アイデア可視化
+
+## ゴール
+
+portfolio一覧を「自動算出データ(ページ1) / 手動入力データ(ページ2)」の2ページに分割し、
+JSトグルで列セットを切り替える。売買アイデアを定型リスト化してページ2に色分けバッジ表示する。
+高市感応度を「売買メモ」にリネームする。
+
+検証可能なゴール:
+- ページ1/2トグルで列セットが切り替わり、データ取得は1回(ページ遷移なし)
+- ページ2に「更新日/ステージ/チャートパターン/売買アイデア(バッジ)/イナゴ元/IN理由(短縮)/売買メモ(短縮)」が出る
+- 売買アイデアは定型リスト単一選択(+未分類)、未分類は警告色
+- 高市感応度のUIラベルが「売買メモ」になる(DBキー takaichi_sensitivity は不変)
+- pytest 緑、`python shintakane.py` 等は不要(HTMLパース無関係)
+
+## スコープ外(issue準拠)
+
+- 戦略ミックスサマリー
+- 売買アイデアの時間軸属性(中期/短期イベント) ← #326連携、本PRでは持たせない
+- ページ2デフォルト表示
+- 過去メモの自動再分類
+
+## 設計判断
+
+### 1. 列のページ切り替え方式: セルに data-page を付与しCSSでtoggle
+- 各 `<th>`/`<td>` に `data-page="1"` または `data-page="2"` を付ける
+- 両ページ共通の列(コード・銘柄名・状態・評価・業態テーマ・順位)は `data-page="both"`
+- `body.portfolio-page-2` クラスの有無で `[data-page="1"]{display:none}` / `[data-page="2"]{display:none}` を切替
+- 既存の sticky thead・inline編集・行展開(details)はDOM構造を変えないため影響なし
+- トグルUIはダッシュボードヘッダ付近にボタン2つ(「指標」「メモ」)を置く
+
+理由: 列セットを2テーブルに分けるとsticky/行展開/モーダルJSのセレクタが二重化し複雑になる。
+セル属性+CSSなら1テーブルのまま、表示/非表示だけで済む(Simplicity First)。
+
+### 2. 売買アイデアの定型リスト: portfolio_shelve.py に定数で定義
+- `TRADE_IDEA_OPTIONS` を `portfolio_shelve.py` に tuple で定義(順序保持)
+  - 初期値(実装時にユーザー確認で確定。暫定): GARP / テーマ / イベント・カタリスト / モメンタム / 底値リバ
+  - 空文字 = 「未分類」(選択肢には出さず、未選択状態を未分類とみなす)
+- gyoutai_themes と違い動的マスターではないので shelve ではなく定数が適切(ETF_code等の
+  外部txtにするほど可変でない)
+- バリデーション: `update_memo()` で trade_idea が `TRADE_IDEA_OPTIONS ∪ {""}` 以外なら ValueError
+  - **既存の自由記述値の救済**: 現行レコードに既に入っている値は、リスト外でも保持を許可
+    (gyoutai_themes の移行漏れ救済と同じパターン)。これにより過去メモが保存拒否で壊れない
+  - **移行層(migrate_portfolio_from_csv)の扱い【確定】**: 移行は `create_record()` で memo を
+    そのまま格納し、`update_memo()` を経由しない(確認済: portfolio_shelve.py create_record は
+    trade_idea を検証しない)。よって**移行は自由記述をそのまま保持する仕様で確定**。定型チェックは
+    かけない。バリデーションは update_memo(=UIからの編集保存)にのみ追加する。
+    過去CSVの `押し目買い` 等はそのまま移行され、UI で「リスト外現行値=⚠️option差し込み +
+    未分類バッジ」として表示し、ユーザーが手動再分類する(issue方針「自動分類しない」と一致)
+
+### 3. 売買アイデアの編集UI: ページ2セル内の select inline編集
+- ページ2の売買アイデア列セルに `<select>` を直接置く(gyoutai_themes と同じ inline 編集系統)
+- change で `/portfolio/<code_s>/memo` に POST(既存AJAX動線を再利用)
+- バッジ色は定型値ごとに固定色をCSSで割当。未分類は警告色(赤系)
+
+**既存の自由記述値の扱い(codex指摘1)**:
+現行 trade_idea は自由記述で `押し目買い` 等の既存値が入っている(test_portfolio_shelve.py:405,
+test_migrate_portfolio_from_csv.py:63 に実在)。issue方針は「過去メモの自動分類はしない=手動再分類」。
+そこで gyoutai_themes と同じ「リスト外の現行値を選択肢に差し込む」方式を採る:
+- select の option を `TRADE_IDEA_OPTIONS` + 空(未分類) で構成
+- **現行値がリスト外なら、先頭に `⚠️ <現行値>` option を selected で差し込む**(gyoutai_themes の
+  未登録name表示と同じパターン: portfolio_list.html:358-360)
+- ユーザーが別の定型値を選べば再分類完了。選ばない限り既存値は保持され消えない
+- これにより事前マイグレーション不要。バッジは未分類(警告色)扱いで表示し、再分類を促す
+
+### 4. IN理由・売買メモの短縮表示: 既存 jukyu_chart パターンを踏襲
+- セルは1行省略表示(`overflow:hidden;text-overflow:ellipsis;white-space:nowrap`)
+- `title`(ホバー)で全文。クリックで既存 `.editable`+`data-multiline="1"` の textarea inline編集
+- jukyu_chart 列が全く同じ実装なので、それを2列(watch_in_reason / takaichi_sensitivity)に展開するだけ
+
+### 5. 高市感応度→売買メモ リネーム
+- UIラベルのみ変更。DBキー `takaichi_sensitivity` は維持(マイグレーション不要)
+- 変更箇所: portfolio_list.html のラベル文字列、detail系に出ていれば同様
+- コメントに「旧:高市感応度」を残し、キー名との対応が追えるようにする
+
+### 6. 展開パネルの扱い
+- IN理由・売買メモ・売買アイデア・イナゴ元はページ2の列に出るため、展開パネル内の
+  該当フォームは**不要**になる。展開パネル(手動メモフォーム)は削除する
+- ただし行展開(details)の仕組み自体は他に使っていなければ撤去。要確認: 展開パネルが
+  手動メモ表示専用なら、行頭の ▸ ボタンごと削除する
+  - フォールバックモードの読み取り専用 ul も整理(売買メモへのラベル変更のみ反映)
+
+## 変更ファイルと具体的変更
+
+### A. `scripts/portfolio_shelve.py`
+1. `TRADE_IDEA_OPTIONS` 定数を追加(tuple)
+2. `update_memo()` の trade_idea バリデーション追加
+   - リスト外かつ現行レコードに無い値 → ValueError
+   - リスト外だが現行レコードに既存 → 許容(救済)
+
+### B. `scripts/webapp/routes/portfolio.py`
+1. `update_memo()` の保存 → 行再構築は既存だが、AJAX応答の `display` は現状
+   `last_research_update`/`stage`/`jukyu_chart`/`gyoutai_*` のみ(portfolio.py:447付近)。
+   今回 inline編集する `trade_idea`/`watch_in_reason`/`inago_origin`/`takaichi_sensitivity`
+   を **`display` に追加**しないと保存後にクライアントが正しい表示値・バッジを同期できない
+   (codex指摘2)。これら4フィールドを display に含める
+   - trade_idea は再分類後のバッジ色判定に必要なので display 値で `data-trade-idea` 属性 or
+     バッジ class をクライアントが付け替える。JS側で再描画する
+2. ValueError(リスト外新規値)を AJAX エラーJSON `{ok:false, error:...}` として返す既存
+   ハンドリングを確認・流用
+
+### C. `scripts/webapp/templates/portfolio_list.html`
+1. ヘッダにページトグルボタン(指標/メモ)を追加
+2. `<style>` に:
+   - `body.portfolio-page-2 [data-page="1"]{display:none}` / 既定で `[data-page="2"]{display:none}`
+   - 売買アイデアバッジ色(定型値ごと + 未分類警告色)
+3. thead の各 `<th>` に `data-page` 属性を付与し、更新日/ステージ/チャートパターンを page2 に
+4. tbody の対応する各 `<td>` に同じ `data-page` を付与
+5. ページ2列を追加:
+   - 売買アイデア(select inline編集 + バッジ表示)
+   - イナゴ元(短縮表示 + inline編集)
+   - IN理由(短縮表示 + inline編集、jukyu_chart パターン)
+   - 売買メモ(短縮表示 + inline編集、jukyu_chart パターン)
+6. 展開パネル(手動メモフォーム)を削除。行頭 ▸ もメモ専用なら削除
+7. フォールバック表示の「高市感応度」→「売買メモ」
+8. `<script>` にページトグルのJS(body class付け外し)を追加
+9. colspan(展開行)を削除 or 調整
+
+### D. `scripts/webapp/helpers.py`
+- 売買アイデアバッジ・未分類判定に必要なら row に値を載せる(memo.trade_idea は既に row.memo にある)
+- compute_cell_styles で trade_idea の未分類警告色を返すか、テンプレ側CSSで処理するか決める
+  → テンプレ側CSS(セレクタ)で処理しstyles関数は触らない方が surgical
+
+### E. detail.html(該当あれば)
+- 高市感応度ラベルが出ていれば「売買メモ」に変更
+
+## テスト(5本以下、parametrize集約)
+
+`tests/test_portfolio_shelve.py` に(shelve層のバリデーション):
+1. `update_memo` で trade_idea にリスト内の値 → 保存成功 / リスト外新規値 → ValueError
+   / リスト外でも現行レコードに既存なら保持(救済) を parametrize で1関数に集約
+
+`tests/test_webapp_portfolio_routes.py` に(route層の契約。codex指摘3 — 最も壊れやすい):
+2. `/portfolio/<code>/memo` AJAX応答の `display` に
+   trade_idea/watch_in_reason/inago_origin/takaichi_sensitivity が含まれる
+3. 既存テスト(:185付近の一覧列・inline編集)が列再編で壊れていないか確認・必要なら更新
+   (列の data-page 化で参照セレクタがズレる可能性。回帰を吸収)
+
+**既存テストの一括更新(codex指摘 — pytest緑の必須条件)**:
+trade_idea を定型値制限すると、自由記述値を保存している既存テストが ValueError で落ちる。
+新規保存値は「現行レコードに無い新規値」なので救済対象外=直撃する。該当箇所を定型値
+(TRADE_IDEA_OPTIONS のいずれか)へ一括置換する:
+- test_webapp_portfolio_routes.py:592, 602, 680, 824 付近(`trade_idea="X"` 等)
+- test_portfolio_shelve.py:414, 443 付近(`"X"`/`"X2"`/`"val_trade_idea"` 等)
+- test_migrate_portfolio_from_csv.py:63 付近: **変更不要**。移行は自由記述を保持する仕様で
+  確定(create_record は trade_idea を検証しない)ため、既存の `押し目買い` テストはそのまま
+  維持する。むしろ「リスト外値が移行後も保持される」回帰防止として残す価値がある
+これは「テストを5本以下」の新規追加方針とは別枠の既存修正(回帰吸収)。
+
+テンプレート(HTML/JS/CSS)のページトグル・短縮表示・バッジ色はブラウザ目視確認(Playwright)。
+
+実行: `pytest tests/test_portfolio_shelve.py tests/test_webapp_portfolio_routes.py tests/test_migrate_portfolio_from_csv.py -v`
+
+## 検証手順
+
+1. pytest 上記
+2. `python -m webapp.app` 起動 → /portfolio
+3. ページトグル(指標/メモ)で列セットが切り替わるか
+4. ページ2で売買アイデア select 変更 → 即保存・バッジ色反映
+5. 未分類銘柄が警告色か
+6. IN理由・売買メモが短縮表示+ホバー全文+クリック編集できるか
+7. 高市感応度ラベルが「売買メモ」になっているか
+8. Playwright スクショ(.playwright-mcp/issue327-*.png)
+
+## 確定事項(ユーザー確認済み)
+
+- 売買アイデアの定型リスト内容: **暫定値で進める**
+  (GARP / テーマ / イベント・カタリスト / モメンタム / 底値リバ)
+- トグルボタンのラベル文言: **「指標 / メモ」**
+- 行展開(▸): **完全撤去する**(手動メモがページ2列に出るため不要)

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -101,9 +101,9 @@ MEMO_FIELDS = frozenset(
         "gyoutai_theme",          # 旧: 業態・テーマ (str/改行区切り、移行期間中のみ残す。issue #187)
         "gyoutai_themes",         # 新: 業態・テーマ (list[str]、UI では最大2件)
         "watch_in_reason",        # ウォッチ・IN理由
-        "trade_idea",             # 投資売買アイデア
+        "trade_idea",             # 売買戦略 (旧: 投資売買アイデア)
         "inago_origin",           # イナゴ元・きっかけ
-        "takaichi_sensitivity",   # 高市感応度
+        "takaichi_sensitivity",   # 売買メモ (旧: 高市感応度)
         "last_research_update",   # 銘柄調査スプシでの更新日 (M/D 形式、年なし)
         "stage",                  # ステージ評価 (例: "1S", "2S(3T)", "3S")
         "jukyu_chart",            # 需給チャートメモ (例: "月足低位ブレイク CWH")
@@ -116,19 +116,19 @@ MEMO_LIST_FIELDS = frozenset({"gyoutai_themes"})
 # gyoutai_themes の UI スロット上限 (issue #187)
 GYOUTAI_THEMES_MAX_SLOTS = 2
 
-# trade_idea の定型リスト (issue #327: 自由記述から単一選択式へ移行)。
+# trade_idea (売買戦略) の定型リスト (issue #327: 自由記述から単一選択式へ移行)。
 # 空文字 = 未分類。リスト外の既存値 (旧自由記述) は update_memo で保持を許可する (救済)。
 # CSV 移行 (create_record 経由) はこのチェックを通らないため自由記述のまま格納される。
-# 「スイング」等の保有期間はここでは表現せず、時間軸属性 (issue #326 連携) で扱う。
+# 時間軸は戦略名に内包する (中期テーマ等)。各戦略の定義・決算またぎ可否は編集画面 issue で管理予定。
 TRADE_IDEA_OPTIONS = (
-    "GARP",
-    "ピーターリンチ",
-    "テーマ",
-    "イベント・カタリスト",
-    "モメンタム",
-    "底値リバ",
-    "夢枠",
-    "大型高配当",
+    "GARP",            # 中長期: 安定成長株を押し目・一時的売り込まれ局面で拾う
+    "ピーターリンチ",    # 中長期: 身近な実感で好印象の銘柄を持つ
+    "中期テーマ",        # 中期: 相場の物色テーマの波に乗る
+    "中期モメンタム",    # 中期: 新高値ブレイク順張り 2〜3ヶ月保有 (メイン戦略)
+    "短期イベント",      # 短期: 決算・材料・政策などカタリスト狙い
+    "底値リバ",          # 短期: 下げすぎリバ。サイズ小・機械的利確損切り
+    "夢枠",             # 長期: 2〜3年の夢に乗る。現物放置
+    "大型高配当",        # 恒常: PF安定・信用代用
 )
 
 ACTION_LOG_FIELDS = frozenset(

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -119,12 +119,16 @@ GYOUTAI_THEMES_MAX_SLOTS = 2
 # trade_idea の定型リスト (issue #327: 自由記述から単一選択式へ移行)。
 # 空文字 = 未分類。リスト外の既存値 (旧自由記述) は update_memo で保持を許可する (救済)。
 # CSV 移行 (create_record 経由) はこのチェックを通らないため自由記述のまま格納される。
+# 「スイング」等の保有期間はここでは表現せず、時間軸属性 (issue #326 連携) で扱う。
 TRADE_IDEA_OPTIONS = (
     "GARP",
+    "ピーターリンチ",
     "テーマ",
     "イベント・カタリスト",
     "モメンタム",
     "底値リバ",
+    "夢枠",
+    "大型高配当",
 )
 
 ACTION_LOG_FIELDS = frozenset(

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -116,6 +116,17 @@ MEMO_LIST_FIELDS = frozenset({"gyoutai_themes"})
 # gyoutai_themes の UI スロット上限 (issue #187)
 GYOUTAI_THEMES_MAX_SLOTS = 2
 
+# trade_idea の定型リスト (issue #327: 自由記述から単一選択式へ移行)。
+# 空文字 = 未分類。リスト外の既存値 (旧自由記述) は update_memo で保持を許可する (救済)。
+# CSV 移行 (create_record 経由) はこのチェックを通らないため自由記述のまま格納される。
+TRADE_IDEA_OPTIONS = (
+    "GARP",
+    "テーマ",
+    "イベント・カタリスト",
+    "モメンタム",
+    "底値リバ",
+)
+
 ACTION_LOG_FIELDS = frozenset(
     {
         "code_s",
@@ -1265,6 +1276,19 @@ def update_memo(
                         f"portfolio_shelve: theme {t!r} はマスター未登録のため新規付与できません"
                     )
                 normalized_fields["gyoutai_themes"] = cleaned
+
+            # trade_idea の定型値チェック (issue #327)
+            # - 空文字 (未分類) と TRADE_IDEA_OPTIONS 内の値は採用
+            # - リスト外でも現行レコードに既に入っている値は保持を許可 (旧自由記述の救済)
+            # - 純新規のリスト外値は ValueError
+            if "trade_idea" in normalized_fields:
+                idea = normalized_fields["trade_idea"]
+                current_idea = current_memo.get("trade_idea", "")
+                if idea and idea not in TRADE_IDEA_OPTIONS and idea != current_idea:
+                    raise ValueError(
+                        f"portfolio_shelve: trade_idea {idea!r} は定型リスト外のため"
+                        f"新規付与できません (許容値: {list(TRADE_IDEA_OPTIONS)})"
+                    )
 
             changed = any(
                 current_memo.get(k, _current_default(k)) != v

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -465,7 +465,7 @@ def update_memo(code_s: str):
                     "jukyu_chart": (row.get("memo") or {}).get("jukyu_chart") or "",
                     "gyoutai_theme": (row.get("memo") or {}).get("gyoutai_theme") or "",
                     "gyoutai_themes": list((row.get("memo") or {}).get("gyoutai_themes") or []),
-                    # issue #327: ページ2列 (売買アイデア / IN理由 / イナゴ元 / 売買メモ) の
+                    # issue #327: ページ2列 (売買戦略 / IN理由 / イナゴ元 / 売買メモ) の
                     # inline 編集後の表示同期に使う
                     "trade_idea": (row.get("memo") or {}).get("trade_idea") or "",
                     "watch_in_reason": (row.get("memo") or {}).get("watch_in_reason") or "",

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -465,6 +465,12 @@ def update_memo(code_s: str):
                     "jukyu_chart": (row.get("memo") or {}).get("jukyu_chart") or "",
                     "gyoutai_theme": (row.get("memo") or {}).get("gyoutai_theme") or "",
                     "gyoutai_themes": list((row.get("memo") or {}).get("gyoutai_themes") or []),
+                    # issue #327: ページ2列 (売買アイデア / IN理由 / イナゴ元 / 売買メモ) の
+                    # inline 編集後の表示同期に使う
+                    "trade_idea": (row.get("memo") or {}).get("trade_idea") or "",
+                    "watch_in_reason": (row.get("memo") or {}).get("watch_in_reason") or "",
+                    "inago_origin": (row.get("memo") or {}).get("inago_origin") or "",
+                    "takaichi_sensitivity": (row.get("memo") or {}).get("takaichi_sensitivity") or "",
                 }
         return jsonify(body)
     _flash_stock_info(code_s, " のメモを保存しました")
@@ -665,6 +671,7 @@ def dashboard():
         fallback_mode=fallback_mode,
         theme_master=theme_master,
         gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
+        trade_idea_options=ps.TRADE_IDEA_OPTIONS,
         hold_summary=hold_summary,
     )
 

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -62,12 +62,18 @@
   .page-toggle button:first-child { border-radius: 4px 0 0 4px; }
   .page-toggle button:last-child { border-radius: 0 4px 4px 0; border-left: none; }
   .page-toggle button.active { background: #4285f4; border-color: #4285f4; color: #fff; }
-  /* issue #327: IN理由・イナゴ元・売買メモの短縮表示セル (1行省略、ホバーで全文) */
+  /* issue #327: IN理由・イナゴ元・売買メモの短縮表示セル (改行反映で2行まで、ホバーで全文)。
+     td に max-height は効かないため内側の .memo-clamp で line-clamp する */
   table.portfolio-list td.memo-short-cell {
     max-width: 12em;
+  }
+  table.portfolio-list td.memo-short-cell .memo-clamp {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: pre-line;
+    line-height: 1.2;
   }
   /* issue #327: 売買戦略 select のバッジ色 (定型値ごとに固定色、未分類/リスト外は警告色) */
   select.trade-idea-select {
@@ -475,7 +481,7 @@
           title="{{ (memo_value ~ ' (クリックで編集)') if (not fallback_mode and memo_value) else ('クリックで編集' if not fallback_mode else memo_value) }}"
           data-full="{{ memo_value }}"
           {% if not fallback_mode %}class="editable memo-short-cell" data-code="{{ row.code_s }}" data-field="{{ memo_field }}" data-multiline="1" data-input-width="{{ input_width }}"{% else %}class="memo-short-cell"{% endif %}
-          style="{% if not fallback_mode %}cursor:pointer{% endif %}">{{ memo_value or "—" }}</td>
+          style="{% if not fallback_mode %}cursor:pointer{% endif %}">{%- if memo_value -%}<div class="memo-clamp">{{ memo_value }}</div>{%- else -%}—{%- endif -%}</td>
       {% endfor %}
     </tr>
     {# issue #327: 手動メモの展開パネルは廃止。全項目をページ2の列 (inline 編集) に移設 #}
@@ -718,13 +724,23 @@ function excludeFromUniverse(codeS) {
     td.textContent = value || '—';
   }
 
-  // 短縮表示 (data-full 全文保持 + 1行省略) する memo フィールド (issue #314 / #327)
+  // 短縮表示 (data-full 全文保持 + 改行反映2行省略) する memo フィールド (issue #314 / #327)
   var SHORT_TEXT_FIELDS = ['jukyu_chart', 'inago_origin', 'watch_in_reason', 'takaichi_sensitivity'];
 
   function renderJukyu(td, value) {
     td.dataset.full = value || '';
     td.title = value ? value + ' (クリックで編集)' : 'クリックで編集';
-    td.textContent = value || '—';
+    td.innerHTML = '';
+    if (!value) {
+      td.textContent = '—';
+      return;
+    }
+    // memo-short-cell では .memo-clamp の CSS (line-clamp 2) が効く。
+    // jukyu-cell ではセレクタ外のため素の div となり従来通り pre-line 全行表示。
+    var div = document.createElement('div');
+    div.className = 'memo-clamp';
+    div.textContent = value;
+    td.appendChild(div);
   }
 
   // PORTFOLIO_COLORS のうち背景色に使われる HEX (compute_cell_styles の bg() / bg_with_white() 出力)。

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -69,7 +69,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  /* issue #327: 売買アイデア select のバッジ色 (定型値ごとに固定色、未分類/リスト外は警告色) */
+  /* issue #327: 売買戦略 select のバッジ色 (定型値ごとに固定色、未分類/リスト外は警告色) */
   select.trade-idea-select {
     width: 100%; max-width: 11em; font-size: 1em; padding: 0 2px; margin: 0;
     border: 1px solid transparent; border-radius: 3px; font-family: inherit;
@@ -77,9 +77,9 @@
   }
   select.trade-idea-select[data-idea="GARP"] { background: #d0e0f8; color: #1a4b8e; }
   select.trade-idea-select[data-idea="ピーターリンチ"] { background: #b8d8f4; color: #0d3a6e; }
-  select.trade-idea-select[data-idea="テーマ"] { background: #d4ead4; color: #285028; }
-  select.trade-idea-select[data-idea="イベント・カタリスト"] { background: #e4d4f4; color: #5a2d82; }
-  select.trade-idea-select[data-idea="モメンタム"] { background: #fde0c0; color: #8a5200; }
+  select.trade-idea-select[data-idea="中期テーマ"] { background: #d4ead4; color: #285028; }
+  select.trade-idea-select[data-idea="中期モメンタム"] { background: #fde0c0; color: #8a5200; }
+  select.trade-idea-select[data-idea="短期イベント"] { background: #e4d4f4; color: #5a2d82; }
   select.trade-idea-select[data-idea="底値リバ"] { background: #c8ecec; color: #1a6b6b; }
   select.trade-idea-select[data-idea="夢枠"] { background: #f8d8e8; color: #8e2a5a; }
   select.trade-idea-select[data-idea="大型高配当"] { background: #ece8c0; color: #6e6200; }
@@ -338,7 +338,7 @@
       <th data-page="2">更新日</th>
       <th data-page="2">ステージ</th>
       <th data-page="2">チャートパターン</th>
-      <th data-page="2" title="定型リストから単一選択。未分類は警告色">売買アイデア</th>
+      <th data-page="2" title="定型リストから単一選択。未分類は警告色">売買戦略</th>
       <th data-page="2">イナゴ元</th>
       <th data-page="2">IN理由</th>
       <th data-page="2" title="旧: 高市感応度">売買メモ</th>
@@ -450,14 +450,14 @@
           data-full="{{ row.memo.jukyu_chart or '' }}"
           {% if not fallback_mode %}class="editable jukyu-cell" data-code="{{ row.code_s }}" data-field="jukyu_chart" data-multiline="1" data-input-width="8em"{% else %}class="jukyu-cell"{% endif %}
           style="{% if not fallback_mode %}cursor:pointer{% endif %}">{{ row.memo.jukyu_chart or "—" }}</td>
-      {# issue #327: 売買アイデア (定型リスト単一選択 + 色分けバッジ)。
+      {# issue #327: 売買戦略 (定型リスト単一選択 + 色分けバッジ)。
          リスト外の旧自由記述値は ⚠️ 付き option を差し込んで保持し、再分類を促す #}
       {% set current_idea = row.memo.trade_idea or '' %}
       <td data-page="2" style="padding:0 2px;">
         <select class="trade-idea-select"
                 data-code="{{ row.code_s }}"
                 data-idea="{{ current_idea }}"
-                title="売買アイデア (選択で即保存)"
+                title="売買戦略 (選択で即保存)"
                 {% if fallback_mode %}disabled{% endif %}>
           <option value="">未分類</option>
           {% if current_idea and current_idea not in trade_idea_options %}
@@ -1010,7 +1010,7 @@ function excludeFromUniverse(codeS) {
   });
 })();
 
-// ========== 売買アイデア inline 編集 (issue #327) ==========
+// ========== 売買戦略 inline 編集 (issue #327) ==========
 // select の change で即 POST。保存成功で data-idea を更新しバッジ色を反映、失敗時は元値に戻す。
 (function() {
   document.querySelectorAll('select.trade-idea-select').forEach(function(sel) {
@@ -1033,7 +1033,7 @@ function excludeFromUniverse(codeS) {
         if (!res.ok || !res.json || res.json.ok !== true) {
           sel.classList.add('error');
           sel.value = prev;
-          alert((res.json && res.json.error) || '売買アイデアの保存に失敗しました');
+          alert((res.json && res.json.error) || '売買戦略の保存に失敗しました');
           return;
         }
         var saved = (res.json.display && res.json.display.trade_idea) || '';

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -76,10 +76,13 @@
     background: #fce4e4; color: #a33;  /* デフォルト = 未分類 (警告色) */
   }
   select.trade-idea-select[data-idea="GARP"] { background: #d0e0f8; color: #1a4b8e; }
+  select.trade-idea-select[data-idea="ピーターリンチ"] { background: #b8d8f4; color: #0d3a6e; }
   select.trade-idea-select[data-idea="テーマ"] { background: #d4ead4; color: #285028; }
   select.trade-idea-select[data-idea="イベント・カタリスト"] { background: #e4d4f4; color: #5a2d82; }
   select.trade-idea-select[data-idea="モメンタム"] { background: #fde0c0; color: #8a5200; }
   select.trade-idea-select[data-idea="底値リバ"] { background: #c8ecec; color: #1a6b6b; }
+  select.trade-idea-select[data-idea="夢枠"] { background: #f8d8e8; color: #8e2a5a; }
+  select.trade-idea-select[data-idea="大型高配当"] { background: #ece8c0; color: #6e6200; }
   select.trade-idea-select.saving { background: #fff8c4; }
   select.trade-idea-select.error { background: #fce4e4; border-color: #d33; }
   /* overflow:auto + max-height で縦スクロールコンテナを作る。

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -52,8 +52,10 @@
   table.portfolio-list [data-page="2"] { display: none; }
   body.portfolio-page-2 table.portfolio-list [data-page="2"] { display: table-cell; }
   body.portfolio-page-2 table.portfolio-list [data-page="1"] { display: none; }
-  .page-toggle { display: inline-flex; gap: 0; }
+  /* Pico は [role=group] に width:100% を当てるため width:auto で打ち消す */
+  .page-toggle { display: inline-flex; gap: 0; flex: 0 0 auto; width: auto; margin: 0; }
   .page-toggle button {
+    width: auto;  /* Pico の button width:100% を打ち消す */
     padding: 0.3em 0.9em; font-size: 0.85em; margin: 0;
     border: 1px solid #ccc; background: #fff; color: #555; cursor: pointer;
   }
@@ -207,11 +209,6 @@
 <div class="dashboard-header">
   <h2 style="margin:0;">保有銘柄ダッシュボード</h2>
   <div class="dashboard-header-actions">
-    {# issue #327: 列セットのページ切り替え (指標=自動算出 / メモ=手動入力) #}
-    <div class="page-toggle" role="group" aria-label="表示列の切り替え">
-      <button type="button" data-page-btn="1" class="active">指標</button>
-      <button type="button" data-page-btn="2">メモ</button>
-    </div>
     <a href="{{ url_for('portfolio.theme_summary') }}"
        class="dashboard-header-link"
        title="業態テーマ別 RS サマリー">📊 テーマサマリー</a>
@@ -266,17 +263,24 @@
      title="現在のフィルタ結果をチャート一覧で確認">📊 チャート一覧</a>
 </form>
 
-<p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">
-  {% if total > 0 %}{{ total }} 件表示{% else %}0 件{% endif %}
-  {% if hold_summary %}
-  <span style="margin-left:1em;">
-    運用総額: {{ '{:,}'.format(hold_summary.total_man) }} 万円
-    /
-    保有株数更新日:
-    {% if hold_summary.qty_updated_at %}{{ hold_summary.qty_updated_at[:10] }}{% else %}未記録{% endif %}
-  </span>
-  {% endif %}
-</p>
+<div style="display:flex;align-items:center;justify-content:space-between;gap:1em;flex-wrap:wrap;margin:0 0 0.4em 0;">
+  <p style="font-size:0.85em;color:#666;margin:0;">
+    {% if total > 0 %}{{ total }} 件表示{% else %}0 件{% endif %}
+    {% if hold_summary %}
+    <span style="margin-left:1em;">
+      運用総額: {{ '{:,}'.format(hold_summary.total_man) }} 万円
+      /
+      保有株数更新日:
+      {% if hold_summary.qty_updated_at %}{{ hold_summary.qty_updated_at[:10] }}{% else %}未記録{% endif %}
+    </span>
+    {% endif %}
+  </p>
+  {# issue #327: 列セットのページ切り替え (指標=自動算出 / メモ=手動入力)。テーブル直上に置く #}
+  <div class="page-toggle" role="group" aria-label="表示列の切り替え">
+    <button type="button" data-page-btn="1" class="active" title="ショートカット: 1">指標</button>
+    <button type="button" data-page-btn="2" title="ショートカット: 2">メモ</button>
+  </div>
+</div>
 
 {% if not fallback_mode %}
 <div id="manage-panel" style="display:none;">
@@ -310,9 +314,9 @@
       <th>コード</th>
       <th>銘柄名</th>
       <th><a href="{{ sort_urls.position }}">状態</a></th>
-      <th>評価</th>
       <th><a href="{{ sort_urls.gyoutai }}">業態・テーマ</a></th>
-      <th><a href="{{ sort_urls.rank }}">順位</a></th>
+      <th data-page="1">評価</th>
+      <th data-page="1"><a href="{{ sort_urls.rank }}">順位</a></th>
       <th data-page="1">売上成長(%)</th>
       <th data-page="1">利益成長(%)</th>
       <th data-page="1">PER</th>
@@ -380,7 +384,6 @@
                 aria-label="保有ステータスを変更">{{ row.status_label }}</button>
         {% endif %}
       </td>
-      <td class="rating-cell"{% if row.overall_rating in ('S', 'A') %} style="background:#fbbc04"{% endif %}>{{ row.overall_rating or "—" }}</td>
       <td class="gyoutai-themes-cell" data-code="{{ row.code_s }}"
           style="max-width:10em;padding:0 2px;line-height:0;{{ row.styles.gyoutai_themes or '' }}">
         {% set themes = row.memo.gyoutai_themes or [] %}
@@ -402,7 +405,8 @@
         </select>
         {% endfor %}
       </td>
-      <td style="{{ row.styles.rank or '' }}">{{ row.rank if row.rank is not none else "—" }}</td>
+      <td data-page="1" class="rating-cell"{% if row.overall_rating in ('S', 'A') %} style="background:#fbbc04"{% endif %}>{{ row.overall_rating or "—" }}</td>
+      <td data-page="1" style="{{ row.styles.rank or '' }}">{{ row.rank if row.rank is not none else "—" }}</td>
       <td data-page="1" {% if row.gyoseki_tooltips.sales_growth %}title="{{ row.gyoseki_tooltips.sales_growth }}"{% endif %}
           style="{{ row.styles.sales_growth or '' }}">{{ row.sales_growth }}</td>
       <td data-page="1" {% if row.gyoseki_tooltips.profit_growth %}title="{{ row.gyoseki_tooltips.profit_growth }}"{% endif %}
@@ -560,11 +564,22 @@
 // ========== ページ切り替え (issue #327: 指標=自動算出 / メモ=手動入力) ==========
 (function() {
   var buttons = document.querySelectorAll('.page-toggle button[data-page-btn]');
+  function switchPage(pageBtn) {
+    document.body.classList.toggle('portfolio-page-2', pageBtn.dataset.pageBtn === '2');
+    buttons.forEach(function(b) { b.classList.toggle('active', b === pageBtn); });
+  }
   buttons.forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      document.body.classList.toggle('portfolio-page-2', btn.dataset.pageBtn === '2');
-      buttons.forEach(function(b) { b.classList.toggle('active', b === btn); });
-    });
+    btn.addEventListener('click', function() { switchPage(btn); });
+  });
+  // キーボードショートカット: 1=指標 / 2=メモ (入力フォーカス中は無効)
+  document.addEventListener('keydown', function(e) {
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    var tag = e.target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+    if (e.key === '1' || e.key === '2') {
+      var btn = document.querySelector('.page-toggle button[data-page-btn="' + e.key + '"]');
+      if (btn) switchPage(btn);
+    }
   });
 })();
 

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -10,8 +10,9 @@
      他ページは max-width + 中央寄せで余白を作るが、本ページは全幅のため
      左右パディングで他ページと同程度の余白を再現する。 */
   main.container { width: 100%; max-width: none !important; padding-left: var(--pico-spacing) !important; padding-right: var(--pico-spacing) !important; }
-  /* 24 列をできるだけ表示するための列幅微調整 (issue #177 / #199 / #314)。
-     全体 font-size ダウン + セル padding 圧縮 + ヘッダ折り返し許可。 */
+  /* 多数の列をできるだけ表示するための列幅微調整 (issue #177 / #199 / #314)。
+     全体 font-size ダウン + セル padding 圧縮 + ヘッダ折り返し許可。
+     issue #327 で列を指標 (ページ1) / メモ (ページ2) に分割し、同時表示数を削減。 */
   table.portfolio-list { width: 100%; font-size: 0.76em; }
   table.portfolio-list th, table.portfolio-list td {
     padding: 0.25em 0.35em;
@@ -46,6 +47,39 @@
     white-space: pre-line;
     line-height: 1.2;
   }
+  /* issue #327: ページ切り替え (指標/メモ)。data-page="1" は指標ページ、
+     data-page="2" は手動メモページ。属性なしの列は両ページ共通。 */
+  table.portfolio-list [data-page="2"] { display: none; }
+  body.portfolio-page-2 table.portfolio-list [data-page="2"] { display: table-cell; }
+  body.portfolio-page-2 table.portfolio-list [data-page="1"] { display: none; }
+  .page-toggle { display: inline-flex; gap: 0; }
+  .page-toggle button {
+    padding: 0.3em 0.9em; font-size: 0.85em; margin: 0;
+    border: 1px solid #ccc; background: #fff; color: #555; cursor: pointer;
+  }
+  .page-toggle button:first-child { border-radius: 4px 0 0 4px; }
+  .page-toggle button:last-child { border-radius: 0 4px 4px 0; border-left: none; }
+  .page-toggle button.active { background: #4285f4; border-color: #4285f4; color: #fff; }
+  /* issue #327: IN理由・イナゴ元・売買メモの短縮表示セル (1行省略、ホバーで全文) */
+  table.portfolio-list td.memo-short-cell {
+    max-width: 12em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* issue #327: 売買アイデア select のバッジ色 (定型値ごとに固定色、未分類/リスト外は警告色) */
+  select.trade-idea-select {
+    width: 100%; max-width: 11em; font-size: 1em; padding: 0 2px; margin: 0;
+    border: 1px solid transparent; border-radius: 3px; font-family: inherit;
+    background: #fce4e4; color: #a33;  /* デフォルト = 未分類 (警告色) */
+  }
+  select.trade-idea-select[data-idea="GARP"] { background: #d0e0f8; color: #1a4b8e; }
+  select.trade-idea-select[data-idea="テーマ"] { background: #d4ead4; color: #285028; }
+  select.trade-idea-select[data-idea="イベント・カタリスト"] { background: #e4d4f4; color: #5a2d82; }
+  select.trade-idea-select[data-idea="モメンタム"] { background: #fde0c0; color: #8a5200; }
+  select.trade-idea-select[data-idea="底値リバ"] { background: #c8ecec; color: #1a6b6b; }
+  select.trade-idea-select.saving { background: #fff8c4; }
+  select.trade-idea-select.error { background: #fce4e4; border-color: #d33; }
   /* overflow:auto + max-height で縦スクロールコンテナを作る。
      thead th の position:sticky (列名固定) はこのコンテナを基準に動くため、
      overflow-y / max-height を欠かすと sticky が壊れる (commit 0bba1b4)。
@@ -173,6 +207,11 @@
 <div class="dashboard-header">
   <h2 style="margin:0;">保有銘柄ダッシュボード</h2>
   <div class="dashboard-header-actions">
+    {# issue #327: 列セットのページ切り替え (指標=自動算出 / メモ=手動入力) #}
+    <div class="page-toggle" role="group" aria-label="表示列の切り替え">
+      <button type="button" data-page-btn="1" class="active">指標</button>
+      <button type="button" data-page-btn="2">メモ</button>
+    </div>
     <a href="{{ url_for('portfolio.theme_summary') }}"
        class="dashboard-header-link"
        title="業態テーマ別 RS サマリー">📊 テーマサマリー</a>
@@ -265,33 +304,37 @@
 <div class="portfolio-table-wrap">
 <table class="portfolio-list">
   <thead>
+    {# issue #327: data-page なし = 両ページ共通、"1" = 指標ページ、"2" = メモページ #}
     <tr>
       {% if delete_mode_allowed %}<th class="bulk-col"></th>{% endif %}
-      <th></th>
       <th>コード</th>
       <th>銘柄名</th>
       <th><a href="{{ sort_urls.position }}">状態</a></th>
       <th>評価</th>
       <th><a href="{{ sort_urls.gyoutai }}">業態・テーマ</a></th>
       <th><a href="{{ sort_urls.rank }}">順位</a></th>
-      <th>売上成長(%)</th>
-      <th>利益成長(%)</th>
-      <th>PER</th>
-      <th>理論株価乖離(%)</th>
-      <th>配当(%)</th>
-      <th title="決算Q (進行中の四半期)">決算Q</th>
-      <th title="進捗率乖離: (売上進捗-前年同期) / (利益進捗-前年同期)">進捗率乖離</th>
-      <th>決算日</th>
-      <th>更新日</th>
-      <th>ステージ</th>
-      <th>チャートパターン</th>
-      <th>RS</th>
-      <th title="RSライン (対TOPIX, 青=上昇/オレンジ=下降) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸">RS(20,5)</th>
-      <th>トレンド</th>
-      <th>タグ</th>
-      <th title="ポ/ブ記号。ホバーで signal 全文 (発生日付含む)">シグナル</th>
-      <th title="バー背景の濃淡で買い集め評価 (A=濃 / E=薄、左=緑 / 右=赤)">需給バランス</th>
-      <th>時価総額</th>
+      <th data-page="1">売上成長(%)</th>
+      <th data-page="1">利益成長(%)</th>
+      <th data-page="1">PER</th>
+      <th data-page="1">理論株価乖離(%)</th>
+      <th data-page="1">配当(%)</th>
+      <th data-page="1" title="決算Q (進行中の四半期)">決算Q</th>
+      <th data-page="1" title="進捗率乖離: (売上進捗-前年同期) / (利益進捗-前年同期)">進捗率乖離</th>
+      <th data-page="1">決算日</th>
+      <th data-page="1">RS</th>
+      <th data-page="1" title="RSライン (対TOPIX, 青=上昇/オレンジ=下降) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸">RS(20,5)</th>
+      <th data-page="1">トレンド</th>
+      <th data-page="1">タグ</th>
+      <th data-page="1" title="ポ/ブ記号。ホバーで signal 全文 (発生日付含む)">シグナル</th>
+      <th data-page="1" title="バー背景の濃淡で買い集め評価 (A=濃 / E=薄、左=緑 / 右=赤)">需給バランス</th>
+      <th data-page="1">時価総額</th>
+      <th data-page="2">更新日</th>
+      <th data-page="2">ステージ</th>
+      <th data-page="2">チャートパターン</th>
+      <th data-page="2" title="定型リストから単一選択。未分類は警告色">売買アイデア</th>
+      <th data-page="2">イナゴ元</th>
+      <th data-page="2">IN理由</th>
+      <th data-page="2" title="旧: 高市感応度">売買メモ</th>
     </tr>
   </thead>
   <tbody>
@@ -308,11 +351,6 @@
         {% endif %}
       </td>
       {% endif %}
-      <td>
-        <details>
-          <summary style="cursor:pointer;list-style:none;">▸</summary>
-        </details>
-      </td>
       <td><a href="https://kabutan.jp/stock/chart?code={{ row.code_s }}" target="_blank" rel="noopener noreferrer">{{ row.code_s }}</a></td>
       <td title="{{ row.stock_name }}"
           style="max-width:10em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
@@ -365,98 +403,75 @@
         {% endfor %}
       </td>
       <td style="{{ row.styles.rank or '' }}">{{ row.rank if row.rank is not none else "—" }}</td>
-      <td {% if row.gyoseki_tooltips.sales_growth %}title="{{ row.gyoseki_tooltips.sales_growth }}"{% endif %}
+      <td data-page="1" {% if row.gyoseki_tooltips.sales_growth %}title="{{ row.gyoseki_tooltips.sales_growth }}"{% endif %}
           style="{{ row.styles.sales_growth or '' }}">{{ row.sales_growth }}</td>
-      <td {% if row.gyoseki_tooltips.profit_growth %}title="{{ row.gyoseki_tooltips.profit_growth }}"{% endif %}
+      <td data-page="1" {% if row.gyoseki_tooltips.profit_growth %}title="{{ row.gyoseki_tooltips.profit_growth }}"{% endif %}
           style="{{ row.styles.profit_growth or '' }}">{{ row.profit_growth }}</td>
-      <td style="{{ row.styles.per or '' }}">{{ row.per }}</td>
-      <td style="{{ row.styles.theoretical_diff or '' }}">{{ row.theoretical_diff }}</td>
-      <td style="{{ row.styles.dividend or '' }}">{{ row.dividend }}</td>
-      <td>{{ row.quarter }}</td>
-      <td {% if row.gyoseki_tooltips.progress_diff %}title="{{ row.gyoseki_tooltips.progress_diff }}"{% endif %}
+      <td data-page="1" style="{{ row.styles.per or '' }}">{{ row.per }}</td>
+      <td data-page="1" style="{{ row.styles.theoretical_diff or '' }}">{{ row.theoretical_diff }}</td>
+      <td data-page="1" style="{{ row.styles.dividend or '' }}">{{ row.dividend }}</td>
+      <td data-page="1">{{ row.quarter }}</td>
+      <td data-page="1" {% if row.gyoseki_tooltips.progress_diff %}title="{{ row.gyoseki_tooltips.progress_diff }}"{% endif %}
           style="{{ row.styles.progress_diff or '' }}">{{ row.progress_diff }}</td>
-      <td data-style-field="kessanbi_md"
+      <td data-page="1" data-style-field="kessanbi_md"
           style="{{ row.styles.kessanbi_md or '' }}">{{ row.kessanbi_md }}</td>
-      <td title="クリックで編集 (M/D 形式)"
+      <td data-page="1" style="{{ row.styles.rs or '' }}">{{ row.rs }}</td>
+      {# issue #227: 株価 + RSライン 3点ミニチャート (旧 RSライン/株価向き 2列を統合) #}
+      <td data-page="1" title="{{ row.price_rs_chart.tooltip }}" style="padding:0 2px;line-height:0;">
+        {% if row.price_rs_chart.svg %}{{ row.price_rs_chart.svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
+      </td>
+      <td data-page="1" title="{{ row.trend_template_tooltip }}" style="width:40px;padding:0;line-height:0;text-align:center;{{ row.styles.trend_template or '' }}">
+        {% if row.kairi_gauge_svg %}{{ row.kairi_gauge_svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
+      </td>
+      <td data-page="1" title="{{ row.tags if row.tags != '—' else '' }}"
+          style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
+      <td data-page="1" title="{{ row.signal_full or '' }}"
+          style="max-width:3em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.signal or '' }}">{{ row.signal_mark }}</td>
+      <td data-page="1" class="spr-gauge-cell" title="{{ row.spr_gauge.tooltip }}">{{ row.spr_gauge.svg|safe }}</td>
+      <td data-page="1" style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
+      {# issue #327: ページ2 (手動入力)。更新日/ステージ/チャートパターンをページ1から移設 #}
+      <td data-page="2" title="クリックで編集 (M/D 形式)"
           data-style-field="last_research_update"
           {% if not fallback_mode %}class="editable" data-code="{{ row.code_s }}" data-field="last_research_update"{% endif %}
           style="{{ row.styles.last_research_update or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.last_research_update or "—" }}</td>
-      <td title="クリックで編集 (ステージ変更時は更新日も自動で当日に) / Ctrl+クリックで株探チャート"
+      <td data-page="2" title="クリックで編集 (ステージ変更時は更新日も自動で当日に) / Ctrl+クリックで株探チャート"
           data-style-field="stage"
           class="stage-cell{% if not fallback_mode %} editable{% endif %}"
           {% if not fallback_mode %}data-code="{{ row.code_s }}" data-field="stage" data-touch-update="1"{% endif %}
           style="{{ row.styles.stage or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.stage or "—" }}</td>
-      <td title="{{ ((row.memo.jukyu_chart or '') ~ ' (クリックで編集)') if (not fallback_mode and row.memo.jukyu_chart) else ('クリックで編集' if not fallback_mode else (row.memo.jukyu_chart or '')) }}"
+      <td data-page="2" title="{{ ((row.memo.jukyu_chart or '') ~ ' (クリックで編集)') if (not fallback_mode and row.memo.jukyu_chart) else ('クリックで編集' if not fallback_mode else (row.memo.jukyu_chart or '')) }}"
           data-full="{{ row.memo.jukyu_chart or '' }}"
           {% if not fallback_mode %}class="editable jukyu-cell" data-code="{{ row.code_s }}" data-field="jukyu_chart" data-multiline="1" data-input-width="8em"{% else %}class="jukyu-cell"{% endif %}
           style="{% if not fallback_mode %}cursor:pointer{% endif %}">{{ row.memo.jukyu_chart or "—" }}</td>
-      <td style="{{ row.styles.rs or '' }}">{{ row.rs }}</td>
-      {# issue #227: 株価 + RSライン 3点ミニチャート (旧 RSライン/株価向き 2列を統合) #}
-      <td title="{{ row.price_rs_chart.tooltip }}" style="padding:0 2px;line-height:0;">
-        {% if row.price_rs_chart.svg %}{{ row.price_rs_chart.svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
-      </td>
-      <td title="{{ row.trend_template_tooltip }}" style="width:40px;padding:0;line-height:0;text-align:center;{{ row.styles.trend_template or '' }}">
-        {% if row.kairi_gauge_svg %}{{ row.kairi_gauge_svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
-      </td>
-      <td title="{{ row.tags if row.tags != '—' else '' }}"
-          style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
-      <td title="{{ row.signal_full or '' }}"
-          style="max-width:3em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.signal or '' }}">{{ row.signal_mark }}</td>
-      <td class="spr-gauge-cell" title="{{ row.spr_gauge.tooltip }}">{{ row.spr_gauge.svg|safe }}</td>
-      <td style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
-    </tr>
-    <tr class="row-detail" id="detail-{{ row.code_s }}" style="display:none;">
-      {# 状態列 + 評価/需給列を含む全列に展開行を合わせる #}
-      <td colspan="{% if delete_mode_allowed %}26{% else %}25{% endif %}" style="background:#f8f8f8;padding:0.8em 1em;">
-        <div style="display:flex;flex-wrap:wrap;gap:0.8em;align-items:flex-start;">
-          {% if row.gyoseki.isKonki %}
-          <div style="flex:0 0 auto;">
-            <strong style="font-size:0.85em;color:#666;">今期</strong>
-          </div>
+      {# issue #327: 売買アイデア (定型リスト単一選択 + 色分けバッジ)。
+         リスト外の旧自由記述値は ⚠️ 付き option を差し込んで保持し、再分類を促す #}
+      {% set current_idea = row.memo.trade_idea or '' %}
+      <td data-page="2" style="padding:0 2px;">
+        <select class="trade-idea-select"
+                data-code="{{ row.code_s }}"
+                data-idea="{{ current_idea }}"
+                title="売買アイデア (選択で即保存)"
+                {% if fallback_mode %}disabled{% endif %}>
+          <option value="">未分類</option>
+          {% if current_idea and current_idea not in trade_idea_options %}
+          <option value="{{ current_idea }}" selected>⚠️ {{ current_idea }}</option>
           {% endif %}
-          <div style="flex:0 1 auto;min-width:300px;max-width:60em;">
-            <strong style="font-size:0.85em;color:#666;">手動メモ</strong>
-            {% if not fallback_mode %}
-            <form action="/portfolio/{{ row.code_s }}/memo" method="POST"
-                  style="display:grid;grid-template-columns:1fr 1fr;gap:0.6em 1em;margin:0.3em 0 0 0;font-size:0.95em;">
-              <input type="hidden" name="return_query" value="{{ return_query }}">
-              {# 業態・テーマ / 更新日 / ステージ は表内 inline 編集に移動 (issue #177)。
-                 需給チャート (チャートパターン列) も表内 inline 編集に移動 (issue #314) #}
-              {% for field, label in [
-                  ("watch_in_reason", "IN 理由"),
-                  ("inago_origin", "イナゴ元"),
-                  ("trade_idea", "売買アイデア"),
-                  ("takaichi_sensitivity", "高市感応度"),
-              ] %}
-              <label style="display:flex;flex-direction:column;gap:0.1em;margin:0;">
-                <span style="color:#666;">{{ label }}</span>
-                <textarea name="{{ field }}" rows="2"
-                          style="font-size:0.95em;padding:0.3em;margin:0;font-family:inherit;"
-                          >{{ row.memo[field] or "" }}</textarea>
-              </label>
-              {% endfor %}
-              <button type="submit"
-                      style="grid-column:1 / -1;justify-self:end;padding:0.3em 0.6em;font-size:0.95em;margin:0.2em 0 0 0;">
-                メモを保存
-              </button>
-            </form>
-            {% else %}
-            {# フォールバックモード時は読み取り専用表示を維持 #}
-            {% if row.memo.last_research_update %}
-            <span style="font-size:0.85em;color:#999;margin-left:0.5em;">調査更新日: {{ row.memo.last_research_update }}</span>
-            {% endif %}
-            <ul style="font-size:0.85em;margin:0.3em 0 0 1em;padding:0;">
-              <li><strong>IN 理由:</strong> {{ row.memo.watch_in_reason or "—" }}</li>
-              <li><strong>売買アイデア:</strong> {{ row.memo.trade_idea or "—" }}</li>
-              <li><strong>イナゴ元:</strong> {{ row.memo.inago_origin or "—" }}</li>
-              <li><strong>高市感応度:</strong> {{ row.memo.takaichi_sensitivity or "—" }}</li>
-              <li><strong>需給チャート:</strong> {{ row.memo.jukyu_chart or "—" }}</li>
-            </ul>
-            {% endif %}
-          </div>
-        </div>
+          {% for idea in trade_idea_options %}
+          <option value="{{ idea }}" {% if idea == current_idea %}selected{% endif %}>{{ idea }}</option>
+          {% endfor %}
+        </select>
       </td>
+      {# issue #327: イナゴ元 / IN理由 / 売買メモ (旧: 高市感応度) は短縮表示 + inline 編集 #}
+      {% for memo_field, input_width in [("inago_origin", "10em"), ("watch_in_reason", "14em"), ("takaichi_sensitivity", "14em")] %}
+      {% set memo_value = row.memo[memo_field] or '' %}
+      <td data-page="2"
+          title="{{ (memo_value ~ ' (クリックで編集)') if (not fallback_mode and memo_value) else ('クリックで編集' if not fallback_mode else memo_value) }}"
+          data-full="{{ memo_value }}"
+          {% if not fallback_mode %}class="editable memo-short-cell" data-code="{{ row.code_s }}" data-field="{{ memo_field }}" data-multiline="1" data-input-width="{{ input_width }}"{% else %}class="memo-short-cell"{% endif %}
+          style="{% if not fallback_mode %}cursor:pointer{% endif %}">{{ memo_value or "—" }}</td>
+      {% endfor %}
     </tr>
+    {# issue #327: 手動メモの展開パネルは廃止。全項目をページ2の列 (inline 編集) に移設 #}
     {% endfor %}
   </tbody>
 </table>
@@ -542,18 +557,16 @@
 </style>
 
 <script>
-// summary クリックで対応する .row-detail を展開
-document.querySelectorAll('table details').forEach(function(d) {
-  d.addEventListener('toggle', function() {
-    var row = d.closest('tr');
-    var nextRow = row.nextElementSibling;
-    if (nextRow && nextRow.classList.contains('row-detail')) {
-      nextRow.style.display = d.open ? '' : 'none';
-    }
-    var summary = d.querySelector('summary');
-    if (summary) summary.textContent = d.open ? '▾' : '▸';
+// ========== ページ切り替え (issue #327: 指標=自動算出 / メモ=手動入力) ==========
+(function() {
+  var buttons = document.querySelectorAll('.page-toggle button[data-page-btn]');
+  buttons.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.body.classList.toggle('portfolio-page-2', btn.dataset.pageBtn === '2');
+      buttons.forEach(function(b) { b.classList.toggle('active', b === btn); });
+    });
   });
-});
+})();
 
 {% if not fallback_mode %}
 // ========== 保有状態モーダル ==========
@@ -686,6 +699,9 @@ function excludeFromUniverse(codeS) {
   function renderPlain(td, value) {
     td.textContent = value || '—';
   }
+
+  // 短縮表示 (data-full 全文保持 + 1行省略) する memo フィールド (issue #314 / #327)
+  var SHORT_TEXT_FIELDS = ['jukyu_chart', 'inago_origin', 'watch_in_reason', 'takaichi_sensitivity'];
 
   function renderJukyu(td, value) {
     td.dataset.full = value || '';
@@ -848,7 +864,7 @@ function excludeFromUniverse(codeS) {
           alert('保存失敗: ' + (res.body && res.body.error || 'unknown'));
           // 元値で再描画
           if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
-          else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
+          else if (SHORT_TEXT_FIELDS.indexOf(field) !== -1) renderJukyu(td, currentValue);
           else renderPlain(td, currentValue);
           return;
         }
@@ -856,7 +872,7 @@ function excludeFromUniverse(codeS) {
         var disp = (res.body.display) || {};
         var displayValue = (disp[field] !== undefined) ? disp[field] : newValue;
         if (field === 'gyoutai_theme') renderGyoutaiTheme(td, displayValue);
-        else if (field === 'jukyu_chart') renderJukyu(td, displayValue);
+        else if (SHORT_TEXT_FIELDS.indexOf(field) !== -1) renderJukyu(td, displayValue);
         else renderPlain(td, displayValue);
 
         // ステージ編集時は同じ行の last_research_update セルも更新
@@ -876,7 +892,7 @@ function excludeFromUniverse(codeS) {
       }).catch(function(err) {
         alert('保存失敗: ' + err);
         if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
-        else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
+        else if (SHORT_TEXT_FIELDS.indexOf(field) !== -1) renderJukyu(td, currentValue);
         else renderPlain(td, currentValue);
       });
     }
@@ -886,7 +902,7 @@ function excludeFromUniverse(codeS) {
       finished = true;
       td.dataset.editing = '';
       if (field === 'gyoutai_theme') renderGyoutaiTheme(td, currentValue);
-      else if (field === 'jukyu_chart') renderJukyu(td, currentValue);
+      else if (SHORT_TEXT_FIELDS.indexOf(field) !== -1) renderJukyu(td, currentValue);
       else renderPlain(td, currentValue);
     }
 
@@ -971,6 +987,45 @@ function excludeFromUniverse(codeS) {
         if (!v) return;
         e.preventDefault();
         window.open('/portfolio?gyoutai_theme=' + encodeURIComponent(v), '_blank', 'noopener');
+      });
+    });
+  });
+})();
+
+// ========== 売買アイデア inline 編集 (issue #327) ==========
+// select の change で即 POST。保存成功で data-idea を更新しバッジ色を反映、失敗時は元値に戻す。
+(function() {
+  document.querySelectorAll('select.trade-idea-select').forEach(function(sel) {
+    if (sel.disabled) return;
+    sel.addEventListener('change', function() {
+      var code = sel.dataset.code;
+      var prev = sel.dataset.idea || '';
+      var fd = new FormData();
+      fd.append('trade_idea', sel.value);
+      sel.classList.add('saving');
+      sel.classList.remove('error');
+      fetch('/portfolio/' + encodeURIComponent(code) + '/memo', {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        body: fd,
+      }).then(function(r) {
+        return r.json().then(function(json) { return { ok: r.ok, json: json }; });
+      }).then(function(res) {
+        sel.classList.remove('saving');
+        if (!res.ok || !res.json || res.json.ok !== true) {
+          sel.classList.add('error');
+          sel.value = prev;
+          alert((res.json && res.json.error) || '売買アイデアの保存に失敗しました');
+          return;
+        }
+        var saved = (res.json.display && res.json.display.trade_idea) || '';
+        sel.dataset.idea = saved;
+        sel.value = saved;
+      }).catch(function(err) {
+        sel.classList.remove('saving');
+        sel.classList.add('error');
+        sel.value = prev;
+        alert('通信エラー: ' + err);
       });
     });
   });

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -402,8 +402,8 @@ class TestUpdateMemo:
 
     def test_update_single_field(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
-        rec = ps.update_memo("4377", {"trade_idea": "モメンタム"}, db_path=db_path)
-        assert rec["memo"]["trade_idea"] == "モメンタム"
+        rec = ps.update_memo("4377", {"trade_idea": "中期モメンタム"}, db_path=db_path)
+        assert rec["memo"]["trade_idea"] == "中期モメンタム"
         # action_log に "メモ更新" 1 件 (初回登録 1 件 + メモ更新 1 件 = 計 2 件)
         logs = ps.list_action_logs("4377", db_path=db_path)
         assert len(logs) == 2
@@ -445,7 +445,7 @@ class TestUpdateMemo:
         ps.add_to_watch("4377", db_path=db_path)
         ps.update_memo(
             "4377",
-            {"trade_idea": "テーマ", "watch_in_reason": "B", "stage": "1S"},
+            {"trade_idea": "中期テーマ", "watch_in_reason": "B", "stage": "1S"},
             db_path=db_path,
         )
         # 1 項目だけ送信、残りは据え置きされるべき
@@ -457,7 +457,7 @@ class TestUpdateMemo:
     def test_update_with_empty_string_overwrites(self, db_path):
         """空文字を明示的に渡したらメモ削除として "" に上書き"""
         ps.add_to_watch("4377", db_path=db_path)
-        ps.update_memo("4377", {"trade_idea": "モメンタム"}, db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "中期モメンタム"}, db_path=db_path)
         rec = ps.update_memo("4377", {"trade_idea": ""}, db_path=db_path)
         assert rec["memo"]["trade_idea"] == ""
         # action_log: 初回登録 + メモ更新×2 = 3 件
@@ -483,9 +483,9 @@ class TestUpdateMemo:
 
     def test_update_no_diff_is_noop(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
-        ps.update_memo("4377", {"trade_idea": "モメンタム"}, db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "中期モメンタム"}, db_path=db_path)
         rec_before = ps.get_record("4377", db_path=db_path)
-        ps.update_memo("4377", {"trade_idea": "モメンタム"}, db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "中期モメンタム"}, db_path=db_path)
         rec_after = ps.get_record("4377", db_path=db_path)
         # updated_at が変わらない (no-op)
         assert rec_before["updated_at"] == rec_after["updated_at"]

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -402,8 +402,8 @@ class TestUpdateMemo:
 
     def test_update_single_field(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
-        rec = ps.update_memo("4377", {"trade_idea": "上値追い"}, db_path=db_path)
-        assert rec["memo"]["trade_idea"] == "上値追い"
+        rec = ps.update_memo("4377", {"trade_idea": "モメンタム"}, db_path=db_path)
+        assert rec["memo"]["trade_idea"] == "モメンタム"
         # action_log に "メモ更新" 1 件 (初回登録 1 件 + メモ更新 1 件 = 計 2 件)
         logs = ps.list_action_logs("4377", db_path=db_path)
         assert len(logs) == 2
@@ -411,24 +411,53 @@ class TestUpdateMemo:
         assert logs[1]["status_from"] is None
         assert logs[1]["status_to"] is None
 
+    @pytest.mark.parametrize(
+        "current, new_value, expect_error",
+        [
+            # 定型リスト内の値は保存できる
+            ("", "GARP", False),
+            ("", "底値リバ", False),
+            # 空文字 (未分類) はいつでも許容
+            ("GARP", "", False),
+            # リスト外の純新規値は ValueError
+            ("", "押し目買い", True),
+            # リスト外でも現行値と同じなら保持を許可 (旧自由記述の救済)
+            ("押し目買い", "押し目買い", False),
+        ],
+    )
+    def test_trade_idea_options_validation(self, db_path, current, new_value, expect_error):
+        """trade_idea の定型値チェック (issue #327): リスト内/空は許容、リスト外新規は拒否、現行値は救済"""
+        ps.add_to_watch("4377", db_path=db_path)
+        if current:
+            # 旧自由記述値は移行 (create_record 直接格納) 相当として update_memo を通さず埋め込む
+            rec = ps.get_record("4377", db_path=db_path)
+            rec["memo"]["trade_idea"] = current
+            ps.upsert_record(rec, db_path=db_path)
+        if expect_error:
+            with pytest.raises(ValueError, match="定型リスト外"):
+                ps.update_memo("4377", {"trade_idea": new_value}, db_path=db_path)
+        else:
+            rec = ps.update_memo("4377", {"trade_idea": new_value}, db_path=db_path)
+            assert rec["memo"]["trade_idea"] == new_value
+
     def test_update_partial_keeps_other_fields(self, db_path):
         """部分更新: fields に含まれないキーは現行値据え置き (codex P1 対応)"""
         ps.add_to_watch("4377", db_path=db_path)
         ps.update_memo(
             "4377",
-            {"trade_idea": "A", "watch_in_reason": "B", "stage": "1S"},
+            {"trade_idea": "テーマ", "watch_in_reason": "B", "stage": "1S"},
             db_path=db_path,
         )
         # 1 項目だけ送信、残りは据え置きされるべき
-        rec = ps.update_memo("4377", {"trade_idea": "X"}, db_path=db_path)
-        assert rec["memo"]["trade_idea"] == "X"
+        rec = ps.update_memo("4377", {"trade_idea": "GARP"}, db_path=db_path)
+        assert rec["memo"]["trade_idea"] == "GARP"
         assert rec["memo"]["watch_in_reason"] == "B"  # 据え置き
         assert rec["memo"]["stage"] == "1S"           # 据え置き
 
     def test_update_with_empty_string_overwrites(self, db_path):
         """空文字を明示的に渡したらメモ削除として "" に上書き"""
         ps.add_to_watch("4377", db_path=db_path)
-        ps.update_memo("4377", {"trade_idea": "上値追い"}, db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "モメンタム"}, db_path=db_path)
         rec = ps.update_memo("4377", {"trade_idea": ""}, db_path=db_path)
         assert rec["memo"]["trade_idea"] == ""
         # action_log: 初回登録 + メモ更新×2 = 3 件
@@ -445,6 +474,7 @@ class TestUpdateMemo:
         # list 系フィールド (gyoutai_themes) は別バリデーション経路なのでこのテストでは除外
         str_fields = ps.MEMO_FIELDS - ps.MEMO_LIST_FIELDS
         all_fields = {f: f"val_{f}" for f in str_fields}
+        all_fields["trade_idea"] = "GARP"  # issue #327: trade_idea は定型値のみ許容
         rec = ps.update_memo("4377", all_fields, db_path=db_path)
         for k, v in all_fields.items():
             assert rec["memo"][k] == v
@@ -453,9 +483,9 @@ class TestUpdateMemo:
 
     def test_update_no_diff_is_noop(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
-        ps.update_memo("4377", {"trade_idea": "上値追い"}, db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "モメンタム"}, db_path=db_path)
         rec_before = ps.get_record("4377", db_path=db_path)
-        ps.update_memo("4377", {"trade_idea": "上値追い"}, db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "モメンタム"}, db_path=db_path)
         rec_after = ps.get_record("4377", db_path=db_path)
         # updated_at が変わらない (no-op)
         assert rec_before["updated_at"] == rec_after["updated_at"]
@@ -483,17 +513,17 @@ class TestUpdateMemo:
 
     def test_update_unregistered_record_raises(self, db_path):
         with pytest.raises(KeyError):
-            ps.update_memo("9999", {"trade_idea": "X"}, db_path=db_path)
+            ps.update_memo("9999", {"trade_idea": "GARP"}, db_path=db_path)
 
     def test_update_invalid_code_s_raises(self, db_path):
         with pytest.raises(ValueError):
-            ps.update_memo("abc", {"trade_idea": "X"}, db_path=db_path)
+            ps.update_memo("abc", {"trade_idea": "GARP"}, db_path=db_path)
 
     def test_update_normalizes_code_s(self, db_path):
         ps.add_to_watch("215A", db_path=db_path)
-        rec = ps.update_memo("215a", {"trade_idea": "X"}, db_path=db_path)
+        rec = ps.update_memo("215a", {"trade_idea": "GARP"}, db_path=db_path)
         assert rec["code_s"] == "215A"
-        assert rec["memo"]["trade_idea"] == "X"
+        assert rec["memo"]["trade_idea"] == "GARP"
 
 
 class TestGyoutaiThemesField:
@@ -532,12 +562,12 @@ class TestGyoutaiThemesField:
 
     def test_update_gyoutai_themes_partial_keeps_other_fields(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
-        ps.update_memo("4377", {"trade_idea": "X"}, db_path=db_path)
+        ps.update_memo("4377", {"trade_idea": "GARP"}, db_path=db_path)
         rec = ps.update_memo(
             "4377", {"gyoutai_themes": ["AI"]}, db_path=db_path
         )
         assert rec["memo"]["gyoutai_themes"] == ["AI"]
-        assert rec["memo"]["trade_idea"] == "X"
+        assert rec["memo"]["trade_idea"] == "GARP"
 
     def test_update_gyoutai_themes_rejects_non_list(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -192,10 +192,10 @@ class TestDashboardGet:
         resp = client.get("/portfolio?status=hold")
         html = resp.data.decode()
 
-        assert "<th>評価</th>" in html
-        # issue #327: チャートパターンはページ2 (手動入力) 列へ移設
+        # issue #327: 評価は指標ページ (ページ1) のみ、チャートパターンはページ2へ移設
+        assert '<th data-page="1">評価</th>' in html
         assert '<th data-page="2">チャートパターン</th>' in html
-        assert '<td class="rating-cell" style="background:#fbbc04">S</td>' in html
+        assert '<td data-page="1" class="rating-cell" style="background:#fbbc04">S</td>' in html
         assert 'data-field="jukyu_chart"' in html
         assert 'data-multiline="1"' in html
         assert "月足低位ブレイク" in html

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -616,13 +616,13 @@ class TestUpdateMemoPost:
         # 3 項目だけ送信 (form に他のキーを含めない)
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "テーマ", "watch_in_reason": "Y2", "stage": "2S"},
+            data={"trade_idea": "中期テーマ", "watch_in_reason": "Y2", "stage": "2S"},
         )
         assert resp.status_code == 302
 
         rec = ps.get_record("6324", db_path=portfolio_db_path)
         # 送られた 3 項目は更新
-        assert rec["memo"]["trade_idea"] == "テーマ"
+        assert rec["memo"]["trade_idea"] == "中期テーマ"
         assert rec["memo"]["watch_in_reason"] == "Y2"
         assert rec["memo"]["stage"] == "2S"
         # 送られなかった 2 項目は据え置き

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -193,7 +193,8 @@ class TestDashboardGet:
         html = resp.data.decode()
 
         assert "<th>評価</th>" in html
-        assert "<th>チャートパターン</th>" in html
+        # issue #327: チャートパターンはページ2 (手動入力) 列へ移設
+        assert '<th data-page="2">チャートパターン</th>' in html
         assert '<td class="rating-cell" style="background:#fbbc04">S</td>' in html
         assert 'data-field="jukyu_chart"' in html
         assert 'data-multiline="1"' in html
@@ -580,6 +581,7 @@ class TestUpdateMemoPost:
         # list 系フィールド (gyoutai_themes) は別 form name (gyoutai_themes_0/1) のため除外
         str_fields = ps.MEMO_FIELDS - ps.MEMO_LIST_FIELDS
         form_data = {field: f"val_{field}" for field in str_fields}
+        form_data["trade_idea"] = "GARP"  # issue #327: trade_idea は定型値のみ許容
         resp = client.post("/portfolio/6324/memo", data=form_data)
         assert resp.status_code == 302
         rec = ps.get_record("6324", db_path=portfolio_db_path)
@@ -593,7 +595,7 @@ class TestUpdateMemoPost:
         """メモ保存後、銘柄コードリンク付きの完了メッセージを表示する"""
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "X"},
+            data={"trade_idea": "GARP"},
             follow_redirects=True,
         )
         html = resp.data.decode()
@@ -603,7 +605,7 @@ class TestUpdateMemoPost:
         """部分送信: 送られたキーだけ更新、未送信フィールドは現行値据え置き (codex P1)"""
         # 事前に 5 項目をセット
         prefilled = {
-            "trade_idea": "X",
+            "trade_idea": "GARP",
             "watch_in_reason": "Y",
             "stage": "1S",
             "inago_origin": "twitter",
@@ -614,13 +616,13 @@ class TestUpdateMemoPost:
         # 3 項目だけ送信 (form に他のキーを含めない)
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "X2", "watch_in_reason": "Y2", "stage": "2S"},
+            data={"trade_idea": "テーマ", "watch_in_reason": "Y2", "stage": "2S"},
         )
         assert resp.status_code == 302
 
         rec = ps.get_record("6324", db_path=portfolio_db_path)
         # 送られた 3 項目は更新
-        assert rec["memo"]["trade_idea"] == "X2"
+        assert rec["memo"]["trade_idea"] == "テーマ"
         assert rec["memo"]["watch_in_reason"] == "Y2"
         assert rec["memo"]["stage"] == "2S"
         # 送られなかった 2 項目は据え置き
@@ -629,7 +631,7 @@ class TestUpdateMemoPost:
 
     def test_memo_empty_string_overwrites(self, client, portfolio_db_path):
         """空文字を明示送信したら "" に上書き (メモ削除扱い)"""
-        ps.update_memo("6324", {"trade_idea": "X"}, db_path=portfolio_db_path)
+        ps.update_memo("6324", {"trade_idea": "GARP"}, db_path=portfolio_db_path)
         resp = client.post(
             "/portfolio/6324/memo",
             data={"trade_idea": ""},
@@ -640,12 +642,12 @@ class TestUpdateMemoPost:
 
     def test_memo_no_diff_no_action_log(self, client, portfolio_db_path):
         """全項目を現行値そのまま送ったら action_log は増えない"""
-        ps.update_memo("6324", {"trade_idea": "X"}, db_path=portfolio_db_path)
+        ps.update_memo("6324", {"trade_idea": "GARP"}, db_path=portfolio_db_path)
         before_logs = ps.list_action_logs("6324", db_path=portfolio_db_path)
 
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "X"},  # 現行値と同じ
+            data={"trade_idea": "GARP"},  # 現行値と同じ
         )
         assert resp.status_code == 302
         after_logs = ps.list_action_logs("6324", db_path=portfolio_db_path)
@@ -654,7 +656,7 @@ class TestUpdateMemoPost:
     def test_memo_unregistered_code_flash_error(self, client, portfolio_db_path):
         resp = client.post(
             "/portfolio/9999/memo",
-            data={"trade_idea": "X"},
+            data={"trade_idea": "GARP"},
         )
         assert resp.status_code == 302
         assert ps.get_record("9999", db_path=portfolio_db_path) is None
@@ -662,7 +664,7 @@ class TestUpdateMemoPost:
     def test_memo_invalid_code_flash_error(self, client):
         resp = client.post(
             "/portfolio/abc/memo",
-            data={"trade_idea": "X"},
+            data={"trade_idea": "GARP"},
         )
         assert resp.status_code == 302
 
@@ -670,22 +672,22 @@ class TestUpdateMemoPost:
         """textarea の改行 \\r\\n は \\n に正規化される"""
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "上値追い\r\n決算待ち\r\n"},
+            data={"watch_in_reason": "上値追い\r\n決算待ち\r\n"},
         )
         assert resp.status_code == 302
         rec = ps.get_record("6324", db_path=portfolio_db_path)
         # 前後 strip + \r\n → \n 正規化
-        assert rec["memo"]["trade_idea"] == "上値追い\n決算待ち"
+        assert rec["memo"]["watch_in_reason"] == "上値追い\n決算待ち"
 
     def test_memo_unknown_form_field_ignored(self, client, portfolio_db_path):
         """MEMO_FIELDS 外のフォームキーは無視され、エラーにならない"""
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "X", "csrf_token": "dummy", "garbage": "ignored"},
+            data={"trade_idea": "GARP", "csrf_token": "dummy", "garbage": "ignored"},
         )
         assert resp.status_code == 302
         rec = ps.get_record("6324", db_path=portfolio_db_path)
-        assert rec["memo"]["trade_idea"] == "X"
+        assert rec["memo"]["trade_idea"] == "GARP"
         assert "csrf_token" not in rec["memo"]
         assert "garbage" not in rec["memo"]
 
@@ -744,6 +746,25 @@ class TestUpdateMemoAjax:
 
         rec = ps.get_record("6324", db_path=portfolio_db_path)
         assert rec["memo"]["jukyu_chart"] == "月足低位ブレイク\nCWH"
+
+    def test_ajax_display_includes_page2_memo_fields(self, client, portfolio_db_path):
+        """issue #327: ページ2列の inline 編集同期用に display へ 4 フィールドを含める"""
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={
+                "trade_idea": "GARP",
+                "watch_in_reason": "新製品サイクル",
+                "inago_origin": "X@foo",
+                "takaichi_sensitivity": "決算前に半分利確",
+            },
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["display"]["trade_idea"] == "GARP"
+        assert body["display"]["watch_in_reason"] == "新製品サイクル"
+        assert body["display"]["inago_origin"] == "X@foo"
+        assert body["display"]["takaichi_sensitivity"] == "決算前に半分利確"
 
     def test_ajax_unknown_code_returns_404_json(self, client):
         resp = client.post(
@@ -828,13 +849,13 @@ class TestGyoutaiThemesPost:
         )
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "X"},
+            data={"trade_idea": "GARP"},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
         assert resp.status_code == 200
         rec = ps.get_record("6324", db_path=portfolio_db_path)
         assert rec["memo"]["gyoutai_themes"] == ["既存"]
-        assert rec["memo"]["trade_idea"] == "X"
+        assert rec["memo"]["trade_idea"] == "GARP"
 
     def test_dashboard_renders_theme_select_options(self, client, portfolio_db_path):
         """issue #282: テーママスターの name がフィルタ select / 行 select の選択肢として出る"""
@@ -978,7 +999,7 @@ class TestFallbackFromTxt:
         """フォールバック中は /portfolio/<code>/memo も reject (issue #175)"""
         portfolio_db_path = str(tmp_path / "test_portfolio_shelve")
         resp = fallback_client.post(
-            "/portfolio/3496/memo", data={"trade_idea": "X"}
+            "/portfolio/3496/memo", data={"trade_idea": "GARP"}
         )
         assert resp.status_code == 302
         # shelve は空のまま (memo 更新で 1 件作られたら fallback 解除事故が起きる)
@@ -1148,7 +1169,7 @@ class TestReturnQueryRedirect:
         """memo POST 時、return_query が反映される"""
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"trade_idea": "X", "return_query": "status=watch"},
+            data={"trade_idea": "GARP", "return_query": "status=watch"},
         )
         assert resp.status_code == 302
         loc = resp.headers["Location"]


### PR DESCRIPTION
## 概要

issue #327 対応。portfolio一覧の列を「指標 (自動算出 / code_rank由来)」と「メモ (手動入力)」の2ページに分割し、JSトグルで切り替える構成にした。売買アイデアは定型リスト単一選択式に変更し、色分けバッジで一覧表示する。

実装プラン (codexレビュー済み): `doc/plans/issue327_portfolio_2page.md`

## 変更内容

### 売買アイデアの定型リスト化
- `TRADE_IDEA_OPTIONS` (GARP / テーマ / イベント・カタリスト / モメンタム / 底値リバ) を `portfolio_shelve.py` に定義
- `update_memo()` でリスト外の純新規値は ValueError。**現行レコードに既にある値は保持を許可**（旧自由記述の救済）
- CSV 移行 (`create_record` 経由) は定型チェックを通らないため過去データはそのまま移行可能
- リスト外の既存値は select に `⚠️ 値` option を差し込んで表示し、未分類（警告色）バッジで手動再分類を促す

### 一覧の2ページ化
- 各 th/td に `data-page="1"|"2"` を付与し CSS + body class で表示切替（テーブルは1つのまま、データ取得1回）
- ヘッダに「指標 / メモ」トグルボタン。デフォルトはページ1（指標）
- 更新日・ステージ・チャートパターンをページ2へ移設
- ページ2に新列: 売買アイデア（select + 色分けバッジ）/ イナゴ元 / IN理由 / 売買メモ（短縮表示 + クリックで inline 編集）
- 手動メモの展開パネル（行頭 ▸）は撤去（全項目がページ2の列に移ったため）

### その他
- 「高市感応度」のUIラベルを「売買メモ」に変更（DBキー `takaichi_sensitivity` は維持、マイグレーション不要）
- AJAX 応答の `display` に trade_idea / watch_in_reason / inago_origin / takaichi_sensitivity を追加（保存後の表示同期用）

## テスト

- `pytest tests/test_portfolio_shelve.py tests/test_webapp_portfolio_routes.py tests/test_migrate_portfolio_from_csv.py` → **232 passed**
- `pytest tests/test_webapp_routes.py` → **100 passed**
- 追加: trade_idea バリデーションの parametrize テスト、AJAX display 契約テスト
- 既存テストの自由記述 trade_idea 値を定型値へ更新（CRLF 正規化テストは watch_in_reason に変更して意図を維持）

## ブラウザ検証 (Playwright)

- 指標⇄メモのページトグル切替
- 売買アイデアバッジ色（定型値ごとの固定色、未分類=警告色、リスト外=⚠️表示）
- select 変更 → AJAX 保存 → バッジ即時反映（実データ 285A で保存→復元を確認）
- IN理由のクリック編集 → Esc キャンセル

## スコープ外（issue 記載どおり）

- 戦略ミックスサマリー
- 売買アイデアの時間軸属性（#326 連携で別途）
- ページ2デフォルト表示

関連: #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)