### PR TITLE
[codex] 詳細チャートのマーカー表示とtooltip修正

### DIFF
--- a/doc/review/extended_marker_size_plan.md
+++ b/doc/review/extended_marker_size_plan.md
@@ -1,0 +1,174 @@
+# extended ブレイクマーカーのサイズを強度連動にするプラン
+
+## 目的・背景
+
+portfolio 詳細チャート（RS ラインチャート）下部のブレイクマーカーのうち、
+extended（高値追い圏で正規ブレイクから弾かれた候補、中抜き◇）のサイズが
+現状 **固定 4.5（×1.8=8.1）** で、実際のブレイクの大きさ（出来高超過率）を
+反映していない。
+
+ユーザー要望: extended◇のサイズも通常ブレイク◆と同じ基準（出来高超過率の
+強度バケット）に従わせ、◆と◇でサイズ・強度ロジックを共通化する。塗り（filled）と
+不透明度だけで両者を区別する。
+
+### 当初設計との関係（経緯）
+
+extended は issue #111 / PR #338（コミット d67dd96）で導入。当初は「高値追い圏 =
+規律上買わない対象外」のため **強度（出来高超過率）をあえて見せず、MA10乖離率のみ保存・
+固定サイズ・半透明** にする意図的設計だった（コード内コメント「強度は出さない」）。
+今回の変更はこの方針を一部転換し「extended でもブレイクの強さ（出来高超過率）を
+サイズで可視化する」もの。ただし **中抜き◇と半透明は『対象外』サインとして維持** し、
+サイズだけ実態連動にする。半透明はサイズが大きくなると薄く見づらくなるため
+opacity 0.3 → 0.5 に少し濃くする。
+
+### 実測で確認済みの事実（5572.T）
+
+| 日付 | 区分 | MA10乖離 | 出来高超過率 | 強度バケット |
+|---|---|---|---|---|
+| 06/15 | ◆通常ブ | -0.6% | +244% | 強 |
+| 06/05 | ◇extended | +13.5% | +256% | 強 |
+| 06/03 | ◇extended | +22.0% | +4944% | 強 |
+
+→ extended でも出来高超過率は「強」相当が出る。固定サイズだと実際の強度を表現できていない。
+
+## 現状の制約（重要）
+
+- `breakout_extended` の保存形式は `"MM/DD,kairi"`（2要素）。**出来高超過率は保存されていない**。
+- `breakout`（通常）は `"MM/DD,per"`（per=出来高超過率）を保存。
+- `_signal_strength_bucket("ブ", num)` は num を出来高超過率前提で判定するため、
+  extended の num（=MA10乖離率）をそのまま渡すと誤判定になる。
+
+→ サイズを出来高超過率の強度に従わせるには、**extended に出来高超過率を新規保存する**
+必要がある。生成側・パース側・描画側の3層に手が入る。
+
+## 変更方針
+
+extended の保存形式を `"MM/DD,kairi"` → `"MM/DD,kairi,per"`（3要素）に拡張する。
+per は通常ブレイクと同じ計算式 `max(100*vol/avg_vol - 100, 0)`。
+これにより後方互換（既存2要素データは per 欠落として読める）を保ちつつ、
+描画側で per から強度バケットを引ける。
+
+## 変更ファイルと具体的変更
+
+### 1. `scripts/price.py`（生成側）
+
+`make_signal`（≈1799-1806 行）の extended 分岐で per も計算して保存する。
+
+```python
+# 現状（1799-1806 付近）
+if kairi <= 5:
+    per = max(100 * vol / avg_vol - 100, 0)
+    breaks.append("%s,%d" % (day, per))
+elif kairi <= BREAKOUT_EXTENDED_KAIRI_MAX:
+    breaks_ext.append("%s,%d" % (day, round(kairi)))
+```
+
+変更後:
+
+```python
+if kairi <= 5:
+    per = max(100 * vol / avg_vol - 100, 0)
+    breaks.append("%s,%d" % (day, per))
+elif kairi <= BREAKOUT_EXTENDED_KAIRI_MAX:
+    # extended も出来高超過率 per を保存し、描画側で強度バケットに使う。
+    # 形式: "MM/DD,kairi,per"（既存 "MM/DD,kairi" との後方互換のため per は末尾追加）
+    per = max(100 * vol / avg_vol - 100, 0)
+    breaks_ext.append("%s,%d,%d" % (day, round(kairi), per))
+```
+
+### 2. `scripts/make_stock_db.py`（extract_signals パース側）
+
+`extract_signals`（1109-1133 行）の extended パースで、3要素目（per）があれば
+`extended_per` として entry に持たせる。2要素しかない旧データは per 欠落とする。
+
+```python
+# 現状: num = int(spl[1]) のみ
+entry = {
+    "kind": kind, "mmdd": spl[0], "num": num,
+    "sig_date": sig_date, "delta": delta,
+}
+if extended:
+    entry["extended"] = True
+```
+
+変更後（extended のときだけ 3要素目を読む）:
+
+```python
+entry = {
+    "kind": kind, "mmdd": spl[0], "num": num,
+    "sig_date": sig_date, "delta": delta,
+}
+if extended:
+    entry["extended"] = True
+    # 3要素目があれば出来高超過率（描画側の強度バケット用）。
+    # 旧2要素データは per なし → 描画側で従来の固定サイズにフォールバック。
+    if len(spl) >= 3:
+        try:
+            entry["extended_per"] = int(spl[2])
+        except ValueError:
+            pass
+```
+
+注意: 通常ブレイク（extended=False）の num はそのまま per なので変更不要。
+num の意味は extended のみ MA10乖離率のまま（tooltip の乖離表示が依存）。
+
+### 3. `scripts/webapp/helpers.py`（描画側）
+
+#### 3-1. `_resolve_signal_markers`（2683-2697 行）
+
+extended marker に `extended_per` を引き継ぎ、per があれば強度バケットを付与する。
+
+```python
+if s.get("extended"):
+    m["extended"] = True
+    per = s.get("extended_per")
+    if per is not None:
+        m["strength"] = _signal_strength_bucket("ブ", per)
+else:
+    m["strength"] = _signal_strength_bucket(s["kind"], s["num"])
+```
+
+#### 3-2. マーカー描画（3165-3175 行）
+
+extended のサイズを、strength があれば size_map から引く（=◆と共通サイズ）。
+strength が無い（旧データ）場合のみ従来の固定 EXT_SIZE にフォールバック。
+塗り（filled=False, 中抜き）と不透明度は extended 識別子として維持する。
+
+```python
+if m.get("extended"):
+    # extended は中抜き◇。サイズは通常ブレイク◆と共通の強度バケット基準。
+    # per 未保存の旧データは strength を持たないため固定サイズにフォールバック。
+    ext_size = size_map[m["strength"]] if m.get("strength") else EXT_SIZE
+    title = "ブ(extended) %s 乖離+%d%% 高値追い圏・対象外" % (sig_md, m["num"])
+    parts.append(_svg_diamond(
+        m["x"], y_bu, ext_size * BU_SIZE_SCALE, "#f57c00", 0.5, title, filled=False))
+    continue
+```
+
+→ 6/5・6/3 の extended は strength="強" → size_map["強"]=6.0 → ×1.8=10.8 となり、
+6/15 の通常ブレイク◆（強, 10.8）と同サイズになる。
+
+## 後方互換・移行
+
+- 既存 DB の `breakout_extended` は2要素（per 欠落）。読み出し側は per 欠落を許容し、
+  従来の固定サイズで描画する（壊れない）。
+- per は次回の銘柄更新（`make_stock_db.py update` / `list_all_db`）で3要素形式に
+  書き換わる。マイグレーションスニペットは不要（自然に上書き更新される）。
+- shelve スキーマ自体は変わらない（リスト内文字列のフォーマット拡張のみ）。
+
+## 検証ポイント（ゴール）
+
+1. `pytest tests/test_price.py tests/test_make_stock_db.py -v` が通る。
+2. extract_signals の extended エントリに、3要素データで `extended_per` が入り、
+   2要素データでは入らないこと（parametrize で1〜2本）。
+3. `cd scripts && python make_stock_db.py update 5572` 後、
+   `breakout_extended` が `"06/05,13,256"` 形式（3要素）になること。
+4. ブラウザで 5572 詳細チャートを開き、extended◇が 6/15 の◆と同サイズ（強）で
+   描画されること（中抜き・半透明は維持）。スクリーンショットで確認。
+
+## 非対象（やらないこと）
+
+- ポケットピボット△のサイズ基準は変更しない。
+- 通常ブレイク◆のサイズ・強度しきい値は変更しない。
+- extended の num（MA10乖離率）の意味・tooltip 表示は変更しない。
+- 強度しきい値（200/100）の調整はこのプランの範囲外。

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1130,6 +1130,13 @@ def extract_signals(stock, max_delta_days=10, include_extended=False):
             }
             if extended:
                 entry["extended"] = True
+                # 3要素目があれば出来高超過率 (描画側のマーカー強度バケット用)。
+                # 旧2要素データは per なし → 描画側で従来の固定サイズにフォールバック。
+                if len(spl) >= 3:
+                    try:
+                        entry["extended_per"] = int(spl[2])
+                    except ValueError:
+                        pass
             out.append(entry)
     return out
 

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -1800,10 +1800,13 @@ def parse_price_text_from_list(price_current, price_list):
                 log_debug("ブレイク:%s,%d" % (day, per))
                 breaks.append("%s,%d" % (day, per))
             elif kairi <= BREAKOUT_EXTENDED_KAIRI_MAX:
-                # 高値追い圏 (規律上は買わない) の extended 候補。kairi を保存し
-                # 詳細チャートの tooltip で乖離を表示する (強度は出さない)。
-                log_debug("ブレイクext:%s,%d" % (day, round(kairi)))
-                breaks_ext.append("%s,%d" % (day, round(kairi)))
+                # 高値追い圏 (規律上は買わない) の extended 候補。kairi (乖離) に加え
+                # 出来高超過率 per も保存し、詳細チャートで乖離 tooltip を出しつつ
+                # マーカーサイズを通常ブレイクと同じ強度バケットで決められるようにする。
+                # 形式: "MM/DD,kairi,per" (既存 "MM/DD,kairi" との後方互換のため末尾追加)。
+                per = max(100 * vol / avg_vol - 100, 0)
+                log_debug("ブレイクext:%s,%d,%d" % (day, round(kairi), per))
+                breaks_ext.append("%s,%d,%d" % (day, round(kairi), per))
     price["breakout"] = breaks
     price["breakout_extended"] = breaks_ext
     # print breaks

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2602,6 +2602,21 @@ def _svg_circle(cx: float, cy: float, r: float, color: str) -> str:
     return f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="{r}" fill="{color}"/>'
 
 
+def _svg_hover_rect(cx: float, cy: float, half_w: float, half_h: float, title: str = "") -> str:
+    """透明 hover ターゲット矩形を返す。
+
+    SVG title は細い polygon だと hover しづらいことがあるため、見た目とは別に
+    マーカー周辺へ当たり判定を広げる。fill-opacity=0 だとブラウザによっては
+    hover 判定が不安定なため、ごく薄い不透明度を使う。
+    """
+    t = "<title>%s</title>" % html.escape(title) if title else ""
+    return (
+        '<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" '
+        'fill="#fff" fill-opacity="0.001">%s</rect>'
+        % (cx - half_w, cy - half_h, half_w * 2, half_h * 2, t)
+    )
+
+
 def _svg_triangle(cx: float, cy: float, size: float, color: str,
                   opacity: float = 1.0, title: str = "") -> str:
     """上向き三角マーカー (issue #253: ポケットピボット用)。"""
@@ -3042,6 +3057,10 @@ def build_price_rs_chart_full(
     parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" width="{width}" height="{height}" style="display:block;">'
     ]
+    # 詳細チャートは親要素 title を使わず、SVG 内で hover 領域を分ける。
+    # 非シグナル要素は pointer-events を切り、チャート本体の透明 hover 面だけが
+    # RS 系 tooltip を出す。マーカーバンドはポ/ブ polygon の title のみ有効にする。
+    parts.append('<g pointer-events="none">')
 
     # 背景枠
     parts.append(
@@ -3146,6 +3165,19 @@ def build_price_rs_chart_full(
             f'fill="#1976d2" font-weight="bold" text-anchor="end">{_format_pct_axis(rs_pct[-1])}</text>'
         )
 
+    # RS(0~99)履歴を右Y軸 (0~99 固定) で右端側に重畳 (最前面)。
+    # 横軸は週足スケールのまま、RS各点は実日付で週足軸 (window_dates/xs) にマップ。
+    # 営業日カレンダー突き合わせは日足 price_log を使う (price_log 引数は週足台帳のため)。
+    daily_price_log = (stock or {}).get("price_log") or []
+    _overlay_rs_rank(
+        parts, rank_pts, daily_price_log,
+        window_dates=window_dates, xs=xs,
+        chart_top=chart_top, chart_h=chart_h,
+        pad_x=pad_x, inner_w=inner_w, pad_right=pad_right,
+    )
+
+    parts.append("</g>")
+
     # ポ/ブ発生日マーカー (issue #253): ポ=緑三角 / ブ=橙ダイヤ。
     # X は発生日を週幅で日割り按分、Y は X軸 + 日付ラベルの下に常設したマーカー専用バンド
     # (騰落率Y軸と無関係) に配置し、株価線/RS線と完全分離する。サイズは強度バケット。
@@ -3175,26 +3207,26 @@ def build_price_rs_chart_full(
             if m.get("extended"):
                 ext_size = size_map[m["strength"]] if m.get("strength") else EXT_SIZE
                 title = "ブ(extended) %s 乖離+%d%% 高値追い圏・対象外" % (sig_md, m["num"])
+                parts.append(_svg_hover_rect(m["x"], y_bu, 8.0, 8.0, title))
                 parts.append(_svg_diamond(
                     m["x"], y_bu, ext_size * BU_SIZE_SCALE, "#f57c00", 0.5, title, filled=False))
                 continue
             size = size_map[m["strength"]]
             title = "%s %s (%s)" % (m["kind"], sig_md, m["strength"])
             if m["kind"] == "ポ":
+                parts.append(_svg_hover_rect(m["x"], y_po, 8.0, 8.0, title))
                 parts.append(_svg_triangle(m["x"], y_po, size * PO_SIZE_SCALE, "#2e7d32", 1.0, title))
             else:  # ブ
+                parts.append(_svg_hover_rect(m["x"], y_bu, 8.0, 8.0, title))
                 parts.append(_svg_diamond(m["x"], y_bu, size * BU_SIZE_SCALE, "#f57c00", opa_map[m["strength"]], title))
 
-    # RS(0~99)履歴を右Y軸 (0~99 固定) で右端側に重畳 (最前面)。
-    # 横軸は週足スケールのまま、RS各点は実日付で週足軸 (window_dates/xs) にマップ。
-    # 営業日カレンダー突き合わせは日足 price_log を使う (price_log 引数は週足台帳のため)。
-    daily_price_log = (stock or {}).get("price_log") or []
-    _overlay_rs_rank(
-        parts, rank_pts, daily_price_log,
-        window_dates=window_dates, xs=xs,
-        chart_top=chart_top, chart_h=chart_h,
-        pad_x=pad_x, inner_w=inner_w, pad_right=pad_right,
-    )
+    if tooltip:
+        chart_hover_h = chart_top + chart_h + 2
+        parts.append(
+            '<rect x="0" y="0" width="%d" height="%.1f" fill="#fff" fill-opacity="0">'
+            '<title>%s</title></rect>'
+            % (width, chart_hover_h, html.escape(tooltip))
+        )
 
     parts.append("</svg>")
     return ("".join(parts), tooltip)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1999,11 +1999,11 @@ def _signal_freshness_alpha(delta: int) -> float:
 # ポ/ブシグナルの強度バケット (issue #253)。
 # tooltip 文言 (_build_signal_display) とチャートマーカーサイズ (項目3) で共有する。
 def _signal_strength_bucket(kind: str, num: int) -> str:
-    """シグナル種別と保存数値から強度ラベル 強/中/弱 を返す。
+    """シグナル種別と保存数値から強度ラベルを返す。
 
-    ポ: num = MA10乖離率% (小さい=MAに近い良い位置=強)。
-    ブ: num = 出来高超過率% (大きい=出来高急増=強)。
-    しきい値は暫定 (issue #253)、実データで要調整。
+    ポ: num = MA10乖離率% (小さい=MAに近い良い位置=強)。3段階 (強/中/弱)。
+    ブ: num = 出来高超過率% (大きい=出来高急増=強)。4段階 (特強/強/中/弱)。
+        しきい値 500/200/100 は DB全体3046件の分布で校正 (特強=上位約10%)。
     """
     if kind == "ポ":
         if num >= -1:
@@ -2012,6 +2012,8 @@ def _signal_strength_bucket(kind: str, num: int) -> str:
             return "中"
         return "弱"
     # ブ
+    if num >= 500:
+        return "特強"
     if num >= 200:
         return "強"
     if num >= 100:
@@ -2037,7 +2039,7 @@ def _build_signal_display(stock: Dict[str, Any]) -> Dict[str, str]:
         signals = extract_signals(stock)
     except Exception:  # noqa: BLE001
         return empty
-    strength_alpha = {"強": 0.85, "中": 0.55, "弱": 0.30}
+    strength_alpha = {"特強": 1.0, "強": 0.85, "中": 0.55, "弱": 0.30}
     tmpls = {
         "ポ": "[ポ] %s %s 押し目買い圧(MA10乖離 %d) / %d日前",
         "ブ": "[ブ] %s %s 出来高ブレイク(出来高+%d%%) / %d日前",
@@ -2690,8 +2692,13 @@ def _resolve_signal_markers(stock, window_dates, xs):
             "sig_date": s["sig_date"],
         }
         if s.get("extended"):
-            # extended は強度を出さない (出来高の大きさを強調すると高値追い規律と逆行)。
             m["extended"] = True
+            # extended_per (出来高超過率) があれば通常ブレイクと同じ強度バケットで
+            # マーカーサイズを決める。旧2要素データは per なし → strength を付けず
+            # 描画側で固定サイズにフォールバックする。
+            per = s.get("extended_per")
+            if per is not None:
+                m["strength"] = _signal_strength_bucket("ブ", per)
         else:
             m["strength"] = _signal_strength_bucket(s["kind"], s["num"])
         markers.append(m)
@@ -3145,12 +3152,14 @@ def build_price_rs_chart_full(
     # 詳細チャートは発生日が X 位置で読めるため鮮度による半透明化は行わない。最前面に描く。
     if window_dates:
         markers = _resolve_signal_markers(stock, window_dates, xs)
-        size_map = {"強": 6.0, "中": 4.5, "弱": 3.0}
-        opa_map = {"強": 1.0, "中": 0.8, "弱": 0.6}
+        # ブは4段階 (特強/強/中/弱)、ポは3段階 (強/中/弱) で特強は使わない。
+        # サイズは等差1.5。opacity は強で上限 (1.0) のため特強も 1.0。
+        size_map = {"特強": 7.5, "強": 6.0, "中": 4.5, "弱": 3.0}
+        opa_map = {"特強": 1.0, "強": 1.0, "中": 0.8, "弱": 0.6}
         # ポは三角・ブは菱形。視認性調整: ポは控えめに縮小、ブは強調して拡大。
         PO_SIZE_SCALE = 0.8
         BU_SIZE_SCALE = 1.8
-        EXT_SIZE = 4.5  # extended は強度を持たないので固定サイズ
+        EXT_SIZE = 4.5  # extended の per 未保存 (旧データ) 時の固定サイズ
         # マーカー専用バンド内: ポは下段、ブはその上の段 (同発生週の重なり回避)。
         y_po = label_y + 16  # 日付ラベル baseline の下
         y_bu = y_po - 6
@@ -3159,13 +3168,15 @@ def build_price_rs_chart_full(
             # づらい (週バーは月曜ラベルで週末終値を示すため視覚的にズレる)。
             # 発生日 (M/D) を tooltip に明示して誤読を防ぐ。
             sig_md = "%d/%d" % (m["sig_date"].month, m["sig_date"].day)
-            # extended (高値追い圏で正規ブレイクから弾かれた候補): strength を持たない
-            # ため size_map 参照より前に分岐。半透明・中抜きの橙ダイヤで弱く表示し、
-            # tooltip に乖離と「対象外」を明記する。num は MA10乖離%。
+            # extended (高値追い圏で正規ブレイクから弾かれた候補): 中抜き・半透明の
+            # 橙ダイヤで「対象外」を表しつつ、サイズは通常ブレイクと同じ強度バケット
+            # (出来高超過率) に連動させる。per 未保存の旧データは strength を持たない
+            # ため固定サイズ EXT_SIZE にフォールバック。num は MA10乖離% で tooltip に出す。
             if m.get("extended"):
+                ext_size = size_map[m["strength"]] if m.get("strength") else EXT_SIZE
                 title = "ブ(extended) %s 乖離+%d%% 高値追い圏・対象外" % (sig_md, m["num"])
                 parts.append(_svg_diamond(
-                    m["x"], y_bu, EXT_SIZE * BU_SIZE_SCALE, "#f57c00", 0.3, title, filled=False))
+                    m["x"], y_bu, ext_size * BU_SIZE_SCALE, "#f57c00", 0.5, title, filled=False))
                 continue
             size = size_map[m["strength"]]
             title = "%s %s (%s)" % (m["kind"], sig_md, m["strength"])

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -170,7 +170,7 @@
      justify-content: space-between により右上スペースに自動配置される。 #}
   {% if price_rs_chart and price_rs_chart.svg %}
   <div class="right" style="flex:0 0 auto;">
-    <div title="{{ price_rs_chart.tooltip }}" style="cursor:help;">
+    <div style="cursor:help;">
       {{ price_rs_chart.svg|safe }}
     </div>
   </div>

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -341,6 +341,22 @@ class TestExtractSignals:
         stock = {"pocket_pivot": ["06/03,2"], "trend_template": []}
         assert make_stock_db.extract_signals(stock) == []
 
+    @pytest.mark.parametrize("suffix, expect_per", [
+        (",13,256", 256),  # 3要素: per あり (マーカー強度バケット用)
+        (",13", None),     # 旧2要素: per 欠落 → 描画側で固定サイズにフォールバック
+    ])
+    def test_extended_per_parsed(self, suffix, expect_per):
+        """include_extended=True で breakout_extended の3要素目を extended_per に読む。
+        旧2要素データは extended_per を持たない (後方互換)。"""
+        today = datetime.today()
+        d = (today - timedelta(days=3)).strftime("%m/%d")  # 当日だと年補完で前年化するため数日前
+        stock, _ = self._stock(breakout_extended=[d + suffix])
+        signals = make_stock_db.extract_signals(
+            stock, max_delta_days=None, include_extended=True)
+        ext = [s for s in signals if s.get("extended")]
+        assert len(ext) == 1
+        assert ext[0].get("extended_per") == expect_per
+
     def test_max_delta_none_keeps_older_signal(self):
         """max_delta_days=None なら 10日超でも access_date_price 基準で取得する"""
         today = datetime.today()

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -1116,7 +1116,11 @@ class TestParsePriceTextFromList:
             price_list.append([date_str, close, close + 10, low, close, vol, close])
         result_dict, _ = price.parse_price_text_from_list(today_close, price_list)
         assert (len(result_dict["breakout"]) >= 1) == expect_regular
-        assert (len(result_dict["breakout_extended"]) >= 1) == expect_ext
+        ext = result_dict["breakout_extended"]
+        assert (len(ext) >= 1) == expect_ext
+        # extended は "MM/DD,kairi,per" の3要素形式 (per=出来高超過率、マーカー強度用)
+        if ext:
+            assert len(str(ext[0]).split(",")) == 3
 
     @pytest.mark.parametrize("bd,next_low,expected", [
         # 7カラム経路 (close=adj_close=[6], low=[3]) の porosity 回帰。割れ日 (bd) で

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1,5 +1,6 @@
 """webapp/helpers.py のテスト (tmp_path で一時DBを作成)"""
 
+import html
 import os
 
 import pytest
@@ -3251,13 +3252,34 @@ class TestSignalDisplay:
         assert "<title>ブ %s " % sig_md in svg
         # ポの強度でサイズが変わる: 強(乖離0, size6) vs 弱(乖離-5, size3)
         svg_strong, _ = helpers.build_price_rs_chart_full(
-            price_log, [], False, stock=_stock(pp=["%s,0" % mmdd]))
+            price_log, rs_line, False, stock=_stock(pp=["%s,0" % mmdd]))
         svg_weak, _ = helpers.build_price_rs_chart_full(
-            price_log, [], False, stock=_stock(pp=["%s,-5" % mmdd]))
+            price_log, rs_line, False, stock=_stock(pp=["%s,-5" % mmdd]))
         assert svg_strong != svg_weak  # サイズ差で polygon 座標が変わる
         # stock なしなら polygon は出ない
         svg2, _ = helpers.build_price_rs_chart_full(price_log, [], False)
         assert "#f57c00" not in svg2
+
+    def test_chart_marker_band_uses_signal_tooltip_only(self):
+        """詳細チャートはRS hover面とシグナルマーカー帯を分離する。"""
+        from datetime import timedelta
+        anchor_now, anchor_day = self._anchor()
+        price_log = [(anchor_day - timedelta(weeks=i), 1000 + i) for i in range(20)]
+        rs_line = [(anchor_day - timedelta(weeks=i), 1.0 + i * 0.01) for i in range(20)]
+        mmdd = anchor_day.strftime("%m/%d")
+        stock = {
+            "trend_template": [],
+            "access_date_price": anchor_now,
+            "breakout": ["%s,180" % mmdd],
+        }
+
+        svg, tooltip = helpers.build_price_rs_chart_full(price_log, rs_line, False, stock=stock)
+
+        assert '<g pointer-events="none">' in svg
+        assert '<rect x="0" y="0"' in svg
+        assert "<title>%s</title></rect>" % html.escape(tooltip) in svg
+        assert 'fill-opacity="0.001"' in svg
+        assert "<title>ブ %d/%d " % (anchor_day.month, anchor_day.day) in svg
 
 
 class TestBuildTrendInfoMa10:


### PR DESCRIPTION
## 概要
- 詳細チャートのブレイクアウト/ポケットピボットマーカーを強度連動サイズに拡張
- extended ブレイクアウトもサイズ連動の中抜きダイヤで表示
- 詳細チャートで RS tooltip とシグナルマーカー tooltip の干渉を解消
- マーカーごとに透明 hover ターゲットを追加し、tooltip の当たり判定を広げた

## 原因
詳細チャートでは親要素の title と SVG 内マーカーの title が競合し、ブレイクアウトマーカー hover 時に RS tooltip が優先されることがあった。あわせて polygon 自体の hover 面積が小さく、tooltip が出にくかった。

## 影響
- 銘柄詳細ページの詳細チャートで、チャート本体は RS tooltip、マーカー帯はシグナル tooltip を安定して表示できる
- ブレイクアウト強度の差がマーカーサイズでも読める

## 確認
- `.venv/bin/pytest -q tests/test_webapp_helpers.py -k 'chart_markers_render_and_size or chart_marker_band_uses_signal_tooltip_only'`
