### PR TITLE
ブレイク/ポケットのStage4判定見直し・トレンド色分離・extendedマーカー・出来高30日化 (issue #111 短期改善)

### DIFF
--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -697,14 +697,24 @@ def get_db_code(rec: dict) -> str:
     return rec["code_s"]
 
 
-_TREND_BG_CLASS = {"◎": "trend-bg-strong", "◯": "trend-bg-good", "—": "trend-bg-none"}
+# 記号→背景色クラス。webapp 一覧 (compute_cell_styles) の色仕様と統一:
+# ◎=濃黄, ◯=薄黄, ×(全条件miss=Stage4崩壊)=青, —(未評価/欠損)=赤。
+_TREND_BG_CLASS = {
+    "◎": "trend-bg-strong", "◯": "trend-bg-good",
+    "×": "trend-bg-collapse", "—": "trend-bg-missing",
+}
+
+# trend_template (Minervini) の全条件数。price.calc_trend_template が不通過項目を
+# misses として返すため、miss 数がこれと等しい = 1つも条件を満たさない完全崩壊
+# (Stage 4)。make_stock_db._TREND_TEMPLATE_ALL (条件名の集合) と件数を揃える。
+TREND_TEMPLATE_CONDITION_COUNT = 7
 
 
 def trend_symbol_from_misses(misses):
     """trend_template (不通過項目 list) から表示用の記号一文字を返す。
 
     make_stock_db.get_trend_template_expr() と判定基準を揃える (◎/◯/▲/△)。
-    7件全 miss (完全 Stage 4 崩壊) は "×"、None や非 list (未評価/データ欠損) は "—"。
+    全条件 miss (完全 Stage 4 崩壊) は "×"、None や非 list (未評価/データ欠損) は "—"。
     両者は意味が異なるため記号で区別する (背景色も別: × → 青, — → 赤)。
     """
     if not isinstance(misses, list):
@@ -716,13 +726,13 @@ def trend_symbol_from_misses(misses):
         return "◯"
     if n <= 4:
         return "▲"
-    if n <= 6:
+    if n < TREND_TEMPLATE_CONDITION_COUNT:
         return "△"
     return "×"
 
 
 def trend_bg_class(symbol):
-    """トレンド記号 (◎/◯/—) から背景色 CSS クラス名を返す。▲/△/その他は ""。"""
+    """トレンド記号 (◎/◯/×/—) から背景色 CSS クラス名を返す。▲/△/その他は ""。"""
     return _TREND_BG_CLASS.get(symbol, "")
 
 

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -703,8 +703,9 @@ _TREND_BG_CLASS = {"◎": "trend-bg-strong", "◯": "trend-bg-good", "—": "tre
 def trend_symbol_from_misses(misses):
     """trend_template (不通過項目 list) から表示用の記号一文字を返す。
 
-    make_stock_db.get_trend_template_expr() と判定基準を揃える (◎/◯/▲/△ + 7件以上は空)。
-    None や非 list は "—" を返す。
+    make_stock_db.get_trend_template_expr() と判定基準を揃える (◎/◯/▲/△)。
+    7件全 miss (完全 Stage 4 崩壊) は "×"、None や非 list (未評価/データ欠損) は "—"。
+    両者は意味が異なるため記号で区別する (背景色も別: × → 青, — → 赤)。
     """
     if not isinstance(misses, list):
         return "—"
@@ -717,7 +718,7 @@ def trend_symbol_from_misses(misses):
         return "▲"
     if n <= 6:
         return "△"
-    return "—"
+    return "×"
 
 
 def trend_bg_class(symbol):

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -951,10 +951,11 @@ tr:hover { background: #f5f5f5; }
 .market-table th.col-spr,   .market-table td.col-spr   { width: 140px; }
 .signal-sell { background: #fdedec; color: #c0392b; font-weight: bold; }
 .signal-buy { background: #eafaf1; color: #27ae60; font-weight: bold; }
-/* トレンド列の背景色 (portfolio_list と仕様統一: ◎=濃黄 / ◯=薄黄 / —=水色) */
-.trend-bg-strong { background: #fbbc04; }  /* ◎ */
-.trend-bg-good   { background: #fce8b2; }  /* ◯ */
-.trend-bg-none   { background: #6fa8dc; }  /* — / 空 */
+/* トレンド列の背景色 (portfolio 一覧と仕様統一: ◎=濃黄 / ◯=薄黄 / ×=青(全崩壊) / —=赤(欠損)) */
+.trend-bg-strong   { background: #fbbc04; }  /* ◎ */
+.trend-bg-good     { background: #fce8b2; }  /* ◯ */
+.trend-bg-collapse { background: #4285f4; }  /* × (全条件miss=Stage4崩壊) */
+.trend-bg-missing  { background: #ea4335; }  /* — / 空 (未評価/欠損) */
 /* 需給バランスセル (issue #247): SPR/rv の横バー 2 本縦積み */
 .spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; }
 .spr-gauge-cell svg { display: block; width: 100%; height: auto; }

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -970,7 +970,7 @@ def get_trend_template_expr(stock):
         return "▲"
     if miss_count <= 6:
         return "△"
-    return ""
+    return "×"  # 7件全 miss = 完全 Stage 4 崩壊 (trend_symbol_from_misses と整合)
 
 
 def get_index_trend_template_expr(stock):
@@ -998,8 +998,22 @@ def get_index_trend_template_expr(stock):
     return ("△ %d/7" % pass_count, miss_str)
 
 
-# ポケットピポット無効化対象の trend_template 不通過項目 (Stage 4 崩壊系, issue #110)。
-_PP_STAGE4_MISSES = {"pr>ma30,40", "ma40Up", "high(low)52"}
+# trend_template (Minervini 7条件) の全項目。calc_trend_template (price.py) が
+# 不通過項目を misses として返すため、misses がこの7項目すべてを含む = 1つも条件を
+# 満たさない = 完全な Stage 4 崩壊、と判定する (issue #110/#111)。
+_TREND_TEMPLATE_ALL = {
+    "pr>ma10", "pr>ma30,40", "ma30>ma40", "ma40Up",
+    "ma10>ma30,40", "high(low)52", "RS",
+}
+
+
+def _is_stage4(misses):
+    """trend_template の不通過項目集合が「全条件 miss」= Stage 4 崩壊か判定する。
+
+    部分的な不通過 (下落途中・Stage 1 底値圏など) は対象外。1つも条件を満たさない
+    完全崩壊銘柄のみ True。ポケットピポット・ブレイク双方で同じ基準を使う (issue #110/#111)。
+    """
+    return _TREND_TEMPLATE_ALL <= misses
 
 
 # シグナル表示で銘柄データ自体を stale とみなす上限 (access_date_price が今日からこの
@@ -1044,7 +1058,7 @@ def _signal_recent_delta(stock, mmdd):
     return delta, sig_day
 
 
-def extract_signals(stock, max_delta_days=10):
+def extract_signals(stock, max_delta_days=10, include_extended=False):
     """表示対象ポ/ブシグナルを返す (issue #253/#310)。
 
     一覧 tooltip/背景色はデフォルトの 10 日以内だけを使い、詳細チャートは
@@ -1056,24 +1070,36 @@ def extract_signals(stock, max_delta_days=10):
       - 各シグナル: access_date_price 基準で delta を計算し、
         max_delta_days が整数なら 0〜max_delta_days のものだけ採用。
 
+    include_extended=True のときのみ breakout_extended (高値追い圏で正規ブレイクから
+    弾かれた候補) を kind="ブ"・extended=True 付きで含める。詳細チャートマーカー専用で、
+    シグナル列・一覧 tooltip 経路 (デフォルト False) には出さない。
+
     Returns:
         list[dict]: [{"kind","mmdd","num","sig_date","delta"}] (表示順)。
+            extended 候補のみ "extended": True を持ち、num は MA10乖離% (正規ブレイクの
+            num=出来高超過% とは意味が異なる)。
             sig_date は access_date_price 基準で年補完した発生日 (date)。
     """
     out = []
     pocket_pivot = stock.get("pocket_pivot", "")
     trend_template = stock.get("trend_template", [])
-    pp_misses = set(trend_template) if isinstance(trend_template, (list, tuple, set)) else set()
-    pp_enabled = pocket_pivot and not (pp_misses & _PP_STAGE4_MISSES)
+    misses = set(trend_template) if isinstance(trend_template, (list, tuple, set)) else set()
+    # Stage 4 崩壊 (7条件全 miss) ではポ/ブともに無効化 (issue #110/#111)。
+    stage4 = _is_stage4(misses)
 
+    # (kind, sigs, extended) の3要素。extended は描画側で半透明中抜き表示する目印。
     sources = []
-    if pp_enabled:
-        sources.append(("ポ", list(pocket_pivot)[:3]))  # 連続ポは最大3件
+    if pocket_pivot and not stage4:
+        sources.append(("ポ", list(pocket_pivot)[:3], False))  # 連続ポは最大3件
     breakout = stock.get("breakout", [])
-    if breakout:
-        sources.append(("ブ", list(breakout)[:1]))  # ブは最新1件のみ
+    if breakout and not stage4:
+        sources.append(("ブ", list(breakout)[:1], False))  # ブは最新1件のみ
+    if include_extended and not stage4:
+        breakout_ext = stock.get("breakout_extended", [])
+        if breakout_ext:
+            sources.append(("ブ", list(breakout_ext)[:3], True))  # extended は直近3件まで
 
-    for kind, sigs in sources:
+    for kind, sigs, extended in sources:
         for sig in sigs:
             spl = str(sig).split(",")
             if len(spl) < 2:
@@ -1091,10 +1117,13 @@ def extract_signals(stock, max_delta_days=10):
                 continue
             if max_delta_days is not None and delta > max_delta_days:
                 continue
-            out.append({
+            entry = {
                 "kind": kind, "mmdd": spl[0], "num": num,
                 "sig_date": sig_date, "delta": delta,
-            })
+            }
+            if extended:
+                entry["extended"] = True
+            out.append(entry)
     return out
 
 
@@ -1141,17 +1170,16 @@ def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
             dt = get_price_day(dt)
             if (date.today() - dt).days <= 30:
                 tags.append("押")
-    # ポケットピポット
-    pocket_pivot = stock.get("pocket_pivot", "")
-    # Stage 4 崩壊銘柄ではポケットピポットを無効化する (issue #110)。
-    # trend_template (週足) の不通過項目に長期トレンド崩壊系が含まれていれば除外。
-    # ・"pr>ma30,40": 株価が長期MA(MA40≒MA200相当)を下回る
-    # ・"ma40Up": MA40 が1ヶ月前より下降 (Stage 4)
-    # ・"high(low)52": 52週高値圏から外れる (crash mode)
+    # Stage 4 崩壊銘柄ではポケットピポット/ブレイクを無効化する (issue #110/#111)。
+    # trend_template (週足) の7条件を1つも満たさない (全 miss) 場合のみ崩壊とみなす。
+    # 部分的な不通過 (下落途中・Stage 1 底値圏) は対象外。
     # trend_template が空(◎)・キー欠落(週足取得失敗)ならベース形成中とみなし除外しない。
     trend_template = stock.get("trend_template", [])
-    pp_misses = set(trend_template) if isinstance(trend_template, (list, tuple, set)) else set()
-    if pocket_pivot and not (pp_misses & {"pr>ma30,40", "ma40Up", "high(low)52"}):
+    misses = set(trend_template) if isinstance(trend_template, (list, tuple, set)) else set()
+    stage4 = _is_stage4(misses)
+    # ポケットピポット
+    pocket_pivot = stock.get("pocket_pivot", "")
+    if pocket_pivot and not stage4:
         for i, sig in enumerate(pocket_pivot):
             if i >= 3:  # 連続ポケットピポットは最大3件まで表示 (issue #110)
                 break
@@ -1166,16 +1194,17 @@ def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
             signal += "%s(%s)," % (spl[0], spl[1])
     # ブレイクアウト
     breakout = stock.get("breakout", [])
-    for brk in breakout:
-        brkspl = brk.split(",")
-        try:
-            delta_day = get_recent_signal_delta(brkspl[0])
-            # mark = "★"  if delta_day < 3 else ""
-        except ValueError:
-            log_warning("ブレイクアウト日付エラー", brkspl[0])
-        signal += "[ブ]"
-        signal += "%s(%s)," % (brkspl[0], brkspl[1])
-        break  # 一つにしておく(最新日)
+    if not stage4:
+        for brk in breakout:
+            brkspl = brk.split(",")
+            try:
+                delta_day = get_recent_signal_delta(brkspl[0])
+                # mark = "★"  if delta_day < 3 else ""
+            except ValueError:
+                log_warning("ブレイクアウト日付エラー", brkspl[0])
+            signal += "[ブ]"
+            signal += "%s(%s)," % (brkspl[0], brkspl[1])
+            break  # 一つにしておく(最新日)
     # 売り圧力レシオ(5日)による買われ過ぎ売われすぎ
     sell_ratio = stock.get("sell_pressure_ratio", [])
     if sell_ratio:

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -998,13 +998,15 @@ def get_index_trend_template_expr(stock):
     return ("△ %d/7" % pass_count, miss_str)
 
 
-# trend_template (Minervini 7条件) の全項目。calc_trend_template (price.py) が
-# 不通過項目を misses として返すため、misses がこの7項目すべてを含む = 1つも条件を
+# trend_template (Minervini) の全条件名。calc_trend_template (price.py) が
+# 不通過項目を misses として返すため、misses がこの全項目を含む = 1つも条件を
 # 満たさない = 完全な Stage 4 崩壊、と判定する (issue #110/#111)。
+# 件数は ks_util.TREND_TEMPLATE_CONDITION_COUNT (× 記号判定) と一致させる。
 _TREND_TEMPLATE_ALL = {
     "pr>ma10", "pr>ma30,40", "ma30>ma40", "ma40Up",
     "ma10>ma30,40", "high(low)52", "RS",
 }
+assert len(_TREND_TEMPLATE_ALL) == TREND_TEMPLATE_CONDITION_COUNT
 
 
 def _is_stage4(misses):

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -33,6 +33,12 @@ INTERVAL_DAY_W = 7
 # を除く上限までは拾って半透明マーカーで可視化する。シグナル列には出さない。
 BREAKOUT_EXTENDED_KAIRI_MAX = 25
 
+# ブレイク検知の出来高平均日数 (issue #111)。20日では短期の急騰を平均が拾いやすく
+# 基準が緩むため、より長期の平常出来高を基準にする。検知ループは直近10日を判定し
+# 各日で前日から遡って平均を取るため、必要データは 10+30=40日。日足取得 period="2mo"
+# (~41営業日) で全検知日が完全な30日平均を保てる上限値 (取得範囲は広げない)。
+BREAKOUT_AVG_VOLUME_DAYS = 30
+
 
 # モメンタムポイント動的キャリブレーション (issue #104) のデフォルト値。
 # market_db['momentum_calib'] が無い・古い・サンプル不足の場合のフォールバック先。
@@ -1737,10 +1743,10 @@ def parse_price_text_from_list(price_current, price_list):
     breaks = []
     breaks_ext = []  # 高値追い圏の extended 候補 (詳細チャートのみ)
     for ind in range(10):
-        # 過去20日平均出来高
+        # 過去 BREAKOUT_AVG_VOLUME_DAYS 日平均出来高 (issue #111)
         avg_vol = 0
         avg_count = 0
-        for j in range(20):
+        for j in range(BREAKOUT_AVG_VOLUME_DAYS):
             if ind + 1 + j >= len(price_list):
                 continue
             avg_vol += price_list[ind + 1 + j][5]  # +1:前日から

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -27,6 +27,12 @@ PRICE_D_FNAME_KABUTAN = os.path.join(
 INTERVAL_DAY_D = 1
 INTERVAL_DAY_W = 7
 
+# ブレイクアウト extended 候補 (詳細チャートのみ表示)。正規ブレイクは MA10乖離
+# +5%以内 (高値追いを避けるオニール/ミネルヴィニ規律) だが、出来高/急騰と上昇は
+# 満たすのに乖離が +5% 超で弾かれた「高値追い圏」の候補を、行き過ぎ (クライマックス)
+# を除く上限までは拾って半透明マーカーで可視化する。シグナル列には出さない。
+BREAKOUT_EXTENDED_KAIRI_MAX = 25
+
 
 # モメンタムポイント動的キャリブレーション (issue #104) のデフォルト値。
 # market_db['momentum_calib'] が無い・古い・サンプル不足の場合のフォールバック先。
@@ -1729,6 +1735,7 @@ def parse_price_text_from_list(price_current, price_list):
 
     # ---- ブレイクアウト
     breaks = []
+    breaks_ext = []  # 高値追い圏の extended 候補 (詳細チャートのみ)
     for ind in range(10):
         # 過去20日平均出来高
         avg_vol = 0
@@ -1773,21 +1780,26 @@ def parse_price_text_from_list(price_current, price_list):
         prev_close = price_list[ind + 1][6]
         chg_rate = (price_list[ind][6] - prev_close) / prev_close if prev_close else 0.0
         # print "AVG:", ind, avg_vol, avg_count, vol, kairi
-        if (vol >= 1.5 * avg_vol or chg_rate >= 0.20) and kairi <= 5:
-            # TODO: ボラティリティ的なブレイクアウトを見たほうが良いが、
-            # ややめんどうなのでまずはma乖離で ローソク足ボラティリティを使えば良い
-            if price_list[ind][6] > price_list[ind + 1][6]:
-                dt = parse_date_str(price_list[ind][0])
-                if dt:
-                    day = dt.strftime("%m/%d")
-                else:
-                    day = price_list[ind][0]
+        vol_or_surge = vol >= 1.5 * avg_vol or chg_rate >= 0.20
+        rising = price_list[ind][6] > price_list[ind + 1][6]
+        if vol_or_surge and rising:
+            dt = parse_date_str(price_list[ind][0])
+            day = dt.strftime("%m/%d") if dt else price_list[ind][0]
+            if kairi <= 5:
+                # TODO: ボラティリティ的なブレイクアウトを見たほうが良いが、
+                # ややめんどうなのでまずはma乖離で ローソク足ボラティリティを使えば良い
                 # ストップ高張り付き時は出来高が減り per が負になりうるため 0 床。
                 # 保存値は常に非負で強度バケット (issue #253 webapp) が単調に振る舞う。
                 per = max(100 * vol / avg_vol - 100, 0)
                 log_debug("ブレイク:%s,%d" % (day, per))
                 breaks.append("%s,%d" % (day, per))
+            elif kairi <= BREAKOUT_EXTENDED_KAIRI_MAX:
+                # 高値追い圏 (規律上は買わない) の extended 候補。kairi を保存し
+                # 詳細チャートの tooltip で乖離を表示する (強度は出さない)。
+                log_debug("ブレイクext:%s,%d" % (day, round(kairi)))
+                breaks_ext.append("%s,%d" % (day, round(kairi)))
     price["breakout"] = breaks
+    price["breakout_extended"] = breaks_ext
     # print breaks
     # ---- 過去価格
     past_prices = []

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2550,13 +2550,20 @@ def _svg_triangle(cx: float, cy: float, size: float, color: str,
 
 
 def _svg_diamond(cx: float, cy: float, size: float, color: str,
-                 opacity: float = 1.0, title: str = "") -> str:
-    """ダイヤ (菱形) マーカー (issue #253: ブレイクアウト用)。"""
+                 opacity: float = 1.0, title: str = "", filled: bool = True) -> str:
+    """ダイヤ (菱形) マーカー (issue #253: ブレイクアウト用)。
+
+    filled=False は輪郭のみ (中抜き)。高値追い圏の extended 候補を半透明で
+    弱く見せるのに使う。
+    """
     pts = "%.1f,%.1f %.1f,%.1f %.1f,%.1f %.1f,%.1f" % (
         cx, cy - size, cx + size, cy, cx, cy + size, cx - size, cy)
     t = "<title>%s</title>" % html.escape(title) if title else ""
-    return ('<polygon points="%s" fill="%s" opacity="%.2f">%s</polygon>'
-            % (pts, color, opacity, t))
+    if filled:
+        return ('<polygon points="%s" fill="%s" opacity="%.2f">%s</polygon>'
+                % (pts, color, opacity, t))
+    return ('<polygon points="%s" fill="none" stroke="%s" stroke-width="1.2" '
+            'opacity="%.2f">%s</polygon>' % (pts, color, opacity, t))
 
 
 def _resolve_signal_markers(stock, window_dates, xs):
@@ -2579,7 +2586,8 @@ def _resolve_signal_markers(stock, window_dates, xs):
         return []
     try:
         from make_stock_db import extract_signals  # 遅延 import
-        signals = extract_signals(stock, max_delta_days=None)
+        # 詳細チャートのみ extended (高値追い圏で弾かれたブレイク候補) を含める。
+        signals = extract_signals(stock, max_delta_days=None, include_extended=True)
     except Exception:  # noqa: BLE001
         return []
     latest = window_dates[-1]  # チャート最新日 (= 直近週)
@@ -2604,12 +2612,17 @@ def _resolve_signal_markers(stock, window_dates, xs):
         x = _interp_x(s["sig_date"])
         if x is None:
             continue  # 窓外 (古い) → drop
-        markers.append({
+        m = {
             "kind": s["kind"], "x": x,
             "num": s["num"], "delta": s["delta"],
             "sig_date": s["sig_date"],
-            "strength": _signal_strength_bucket(s["kind"], s["num"]),
-        })
+        }
+        if s.get("extended"):
+            # extended は強度を出さない (出来高の大きさを強調すると高値追い規律と逆行)。
+            m["extended"] = True
+        else:
+            m["strength"] = _signal_strength_bucket(s["kind"], s["num"])
+        markers.append(m)
     return markers
 
 
@@ -2959,15 +2972,24 @@ def build_price_rs_chart_full(
         # ポは三角・ブは菱形。視認性調整: ポは控えめに縮小、ブは強調して拡大。
         PO_SIZE_SCALE = 0.8
         BU_SIZE_SCALE = 1.8
+        EXT_SIZE = 4.5  # extended は強度を持たないので固定サイズ
         # マーカー専用バンド内: ポは下段、ブはその上の段 (同発生週の重なり回避)。
         y_po = label_y + 16  # 日付ラベル baseline の下
         y_bu = y_po - 6
         for m in markers:
-            size = size_map[m["strength"]]
             # 週足チャートに日足発生日を重ねるため、X位置だけでは発生日が読み取り
             # づらい (週バーは月曜ラベルで週末終値を示すため視覚的にズレる)。
             # 発生日 (M/D) を tooltip に明示して誤読を防ぐ。
             sig_md = "%d/%d" % (m["sig_date"].month, m["sig_date"].day)
+            # extended (高値追い圏で正規ブレイクから弾かれた候補): strength を持たない
+            # ため size_map 参照より前に分岐。半透明・中抜きの橙ダイヤで弱く表示し、
+            # tooltip に乖離と「対象外」を明記する。num は MA10乖離%。
+            if m.get("extended"):
+                title = "ブ(extended) %s 乖離+%d%% 高値追い圏・対象外" % (sig_md, m["num"])
+                parts.append(_svg_diamond(
+                    m["x"], y_bu, EXT_SIZE * BU_SIZE_SCALE, "#f57c00", 0.3, title, filled=False))
+                continue
+            size = size_map[m["strength"]]
             title = "%s %s (%s)" % (m["kind"], sig_md, m["strength"])
             if m["kind"] == "ポ":
                 parts.append(_svg_triangle(m["x"], y_po, size * PO_SIZE_SCALE, "#2e7d32", 1.0, title))
@@ -3416,14 +3438,17 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
         elif rs_raw >= 70:
             styles["rs"] = bg("薄黄")
 
-    # --- トレンド (ルール 24, 25, 26): "◎" 濃黄 / "◯" 薄黄 / 空欄("—") 水色
+    # --- トレンド (ルール 24, 25, 26): "◎" 濃黄 / "◯" 薄黄 / "×"(全miss=Stage4崩壊) 青 /
+    #     "—"(未評価/データ欠損) 赤。× と — は意味が異なるため別色 (issue #111)。
     trend = row.get("trend_template") or ""
     if "◎" in trend:
         styles["trend_template"] = bg("濃黄")
     elif "◯" in trend:
         styles["trend_template"] = bg("薄黄")
+    elif "×" in trend:
+        styles["trend_template"] = bg("青")
     elif not trend or trend == "—":
-        styles["trend_template"] = bg("水色")
+        styles["trend_template"] = bg("赤")
 
     # --- シグナル (ルール 2-7): 強い色から順に評価
     tags = row.get("tags") or ""

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -466,10 +466,12 @@ nav .quick-search {
 }
 
 /* トレンド表示の背景色 (issue #248)
-   portfolio_list は inline style、detail.html はクラスで適用。仕様統一: ◎=濃黄/◯=薄黄/—=水色 */
-.trend-bg-strong { background: #fbbc04; }
-.trend-bg-good   { background: #fce8b2; }
-.trend-bg-none   { background: #6fa8dc; }
+   portfolio_list は inline style、detail.html はクラスで適用。
+   仕様統一: ◎=濃黄/◯=薄黄/×=青(全崩壊)/—=赤(欠損) */
+.trend-bg-strong   { background: #fbbc04; }
+.trend-bg-good     { background: #fce8b2; }
+.trend-bg-collapse { background: #4285f4; }
+.trend-bg-missing  { background: #ea4335; }
 
 /* 需給バランスセル (issue #247): SPR/rv の横バー 2 本縦積み */
 .spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; width: 80px; }

--- a/tests/test_ks_util.py
+++ b/tests/test_ks_util.py
@@ -436,3 +436,28 @@ class TestKairiGaugeSvg:
         )
         assert svg.startswith("<svg")
         assert expect_color in svg
+
+
+class TestTrendSymbolAndBgClass:
+    """trend_symbol_from_misses / trend_bg_class: miss 数→記号→背景色クラスの対応。
+
+    webapp 一覧 (compute_cell_styles) の色仕様と統一する (issue #111):
+    ◎/◯ は黄系、× (全条件miss=Stage4崩壊)=青, — (未評価/欠損)=赤。▲/△ は色なし。
+    """
+
+    _COND = ["c%d" % i for i in range(7)]  # 7条件ぶんのダミー miss
+
+    @pytest.mark.parametrize(
+        "misses, symbol, bg_cls",
+        [
+            ([], "◎", "trend-bg-strong"),
+            (_COND[:2], "◯", "trend-bg-good"),
+            (_COND[:3], "▲", ""),                       # 色なし
+            (_COND[:6], "△", ""),                       # 色なし
+            (_COND, "×", "trend-bg-collapse"),          # 全7 miss = 崩壊 → 青
+            (None, "—", "trend-bg-missing"),            # 未評価/欠損 → 赤
+        ],
+    )
+    def test_symbol_and_bg(self, misses, symbol, bg_cls):
+        assert ks_util.trend_symbol_from_misses(misses) == symbol
+        assert ks_util.trend_bg_class(symbol) == bg_cls

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -73,7 +73,7 @@ class TestGetTrendTemplateExpr:
             ({"trend_template": []}, "◎"),                                   # 全通過
             ({"trend_template": ["a", "b", "c"]}, "▲"),                      # 3-4 ミス
             ({"trend_template": ["a", "b", "c", "d", "e"]}, "△"),            # 5-6 ミス
-            ({"trend_template": ["a", "b", "c", "d", "e", "f", "g"]}, ""),   # 7+ ミス
+            ({"trend_template": ["a", "b", "c", "d", "e", "f", "g"]}, "×"),  # 7 ミス(全崩壊)
         ],
     )
     def test_classification_exact(self, stock, expected):
@@ -151,20 +151,25 @@ class TestMakeSignal:
 
     # ---- issue #110: ポケットピポット改善 ----
 
+    _ALL7 = [
+        "pr>ma10", "pr>ma30,40", "ma30>ma40", "ma40Up",
+        "ma10>ma30,40", "high(low)52", "RS",
+    ]
+
     @pytest.mark.parametrize(
         "trend_template, expect_signal",
         [
             ([], True),  # 全通過(◎) → タグ付与
             (None, True),  # legacy None → 空扱い
-            (["RS"], True),  # 除外対象外のmiss → タグ付与
-            (["pr>ma30,40"], False),  # 長期MA割れ → 除外
-            (["ma40Up"], False),  # MA40下降(Stage4) → 除外
-            (["high(low)52"], False),  # 52週高値圏外(crash) → 除外
+            (["RS"], True),  # 1項目だけmiss → タグ付与
+            (["pr>ma30,40", "ma40Up", "high(low)52"], True),  # 部分崩壊(旧3条件) → タグ付与
+            (_ALL7[:6], True),  # 6項目miss(1つ通過) → タグ付与
+            (_ALL7, False),  # 7項目全miss(完全Stage4崩壊) → 除外
             ("__missing__", True),  # trend_template キー欠落 → タグ付与
         ],
     )
     def test_pocket_pivot_stage4_filter(self, trend_template, expect_signal):
-        """項目1: Stage 4 崩壊銘柄ではポケットピポットを除外する"""
+        """Stage 4 崩壊(7条件全miss)銘柄でのみポケットピポットを除外する (issue #110/#111)"""
         today = datetime.today()
         recent = (today - timedelta(days=2)).strftime("%m/%d")
         stock = {
@@ -307,9 +312,11 @@ class TestExtractSignals:
     @pytest.mark.parametrize(
         "case, kw_factory, expect_kinds",
         [
-            # Stage4 崩壊 → ポ全除外
+            # Stage4 崩壊 (7条件全miss) → ポ全除外
             ("stage4_drop", lambda d: {
-                "pocket_pivot": ["%s,2" % d(2)], "trend_template": ["ma40Up"]}, []),
+                "pocket_pivot": ["%s,2" % d(2)],
+                "trend_template": ["pr>ma10", "pr>ma30,40", "ma30>ma40", "ma40Up",
+                                   "ma10>ma30,40", "high(low)52", "RS"]}, []),
             # ポ4件目以降は落ちる (3件まで)
             ("pp_cap3", lambda d: {
                 "pocket_pivot": ["%s,%d" % (d(n), n) for n in (1, 2, 3, 4)]},

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -1086,6 +1086,38 @@ class TestParsePriceTextFromList:
         else:
             assert len(breaks) == 0
 
+    @pytest.mark.parametrize(
+        "today_close, today_low, prev_close, expect_regular, expect_ext",
+        [
+            # 乖離+9%: 正規ブレイク(+5%以内)から弾かれ extended に入る
+            (1150, 1120, 1100, False, True),
+            # 乖離+22%: 当日は extended、前日もブレイク条件を満たし regular に入る
+            (1300, 1280, 1250, True, True),
+            # 乖離が小さい(押し目位置): 正規ブレイクで extended には入らない
+            (1080, 1070, 1050, True, False),
+        ],
+    )
+    def test_breakout_extended(self, today_close, today_low, prev_close,
+                               expect_regular, expect_ext):
+        """高値追い圏 (+5% < kairi <= 25%) で弾かれたブレイク候補が
+        breakout_extended に入ること (詳細チャートの半透明マーカー用)。"""
+        from datetime import date as _date, timedelta
+        d0 = _date(2025, 12, 31)
+        price_list = []
+        for i in range(25):
+            dt = d0 - timedelta(days=i)
+            date_str = "%d年%d月%d日" % (dt.year, dt.month, dt.day)
+            if i == 0:
+                close, low, vol = today_close, today_low, 300000
+            elif i == 1:
+                close, low, vol = prev_close, prev_close - 5, 100000
+            else:
+                close, low, vol = 1000, 995, 100000  # 横ばい → ma10≈1000
+            price_list.append([date_str, close, close + 10, low, close, vol, close])
+        result_dict, _ = price.parse_price_text_from_list(today_close, price_list)
+        assert (len(result_dict["breakout"]) >= 1) == expect_regular
+        assert (len(result_dict["breakout_extended"]) >= 1) == expect_ext
+
     @pytest.mark.parametrize("bd,next_low,expected", [
         # 7カラム経路 (close=adj_close=[6], low=[3]) の porosity 回帰。割れ日 (bd) で
         # adj_close だけ10maを割り、翌営業日 (bd-1) の安値で維持/切断が分岐することを検証。

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1681,14 +1681,15 @@ class TestComputeCellStyles:
         else:
             assert styles["per"] == expected_color
 
-    # ----- トレンド (◎ 濃黄 / ◯ 薄黄 / —, 空欄 水色 / ◎◯ で ◎優先) -----
+    # ----- トレンド (◎ 濃黄 / ◯ 薄黄 / × 青(全崩壊) / —, 空欄 赤(欠損) / ◎◯ で ◎優先) -----
     @pytest.mark.parametrize(
         "trend, expected",
         [
             ("◎pr>ma10", f"background:{C['濃黄']}"),
             ("◯RS", f"background:{C['薄黄']}"),
-            ("—", f"background:{C['水色']}"),
-            ("", f"background:{C['水色']}"),
+            ("×", f"background:{C['青']}"),       # 7件全miss = Stage4崩壊
+            ("—", f"background:{C['赤']}"),       # 未評価/データ欠損
+            ("", f"background:{C['赤']}"),
             ("◎◯", f"background:{C['濃黄']}"),  # ◎優先
             ("▲", None),                          # 対象外記号
         ],
@@ -1824,10 +1825,10 @@ class TestComputeCellStyles:
             assert styles["last_research_update"] == expected
 
     # ----- 統合: 空 row / today デフォルト -----
-    def test_empty_row_only_trend_water_blue(self):
-        """空 row では trend_template が空欄扱いで水色のみ付く"""
+    def test_empty_row_only_trend_data_missing_red(self):
+        """空 row では trend_template が欠損扱いで赤のみ付く"""
         styles = helpers.compute_cell_styles({}, today=TODAY)
-        assert styles == {"trend_template": f"background:{C['水色']}"}
+        assert styles == {"trend_template": f"background:{C['赤']}"}
 
     def test_default_today_uses_date_today(self):
         """today 省略時は date.today() を使う (落ちないことの確認)"""


### PR DESCRIPTION
## 概要

issue #111 の短期改善（項目1・2・3）と、その検討過程で見つかったトレンド表示の問題、および詳細チャートのブレイク可視化をまとめて対応。

## 変更内容

### 1. Stage 4 判定を「7条件全miss」基準に統一（項目2の発展）
- ブレイク/ポケットのシグナル抑制を `trend_template` 7条件を**1つも満たさない（全miss）** = 完全Stage 4崩壊、の単一基準 `_is_stage4()` に統一。
- 当初の項目2は「下降トレンド2条件」案だったが、実データで抑制55.5%のうち約45%がStage 1底値圏の初動を巻き込むと判明。「全miss」基準なら底値圏（必ず何か通過）を巻き込まず精密に除外できる。
- 旧2定数（`_PP_/_BREAKOUT_STAGE4_MISSES`）を廃止しシンプル化。
- **抑制率**: ブレイク 55.5%→**17.6%**、ポケット 63.9%→**14.4%**。

### 2. portfolioトレンド列の色分離
- 従来 `trend_symbol_from_misses` が「全miss崩壊」と「データ欠損」を両方 `"—"`→水色で**混同**していた。
- 全崩壊を `"×"`、未評価/欠損を `"—"` と記号で区別し、色も **×→青（最悪トレンド）/ —→赤（データ欠損）** に分離。
- E2E確認: 6758・3697 等が正しく ×（青）で表示。

### 3. ブレイク検知の出来高平均を20日→30日に変更（項目1）
- 20日は直近の急騰を平均が拾いやすく基準が緩むため、より長期の平常出来高基準へ。
- **取得範囲は広げない**: `period="2mo"`(~41営業日) で全検知日が完全な30日平均を保てる上限値（必要データ 10+30=40日）。
- 実データ: 2980 が20日では未検知→30日で検知、5572 の per 162→177。

### 4. 詳細チャートにブレイク extended マーカー
- 高値追い圏（`+5% < MA10乖離 <= +25%`）で正規ブレイクから弾かれた候補を、詳細チャートのみ**半透明中抜き橙ダイヤ**で可視化（signal列は現状維持）。
- tooltip に理由明記（例: `ブ(extended) 6/3 乖離+22% 高値追い圏・対象外`）。

### 項目3（年跨ぎ date parse）
- `_signal_recent_delta` で既に年補完済みのため対応不要（確認済み）。

## テスト
- `pytest -m "not local_db and not live_html"` → **1810 passed, 1 skipped**
- E2E（Playwright）: 詳細チャートの正規/extendedマーカー描画・tooltip、portfolioトレンド列の青/赤を確認。

## 未対応（このPRの対象外）
- issue #111 項目4（ピボット価格ベースのブレイク検出新設）は issue #109（CWH/VCP）連動の中期課題のため未着手。**親issueは継続のため本PRでは close しない。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)