### PR TITLE
feat(portfolio): RS(20,5)列に前日比RSライン騰落率を追加 (ツールチップ+ソート) (issue #332)

### DIFF
--- a/doc/plans/issue332_rs_daily_change.md
+++ b/doc/plans/issue332_rs_daily_change.md
@@ -1,0 +1,133 @@
+# issue #332: portfolio RS(20,5)列に前日比RSライン騰落率を追加 (ツールチップ + ソート)
+
+## 目的
+
+保有銘柄を「当日の対TOPIX相対挙動 (前日比RSライン騰落率)」で可視化・ランキングできるようにし、
+急落時のポジション削減 (相対的に弱い銘柄から切る) の判断材料を提供する。
+
+## 前提 (調査済みの現状)
+
+- **計算ロジックは実装済み**: `make_stock_db.compute_rs_line_changes(stock, market_db, topix_map)` が
+  `(a, b, d)` を返す。`d` = 前日比RSライン騰落率(%) = `(rs_line[今日] - rs_line[1日前]) / rs_line[1日前] * 100` (issue #283)。
+- **業態テーマページに前例あり**: `helpers.py` の theme_summary 構築 (3679-3692行付近) が
+  `compute_rs_line_changes` を呼び `d` を集計し「1日乖離」列・ソートに利用 (issue #328)。
+- **portfolio リスト本体にソート機構は既存**: `routes/portfolio.py` の
+  `PORTFOLIO_SORT_KEYS = {"position","rank","gyoutai"}` / `_parse_sort_key` / `_build_query_string` /
+  `sort_urls` が既にあり、`list_portfolio_with_indicators(records, sort_key)` でソートを切替。
+  → #332 はこの機構に前日比キーを1つ足す形。
+- **portfolio 側は前日比 d を計算していない**: `list_portfolio_with_indicators` は
+  `build_stock_chart_payload(stock, market_db, mode="mini")` で SVG + tooltip を作るが、
+  `compute_rs_line_changes` は呼んでおらず、前日比は row に存在しない。
+- **#327 (2ページ化) は main 未マージ**: このブランチには `data-page` 属性なし。RS(20,5) 列は単一テーブル内。
+  #327 とのマージコンフリクトは並行作業のため後で解消する前提 (本プランのスコープ外)。
+
+## 確定した仕様判断
+
+- **ソート方向**: 前日比 **降順のみ固定** (業態テーマ dev_1d と同じ向き = 強い順が上)。
+  昇順/降順トグルは入れない。急落時の「弱い順から切る」は一覧下部を見る運用。
+- **ツールチップ表記**: RS(20,5) セルの既存 tooltip (株価 / RSライン乖離 の2行) に
+  「前日比: +X.X%」の行を追記する。
+- **総合スコアリングには組み込まない** (issue スコープ通り)。code_rank.csv にも追加しない。
+
+## 変更点
+
+### 1. `scripts/webapp/helpers.py`
+
+**1-a. `list_portfolio_with_indicators` で前日比 d を計算し row に格納**
+
+theme_summary と同じパターンを流用する。market_db ロード済みのループ内で、銘柄ごとに
+`compute_rs_line_changes(stock, market_db, topix_map=topix_map)` を呼び、`d` を `row["rs_change_1d"]` に格納。
+
+- topix_map: theme_summary は `compute_rs_line_changes` に topix_map を渡して TOPIX マップ再構築を
+  避けている。portfolio 側も同様に topix_map を1回構築して渡す (N銘柄 × 再構築を防ぐ)。
+  topix_map の構築方法は theme_summary 実装 (helpers.py 内) と同じヘルパを再利用する。
+- 例外時は `row["rs_change_1d"] = None`。
+- market_db が None のときは全 row で None。
+
+**1-b. ツールチップに前日比を追加 (mini 経路のみ、opt-in)**
+
+`build_stock_chart_payload` → `build_price_rs_chart_mini` → `_build_chart_tooltip` の経路で
+tooltip 文字列が生成される。
+
+⚠️ **codex 指摘対応**: `_build_chart_tooltip` は mini (日足、portfolio 一覧) だけでなく
+**full (週足、詳細ページ) からも共有**されている (`build_price_rs_chart_full` が
+`unit_label="週"` で呼ぶ、helpers.py:2738)。tooltip 内に無条件で前日比行を足すと、
+issue #332 の対象外である詳細ページ週足チャートにも波及してしまう。
+
+→ **opt-in 引数方式を採用**:
+- `_build_chart_tooltip(..., include_prev_change: bool = False)` を追加。
+  True のときだけ末尾に「前日比: {符号付き}%」行を足す。
+- `build_price_rs_chart_mini` (portfolio 経路) からは `include_prev_change=True` で呼ぶ。
+- `build_price_rs_chart_full` (詳細ページ経路) はデフォルト False のまま = 挙動不変。
+- 前日比は `_build_chart_tooltip` 内の `rs_values` (= mini の `rs_asc`、昇順 rs_line 値列) の
+  末尾2点 `rs_values[-1]` / `rs_values[-2]` から計算する (d を引数で渡さず自己完結)。
+
+  ⚠️ 整合性チェック: `rs_asc` は `_asc_series_from_log(rs_line, _SPARK_LOOKBACK)` で得た
+  **直近20本の昇順列**。末尾2点 = 最新・前日。`compute_rs_line_changes` の d も
+  `compute_rs_line` の rs_line 先頭2点 (最新・前日) 比較。両者の「最新」「前日」は同一営業日を
+  指すため数値は一致する。`rs_values` が2点未満、または前日値が0の場合は「前日比: —」表示にする
+  (compute_rs_line_changes の d=None 条件と揃える)。
+
+  注: ソート用の `row["rs_change_1d"]` (1-a) と tooltip 表示値は同じ定義だが、前者は
+  `compute_rs_line_changes` 経由、後者は tooltip 内で rs_values から直接計算という二経路になる。
+  両者は同一 rs_line に由来し定義も一致するため値はズレない (どちらも隣接2点比較)。
+  実装簡潔性のため二経路を許容する (共通化のための引数引き回しはしない)。
+
+### 2. `scripts/webapp/routes/portfolio.py`
+
+- `PORTFOLIO_SORT_KEYS` に `"rs_change_1d"` を追加。
+- `sort_urls` の生成対象キー (`("position","rank","gyoutai")`) に `"rs_change_1d"` を追加。
+  `sort_urls` は route 側で `"?" + _build_query_string(...)` と**先頭 `?` 付き**で生成される。
+  → テンプレートでは `href="{{ sort_urls['rs_change_1d'] }}"` (= `?` 前置しない)。既存リンクと同形。
+- `_build_query_string` / `_parse_sort_key` は `PORTFOLIO_SORT_KEYS` を参照しているので追加だけで動く。
+
+### 3. `scripts/webapp/helpers.py` の `list_portfolio_with_indicators` ソート分岐
+
+- `sort_key == "rs_change_1d"` の分岐を追加。前日比 **降順**、None は末尾、同値はコード順:
+  ```python
+  rows.sort(key=lambda r: (
+      r.get("rs_change_1d") is None,
+      -(r.get("rs_change_1d") or 0.0),
+      r.get("code_s", ""),
+  ))
+  ```
+
+### 4. `scripts/webapp/templates/portfolio_list.html`
+
+- RS(20,5) 列ヘッダをソートリンク化:
+  ```html
+  <th class="{% if active_sort == 'rs_change_1d' %}sort-active{% endif %}"
+      title="...3点ミニチャート...。クリックで前日比RSライン騰落率の降順ソート">
+    <a href="{{ sort_urls['rs_change_1d'] }}">{% if active_sort == 'rs_change_1d' %}▼前日比{% else %}RS(20,5){% endif %}</a>
+  </th>
+  ```
+  - ソート適用中はヘッダ表示を「▼前日比」に切替 (issue 要件: ソートキー明示)。
+  - `sort-active` の CSS は theme_summary の `th.sort-active a { color: #2c5282; }` を流用。
+    portfolio_list.html に同等の最小 CSS を追加。
+- ツールチップは helpers 側で生成済み (row.price_rs_chart.tooltip) なので template 変更不要。
+
+## テスト (`tests/test_webapp_portfolio_routes.py` / 既存に集約)
+
+CLAUDE.md「1 PR 5本以下・parametrize 集約」に従い最小限:
+
+1. **ソート動作**: `?sort=rs_change_1d` で前日比降順・None末尾・同値コード順になることを1本で検証
+   (rs_change_1d を直接 row に注入 or stock データを用意)。
+2. **ソートキー受理**: `_parse_sort_key` が `rs_change_1d` を受理し、不正値が DEFAULT に落ちることを確認
+   (既存の parse テストがあれば parametrize に1ケース追加)。
+3. **ツールチップ**: `_build_chart_tooltip(..., include_prev_change=True)` が前日比行を含むこと /
+   `include_prev_change=False` (デフォルト = full 経路) では前日比行を含まないこと /
+   末尾2点不足時・前日値0時「前日比: —」になることを parametrize 1本で検証。
+
+`compute_rs_line_changes` の d 自体は make_stock_db 側で既存テスト済みのため再テストしない。
+
+## 検証手順
+
+1. 上記テストを実行 (`pytest tests/test_webapp_portfolio_routes.py -v`、helpers 変更のため
+   `pytest tests/test_webapp_helpers.py -v` も)。
+2. WebApp 起動し、RS(20,5) ヘッダクリックで前日比降順に並ぶこと・ヘッダが「▼前日比」になること・
+   tooltip に前日比行が出ることをブラウザ確認。
+
+## スコープ外 (issue 記載通り)
+
+- 前日比指標の code_rank.csv 追加 / スコアリング組み込み / 急落日自動バナー。
+- #327 とのマージコンフリクト解消 (並行ブランチ統合時に別途対応)。

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1857,6 +1857,17 @@ def list_portfolio_with_indicators(
     except Exception:  # noqa: BLE001
         market_db = None
 
+    # issue #332: 前日比RSライン騰落率 (1日比) を銘柄ごとに計算するための TOPIX マップ。
+    # theme_summary と同じく topix_map を1回だけ構築し compute_rs_line_changes に渡して
+    # 内部の TOPIX マップ再構築 (N銘柄ぶん) を避ける。
+    topix_map = None
+    if market_db is not None:
+        try:
+            from make_stock_db import _topix_close_map  # 遅延 import
+            topix_map = _topix_close_map(market_db)
+        except Exception:  # noqa: BLE001
+            topix_map = None
+
     rows: List[Dict[str, Any]] = []
     for rec in records:
         code_s = rec.get("code_s", "")
@@ -1868,6 +1879,17 @@ def list_portfolio_with_indicators(
         row.update(_extract_indicators_for_portfolio(stock))
         # issue #227: 3点ミニチャート (svg + tooltip)
         row["price_rs_chart"] = build_stock_chart_payload(stock, market_db, mode="mini")
+        # issue #332: 前日比RSライン騰落率 (1日比) を RS(20,5) 列ソート用に格納。
+        # compute_rs_line_changes は (5日乖離A, 20日乖離B, 前日比D) を返す。D のみ使う。
+        if topix_map:
+            try:
+                from make_stock_db import compute_rs_line_changes  # 遅延 import
+                _a, _b, d = compute_rs_line_changes(stock, market_db, topix_map=topix_map)
+            except Exception:  # noqa: BLE001
+                d = None
+        else:
+            d = None
+        row["rs_change_1d"] = d
         row["styles"] = compute_cell_styles(row, today=today)
         # issue #178: ステータス列 (badge) 表示用の query / label を埋める
         status = rec.get("status", "")
@@ -1909,6 +1931,13 @@ def list_portfolio_with_indicators(
             r["gyoutai_first"],
             r.get("rank") is None,
             r.get("rank") or 0,
+            r.get("code_s", ""),
+        ))
+    elif sort_key == "rs_change_1d":
+        # issue #332: 前日比RSライン騰落率 降順。None (算出不可) は末尾、同値はコード順。
+        rows.sort(key=lambda r: (
+            r.get("rs_change_1d") is None,
+            -(r.get("rs_change_1d") or 0.0),
             r.get("code_s", ""),
         ))
     else:
@@ -2498,11 +2527,24 @@ def _format_ma_deviation(values: List[float], window: int) -> str:
     return f"{pct:+.1f}%"
 
 
+def _format_prev_change(values: List[float]) -> str:
+    """rs_line 値列 (古い順) の末尾2点から前日比 (1日比) % を整形する (issue #332)。
+
+    前日比 = (最新 - 前日) / 前日 * 100。compute_rs_line_changes の D と同定義 (隣接2点比較)。
+    2点未満・前日値0は "—"。
+    """
+    if not values or len(values) < 2 or values[-2] == 0:
+        return "—"
+    pct = (values[-1] - values[-2]) / values[-2] * 100
+    return f"{pct:+.1f}%"
+
+
 def _build_chart_tooltip(
     price_values: List[float],
     rs_values: List[float],
     has_blue_dot: bool,
     unit_label: str = "日",
+    include_prev_change: bool = False,
 ) -> str:
     """チャート tooltip (title 属性向け) を生成する。
 
@@ -2510,6 +2552,9 @@ def _build_chart_tooltip(
     RSライン行は移動平均乖離率 (今日 vs 直近 20本/5本平均、issue #283)。1 点比較
     だとヒゲでブレるため、平均基準で勢い・過熱を安定して見せる。
     unit_label は "日" (日足 mini) / "週" (週足 full) を切り替える。
+
+    include_prev_change=True のとき RSライン前日比 (1日比) 行を足す (issue #332)。
+    portfolio 一覧の mini チャートのみ有効化し、詳細ページ週足 (full) には出さない。
     """
     lines = [
         f"株価: 20{unit_label} {_format_total_change(price_values, _SPARK_LOOKBACK)}, "
@@ -2517,6 +2562,8 @@ def _build_chart_tooltip(
         f"RSライン乖離: 20{unit_label}平均 {_format_ma_deviation(rs_values, _SPARK_LOOKBACK)}, "
         f"5{unit_label}平均 {_format_ma_deviation(rs_values, _SPARK_RECENT)}",
     ]
+    if include_prev_change:
+        lines.append(f"前日比: {_format_prev_change(rs_values)}")
     if has_blue_dot:
         lines.append("新高値: ●")
     return "\n".join(lines)
@@ -2657,7 +2704,8 @@ def build_price_rs_chart_mini(
     if len(rs_asc) < 2:
         return ("—", "")
 
-    tooltip = _build_chart_tooltip(price_asc, rs_asc, has_blue_dot)
+    # issue #332: portfolio 一覧の mini チャートのみ前日比 (1日比) 行を tooltip に足す。
+    tooltip = _build_chart_tooltip(price_asc, rs_asc, has_blue_dot, include_prev_change=True)
 
     pad_x = 4
     pad_y = 3

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -56,7 +56,7 @@ STATUS_CHOICES = [
     ("watch", "3監", STATUS_VALUE_TO_LABEL["3監"]),
 ]
 DEFAULT_STATUS_QUERY = STATUS_CHOICES[0][0]  # "hold" — 書き込み POST 後フォールバック先
-PORTFOLIO_SORT_KEYS = {"position", "rank", "gyoutai"}
+PORTFOLIO_SORT_KEYS = {"position", "rank", "gyoutai", "rs_change_1d"}  # rs_change_1d: issue #332
 DEFAULT_SORT_KEY = "position"
 
 
@@ -633,7 +633,7 @@ def dashboard():
             k,
             include_empty_status=preserve_all_status,
         )
-        for k in ("position", "rank", "gyoutai")
+        for k in ("position", "rank", "gyoutai", "rs_change_1d")  # rs_change_1d: issue #332
     }
 
     # 保有フィルタ表示時のみ、運用総額と PF 全体の qty 最終更新日を集計

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -29,6 +29,8 @@
     background: var(--pico-background-color);
     box-shadow: 0 1px 0 #d8dee6;
   }
+  /* issue #332: ソート適用中のヘッダを強調 (theme_summary と同色) */
+  table.portfolio-list thead th.sort-active a { color: #2c5282; font-weight: bold; }
   /* 数値・短文列は明示的に狭くする */
   table.portfolio-list td.num { text-align: right; }
   table.portfolio-list td.rating-cell { text-align: center; white-space: nowrap; }
@@ -286,7 +288,9 @@
       <th>ステージ</th>
       <th>チャートパターン</th>
       <th>RS</th>
-      <th title="RSライン (対TOPIX, 青=上昇/オレンジ=下降) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸">RS(20,5)</th>
+      {# issue #332: ヘッダクリックで前日比RSライン騰落率の降順ソート。適用中はソートキーを明示 (▼前日比) #}
+      <th class="{% if active_sort == 'rs_change_1d' %}sort-active{% endif %}"
+          title="RSライン (対TOPIX, 青=上昇/オレンジ=下降) の 3点ミニチャート (t-20, t-5, t-0)。RSライン新高値で青丸。クリックで前日比RSライン騰落率の降順ソート"><a href="{{ sort_urls['rs_change_1d'] }}">{% if active_sort == 'rs_change_1d' %}▼前日比{% else %}RS(20,5){% endif %}</a></th>
       <th>トレンド</th>
       <th>タグ</th>
       <th title="ポ/ブ記号。ホバーで signal 全文 (発生日付含む)">シグナル</th>

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -2061,6 +2061,34 @@ class TestListPortfolioWithIndicators:
         rows = helpers.list_portfolio_with_indicators(records, sort_key=sort_key)
         assert [r["code_s"] for r in rows] == expected
 
+    def test_sort_by_rs_change_1d_desc_none_last(self, monkeypatch, stub_externals):
+        """issue #332: 前日比RSライン騰落率 降順、None は末尾、同値はコード順。"""
+        import make_stock_db
+        import make_market_db
+        # market_db / topix_map を truthy にして compute_rs_line_changes 経路を通す
+        # (helpers は make_market_db / make_stock_db から遅延 import するため両モジュールを差し替え)
+        monkeypatch.setattr(make_market_db, "get_market_db", lambda: {"_": 1})
+        monkeypatch.setattr(make_stock_db, "_topix_close_map", lambda mdb: {"_": 1})
+        # 前日比 D をコード別に注入 (A, B は未使用なので None)
+        prev = {"0001": 2.0, "0002": -1.0, "0003": 2.0, "0004": None}
+        monkeypatch.setattr(
+            make_stock_db, "compute_rs_line_changes",
+            lambda stock, mdb, topix_map=None: (None, None, prev[stock["code_s"]]),
+        )
+        monkeypatch.setattr(
+            helpers, "_bulk_get_stock_data",
+            lambda codes: {c: {"code_s": c} for c in codes},
+        )
+        records = [
+            self._make("0002", "1保", rank=1),  # -1.0
+            self._make("0004", "1保", rank=2),  # None → 末尾
+            self._make("0003", "1保", rank=3),  # 2.0 (0001 と同値、コード順で後)
+            self._make("0001", "1保", rank=4),  # 2.0
+        ]
+        rows = helpers.list_portfolio_with_indicators(records, sort_key="rs_change_1d")
+        # 降順: 2.0 (0001, 0003 コード順) → -1.0 (0002) → None (0004) 末尾
+        assert [r["code_s"] for r in rows] == ["0001", "0003", "0002", "0004"]
+
     # ===== issue #269: position_ratio 集計 =====
     @pytest.mark.parametrize(
         "records, prices, expected",
@@ -2301,6 +2329,28 @@ class TestPriceRsSparkline:
         assert "stroke-dasharray" in svg  # RSライン点線
         assert "株価:" in tooltip
         assert "RSライン乖離:" in tooltip
+
+    # --- issue #332: 前日比 (1日比) は mini (portfolio) のみ tooltip に出す ---
+
+    def test_mini_chart_tooltip_includes_prev_change_but_full_does_not(self):
+        # rs_line 末尾2点 (最新 1.10 / 前日 1.08) → 前日比 +1.9%。mini にだけ出る。
+        price_log = self._make_log([110, 108, 106, 104, 102, 100])
+        rs_line = self._make_log([1.10, 1.08, 1.06, 1.04, 1.02, 1.00])
+        _, mini_tooltip = helpers.build_price_rs_chart_mini(price_log, rs_line, has_blue_dot=False)
+        assert "前日比:" in mini_tooltip
+        assert "+1.9%" in mini_tooltip
+        # full (詳細ページ週足) には出さない (issue #332: 対象外への波及防止)
+        _, full_tooltip = helpers.build_price_rs_chart_full(price_log, rs_line, has_blue_dot=False)
+        assert "前日比:" not in full_tooltip
+
+    @pytest.mark.parametrize("rs_values,expected", [
+        ([1.00, 1.05], "+5.0%"),      # 古い順 [前日, 最新] → 上昇
+        ([1.05, 1.00], "-4.8%"),      # 下落
+        ([1.05], "—"),                # 2点未満
+        ([0.0, 1.00], "—"),           # 前日値0 → 0除算回避
+    ])
+    def test_format_prev_change(self, rs_values, expected):
+        assert helpers._format_prev_change(rs_values) == expected
 
     def test_full_chart_includes_date_labels(self):
         price_log = self._make_log(list(range(120, 100, -1)))

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -1053,6 +1053,15 @@ class TestDashboardFilter:
         assert "status=&amp;sort=position" in html
         assert "status=&amp;sort=gyoutai" in html
 
+    def test_rs_change_1d_sort_header_active(self, client):
+        """issue #332: ?sort=rs_change_1d で 200・RS(20,5)ヘッダが ▼前日比 に切替・sort リンク存在"""
+        resp = client.get("/portfolio?sort=rs_change_1d")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "sort=rs_change_1d" in html  # 各ヘッダの sort リンク
+        assert "▼前日比" in html            # 適用中のソートキー明示
+        assert "sort-active" in html
+
     def test_gyoutai_boundary_only_for_gyoutai_sort(self, client, portfolio_db_path):
         """issue #274: 業態境界線は gyoutai sort のときだけ出す"""
         ps.update_memo("3496", {"gyoutai_themes": ["AI"]}, db_path=portfolio_db_path)


### PR DESCRIPTION
## 概要

Closes #332

portfolio ページの RS(20,5) 列に「前日比RSライン騰落率 (1日比)」を追加。保有銘柄を当日の対TOPIX相対挙動でランキングできるようにし、急落時のポジション削減判断 (相対的に弱い銘柄から切る) の材料を提供する。

## 変更点

| ファイル | 変更 |
|---|---|
| `helpers.py` | `list_portfolio_with_indicators` で前日比 D を計算し `row["rs_change_1d"]` に格納 (topix_map を1回構築、theme_summary と同パターン) ／ 降順ソート分岐追加 ／ `_build_chart_tooltip` に `include_prev_change` 引数追加・`_format_prev_change` 新設 |
| `routes/portfolio.py` | `PORTFOLIO_SORT_KEYS` / `sort_urls` に `rs_change_1d` を追加 |
| `portfolio_list.html` | RS(20,5) ヘッダをソートリンク化・適用中「▼前日比」表示・`sort-active` CSS |

## 仕様判断

- **ソート方向**: 前日比 **降順固定** (業態テーマ `dev_1d` と同じ向き = 強い順が上)。
- **ツールチップ波及防止**: `_build_chart_tooltip` は portfolio mini と詳細ページ week full で共有されるため、`include_prev_change=False` を既定とし mini 経路のみ True で前日比行を足す。詳細ページの挙動は不変。

## テスト

- `_format_prev_change` (4ケース parametrize) / mini=前日比あり・full=なし / 前日比降順・None末尾・同値コード順ソート / `?sort=rs_change_1d` 結合テスト。
- 変更モジュール全体で 416 passed (回帰なし)。
- WebApp 実機確認: 前日比降順 (+13.1% → +8.9% → +7.6% → +6.2%)・ヘッダ「▼前日比」切替・ツールチップ表示を確認。

## スコープ外 (issue 記載通り)

- 前日比指標の code_rank.csv 追加 / スコアリング組み込み / 急落日自動バナー。
- #327 (portfolio 2ページ化、PR #334) とのマージコンフリクト解消は並行ブランチ統合時に別途対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)