### PR TITLE
feat(webapp): 四季報コメント順次更新ページを追加 (#313)

### DIFF
--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -21,6 +21,7 @@ from flask import Blueprint, flash, jsonify, redirect, render_template, request,
 
 import portfolio
 import portfolio_shelve as ps
+import research_shelve
 from webapp.helpers import (
     THEME_SUMMARY_SORT_FIELDS,
     build_portfolio_theme_summary,
@@ -724,6 +725,100 @@ def charts():
         active_status_query=active_status_query,
         active_gyoutai_theme=active_gyoutai_theme or "",
     )
+
+
+@portfolio_bp.route("/portfolio/shikiho")
+def shikiho_page():
+    """四季報コメント順次更新ページ (issue #313)。
+
+    /portfolio/charts と同じ status / gyoutai_theme フィルタ・業態順で銘柄を抽出し、
+    四季報フォーム1セットをクライアント側で銘柄切替する。四季報本体は切替時に
+    都度 AJAX 取得 (GET /portfolio/shikiho/<code_s>/data) するため、ここでは
+    銘柄リストと「今号入力済みか」フラグだけを渡す。research 未登録銘柄は
+    保存 (save_shikiho) が失敗するため対象から除外する。
+    """
+    active_status = _parse_status_filter(request.args)
+    active_gyoutai_theme = _parse_gyoutai_theme(request.args)
+
+    # 銘柄抽出は charts() と同一規則 (issue #186 fallback / issue #215 フィルタ)。
+    all_records_inc = ps.list_records(include_excluded=True)
+    if not all_records_inc:
+        visible_records = _build_fallback_records()
+    else:
+        visible_records = [r for r in all_records_inc if not r.get("excluded", False)]
+
+    if active_gyoutai_theme:
+        filtered_records = [
+            r for r in visible_records
+            if active_gyoutai_theme in ((r.get("memo") or {}).get("gyoutai_themes") or [])
+        ]
+    elif active_status is None:
+        filtered_records = visible_records
+    else:
+        filtered_records = [r for r in visible_records if r.get("status") == active_status]
+    rows = list_portfolio_with_indicators(filtered_records, sort_key="gyoutai")
+
+    current_period = research_shelve.current_shikiho_period()
+    # research 全件を1回の open で dict 化 (318銘柄ぶんの open/close を回避)。
+    all_research = {r["code_s"]: r for r in research_shelve.list_research_records()}
+
+    stocks = []
+    done_count = 0
+    for r in rows:
+        code_s = r["code_s"]
+        rec = all_research.get(code_s)
+        if rec is None:
+            continue  # research 未登録は save_shikiho が失敗するため対象外
+        # list_research_records() は正規化を通さないため、旧形式 (str要素) 混在に備えて正規化。
+        comments = research_shelve._normalize_shikiho_comments(rec.get("shikiho_comments") or [])
+        has_current = any(
+            (c.get("period") or "").strip() == current_period
+            and (c.get("comment") or "").strip()
+            for c in comments
+        )
+        if has_current:
+            done_count += 1
+        stocks.append({
+            "code_s": code_s,
+            "stock_name": r.get("stock_name") or "",
+            "has_current": has_current,
+        })
+
+    active_status_query = (
+        STATUS_VALUE_TO_QUERY[active_status] if active_status in STATUS_VALUE_TO_QUERY else ""
+    )
+    return render_template(
+        "portfolio_shikiho.html",
+        stocks=stocks,
+        total=len(stocks),
+        done_count=done_count,
+        current_period=current_period,
+        active_status_query=active_status_query,
+        active_gyoutai_theme=active_gyoutai_theme or "",
+    )
+
+
+@portfolio_bp.route("/portfolio/shikiho/<code_s>/data")
+def shikiho_data(code_s):
+    """四季報順次更新ページの1銘柄ぶん軽量データ (issue #313)。
+
+    overview + shikiho_comments (降順) を JSON で返す。get_research_record() は
+    正規化済みを返すので _normalize は不要。get_research_detail() は post_price_changes
+    バックフィル等が走るため使わない。shikiho_page が未登録を除外するため通常
+    404 には到達しないが、防御的に残す。
+    """
+    rec = research_shelve.get_research_record(code_s)
+    if rec is None:
+        return jsonify({"ok": False, "error": "not found"}), 404
+    comments = research_shelve.sort_shikiho_comments_desc(rec.get("shikiho_comments") or [])
+    return jsonify({
+        "ok": True,
+        "overview": rec.get("overview") or "",
+        "shikiho_comments": [
+            {"period": c.get("period") or "", "comment": c.get("comment") or ""}
+            for c in comments
+        ],
+    })
 
 
 # ===========================================

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -225,6 +225,9 @@
   <a href="{{ url_for('portfolio.charts') }}?status={{ active_status_query }}{% if active_gyoutai_theme %}&gyoutai_theme={{ active_gyoutai_theme|urlencode }}{% endif %}"
      style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
      title="現在のフィルタ結果をチャート一覧で確認">📊 チャート一覧</a>
+  <a href="{{ url_for('portfolio.shikiho_page') }}?status={{ active_status_query }}{% if active_gyoutai_theme %}&gyoutai_theme={{ active_gyoutai_theme|urlencode }}{% endif %}"
+     style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
+     title="四季報コメントを順次更新">📝 四季報更新</a>
 </form>
 
 <p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">

--- a/scripts/webapp/templates/portfolio_shikiho.html
+++ b/scripts/webapp/templates/portfolio_shikiho.html
@@ -1,0 +1,291 @@
+{% extends "base.html" %}
+{% block title %}四季報順次更新 - Shintakane Research{% endblock %}
+
+{% block content %}
+{# issue #313: portfolio 銘柄の四季報コメントを 1 銘柄ずつ順次更新する専用ページ。
+   銘柄切替・AJAX 取得・自動保存はこのページ内の専用 JS で完結 (app.js の四季報 JS は
+   銘柄切替と相性が悪いため再利用しない)。四季報本体は切替時に都度 GET で取得 (方式b)。 #}
+<style>
+  .sk-bar {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 0.9em;
+    padding: 0.4em 0.6em; margin-bottom: 0.5em;
+    background: #f5f7fa; border: 1px solid #d8dee6; border-radius: 4px;
+    font-size: 0.9em;
+  }
+  .sk-bar .nav-btn {
+    padding: 0.2em 0.8em; font-size: 0.9em; border: 1px solid #bbb;
+    background: #fff; color: #333; border-radius: 3px; cursor: pointer;
+  }
+  .sk-progress { color: #555; }
+  .sk-count { color: #555; }
+  .sk-header { margin-bottom: 0.6em; font-size: 1.05em; }
+  .sk-header .name { font-weight: 600; color: #222; text-decoration: none; }
+  .sk-header .name:hover { text-decoration: underline; }
+  .sk-header .kabu { color: #555; font-size: 0.85em; text-decoration: none; margin-left: 0.6em; }
+  .sk-header .done-mark { color: #1a3; font-weight: 700; margin-left: 0.5em; }
+  .memo-field { margin-bottom: 0.8em; }
+  .memo-field label { display: block; font-size: 0.85em; color: #555; margin-bottom: 0.2em; }
+  .shikiho-entry { display: flex; align-items: start; gap: 0.3em; margin-bottom: 0.3em; }
+  .shikiho-entry .period { font-size: 0.8em; color: #888; min-width: 3em; padding-top: 0.6em; }
+</style>
+
+<div style="margin-bottom:0.4em;">
+  <a href="{{ url_for('portfolio.dashboard') }}?status={{ active_status_query }}{% if active_gyoutai_theme %}&gyoutai_theme={{ active_gyoutai_theme|urlencode }}{% endif %}"
+     style="font-size:0.85em;color:#555;text-decoration:none;">← 保有銘柄ダッシュボードに戻る</a>
+</div>
+
+{% if total == 0 %}
+<p style="padding:1em;color:#666;">対象銘柄なし</p>
+{% else %}
+<div class="sk-bar">
+  <span class="sk-progress">今号({{ current_period }})入力済 <span id="done-count">{{ done_count }}</span> / {{ total }}</span>
+  <label style="cursor:pointer;"><input type="checkbox" id="filter-todo"> 今号未入力のみ</label>
+  <span>
+    <button type="button" class="nav-btn" id="prev-btn">← 前</button>
+    <button type="button" class="nav-btn" id="next-btn">次 →</button>
+  </span>
+  <span class="sk-count" id="nav-count"></span>
+</div>
+
+<div class="sk-header">
+  <a class="name" id="sk-name" target="_blank" rel="noopener"></a>
+  <a class="kabu" id="sk-kabu" target="_blank" rel="noopener">株探</a>
+  <span class="done-mark" id="sk-done" style="display:none;">✓ 今号入力済</span>
+</div>
+
+<form id="shikiho-form" action="" method="post">
+  <div class="memo-field">
+    <label>企業概要</label>
+    <textarea id="sk-overview" name="overview" rows="3"></textarea>
+  </div>
+  <div class="memo-field">
+    <label>四季報コメント (<span id="shikiho-count">0</span>/8件)</label>
+    <div id="shikiho-edit-area"></div>
+    <button type="button" id="btn-add-shikiho" class="outline"
+            style="margin-top:0.3em;padding:0.2em 0.8em;font-size:0.85em;">+ 追加</button>
+  </div>
+</form>
+
+<script>
+  (function () {
+    var STOCKS = {{ stocks|tojson }};
+    var CURRENT_PERIOD = {{ current_period|tojson }};
+    var MAX_SHIKIHO = 8;
+
+    var form = document.getElementById('shikiho-form');
+    var overviewEl = document.getElementById('sk-overview');
+    var editArea = document.getElementById('shikiho-edit-area');
+    var countEl = document.getElementById('shikiho-count');
+    var nameLink = document.getElementById('sk-name');
+    var kabuLink = document.getElementById('sk-kabu');
+    var doneMark = document.getElementById('sk-done');
+    var navCountEl = document.getElementById('nav-count');
+    var doneCountEl = document.getElementById('done-count');
+    var filterToggle = document.getElementById('filter-todo');
+
+    // navIds: トグル切替時に確定する固定スナップショット (保存では作り直さない)。
+    var navIds = STOCKS.map(function (s) { return s.code_s; });
+    var pos = 0;
+    var loadedSnapshot = '';  // 直近 renderForm 時のフォーム値 (dirty 判定用)
+    var saveChain = Promise.resolve();  // 保存の直列化
+
+    function byCode(code) {
+      return STOCKS.filter(function (s) { return s.code_s === code; })[0];
+    }
+
+    // 四季報行を 1 つ生成 (period span + hidden + textarea)。
+    function makeEntry(idx, period, comment) {
+      var div = document.createElement('div');
+      div.className = 'shikiho-entry';
+      var span = document.createElement('span');
+      span.className = 'period';
+      span.textContent = period || '-';
+      var hidden = document.createElement('input');
+      hidden.type = 'hidden';
+      hidden.name = 'shikiho_periods_' + idx;
+      hidden.value = period || '';
+      var ta = document.createElement('textarea');
+      ta.name = 'shikiho_comments_' + idx;
+      ta.rows = 4;
+      ta.style.flex = '1';
+      ta.value = comment || '';
+      div.appendChild(span);
+      div.appendChild(hidden);
+      div.appendChild(ta);
+      return div;
+    }
+
+    function updateCount() {
+      countEl.textContent = editArea.querySelectorAll('.shikiho-entry').length;
+    }
+
+    // フォーム値を 1 本の文字列に直列化 (dirty 判定用)。
+    function serializeForm() {
+      var parts = [overviewEl.value];
+      editArea.querySelectorAll('.shikiho-entry').forEach(function (e) {
+        var p = e.querySelector('input[type=hidden]').value;
+        var c = e.querySelector('textarea').value;
+        parts.push(p + '' + c);
+      });
+      return parts.join('');
+    }
+
+    function isDirty() {
+      return serializeForm() !== loadedSnapshot;
+    }
+
+    // 現在のフォーム内容から「今号の非空コメント有無」を判定。
+    function formHasCurrent() {
+      var entries = editArea.querySelectorAll('.shikiho-entry');
+      for (var i = 0; i < entries.length; i++) {
+        var p = entries[i].querySelector('input[type=hidden]').value.trim();
+        var c = entries[i].querySelector('textarea').value.trim();
+        if (p === CURRENT_PERIOD && c) return true;
+      }
+      return false;
+    }
+
+    function refreshDoneCount() {
+      var done = STOCKS.filter(function (s) { return s.has_current; }).length;
+      doneCountEl.textContent = done;
+    }
+
+    function setDoneMark(has) {
+      doneMark.style.display = has ? '' : 'none';
+    }
+
+    // 1 銘柄ぶんの四季報を AJAX 取得してフォームを再構築。
+    function renderForm(code) {
+      var s = byCode(code);
+      var enc = encodeURIComponent(code);
+      nameLink.textContent = code + (s ? ' ' + s.stock_name : '');
+      nameLink.href = '/stock/' + enc;
+      kabuLink.href = 'https://kabutan.jp/stock/chart?code=' + enc;
+      form.action = '/stock/' + enc + '/shikiho';
+      navCountEl.textContent = (pos + 1) + ' / ' + navIds.length;
+
+      return fetch('/portfolio/shikiho/' + enc + '/data')
+        .then(function (resp) { return resp.json(); })
+        .then(function (body) {
+          if (!body || body.ok !== true) {
+            overviewEl.value = '';
+            editArea.innerHTML = '';
+            updateCount();
+            loadedSnapshot = serializeForm();
+            return;
+          }
+          overviewEl.value = body.overview || '';
+          editArea.innerHTML = '';
+          (body.shikiho_comments || []).forEach(function (item, i) {
+            editArea.appendChild(makeEntry(i, item.period, item.comment));
+          });
+          updateCount();
+          loadedSnapshot = serializeForm();
+          setDoneMark(s ? s.has_current : false);
+        });
+    }
+
+    // 行追加 (period は今号を自動付与)。8 件超は末尾 (最古) を削除してから追加。
+    function addEntry() {
+      var entries = editArea.querySelectorAll('.shikiho-entry');
+      if (entries.length >= MAX_SHIKIHO) {
+        entries[entries.length - 1].remove();
+      }
+      var idx = editArea.querySelectorAll('.shikiho-entry').length;
+      var div = makeEntry(idx, CURRENT_PERIOD, '');
+      editArea.appendChild(div);
+      // name の index を振り直す (途中削除でズレないように)
+      reindex();
+      updateCount();
+      div.querySelector('textarea').focus();
+    }
+
+    // 各行の name index を 0..n に振り直す。
+    function reindex() {
+      editArea.querySelectorAll('.shikiho-entry').forEach(function (e, i) {
+        e.querySelector('input[type=hidden]').name = 'shikiho_periods_' + i;
+        e.querySelector('textarea').name = 'shikiho_comments_' + i;
+      });
+    }
+
+    // dirty があれば現フォームを POST。保存後にローカル has_current / 進捗を更新。Promise を返す。
+    function flushSave() {
+      if (!isDirty()) return Promise.resolve();
+      var code = (byCode(navIds[pos]) || {}).code_s || navIds[pos];
+      var fd = new FormData(form);
+      saveChain = saveChain.then(function () {
+        return fetch(form.action, { method: 'POST', body: fd }).then(function (resp) {
+          if (!resp.ok) return;
+          var s = byCode(code);
+          if (s) s.has_current = formHasCurrent();
+          loadedSnapshot = serializeForm();
+          refreshDoneCount();
+          setDoneMark(s ? s.has_current : false);
+        });
+      }).catch(function () { /* ネットワークエラーでもキュー継続 */ });
+      return saveChain;
+    }
+
+    function goPrev() {
+      if (pos <= 0) return;
+      flushSave().then(function () { pos--; renderForm(navIds[pos]); });
+    }
+    function goNext() {
+      if (pos >= navIds.length - 1) return;
+      flushSave().then(function () { pos++; renderForm(navIds[pos]); });
+    }
+
+    // トグル切替: 保存 flush → navIds をスナップショット再構築 → 先頭へ。
+    function applyFilter() {
+      flushSave().then(function () {
+        if (filterToggle.checked) {
+          navIds = STOCKS.filter(function (s) { return !s.has_current; })
+                         .map(function (s) { return s.code_s; });
+        } else {
+          navIds = STOCKS.map(function (s) { return s.code_s; });
+        }
+        pos = 0;
+        if (navIds.length === 0) {
+          nameLink.textContent = '今号未入力の銘柄なし';
+          nameLink.removeAttribute('href');
+          kabuLink.removeAttribute('href');
+          form.action = '';
+          overviewEl.value = '';
+          editArea.innerHTML = '';
+          updateCount();
+          navCountEl.textContent = '0 / 0';
+          setDoneMark(false);
+          loadedSnapshot = serializeForm();
+          return;
+        }
+        renderForm(navIds[pos]);
+      });
+    }
+
+    document.getElementById('prev-btn').addEventListener('click', goPrev);
+    document.getElementById('next-btn').addEventListener('click', goNext);
+    document.getElementById('btn-add-shikiho').addEventListener('click', addEntry);
+    filterToggle.addEventListener('change', applyFilter);
+
+    // キーボード: ← / → (k / j)。入力欄フォーカス中は無効。
+    document.addEventListener('keydown', function (e) {
+      var el = document.activeElement;
+      if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT')) {
+        return;
+      }
+      if (e.key === 'ArrowLeft' || e.key === 'k' || e.key === 'K') { e.preventDefault(); goPrev(); }
+      else if (e.key === 'ArrowRight' || e.key === 'j' || e.key === 'J') { e.preventDefault(); goNext(); }
+    });
+
+    // ページ離脱時、未保存なら sendBeacon でベストエフォート保存。
+    window.addEventListener('beforeunload', function () {
+      if (isDirty() && form.action) {
+        navigator.sendBeacon(form.action, new FormData(form));
+      }
+    });
+
+    renderForm(navIds[pos]);
+  })();
+</script>
+{% endif %}
+{% endblock %}

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1542,3 +1542,65 @@ class TestSuggestThemes:
         ps.update_memo("3496", {"gyoutai_themes": ["不動産"]})
         resp = suggest_app.test_client().post("/stock/3496/suggest_themes")
         assert resp.status_code == 409
+
+
+# ==================================================
+# /portfolio/shikiho (issue #313)
+# ==================================================
+class TestPortfolioShikihoRoute:
+    """四季報順次更新ページ (一覧ルート + 軽量 data エンドポイント) の統合テスト"""
+
+    @pytest.fixture
+    def shikiho_app(self, db_path, tmp_path, monkeypatch):
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+
+        period = rs.current_shikiho_period()
+        # 3496: 今号コメントあり (=入力済み)。9999: research 未登録 (portfolio のみ)。
+        rec = rs.create_research_record(
+            "3496", "アズーム", overall_rating="A",
+            overview="駐車場サブリース",
+            shikiho_comments=[
+                {"period": "25.12", "comment": "旧号コメント"},
+                {"period": period, "comment": "今号コメント"},
+            ],
+        )
+        rs.upsert_research_record(rec, db_path=db_path)
+        # _parse_status_filter は status 未指定時に保有 (1保) をデフォルトにするため、
+        # charts() と同じく ?status= (空="すべて") を付けてテストする。両銘柄は 3監 のまま。
+        ps.add_to_watch("3496", reason="テスト", db_path=portfolio_db)
+        ps.add_to_watch("9999", reason="未登録テスト", db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        return app
+
+    def test_shikiho_page_renders_with_progress(self, shikiho_app):
+        period = rs.current_shikiho_period()
+        resp = shikiho_app.test_client().get("/portfolio/shikiho?status=")
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert period in html  # 今号 period 表示
+        # research 登録済みの 3496 は対象、未登録の 9999 は除外される
+        assert "3496" in html
+        # done_count=1 (3496 が今号入力済み)、total=1 (9999 除外)
+        assert '<span id="done-count">1</span> / 1' in html
+
+    def test_shikiho_data_returns_overview_and_comments(self, shikiho_app):
+        period = rs.current_shikiho_period()
+        resp = shikiho_app.test_client().get("/portfolio/shikiho/3496/data")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["overview"] == "駐車場サブリース"
+        # 降順 (新しい period が先頭)
+        assert body["shikiho_comments"][0]["period"] == period
+
+    def test_shikiho_data_404_for_unregistered(self, shikiho_app):
+        resp = shikiho_app.test_client().get("/portfolio/shikiho/9999/data")
+        assert resp.status_code == 404
+        assert resp.get_json()["ok"] is False


### PR DESCRIPTION
## 概要

四季報の発売に合わせて portfolio 銘柄の四季報コメントを順次更新する作業を効率化する専用ページ `/portfolio/shikiho` を新設。`/portfolio/charts` のイメージで、四季報フォーム(企業概要 + コメント)だけに特化し、1 銘柄ずつクライアント側で切替してサーバ往復を最小化する。

Closes #313

## 実装

### バックエンド (`scripts/webapp/routes/portfolio.py`)
- `GET /portfolio/shikiho` — charts() と同じ status/業態テーマフィルタ・業態順で銘柄抽出。`list_research_records()` で四季報を 1 回 open 取得して「今号入力済み」を判定し、進捗カウンタと銘柄リストを渡す。**research 未登録銘柄は `save_shikiho` が失敗するため対象から除外**。
- `GET /portfolio/shikiho/<code_s>/data` — 1 銘柄の overview + 四季報コメント(降順)を返す軽量 JSON。切替時に都度取得する方式（初期ロードを軽く保つ）。

### フロント (`scripts/webapp/templates/portfolio_shikiho.html` 新規)
- 前/次ボタン + キーボード `←→`/`jk`（入力欄フォーカス中は無効）
- 「今号未入力のみ」フィルタ（トグルON時点の銘柄列を固定）+ 進捗カウンタ「今号入力済 X / 全N」
- 銘柄切替時の自動保存 flush（dirty 判定 → `POST /stock/<code_s>/shikiho`）、`beforeunload` で sendBeacon ベストエフォート保存
- app.js の四季報 JS（固定 ID + DOMContentLoad 時の初期値キャプチャ）は銘柄切替と相性が悪いため再利用せず、専用インライン JS で実装

### 導線 (`scripts/webapp/templates/portfolio_list.html`)
- portfolio 一覧の「📊 チャート一覧」隣に「📝 四季報更新」リンクを追加

### 無変更
保存ルート `POST /stock/<code_s>/shikiho` / `save_shikiho` / `app.js` / `research_shelve.py` はそのまま流用。

## テスト・検証

- **ユニット**: `tests/test_webapp_routes.py` に `TestPortfolioShikihoRoute` 3 本追加。全 103 本パス、回帰なし。
- **E2E** (Playwright, 本番DB):
  - 初期表示で AJAX 取得・進捗「今号(26.6)入力済 2 / 318」
  - 前/次で銘柄切替＋AJAX 再取得＋form.action 差し替え
  - 「今号未入力のみ」トグルで 1 / 316 に絞り込み
  - overview 編集 → 次へで保存 flush → 戻って DB 永続化を確認（テストデータは復元済み）

## 補足

実装着手前に codex(gpt-5.4)でプランを 3 回レビューし、未登録銘柄の扱い・TODO フィルタのナビ固定・旧形式 `shikiho_comments` の正規化を解消済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)