### PR TITLE
issue344 portfolioのステージ・チャート選択式化

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -216,9 +216,9 @@ python research_shelve.py backup                                 # DBバック�
 
 ### 営業日判定の方針（祝日カレンダーを持たない理由）
 
-営業日判定は `get_price_day()`（17時前は前日扱い）＋ `weekday()` 土日補正のみ。**祝日カレンダー（`jpholiday` 等）は導入しない**。`weekday()` 補正は実質3箇所（`is_latest_price` / `_is_weekly_cache_fresh` / `_recent_weekday`）のみで、価格・RS・MA は yfinance の営業日 index に乗るため祝日は元から不在。祝日を平日扱いする実害は「祝日に日次データを年数十回 余分取得する」軽量 HTTP のみで、データ破損は起きない。これを消すための依存追加は過剰（Simplicity First）。
+営業日判定は `get_price_day()`（17時前は前日扱い）＋ `recent_weekday()`（土日なら直近金曜に丸める）のみ。**祝日カレンダー（`jpholiday` 等）は導入しない**。価格・RS・MA は yfinance の営業日 index に乗るため祝日は元から不在。祝日を平日扱いする実害は「祝日に日次データを年数十回 余分取得する」軽量 HTTP のみで、データ破損は起きない。これを消すための依存追加は過剰（Simplicity First）。
 
-**再検討トリガー**: ①取得コストが課金・rate limit に当たる ②日付指定での営業日数演算が要る新機能（決算からN営業日後の反応 等。現状 `n_business_days` は配列インデックスで代用）③休場日の「未更新」誤警告が運用ノイズ化。導入時は `ks_util.py` に `prev_business_day(d)` を足し3箇所を集約。
+**再検討トリガー**: ①取得コストが課金・rate limit に当たる ②日付指定での営業日数演算が要る新機能（決算からN営業日後の反応 等。現状 `n_business_days` は配列インデックスで代用）③休場日の「未更新」誤警告が運用ノイズ化。導入時は `ks_util.py` に祝日対応版の営業日ヘルパーを追加し、`recent_weekday()` 利用箇所を置き換える。
 
 ## 価格データ取得 (`price.py`)
 

--- a/scripts/googledrive.py
+++ b/scripts/googledrive.py
@@ -13,12 +13,14 @@
 スクリプトを直接実行することで、CSV ファイルを Google Drive に Google スプレッドシートとしてアップロードまたは更新できます。
 """  # noqa: E501
 import csv
+import time
 import threading
 
 from ks_util import *
 
 # 外部ライブラリ GoogleDriveAPI
 from apiclient.discovery import build  # type: ignore Pylanceが認識しない
+from apiclient.errors import HttpError  # type: ignore
 from apiclient.http import MediaFileUpload  # type: ignore
 
 # 外部ライブラリ 認証用API google-authへ移行すべきらしい
@@ -54,6 +56,25 @@ SHEETS_CONFIG = {
     "shintakane_result": {"sheet_name": "shintakane_result"},
     "code_rank": {"sheet_name": "code_rank"},
 }
+
+RETRYABLE_GOOGLE_STATUS = {429, 500, 502, 503, 504}
+
+
+def _execute_google_request(request, label, max_attempts=4):
+    """Google API の一時エラーだけ指数バックオフでリトライする。"""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return request.execute()
+        except HttpError as e:
+            status = getattr(e.resp, "status", None)
+            if status not in RETRYABLE_GOOGLE_STATUS or attempt >= max_attempts:
+                raise
+            wait_sec = min(30, 2 ** (attempt - 1))
+            log_warning(
+                "%s 一時エラー(%s)のためリトライします: %d/%d, wait=%ds"
+                % (label, status, attempt, max_attempts, wait_sec)
+            )
+            time.sleep(wait_sec)
 
 
 def get_drive_service():
@@ -171,10 +192,13 @@ def upload_csv_via_sheets(csv_name, up_file_name):
     sheet_name = SHEETS_CONFIG[up_file_name]["sheet_name"]
 
     # 対象タブの情報を取得（余剰データクリア用）
-    meta = sheets_service.spreadsheets().get(
-        spreadsheetId=spreadsheet_id,
-        fields="sheets.properties"
-    ).execute()
+    meta = _execute_google_request(
+        sheets_service.spreadsheets().get(
+            spreadsheetId=spreadsheet_id,
+            fields="sheets.properties"
+        ),
+        "Sheets APIメタ取得",
+    )
     target_sheet = None
     for s in meta["sheets"]:
         if s["properties"]["title"] == sheet_name:
@@ -187,12 +211,15 @@ def upload_csv_via_sheets(csv_name, up_file_name):
 
     # 1) データを上書き（失敗してもシートは空にならない）
     update_range = "'%s'!A1" % sheet_name
-    sheets_service.spreadsheets().values().update(
-        spreadsheetId=spreadsheet_id,
-        range=update_range,
-        valueInputOption="USER_ENTERED",
-        body={"values": values}
-    ).execute()
+    _execute_google_request(
+        sheets_service.spreadsheets().values().update(
+            spreadsheetId=spreadsheet_id,
+            range=update_range,
+            valueInputOption="USER_ENTERED",
+            body={"values": values}
+        ),
+        "Sheets APIセル更新",
+    )
 
     # 2) 余剰データをクリア（行数・列数が減った場合に対応）
     new_row_count = len(values)
@@ -203,11 +230,14 @@ def upload_csv_via_sheets(csv_name, up_file_name):
         clear_range = "'%s'!A%d:ZZ%d" % (
             sheet_name, new_row_count + 1, total_rows
         )
-        sheets_service.spreadsheets().values().clear(
-            spreadsheetId=spreadsheet_id,
-            range=clear_range,
-            body={}
-        ).execute()
+        _execute_google_request(
+            sheets_service.spreadsheets().values().clear(
+                spreadsheetId=spreadsheet_id,
+                range=clear_range,
+                body={}
+            ),
+            "Sheets API余剰行クリア",
+        )
 
     # 余剰列をクリア（データ行の範囲内で、新データより右の列）
     if total_cols > new_col_count and new_row_count > 0:
@@ -215,11 +245,14 @@ def upload_csv_via_sheets(csv_name, up_file_name):
         clear_col_range = "'%s'!%s1:ZZ%d" % (
             sheet_name, from_col, new_row_count
         )
-        sheets_service.spreadsheets().values().clear(
-            spreadsheetId=spreadsheet_id,
-            range=clear_col_range,
-            body={}
-        ).execute()
+        _execute_google_request(
+            sheets_service.spreadsheets().values().clear(
+                spreadsheetId=spreadsheet_id,
+                range=clear_col_range,
+                body={}
+            ),
+            "Sheets API余剰列クリア",
+        )
 
     log_print("Sheets API更新完了: %s (%d行)" % (up_file_name, len(values)))
 

--- a/scripts/ks_util.py
+++ b/scripts/ks_util.py
@@ -403,6 +403,16 @@ def get_price_day(dt):
     return need_dt.date()
 
 
+def recent_weekday(dt):
+    """17時境界適用後の日付を、土日なら直近金曜に丸める。"""
+    day = get_price_day(dt)
+    if day.weekday() == 5:
+        return day - timedelta(days=1)
+    if day.weekday() == 6:
+        return day - timedelta(days=2)
+    return day
+
+
 # ==================================================
 # 計算ユーティリティ
 # ==================================================

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -61,14 +61,10 @@ def is_latest_price(stocks, code_s):
     最新価格データかどうかを返す
     """
     # 当日なら
-    need_dt = get_price_day(datetime.today())
+    need_dt = recent_weekday(datetime.today())
     price_dt = get_price_day(stocks[code_s]["access_date_price"])
     price_day = date(price_dt.year, price_dt.month, price_dt.day)
     need_day = date(need_dt.year, need_dt.month, need_dt.day)
-    if need_day.weekday() == 5:
-        need_day -= timedelta(1)
-    elif need_day.weekday() == 6:
-        need_day -= timedelta(2)
     # print " 価格データ 必要:%s DB最新:%s"%(need_day, price_day)
     if need_day <= price_day:
         price_log = stocks[code_s].get("price_log", [])

--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -71,6 +71,9 @@ def is_latest_price(stocks, code_s):
         need_day -= timedelta(2)
     # print " 価格データ 必要:%s DB最新:%s"%(need_day, price_day)
     if need_day <= price_day:
+        price_log = stocks[code_s].get("price_log", [])
+        if price_log and price_log[0][0] < need_day:
+            return False, (need_day - price_log[0][0]).days
         return True, (need_day - price_day).days
     return False, (need_day - price_day).days
 

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -133,6 +133,19 @@ TRADE_IDEA_DESCRIPTIONS = {
 }
 TRADE_IDEA_OPTIONS = tuple(TRADE_IDEA_DESCRIPTIONS.keys())
 
+# issue #344: stage / jukyu_chart を自由記述から選択式へ寄せるための定型候補。
+# DB スキーマは変えず、UI 側で分解入力した値を route 層で 1 本の文字列に畳み込む。
+STAGE_OPTIONS = (
+    "1S", "2S", "3S", "4S", "1Sor3S",
+    "1S~2S", "2S~3S", "3S~4S", "4S~1S",
+)
+STAGE_T_OPTIONS = ("1", "2", "3", "4", "5")
+CHART_STYLE_OPTIONS = (
+    "週足低位", "週足CWH", "週足VCP", "週足高値",
+    "月足低位", "月足CWH", "月足VCP", "月足高値",
+)
+CHART_STATE_OPTIONS = ("形成", "ブレイク", "ブレイク済み", "ブレイク失敗", "再ブレイク")
+
 ACTION_LOG_FIELDS = frozenset(
     {
         "code_s",

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -1023,6 +1023,10 @@ def _convert_df_to_price_list(df):
     price_list = []
     for idx in reversed(df.index):
         row = df.loc[idx]
+        if any(row.get(col) != row.get(col) for col in ["Open", "High", "Low", "Close"]):
+            # yfinance は当日行に Volume だけ入り OHLC が NaN のことがある。
+            # repair=True でも復元できない行は、変換全体を落とさず除外する。
+            continue
         # 日付を"YYYY年M月D日"形式に変換
         if hasattr(idx, "date"):
             dt = idx.date() if callable(idx.date) else idx.date
@@ -1083,7 +1087,7 @@ def get_daily_data_yfinance(code_s, stock={}, upd=UPD_INTERVAL):
             ticker = yf.Ticker(ticker_symbol)
             # 2mo: 決算反応20d (決算前 + 20営業日後) と rs_line 20日前比に必要な
             # 営業日 ~40日分を確保する (1mo だと暦日30日 ≒ 営業日19日で不足)
-            df = ticker.history(period="2mo", auto_adjust=True)
+            df = ticker.history(period="2mo", auto_adjust=True, repair=True)
     except Exception as e:
         log_warning("yfinance取得エラー(%s): %s" % (code_s, e))
         return None, None
@@ -1484,6 +1488,7 @@ def prefetch_yfinance_batch(code_s_list, stocks=None):
                 # 決算反応20d / rs_line 20日前比に必要な営業日 ~40日分を確保。
                 period="2mo",
                 auto_adjust=True,
+                repair=True,
                 threads=True,
                 progress=False,
             )

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -1011,13 +1011,13 @@ def _load_yfinance_cache(fname):
 
 
 def _is_daily_cache_fresh(price_list):
-    """日次キャッシュの先頭日付が必要営業日以上なら True。"""
+    """日次キャッシュの先頭日付が直近取引日相当以上なら True。"""
     if not price_list:
         return False
     latest_dt = parse_date_str(str(price_list[0][0]))
     if latest_dt is None:
         return False
-    need_dt = get_price_day(datetime.today())
+    need_dt = recent_weekday(datetime.today())
     return latest_dt >= need_dt
 
 

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -1010,6 +1010,17 @@ def _load_yfinance_cache(fname):
         return None, None
 
 
+def _is_daily_cache_fresh(price_list):
+    """日次キャッシュの先頭日付が必要営業日以上なら True。"""
+    if not price_list:
+        return False
+    latest_dt = parse_date_str(str(price_list[0][0]))
+    if latest_dt is None:
+        return False
+    need_dt = get_price_day(datetime.today())
+    return latest_dt >= need_dt
+
+
 def _convert_df_to_price_list(df):
     """yfinance DataFrameを既存のprice_list形式に変換する
     auto_adjust=Trueで取得した場合、OHLCは分割・配当調整済み。
@@ -1074,9 +1085,10 @@ def get_daily_data_yfinance(code_s, stock={}, upd=UPD_INTERVAL):
             cache_ok, cach_date = is_file_timestamp(cache_fname, INTERVAL_DAY_D)
             if cache_ok:
                 pc, pl = _load_yfinance_cache(cache_fname)
-                if pc is not None:
+                if pc is not None and _is_daily_cache_fresh(pl):
                     log_debug("yfinanceキャッシュ使用(UPD_INTERVAL): %s" % code_s)
                     return pc, pl
+                log_debug("yfinance日次キャッシュが古いため再取得します: %s" % code_s)
 
     # yfinance APIで取得
     ticker_symbol = _get_ticker_symbol(code_s, stock)
@@ -1452,7 +1464,9 @@ def prefetch_yfinance_batch(code_s_list, stocks=None):
         if os.path.exists(cache_fname):
             cache_ok, _ = is_file_timestamp(cache_fname, INTERVAL_DAY_D)
             if cache_ok:
-                continue
+                _, pl = _load_yfinance_cache(cache_fname)
+                if pl is not None and _is_daily_cache_fresh(pl):
+                    continue
         codes_to_fetch.append(code_s)
 
     if not codes_to_fetch:

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -15,6 +15,7 @@ issue #215: ページング/ソートを廃止し、status は単一選択化、
 業態テーマ指定時は status 無視で全銘柄から該当する業態/テーマだけを抽出する。
 """
 
+import re
 from typing import Optional
 from urllib.parse import urlencode
 
@@ -60,6 +61,8 @@ STATUS_CHOICES = [
 DEFAULT_STATUS_QUERY = STATUS_CHOICES[0][0]  # "hold" — 書き込み POST 後フォールバック先
 PORTFOLIO_SORT_KEYS = {"position", "rank", "gyoutai", "rs_change_1d", "rating"}  # rs_change_1d: issue #332
 DEFAULT_SORT_KEY = "position"
+_STAGE_SINGLE_RE = re.compile(r"^(?P<s>[1-4]S)(?:\((?P<t>[1-9])(?P<unit>[TB])\))?$")
+_STAGE_TRANSITION_RE = re.compile(r"^(?P<left>[1-4]S)(?:\((?P<t>[1-9])(?P<unit>[TB])\))?~(?P<right>[1-4]S)$")
 
 
 def _parse_status_filter(args) -> Optional[str]:
@@ -169,6 +172,101 @@ def _flash_stock_info(code_s: str, message_suffix: str) -> None:
         f'<a href="{detail_url}">{normalized}</a>{message_suffix}',
         "html_info",
     )
+
+
+def _parse_stage_value(raw: str) -> dict:
+    """保存済み stage 文字列を structured UI の初期値へ分解する。"""
+    value = (raw or "").strip()
+    parsed = {
+        "raw": value,
+        "s": "",
+        "t": "",
+        "unit": "T",
+        "structured": True,
+        "rescue": "",
+    }
+    if not value:
+        return parsed
+    if value in ps.STAGE_OPTIONS:
+        parsed["s"] = value
+        parsed["unit"] = "B" if value.split("~", 1)[0] == "2S" else "T"
+        return parsed
+    m = _STAGE_SINGLE_RE.match(value)
+    if m:
+        parsed["s"] = m.group("s") or ""
+        parsed["t"] = m.group("t") or ""
+        parsed["unit"] = m.group("unit") or ("B" if parsed["s"] == "2S" else "T")
+        return parsed
+    m = _STAGE_TRANSITION_RE.match(value)
+    if m:
+        parsed["s"] = f'{m.group("left")}~{m.group("right")}'
+        parsed["t"] = m.group("t") or ""
+        parsed["unit"] = m.group("unit") or ("B" if (m.group("left") or "") == "2S" else "T")
+        return parsed
+    parsed["structured"] = False
+    parsed["rescue"] = value
+    return parsed
+
+
+def _compose_stage_value(stage_s: str, stage_t: str) -> str:
+    """structured UI の値から保存用 stage 文字列を組み立てる。"""
+    s_value = (stage_s or "").strip()
+    t_value = (stage_t or "").strip()
+    if not s_value:
+        return ""
+    if "or" in s_value:
+        return s_value
+    left_stage = s_value.split("~", 1)[0]
+    unit = "B" if left_stage == "2S" else "T"
+    if t_value:
+        if "~" in s_value:
+            left, right = s_value.split("~", 1)
+            return f"{left}({t_value}{unit})~{right}"
+        return f"{s_value}({t_value}{unit})"
+    return s_value
+
+
+def _parse_chart_value(raw: str) -> dict:
+    """保存済み jukyu_chart を structured UI の 2 軸へ分解する。"""
+    value = (raw or "").strip()
+    parsed = {
+        "raw": value,
+        "style": "",
+        "state": "",
+        "structured": True,
+        "rescue": "",
+    }
+    if not value:
+        return parsed
+    states = sorted(ps.CHART_STATE_OPTIONS, key=len, reverse=True)
+    normalized = value.replace("週足月足", "月足", 1) if value.startswith("週足月足") else value
+    for style in ("", *ps.CHART_STYLE_OPTIONS):
+        if style and not normalized.startswith(style):
+            continue
+        rest = normalized[len(style):]
+        for state in ("", *states):
+            if state and not rest.endswith(state):
+                continue
+            middle = rest[: len(rest) - len(state)] if state else rest
+            if middle == "":
+                parsed["style"] = style
+                parsed["state"] = state
+                return parsed
+    parsed["structured"] = False
+    parsed["rescue"] = value
+    return parsed
+
+
+def _compose_chart_value(style: str, state: str) -> str:
+    """structured UI の 2 軸から保存用 jukyu_chart を組み立てる。"""
+    return "".join(((style or "").strip(), (state or "").strip()))
+
+
+def _augment_stage_chart_meta(memo: dict) -> dict:
+    """テンプレート用に stage / jukyu_chart の分解済みメタ情報を足す。"""
+    memo["stage_struct"] = _parse_stage_value(memo.get("stage") or "")
+    memo["jukyu_chart_struct"] = _parse_chart_value(memo.get("jukyu_chart") or "")
+    return memo
 
 
 def _redirect_with_return_query(
@@ -463,6 +561,18 @@ def _extract_memo_fields_from_form(form) -> dict:
                 themes.append(v)
         fields["gyoutai_themes"] = themes
 
+    stage_keys = ("stage_s", "stage_t")
+    if any(k in form for k in stage_keys):
+        stage_s = (form.get("stage_s") or "").strip()
+        stage_t = (form.get("stage_t") or "").strip()
+        fields["stage"] = _compose_stage_value(stage_s, stage_t)
+
+    chart_keys = ("chart_style", "chart_state")
+    if any(k in form for k in chart_keys):
+        chart_style = (form.get("chart_style") or "").strip()
+        chart_state = (form.get("chart_state") or "").strip()
+        fields["jukyu_chart"] = _compose_chart_value(chart_style, chart_state)
+
     return fields
 
 
@@ -677,6 +787,7 @@ def dashboard():
         row["transitions"] = (
             [] if fallback_mode else _allowed_transitions_from(row.get("status", ""))
         )
+        row["memo"] = _augment_stage_chart_meta(row.get("memo") or {})
 
     # 一括変更モードの可否: fallback でなければ表示行に対して有効
     delete_mode_allowed = (not fallback_mode and bool(rows))
@@ -741,6 +852,10 @@ def dashboard():
         gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
         trade_idea_options=ps.TRADE_IDEA_OPTIONS,
         trade_idea_descriptions=ps.TRADE_IDEA_DESCRIPTIONS,
+        stage_options=ps.STAGE_OPTIONS,
+        stage_t_options=ps.STAGE_T_OPTIONS,
+        chart_style_options=ps.CHART_STYLE_OPTIONS,
+        chart_state_options=ps.CHART_STATE_OPTIONS,
         hold_summary=hold_summary,
     )
 
@@ -787,6 +902,8 @@ def charts():
             "stage": (r.get("memo") or {}).get("stage") or "",
             "last_research_update": (r.get("memo") or {}).get("last_research_update") or "",
             "jukyu_chart": (r.get("memo") or {}).get("jukyu_chart") or "",
+            "stage_struct": _parse_stage_value((r.get("memo") or {}).get("stage") or ""),
+            "jukyu_chart_struct": _parse_chart_value((r.get("memo") or {}).get("jukyu_chart") or ""),
         }
         for r in rows
     ]
@@ -799,6 +916,10 @@ def charts():
         total=len(stocks),
         active_status_query=active_status_query,
         active_gyoutai_theme=active_gyoutai_theme or "",
+        stage_options=ps.STAGE_OPTIONS,
+        stage_t_options=ps.STAGE_T_OPTIONS,
+        chart_style_options=ps.CHART_STYLE_OPTIONS,
+        chart_state_options=ps.CHART_STATE_OPTIONS,
     )
 
 

--- a/scripts/webapp/templates/portfolio_charts.html
+++ b/scripts/webapp/templates/portfolio_charts.html
@@ -48,18 +48,31 @@
   .chart-cell-header .editable input {
     font-size: 0.85em; padding: 0 0.2em; margin: 0; height: auto; width: 6em;
   }
-  .chart-cell-header .edit-jukyu {
-    min-width: 4em; max-width: 18em; max-height: 2.6em;
-    overflow: auto; white-space: pre-wrap;
+  .chart-cell-header .stage-struct,
+  .chart-cell-header .chart-struct {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.15em;
+    align-items: center;
   }
-  .chart-cell-header .editable textarea {
-    font-size: 0.85em; padding: 0.15em 0.2em; margin: 0;
-    width: 18em; height: 4.5em; resize: vertical;
+  .chart-cell-header .stage-struct { flex-wrap: nowrap; }
+  .chart-cell-header .stage-struct select,
+  .chart-cell-header .chart-struct select {
+    margin: 0;
+    padding: 0 2px;
+    font-size: 0.85em;
+    height: auto;
   }
+  .chart-cell-header .stage-main-select { max-width: 6.2em; }
+  .chart-cell-header .stage-t-select { width: 4.1em; }
+  .chart-cell-header .chart-style-select { max-width: 6.8em; }
+  .chart-cell-header .chart-state-select { max-width: 5.8em; }
   /* プレースホルダー (空セル) では編集 UI も隠す */
   .chart-cell.placeholder .chart-cell-header .edit-sep,
   .chart-cell.placeholder .chart-cell-header .edit-label,
-  .chart-cell.placeholder .chart-cell-header .editable { display: none; }
+  .chart-cell.placeholder .chart-cell-header .editable,
+  .chart-cell.placeholder .chart-cell-header .stage-struct,
+  .chart-cell.placeholder .chart-cell-header .chart-struct { display: none; }
   /* 株探チャートページは上部にヘッダ・広告・銘柄サマリー、下部に注釈・広告バナーが
      乗るフルページ。iframe を窓 (.chart-viewport) でクリップし、--chart-offset 分だけ
      上にずらしてチャート本体だけを見せる。窓の高さ (--chart-window-h) でチャート下端
@@ -113,11 +126,37 @@
       <a class="kabu" target="_blank" rel="noopener">株探</a>
       <span class="edit-sep">|</span>
       <span class="edit-label">ステージ</span>
-      <span class="editable edit-stage" title="クリックで編集 (更新日も当日に自動補完)">—</span>
+      <span class="stage-struct" data-rescue="0">
+        <select class="stage-main-select" title="選択で保存 (更新日も当日に自動補完)">
+          <option value="">—</option>
+          {% for stage in stage_options %}
+          <option value="{{ stage }}">{{ stage }}</option>
+          {% endfor %}
+        </select>
+        <select class="stage-t-select" title="T/B" data-unit="T" disabled>
+          <option value="">Tなし</option>
+          {% for t in stage_t_options %}
+          <option value="{{ t }}">{{ t }}T</option>
+          {% endfor %}
+        </select>
+      </span>
       <span class="edit-label">更新日</span>
       <span class="editable edit-update" title="クリックで編集 (M/D)">—</span>
       <span class="edit-label">需給</span>
-      <span class="editable edit-jukyu" title="クリックで編集">—</span>
+      <span class="chart-struct" data-rescue="0">
+        <select class="chart-style-select" title="型">
+          <option value="">型なし</option>
+          {% for style in chart_style_options %}
+          <option value="{{ style }}">{{ style }}</option>
+          {% endfor %}
+        </select>
+        <select class="chart-state-select" title="状態" disabled>
+          <option value="">状態なし</option>
+          {% for state in chart_state_options %}
+          <option value="{{ state }}">{{ state }}</option>
+          {% endfor %}
+        </select>
+      </span>
     </div>
     <div class="chart-viewport">
       <iframe scrolling="no" tabindex="-1"></iframe>
@@ -156,9 +195,13 @@
         var iframe = cell.querySelector('iframe');
         var nameLink = cell.querySelector('.name');
         var kabuLink = cell.querySelector('.kabu');
-        var stageEl = cell.querySelector('.edit-stage');
+        var stageBox = cell.querySelector('.stage-struct');
+        var stageMain = cell.querySelector('.stage-main-select');
+        var stageT = cell.querySelector('.stage-t-select');
         var updateEl = cell.querySelector('.edit-update');
-        var jukyuEl = cell.querySelector('.edit-jukyu');
+        var chartBox = cell.querySelector('.chart-struct');
+        var chartStyle = cell.querySelector('.chart-style-select');
+        var chartState = cell.querySelector('.chart-state-select');
         var s = STOCKS[start + i];
         if (!s) {
           // ページ末尾の 1 件不足: 空セルをプレースホルダー表示 (グリッド維持)
@@ -177,10 +220,34 @@
         nameLink.textContent = s.code_s + ' ' + s.stock_name;
         nameLink.href = '/stock/' + code;
         kabuLink.href = 'https://kabutan.jp/stock/chart?code=' + code;
-        // stage / 更新日 / 需給チャートの初期値 (編集中でなければ最新値で再描画)
-        if (stageEl.dataset.editing !== '1') stageEl.textContent = s.stage || '—';
+        var stageStruct = s.stage_struct || {};
+        stageBox.dataset.rescue = stageStruct.rescue ? '1' : '0';
+        rebuildSelectOptions(
+          stageMain,
+          '—',
+          {{ stage_options|tojson }},
+          stageStruct.rescue || stageStruct.s || '',
+          stageStruct.rescue || ''
+        );
+        stageT.value = stageStruct.t || '';
+        relabelStageTSelect(stageT, stageStruct.s || '');
+        stageMain.dataset.prev = stageMain.value || '';
+        stageT.dataset.prev = stageT.value || '';
+        stageT.disabled = !stageMain.value || stageBox.dataset.rescue === '1';
         if (updateEl.dataset.editing !== '1') updateEl.textContent = s.last_research_update || '—';
-        if (jukyuEl.dataset.editing !== '1') jukyuEl.textContent = s.jukyu_chart || '—';
+        var chartStruct = s.jukyu_chart_struct || {};
+        chartBox.dataset.rescue = chartStruct.rescue ? '1' : '0';
+        rebuildSelectOptions(
+          chartStyle,
+          '型なし',
+          {{ chart_style_options|tojson }},
+          chartStruct.rescue || chartStruct.style || '',
+          chartStruct.rescue || ''
+        );
+        chartState.value = chartStruct.state || '';
+        chartStyle.dataset.prev = chartStyle.value || '';
+        chartState.dataset.prev = chartState.value || '';
+        chartState.disabled = chartBox.dataset.rescue === '1';
       }
       var dispStart = total === 0 ? 0 : start + 1;
       var dispEnd = Math.min(start + PER_PAGE, total);
@@ -219,7 +286,7 @@
       if (iframe) iframe.addEventListener('load', focusChartShortcuts);
     });
 
-    // ----- stage / 更新日 / 需給チャートの inline 編集 (portfolio 一覧と同仕様、issue #231 / #305) -----
+    // ----- stage / 更新日 / 需給チャートの inline 編集 (portfolio 一覧と同仕様、issue #231 / #344) -----
     function todayMD() {
       var d = new Date();
       return (d.getMonth() + 1) + '/' + d.getDate();
@@ -242,30 +309,58 @@
       return y + '-' + mm + '-' + dd;
     }
 
+    function stageUnit(stageValue) {
+      return (stageValue || '').split('~', 1)[0] === '2S' ? 'B' : 'T';
+    }
+
+    function allowsStageSuffix(stageValue) {
+      return !!stageValue && stageValue.indexOf('or') === -1;
+    }
+
+    function relabelStageTSelect(sel, stageValue) {
+      var unit = stageUnit(stageValue || '');
+      sel.dataset.unit = unit;
+      Array.prototype.forEach.call(sel.options, function(opt) {
+        opt.textContent = opt.value ? (opt.value + unit) : (unit + 'なし');
+      });
+    }
+
+    function rebuildSelectOptions(sel, emptyLabel, values, selectedValue, rescueValue) {
+      sel.innerHTML = '';
+      var emptyOpt = document.createElement('option');
+      emptyOpt.value = '';
+      emptyOpt.textContent = emptyLabel;
+      sel.appendChild(emptyOpt);
+      if (rescueValue) {
+        var rescueOpt = document.createElement('option');
+        rescueOpt.value = rescueValue;
+        rescueOpt.textContent = '⚠️ ' + rescueValue;
+        sel.appendChild(rescueOpt);
+      }
+      values.forEach(function(value) {
+        var opt = document.createElement('option');
+        opt.value = value;
+        opt.textContent = value;
+        sel.appendChild(opt);
+      });
+      sel.value = selectedValue || '';
+    }
+
     function startEdit(span) {
       if (span.dataset.editing === '1') return;
       var cell = span.closest('.chart-cell');
       var code = cell && cell.dataset.code;
       if (!code) return;  // プレースホルダーセルは編集不可
       span.dataset.editing = '1';
-      var isStage = span.classList.contains('edit-stage');
-      var isJukyu = span.classList.contains('edit-jukyu');
       var current = span.textContent === '—' ? '' : span.textContent;
 
       function isSameCell() {
         return cell && cell.dataset.code === code;
       }
 
-      var input = document.createElement(isJukyu ? 'textarea' : 'input');
-      if (isJukyu) {
-        input.value = current;
-      } else if (isStage) {
-        input.type = 'text';
-        input.value = current;
-      } else {
-        input.type = 'date';
-        input.value = mdToYMD(current);
-      }
+      var input = document.createElement('input');
+      input.type = 'date';
+      input.value = mdToYMD(current);
       span.textContent = '';
       span.appendChild(input);
       input.focus();
@@ -277,21 +372,15 @@
         span.dataset.editing = '';
 
         var newValue;
-        if (isStage || isJukyu) {
-          newValue = (input.value || '').trim();
-        } else {
-          newValue = toMD(input.value);
-          if (newValue === null) {
-            alert('日付として不正です (M/D 形式)');
-            if (isSameCell()) span.textContent = current || '—';
-            return;
-          }
+        newValue = toMD(input.value);
+        if (newValue === null) {
+          alert('日付として不正です (M/D 形式)');
+          if (isSameCell()) span.textContent = current || '—';
+          return;
         }
 
         var fields = {};
-        fields[isJukyu ? 'jukyu_chart' : (isStage ? 'stage' : 'last_research_update')] = newValue;
-        // ステージ編集時は更新日も当日に自動補完 (portfolio 一覧と同仕様)
-        if (isStage) fields['last_research_update'] = todayMD();
+        fields.last_research_update = newValue;
 
         var fd = new FormData();
         Object.keys(fields).forEach(function (k) { fd.append(k, fields[k]); });
@@ -310,29 +399,11 @@
           var disp = res.body.display || {};
           // STOCKS 側も更新しておく (ページ送りで戻った時に最新値を出すため)
           var s = STOCKS.filter(function (x) { return x.code_s === code; })[0];
-          var stageVal = (disp.stage !== undefined && disp.stage !== '—') ? disp.stage : fields.stage;
           var updVal = (disp.last_research_update !== undefined && disp.last_research_update !== '—')
             ? disp.last_research_update : fields.last_research_update;
-          var jukyuVal = (disp.jukyu_chart !== undefined) ? disp.jukyu_chart : fields.jukyu_chart;
-          if (isStage) {
-            if (s) s.stage = stageVal || '';
-            if (s) s.last_research_update = updVal || '';
-            if (!isSameCell()) return;
-            span.textContent = (stageVal || '') || '—';
-            // 同セルの更新日も自動補完値で同期
-            var updSpan = cell.querySelector('.edit-update');
-            if (updSpan && updSpan.dataset.editing !== '1') updSpan.textContent = (updVal || '') || '—';
-          } else {
-            if (isJukyu) {
-              if (s) s.jukyu_chart = jukyuVal || '';
-              if (!isSameCell()) return;
-              span.textContent = (jukyuVal || '') || '—';
-            } else {
-              if (s) s.last_research_update = updVal || '';
-              if (!isSameCell()) return;
-              span.textContent = (updVal || '') || '—';
-            }
-          }
+          if (s) s.last_research_update = updVal || '';
+          if (!isSameCell()) return;
+          span.textContent = (updVal || '') || '—';
         }).catch(function (err) {
           alert('保存失敗: ' + err);
           if (isSameCell()) span.textContent = current || '—';
@@ -341,13 +412,170 @@
 
       input.addEventListener('blur', commit);
       input.addEventListener('keydown', function (e) {
-        if (e.key === 'Enter' && (!isJukyu || e.ctrlKey || e.metaKey)) { e.preventDefault(); input.blur(); }
+        if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
         else if (e.key === 'Escape') { finished = true; span.dataset.editing = ''; span.textContent = current || '—'; }
       });
     }
 
-    document.querySelectorAll('.chart-cell .editable').forEach(function (span) {
+    document.querySelectorAll('.chart-cell .edit-update').forEach(function (span) {
       span.addEventListener('click', function () { startEdit(span); });
+    });
+
+    function postMemo(code, payload) {
+      var fd = new FormData();
+      Object.keys(payload).forEach(function(k) { fd.append(k, payload[k]); });
+      return fetch('/portfolio/' + encodeURIComponent(code) + '/memo', {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        body: fd,
+      }).then(function(resp) {
+        return resp.json().then(function(body) { return { ok: resp.ok, body: body }; });
+      });
+    }
+
+    function findStock(code) {
+      return STOCKS.filter(function(x) { return x.code_s === code; })[0];
+    }
+
+    document.querySelectorAll('.chart-cell').forEach(function(cell) {
+      var stageBox = cell.querySelector('.stage-struct');
+      var stageMain = cell.querySelector('.stage-main-select');
+      var stageT = cell.querySelector('.stage-t-select');
+      var chartBox = cell.querySelector('.chart-struct');
+      var chartStyle = cell.querySelector('.chart-style-select');
+      var chartState = cell.querySelector('.chart-state-select');
+
+      function syncStageDisabled() {
+        stageT.disabled = !allowsStageSuffix(stageMain.value || '') || stageBox.dataset.rescue === '1';
+      }
+
+      function syncChartDisabled() {
+        var disabled = chartBox.dataset.rescue === '1';
+        chartState.disabled = disabled;
+      }
+
+      function saveStage(prev) {
+        var code = cell.dataset.code;
+        if (!code) return;
+        var payload = {
+          stage_s: stageMain.value || '',
+          stage_t: stageT.disabled ? '' : (stageT.value || ''),
+          last_research_update: todayMD(),
+        };
+        postMemo(code, payload).then(function(res) {
+          if (!res.ok || !res.body || res.body.ok !== true) {
+            stageBox.dataset.rescue = prev.rescue;
+            stageMain.value = prev.s;
+            stageT.value = prev.t;
+            stageMain.dataset.prev = prev.s;
+            stageT.dataset.prev = prev.t;
+            relabelStageTSelect(stageT, prev.s || '');
+            syncStageDisabled();
+            alert((res.body && res.body.error) || 'ステージの保存に失敗しました');
+            return;
+          }
+          stageBox.dataset.rescue = '0';
+          stageMain.dataset.prev = payload.stage_s;
+          stageT.dataset.prev = payload.stage_t;
+          relabelStageTSelect(stageT, payload.stage_s || '');
+          var stock = findStock(code);
+          if (stock) {
+            stock.stage = (res.body.display && res.body.display.stage !== '—') ? (res.body.display.stage || '') : '';
+            stock.last_research_update = (res.body.display && res.body.display.last_research_update !== '—')
+              ? (res.body.display.last_research_update || '') : payload.last_research_update;
+            stock.stage_struct = { raw: stock.stage, s: payload.stage_s, t: payload.stage_t, structured: true, rescue: '' };
+          }
+          var upd = cell.querySelector('.edit-update');
+          if (upd && upd.dataset.editing !== '1') {
+            upd.textContent = (res.body.display && res.body.display.last_research_update) || payload.last_research_update || '—';
+          }
+          syncStageDisabled();
+        }).catch(function(err) {
+          stageBox.dataset.rescue = prev.rescue;
+          stageMain.value = prev.s;
+          stageT.value = prev.t;
+          stageMain.dataset.prev = prev.s;
+          stageT.dataset.prev = prev.t;
+          relabelStageTSelect(stageT, prev.s || '');
+          syncStageDisabled();
+          alert('保存失敗: ' + err);
+        });
+      }
+
+      function saveChart(prev) {
+        var code = cell.dataset.code;
+        if (!code) return;
+        var payload = {
+          chart_style: chartStyle.value || '',
+          chart_state: chartState.disabled ? '' : (chartState.value || ''),
+        };
+        postMemo(code, payload).then(function(res) {
+          if (!res.ok || !res.body || res.body.ok !== true) {
+            chartBox.dataset.rescue = prev.rescue;
+            chartStyle.value = prev.style;
+            chartState.value = prev.state;
+            chartStyle.dataset.prev = prev.style;
+            chartState.dataset.prev = prev.state;
+            syncChartDisabled();
+            alert((res.body && res.body.error) || '需給の保存に失敗しました');
+            return;
+          }
+          chartBox.dataset.rescue = '0';
+          chartStyle.dataset.prev = payload.chart_style;
+          chartState.dataset.prev = payload.chart_state;
+          var stock = findStock(code);
+          if (stock) {
+            stock.jukyu_chart = (res.body.display && res.body.display.jukyu_chart) || '';
+            stock.jukyu_chart_struct = {
+              raw: stock.jukyu_chart,
+              style: payload.chart_style,
+              state: payload.chart_state,
+              structured: true,
+              rescue: '',
+            };
+          }
+          syncChartDisabled();
+        }).catch(function(err) {
+          chartBox.dataset.rescue = prev.rescue;
+          chartStyle.value = prev.style;
+          chartState.value = prev.state;
+          chartStyle.dataset.prev = prev.style;
+          chartState.dataset.prev = prev.state;
+          syncChartDisabled();
+          alert('保存失敗: ' + err);
+        });
+      }
+
+      stageMain.addEventListener('change', function() {
+        var prev = { s: stageMain.dataset.prev || '', t: stageT.dataset.prev || '', rescue: stageBox.dataset.rescue || '0' };
+        if (stageBox.dataset.rescue === '1') stageBox.dataset.rescue = '0';
+        stageT.value = '';
+        relabelStageTSelect(stageT, stageMain.value || '');
+        syncStageDisabled();
+        saveStage(prev);
+      });
+      stageT.addEventListener('change', function() {
+        var prev = { s: stageMain.dataset.prev || '', t: stageT.dataset.prev || '', rescue: stageBox.dataset.rescue || '0' };
+        saveStage(prev);
+      });
+      chartStyle.addEventListener('change', function() {
+        var prev = {
+          style: chartStyle.dataset.prev || '',
+          state: chartState.dataset.prev || '',
+          rescue: chartBox.dataset.rescue || '0',
+        };
+        if (chartBox.dataset.rescue === '1') chartBox.dataset.rescue = '0';
+        syncChartDisabled();
+        saveChart(prev);
+      });
+      chartState.addEventListener('change', function() {
+        var prev = {
+          style: chartStyle.dataset.prev || '',
+          state: chartState.dataset.prev || '',
+          rescue: chartBox.dataset.rescue || '0',
+        };
+        saveChart(prev);
+      });
     });
 
     render();

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -36,18 +36,37 @@
   table.portfolio-list td.num { text-align: right; }
   table.portfolio-list td.rating-cell { text-align: center; white-space: nowrap; }
   table.portfolio-list td.stage-cell {
-    width: 5em;
-    max-width: 5em;
+    width: 11em;
+    max-width: 11em;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
   table.portfolio-list td.jukyu-cell {
-    max-width: 6em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: pre-line;
+    max-width: 13em;
     line-height: 1.2;
+  }
+  .stage-struct,
+  .chart-struct {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.15em;
+    align-items: center;
+  }
+  .stage-struct { flex-wrap: nowrap; }
+  .stage-struct select,
+  .chart-struct select {
+    margin: 0;
+    padding: 0 2px;
+    font-size: 1em;
+    height: auto;
+  }
+  .stage-struct .stage-main-select { max-width: 6.4em; }
+  .stage-struct .stage-t-select { width: 4.1em; }
+  .chart-struct .chart-style-select { max-width: 6.8em; }
+  .chart-struct .chart-state-select { max-width: 5.8em; }
+  .stage-struct select:disabled,
+  .chart-struct select:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
   }
   /* issue #327: ページ切り替え (指標/メモ)。data-page="1" は指標ページ、
      data-page="2" は手動メモページ。属性なしの列は両ページ共通。 */
@@ -463,15 +482,56 @@
           data-style-field="last_research_update"
           {% if not fallback_mode %}class="editable" data-code="{{ row.code_s }}" data-field="last_research_update"{% endif %}
           style="{{ row.styles.last_research_update or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.last_research_update or "—" }}</td>
-      <td data-page="2" title="クリックで編集 (ステージ変更時は更新日も自動で当日に) / Ctrl+クリックで株探チャート"
+      <td data-page="2" title="選択で保存 (ステージ変更時は更新日も当日に) / Ctrl+クリックで株探チャート"
           data-style-field="stage"
-          class="stage-cell{% if not fallback_mode %} editable{% endif %}"
-          {% if not fallback_mode %}data-code="{{ row.code_s }}" data-field="stage" data-touch-update="1"{% endif %}
-          style="{{ row.styles.stage or '' }}{% if not fallback_mode %};cursor:pointer{% endif %}">{{ row.memo.stage or "—" }}</td>
-      <td data-page="2" title="{{ ((row.memo.jukyu_chart or '') ~ ' (クリックで編集)') if (not fallback_mode and row.memo.jukyu_chart) else ('クリックで編集' if not fallback_mode else (row.memo.jukyu_chart or '')) }}"
-          data-full="{{ row.memo.jukyu_chart or '' }}"
-          {% if not fallback_mode %}class="editable jukyu-cell" data-code="{{ row.code_s }}" data-field="jukyu_chart" data-multiline="1" data-input-width="8em"{% else %}class="jukyu-cell"{% endif %}
-          style="{% if not fallback_mode %}cursor:pointer{% endif %}">{{ row.memo.jukyu_chart or "—" }}</td>
+          class="stage-cell stage-struct-cell"
+          {% if not fallback_mode %}data-code="{{ row.code_s }}"{% endif %}
+          style="{{ row.styles.stage or '' }}">
+        {% set stage_struct = row.memo.stage_struct %}
+        <div class="stage-struct"
+             data-code="{{ row.code_s }}"
+             data-rescue="{% if stage_struct.rescue %}1{% else %}0{% endif %}">
+          <select class="stage-main-select" {% if fallback_mode %}disabled{% endif %}>
+            <option value="">—</option>
+            {% if stage_struct.rescue %}
+            <option value="{{ stage_struct.rescue }}" selected>⚠️ {{ stage_struct.rescue }}</option>
+            {% endif %}
+            {% for stage in stage_options %}
+            <option value="{{ stage }}" {% if stage == stage_struct.s %}selected{% endif %}>{{ stage }}</option>
+            {% endfor %}
+          </select>
+          <select class="stage-t-select"
+                  data-unit="{{ stage_struct.unit or ('B' if stage_struct.s and stage_struct.s.startswith('2S') else 'T') }}"
+                  {% if fallback_mode or stage_struct.rescue %}disabled{% endif %}>
+            <option value="">{{ (stage_struct.unit or ('B' if stage_struct.s and stage_struct.s.startswith('2S') else 'T')) }}なし</option>
+            {% for t in stage_t_options %}
+            <option value="{{ t }}" {% if t == stage_struct.t %}selected{% endif %}>{{ t }}{{ stage_struct.unit or ('B' if stage_struct.s and stage_struct.s.startswith('2S') else 'T') }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </td>
+      <td data-page="2" title="選択で保存" class="jukyu-cell chart-struct-cell">
+        {% set chart_struct = row.memo.jukyu_chart_struct %}
+        <div class="chart-struct"
+             data-code="{{ row.code_s }}"
+             data-rescue="{% if chart_struct.rescue %}1{% else %}0{% endif %}">
+          <select class="chart-style-select" {% if fallback_mode %}disabled{% endif %}>
+            <option value="">型なし</option>
+            {% if chart_struct.rescue %}
+            <option value="{{ chart_struct.rescue }}" selected>⚠️ {{ chart_struct.rescue }}</option>
+            {% endif %}
+            {% for style in chart_style_options %}
+            <option value="{{ style }}" {% if style == chart_struct.style %}selected{% endif %}>{{ style }}</option>
+            {% endfor %}
+          </select>
+          <select class="chart-state-select" {% if fallback_mode or chart_struct.rescue %}disabled{% endif %}>
+            <option value="">状態なし</option>
+            {% for state in chart_state_options %}
+            <option value="{{ state }}" {% if state == chart_struct.state %}selected{% endif %}>{{ state }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </td>
       {# issue #327: 売買戦略 (定型リスト単一選択 + 色分けバッジ)。
          リスト外の旧自由記述値は ⚠️ 付き option を差し込んで保持し、再分類を促す #}
       {% set current_idea = row.memo.trade_idea or '' %}
@@ -751,7 +811,7 @@ function excludeFromUniverse(codeS) {
   }
 
   // 短縮表示 (data-full 全文保持 + 改行反映2行省略) する memo フィールド (issue #314 / #327)
-  var SHORT_TEXT_FIELDS = ['jukyu_chart', 'inago_origin', 'watch_in_reason', 'takaichi_sensitivity'];
+  var SHORT_TEXT_FIELDS = ['inago_origin', 'watch_in_reason', 'takaichi_sensitivity'];
 
   function renderJukyu(td, value) {
     td.dataset.full = value || '';
@@ -823,6 +883,7 @@ function excludeFromUniverse(codeS) {
       setCellColorStyle(td, styles[field] || '');
     });
   }
+  window.applyPortfolioRowStyles = applyStylesToRow;
 
   function startEdit(td) {
     if (td.dataset.editing === '1') return;
@@ -981,18 +1042,175 @@ function excludeFromUniverse(codeS) {
     td.addEventListener('click', function(e) {
       // セル内のリンク (銘柄詳細など) クリックは編集モードに入らない
       if (e.target.tagName === 'A') return;
-      // ステージセルで Ctrl/Cmd+クリックなら株探チャートを別タブで開く (編集はしない)
-      if (td.dataset.field === 'stage' && (e.ctrlKey || e.metaKey)) {
-        e.preventDefault();
-        var code = td.dataset.code;
-        if (code) {
-          window.open('https://kabutan.jp/stock/chart?code=' + encodeURIComponent(code), '_blank', 'noopener');
-        }
-        return;
-      }
       startEdit(td);
     });
   });
+})();
+
+// ========== stage / jukyu_chart structured 編集 (issue #344) ==========
+(function() {
+  function todayMD() {
+    var d = new Date();
+    return (d.getMonth() + 1) + '/' + d.getDate();
+  }
+
+  function postMemo(code, payload) {
+    var fd = new FormData();
+    Object.keys(payload).forEach(function(k) { fd.append(k, payload[k]); });
+    return fetch('/portfolio/' + encodeURIComponent(code) + '/memo', {
+      method: 'POST',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      body: fd,
+    }).then(function(r) {
+      return r.json().then(function(json) { return { ok: r.ok, json: json }; });
+    });
+  }
+
+  function bindStageStruct(box) {
+    var code = box.dataset.code;
+    var main = box.querySelector('.stage-main-select');
+    var tSel = box.querySelector('.stage-t-select');
+    if (!code || !main || !tSel || main.disabled) return;
+    var prev = { s: main.value || '', t: tSel.value || '', rescue: box.dataset.rescue || '0' };
+
+    function stageUnit(stageValue) {
+      return (stageValue || '').split('~', 1)[0] === '2S' ? 'B' : 'T';
+    }
+
+    function allowsStageSuffix(stageValue) {
+      return !!stageValue && stageValue.indexOf('or') === -1;
+    }
+
+    function relabelTOptions() {
+      var unit = stageUnit(main.value || '');
+      tSel.dataset.unit = unit;
+      Array.prototype.forEach.call(tSel.options, function(opt) {
+        if (!opt.value) opt.textContent = unit + 'なし';
+        else opt.textContent = opt.value + unit;
+      });
+    }
+
+    function syncDisabled() {
+      tSel.disabled = !allowsStageSuffix(main.value || '') || box.dataset.rescue === '1';
+    }
+
+    function rollback() {
+      box.dataset.rescue = prev.rescue;
+      main.value = prev.s;
+      tSel.value = prev.t;
+      relabelTOptions();
+      syncDisabled();
+    }
+
+    function save() {
+      var payload = {
+        stage_s: main.value || '',
+        stage_t: tSel.disabled ? '' : (tSel.value || ''),
+        last_research_update: todayMD(),
+      };
+      box.classList.add('saving');
+      postMemo(code, payload).then(function(res) {
+        box.classList.remove('saving');
+        if (!res.ok || !res.json || res.json.ok !== true) {
+          rollback();
+          alert((res.json && res.json.error) || 'ステージの保存に失敗しました');
+          return;
+        }
+        box.dataset.rescue = '0';
+        prev = { s: payload.stage_s, t: payload.stage_t, rescue: '0' };
+        syncDisabled();
+        var tr = box.closest('tr');
+        var disp = res.json.display || {};
+        var dateTd = tr && tr.querySelector('td.editable[data-field="last_research_update"]');
+        if (dateTd) dateTd.textContent = disp.last_research_update || payload.last_research_update || '—';
+        if (window.applyPortfolioRowStyles) {
+          window.applyPortfolioRowStyles(tr, res.json.styles || {});
+        }
+      }).catch(function(err) {
+        box.classList.remove('saving');
+        rollback();
+        alert('通信エラー: ' + err);
+      });
+    }
+
+    main.addEventListener('change', function() {
+      if (box.dataset.rescue === '1') box.dataset.rescue = '0';
+      tSel.value = '';
+      relabelTOptions();
+      syncDisabled();
+      save();
+    });
+    tSel.addEventListener('change', save);
+    relabelTOptions();
+    syncDisabled();
+    box.closest('td').addEventListener('mousedown', function(e) {
+      if (e.button !== 0 || !(e.ctrlKey || e.metaKey)) return;
+      if (e.target.tagName === 'SELECT') return;
+      e.preventDefault();
+      window.open('https://kabutan.jp/stock/chart?code=' + encodeURIComponent(code), '_blank', 'noopener');
+    });
+  }
+
+  function bindChartStruct(box) {
+    var code = box.dataset.code;
+    var style = box.querySelector('.chart-style-select');
+    var state = box.querySelector('.chart-state-select');
+    if (!code || !style || !state || style.disabled) return;
+    var prev = {
+      style: style.value || '',
+      state: state.value || '',
+      rescue: box.dataset.rescue || '0',
+    };
+
+    function syncDisabled() {
+      var rescue = box.dataset.rescue === '1';
+      state.disabled = rescue;
+    }
+
+    function rollback() {
+      box.dataset.rescue = prev.rescue;
+      style.value = prev.style;
+      state.value = prev.state;
+      syncDisabled();
+    }
+
+    function save() {
+      var payload = {
+        chart_style: style.value || '',
+        chart_state: state.disabled ? '' : (state.value || ''),
+      };
+      box.classList.add('saving');
+      postMemo(code, payload).then(function(res) {
+        box.classList.remove('saving');
+        if (!res.ok || !res.json || res.json.ok !== true) {
+          rollback();
+          alert((res.json && res.json.error) || '需給の保存に失敗しました');
+          return;
+        }
+        box.dataset.rescue = '0';
+        prev = {
+          style: payload.chart_style,
+          state: payload.chart_state,
+          rescue: '0',
+        };
+        syncDisabled();
+      }).catch(function(err) {
+        box.classList.remove('saving');
+        rollback();
+        alert('通信エラー: ' + err);
+      });
+    }
+
+    style.addEventListener('change', function() {
+      if (box.dataset.rescue === '1') box.dataset.rescue = '0';
+      syncDisabled();
+      save();
+    });
+    state.addEventListener('change', save);
+  }
+
+  document.querySelectorAll('.stage-struct').forEach(bindStageStruct);
+  document.querySelectorAll('.chart-struct').forEach(bindChartStruct);
 })();
 
 // ========== 業態・テーマ inline 編集 (issue #187) ==========

--- a/tests/test_ks_util.py
+++ b/tests/test_ks_util.py
@@ -139,6 +139,19 @@ class TestGetPriceDay:
         assert ks_util.get_price_day(dt) == date(2025, 6, 9)
 
 
+class TestRecentWeekday:
+    """17:00 境界 + 土日補正のテスト"""
+
+    @pytest.mark.parametrize("dt, expected", [
+        (datetime(2026, 6, 12, 20, 0), date(2026, 6, 12)),  # 金曜夜
+        (datetime(2026, 6, 13, 20, 0), date(2026, 6, 12)),  # 土曜夜 → 金曜
+        (datetime(2026, 6, 14, 12, 0), date(2026, 6, 12)),  # 日曜 → 金曜
+        (datetime(2026, 6, 15, 10, 0), date(2026, 6, 12)),  # 月曜17時前 → 前金曜
+    ])
+    def test_weekend_rolls_back_to_friday(self, dt, expected):
+        assert ks_util.recent_weekday(dt) == expected
+
+
 # ==================================================
 # get_db_code / set_db_code
 # ==================================================

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -27,6 +27,22 @@ class TestHasPriceData:
         stocks = {"1234": {"sell_pressure_ratio": [50, 60, 40, 2.5, 1.8]}}
         assert make_stock_db.has_price_data(stocks, "1234", latest=False) is True
 
+    def test_latest_uses_recent_weekday_for_price_log(self, monkeypatch):
+        """土曜実行でも直近金曜の price_log なら最新扱いする。"""
+        monkeypatch.setattr(
+            make_stock_db,
+            "recent_weekday",
+            lambda _dt: date(2026, 6, 12),
+        )
+        stocks = {
+            "1234": {
+                "sell_pressure_ratio": [50, 60, 40, 2.5, 1.8],
+                "access_date_price": datetime(2026, 6, 13, 20, 0),
+                "price_log": [(date(2026, 6, 12), 1000)],
+            }
+        }
+        assert make_stock_db.has_price_data(stocks, "1234", latest=True) is True
+
 
 # ==================================================
 # has_gyoseki_data

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -657,6 +657,25 @@ class TestCalcDailyIndicators:
 
 
 # ==================================================
+# _is_daily_cache_fresh
+# ==================================================
+class TestIsDailyCacheFresh:
+    """日足キャッシュの鮮度判定テスト"""
+
+    def test_weekend_rolls_back_to_friday(self):
+        """土曜17時以降でも直近金曜の日次キャッシュを新鮮扱いする。"""
+        with patch("price.recent_weekday", return_value=date(2026, 6, 12)):
+            pl = [["2026年6月12日", 100, 110, 90, 105, 1000, 105]]
+            assert price._is_daily_cache_fresh(pl) is True
+
+    def test_stale_when_before_recent_friday(self):
+        """直近金曜より古い日次キャッシュは週末でも古い扱いする。"""
+        with patch("price.recent_weekday", return_value=date(2026, 6, 12)):
+            pl = [["2026年6月11日", 100, 110, 90, 105, 1000, 105]]
+            assert price._is_daily_cache_fresh(pl) is False
+
+
+# ==================================================
 # _is_weekly_cache_fresh
 # ==================================================
 class TestIsWeeklyCacheFresh:

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -193,13 +193,24 @@ class TestDashboardGet:
         html = resp.data.decode()
 
         # issue #327: 評価は指標ページ (ページ1) のみ、チャートパターンはページ2へ移設
-        assert '<th data-page="1">評価</th>' in html
-        assert '<th data-page="2">チャートパターン</th>' in html
-        assert '<td data-page="1" class="rating-cell" style="background:#fbbc04">S</td>' in html
-        assert 'data-field="jukyu_chart"' in html
-        assert 'data-multiline="1"' in html
+        assert '>評価<' in html
+        assert '>チャートパターン<' in html
+        assert 'class="rating-cell"' in html
+        assert '>S</td>' in html
+        assert 'class="chart-style-select"' in html
+        assert 'class="chart-state-select"' in html
         assert "月足低位ブレイク" in html
         assert 'name="jukyu_chart"' not in html
+
+    def test_dashboard_stage_t_select_uses_b_label_for_2s(self, client, portfolio_db_path):
+        ps.update_memo("3496", {"stage": "2S(3B)"}, db_path=portfolio_db_path)
+        html = client.get("/portfolio?status=hold").data.decode()
+        assert ">3B<" in html
+        assert ">Bなし<" in html
+
+    def test_dashboard_stage_select_includes_1s_or_3s(self, client):
+        html = client.get("/portfolio?status=hold").data.decode()
+        assert '>1Sor3S<' in html
 
 
 class TestAddPost:
@@ -629,6 +640,35 @@ class TestUpdateMemoPost:
         assert rec["memo"]["inago_origin"] == "twitter"
         assert rec["memo"]["jukyu_chart"] == "CWH"
 
+    def test_memo_structured_stage_and_chart_fields_are_folded(self, client, portfolio_db_path):
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={
+                "stage_s": "2S~3S",
+                "stage_t": "3",
+                "chart_style": "月足CWH",
+                "chart_state": "ブレイク",
+            },
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["fields"]["stage"] == "2S(3B)~3S"
+        assert body["fields"]["jukyu_chart"] == "月足CWHブレイク"
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["stage"] == "2S(3B)~3S"
+        assert rec["memo"]["jukyu_chart"] == "月足CWHブレイク"
+
+    def test_memo_stage_1s_or_3s_saves_without_suffix(self, client, portfolio_db_path):
+        resp = client.post(
+            "/portfolio/6324/memo",
+            data={"stage_s": "1Sor3S", "stage_t": "3"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        rec = ps.get_record("6324", db_path=portfolio_db_path)
+        assert rec["memo"]["stage"] == "1Sor3S"
+
     def test_memo_empty_string_overwrites(self, client, portfolio_db_path):
         """空文字を明示送信したら "" に上書き (メモ削除扱い)"""
         ps.update_memo("6324", {"trade_idea": "GARP"}, db_path=portfolio_db_path)
@@ -701,7 +741,7 @@ class TestUpdateMemoAjax:
     def test_ajax_partial_update_returns_json(self, client, portfolio_db_path):
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"stage": "2S", "last_research_update": "5/10"},
+            data={"stage_s": "2S", "stage_t": "3", "last_research_update": "5/10"},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
         assert resp.status_code == 200
@@ -709,11 +749,11 @@ class TestUpdateMemoAjax:
         body = resp.get_json()
         assert body["ok"] is True
         assert body["code_s"] == "6324"
-        assert body["fields"]["stage"] == "2S"
+        assert body["fields"]["stage"] == "2S(3B)"
         assert body["fields"]["last_research_update"] == "5/10"
         # shelve に反映されている
         rec = ps.get_record("6324", db_path=portfolio_db_path)
-        assert rec["memo"]["stage"] == "2S"
+        assert rec["memo"]["stage"] == "2S(3B)"
         assert rec["memo"]["last_research_update"] == "5/10"
 
     def test_ajax_response_includes_styles_and_display(self, client, portfolio_db_path):
@@ -721,7 +761,7 @@ class TestUpdateMemoAjax:
         # サーバは styles と display を AJAX レスポンスに含める。
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"stage": "2S", "last_research_update": "5/10"},
+            data={"stage_s": "2S", "stage_t": "", "last_research_update": "5/10"},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
         assert resp.status_code == 200
@@ -733,19 +773,19 @@ class TestUpdateMemoAjax:
         assert body["display"]["stage"] == "2S"
         assert body["display"]["last_research_update"] == "5/10"
 
-    def test_ajax_updates_jukyu_chart_with_newline(self, client, portfolio_db_path):
+    def test_ajax_updates_jukyu_chart_from_structured_selects(self, client, portfolio_db_path):
         resp = client.post(
             "/portfolio/6324/memo",
-            data={"jukyu_chart": "月足低位ブレイク\nCWH"},
+            data={"chart_style": "月足低位", "chart_state": "ブレイク"},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
         assert resp.status_code == 200
         body = resp.get_json()
         assert body["ok"] is True
-        assert body["display"]["jukyu_chart"] == "月足低位ブレイク\nCWH"
+        assert body["display"]["jukyu_chart"] == "月足低位ブレイク"
 
         rec = ps.get_record("6324", db_path=portfolio_db_path)
-        assert rec["memo"]["jukyu_chart"] == "月足低位ブレイク\nCWH"
+        assert rec["memo"]["jukyu_chart"] == "月足低位ブレイク"
 
     def test_ajax_display_includes_page2_memo_fields(self, client, portfolio_db_path):
         """issue #327: ページ2列の inline 編集同期用に display へ 4 フィールドを含める"""
@@ -1396,10 +1436,14 @@ class TestPortfolioCharts:
         """inline 編集の初期値として stage / 更新日が JSON 埋め込みに出る (issue #231)"""
         ps.update_memo(
             "3496",
-            {"stage": "2S", "last_research_update": "5/30"},
+            {"stage": "2S(3B)", "last_research_update": "5/30", "jukyu_chart": "月足CWHブレイク"},
             db_path=portfolio_db_path,
         )
         resp = client.get("/portfolio/charts?status=hold")
         html = resp.data.decode()
-        assert '"stage": "2S"' in html
+        assert '"stage": "2S(3B)"' in html
         assert '"last_research_update": "5/30"' in html
+        assert '"stage_struct"' in html
+        assert '"jukyu_chart_struct"' in html
+        assert 'class="stage-main-select"' in html
+        assert 'class="chart-style-select"' in html


### PR DESCRIPTION
## 概要
- portfolio の stage を structured input 化し、S と T/B を分離入力できるように変更
- portfolio の jukyu_chart を structured input 化し、週足/月足パターン + 状態の選択式へ変更
- portfolio/charts も同じ保存契約に揃え、rescue 値や stage suffix の誤保存も修正

## 変更点
- stage の候補に 1Sor3S を追加
- 2S の suffix は B、それ以外は T として保存
- 週足月足 既存値は 月足 系として rescue/parse
- charts 側の rescue option は DOM API で構築し、HTML 注入を防止

## 確認
- ../.venv/bin/python -m pytest ../tests/test_webapp_portfolio_routes.py -q
