### PR TITLE
feat(portfolio): 売買戦略マスター編集画面を追加 (issue #335)

### DIFF
--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -69,6 +69,7 @@ KEY_RECORD_PREFIX = "record:"
 KEY_ACTION_LOG_PREFIX = "action_log:"
 KEY_SEQ_PREFIX = "_seq:"
 KEY_THEME_PREFIX = "theme:"
+KEY_TRADE_IDEA_PREFIX = "trade_idea:"
 
 # テーママスター (issue #282)
 THEME_FIELDS = frozenset({"name", "description", "created_at"})
@@ -132,6 +133,20 @@ TRADE_IDEA_DESCRIPTIONS = {
     "大型高配当": "恒常: PF安定・信用代用",
 }
 TRADE_IDEA_OPTIONS = tuple(TRADE_IDEA_DESCRIPTIONS.keys())
+
+# 戦略マスター (issue #335: 定数 shelve 移行・編集画面)
+VALID_TIME_HORIZONS = ("短期", "中期", "中長期", "長期", "恒常", "")
+
+_TRADE_IDEA_SEED = [
+    {"name": "GARP",           "description": "安定成長株を押し目・一時的売り込まれ局面で拾う。業績成長シナリオが崩れたら売る",    "time_horizon": "中長期", "over_earnings": True},
+    {"name": "ピーターリンチ", "description": "身近な実感で好印象の銘柄を持つ。身近な実感・好印象が消えたら売る",                  "time_horizon": "中長期", "over_earnings": False},
+    {"name": "中期テーマ",     "description": "相場の物色テーマの波に乗る。物色が他テーマへ移ったら売る",                          "time_horizon": "中期",   "over_earnings": False},
+    {"name": "中期モメンタム", "description": "新高値ブレイク順張り 2〜3ヶ月保有。トレンド（チャート）が崩れたら売る",             "time_horizon": "中期",   "over_earnings": False},
+    {"name": "短期イベント",   "description": "決算・材料・政策などカタリスト狙い。イベント通過で手仕舞い",                        "time_horizon": "短期",   "over_earnings": True},
+    {"name": "底値リバ",       "description": "下げすぎリバ取り。MAタッチ/10%で機械的利確。サイズ小・損切り事前設定",             "time_horizon": "短期",   "over_earnings": False},
+    {"name": "夢枠",           "description": "2〜3年の夢に乗る。現物放置。売らない",                                              "time_horizon": "長期",   "over_earnings": True},
+    {"name": "大型高配当",     "description": "PF安定・信用代用を兼ねる。恒常保有。売らない",                                      "time_horizon": "恒常",   "over_earnings": True},
+]
 
 # issue #344: stage / jukyu_chart を自由記述から選択式へ寄せるための定型候補。
 # DB スキーマは変えず、UI 側で分解入力した値を route 層で 1 本の文字列に畳み込む。
@@ -1166,6 +1181,259 @@ def _rewrite_theme_in_records(
     return affected
 
 
+# ===========================================
+# 戦略マスター CRUD (issue #335)
+# ===========================================
+
+def _trade_idea_key(name: str) -> str:
+    return f"{KEY_TRADE_IDEA_PREFIX}{name}"
+
+
+def validate_strategy_name(name: Any) -> str:
+    """戦略 name を検証して正規化済み name を返す (validate_theme_name と同じルール)。"""
+    try:
+        return validate_theme_name(name)
+    except TypeError as e:
+        raise TypeError(str(e).replace("theme name", "strategy name")) from e
+    except ValueError as e:
+        raise ValueError(str(e).replace("theme name", "strategy name")) from e
+
+
+def list_trade_ideas(*, db_path: Optional[str] = None) -> List[Dict[str, Any]]:
+    """戦略マスターを name 昇順で取得する。"""
+    path = _resolve_db_path(db_path)
+    results: List[Dict[str, Any]] = []
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_TRADE_IDEA_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            results.append(dict(value))
+    results.sort(key=lambda r: r.get("name", ""))
+    return results
+
+
+def get_trade_idea(name: str, *, db_path: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """1件取得 (存在しなければ None)。"""
+    normalized = validate_strategy_name(name)
+    path = _resolve_db_path(db_path)
+    with ShelveDB(path) as db:
+        value = db.get(_trade_idea_key(normalized))
+    return dict(value) if isinstance(value, dict) else None
+
+
+def _validate_trade_idea_fields(
+    time_horizon: Any,
+    over_earnings: Any,
+) -> tuple:
+    """time_horizon / over_earnings の型・値チェック。正規化後の (time_horizon, over_earnings) を返す。"""
+    if time_horizon is None:
+        time_horizon = ""
+    if not isinstance(time_horizon, str):
+        raise TypeError(f"time_horizon must be str or None, got {type(time_horizon).__name__}")
+    if time_horizon not in VALID_TIME_HORIZONS:
+        raise ValueError(f"time_horizon {time_horizon!r} は無効です (許容値: {list(VALID_TIME_HORIZONS)})")
+    if over_earnings is None:
+        over_earnings = False
+    if not isinstance(over_earnings, bool):
+        raise TypeError(f"over_earnings must be bool or None, got {type(over_earnings).__name__}")
+    return time_horizon, over_earnings
+
+
+def create_trade_idea(
+    name: str,
+    description: str = "",
+    time_horizon: str = "",
+    over_earnings: bool = False,
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """戦略を新規作成する。重複は ValueError。"""
+    normalized = validate_strategy_name(name)
+    desc = _validate_theme_description(description)
+    th, oe = _validate_trade_idea_fields(time_horizon, over_earnings)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _trade_idea_key(normalized)
+            if key in db:
+                raise ValueError(f"strategy {normalized!r} は既に存在します")
+            record = {
+                "name": normalized,
+                "description": desc,
+                "time_horizon": th,
+                "over_earnings": oe,
+                "created_at": now_iso(),
+            }
+            db[key] = record
+    log_print("portfolio_shelve: strategy 作成", normalized)
+    return dict(record)
+
+
+def update_trade_idea(
+    name: str,
+    new_name: Optional[str] = None,
+    description: Optional[str] = None,
+    time_horizon: Optional[str] = None,
+    over_earnings: Optional[bool] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """戦略を更新する (リネーム / 説明文 / 時間軸 / 決算またぎ編集)。
+
+    - new_name が現行と異なれば旧キー削除 + 新キー作成 + 全 record の memo[trade_idea] 書き換え
+    - 同 _flock + 同 ShelveDB セッション内で完結
+
+    戻り値: 更新後の strategy レコード
+    """
+    normalized = validate_strategy_name(name)
+    new_normalized = validate_strategy_name(new_name) if new_name is not None else None
+    desc_value = _validate_theme_description(description) if description is not None else None
+    if time_horizon is not None or over_earnings is not None:
+        th_value, oe_value = _validate_trade_idea_fields(
+            time_horizon if time_horizon is not None else "",
+            over_earnings if over_earnings is not None else False,
+        )
+    else:
+        th_value, oe_value = None, None
+
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            old_key = _trade_idea_key(normalized)
+            if old_key not in db:
+                raise KeyError(f"strategy {normalized!r} は存在しません")
+            current = dict(db[old_key])
+
+            renaming = new_normalized is not None and new_normalized != normalized
+            if renaming:
+                new_key = _trade_idea_key(new_normalized)
+                if new_key in db:
+                    raise ValueError(f"strategy {new_normalized!r} は既に存在します")
+                current["name"] = new_normalized
+            if desc_value is not None:
+                current["description"] = desc_value
+            if time_horizon is not None:
+                current["time_horizon"] = th_value
+            if over_earnings is not None:
+                current["over_earnings"] = oe_value
+
+            if renaming:
+                del db[old_key]
+                db[new_key] = current
+                affected_codes = _rewrite_trade_idea_in_records(db, normalized, new_normalized)
+            else:
+                db[old_key] = current
+                affected_codes = []
+
+            for code in affected_codes:
+                _append_action_log_inner(db, code, "メモ更新")
+    if renaming:
+        log_print(
+            "portfolio_shelve: strategy リネーム",
+            f"{normalized} -> {new_normalized}",
+            f"affected={len(affected_codes)}",
+        )
+    else:
+        log_print("portfolio_shelve: strategy 更新", normalized)
+    return dict(current)
+
+
+def delete_trade_idea(name: str, *, db_path: Optional[str] = None) -> int:
+    """戦略を削除する。全 record の memo[trade_idea] を空文字にリセット。
+
+    戻り値: 影響を受けた銘柄数
+    """
+    normalized = validate_strategy_name(name)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            key = _trade_idea_key(normalized)
+            if key not in db:
+                raise KeyError(f"strategy {normalized!r} は存在しません")
+            del db[key]
+            affected_codes = _rewrite_trade_idea_in_records(db, normalized, None)
+            for code in affected_codes:
+                _append_action_log_inner(db, code, "メモ更新")
+    log_print(
+        "portfolio_shelve: strategy 削除",
+        normalized,
+        f"affected={len(affected_codes)}",
+    )
+    return len(affected_codes)
+
+
+def count_trade_idea_usage(*, db_path: Optional[str] = None) -> Dict[str, int]:
+    """name -> 使用銘柄数 を返す (編集画面表示用)。"""
+    path = _resolve_db_path(db_path)
+    counts: Dict[str, int] = {}
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_RECORD_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            memo = value.get("memo") or {}
+            idea = memo.get("trade_idea") or ""
+            if idea:
+                counts[idea] = counts.get(idea, 0) + 1
+    return counts
+
+
+def seed_trade_ideas(*, db_path: Optional[str] = None) -> int:
+    """戦略マスターが空のときのみシードデータを投入する（冪等）。投入数を返す。"""
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            existing = [k for k in db.keys() if k.startswith(KEY_TRADE_IDEA_PREFIX)]
+            if existing:
+                return 0
+            for seed in _TRADE_IDEA_SEED:
+                record = {
+                    "name": seed["name"],
+                    "description": seed["description"],
+                    "time_horizon": seed["time_horizon"],
+                    "over_earnings": seed["over_earnings"],
+                    "created_at": now_iso(),
+                }
+                db[_trade_idea_key(seed["name"])] = record
+    log_print("portfolio_shelve: strategy シード投入", f"{len(_TRADE_IDEA_SEED)} 件")
+    return len(_TRADE_IDEA_SEED)
+
+
+def _rewrite_trade_idea_in_records(
+    db: ShelveDB,
+    old_name: str,
+    new_name: Optional[str],
+) -> List[str]:
+    """全 record:* を走査し、memo[trade_idea] が old_name の銘柄を new_name に書き換える。
+
+    - new_name=None なら空文字にリセット (削除時)
+    - 変更があった record は updated_at を更新
+    - 戻り値: 変更があった code_s のリスト
+
+    呼び出し側で _flock + ShelveDB セッションを保持していること前提。
+    """
+    affected: List[str] = []
+    record_keys = [k for k in db.keys() if k.startswith(KEY_RECORD_PREFIX)]
+    for key in record_keys:
+        record = db[key]
+        if not isinstance(record, dict):
+            continue
+        memo = record.get("memo") or {}
+        if memo.get("trade_idea") != old_name:
+            continue
+        new_memo = dict(memo)
+        new_memo["trade_idea"] = new_name if new_name is not None else ""
+        new_record = dict(record)
+        new_record["memo"] = new_memo
+        new_record["updated_at"] = now_iso()
+        db[key] = new_record
+        affected.append(record.get("code_s") or key[len(KEY_RECORD_PREFIX):])
+    return affected
+
+
 def _append_action_log_inner(
     db: ShelveDB,
     code_s: str,
@@ -1296,18 +1564,24 @@ def update_memo(
                     )
                 normalized_fields["gyoutai_themes"] = cleaned
 
-            # trade_idea の定型値チェック (issue #327)
-            # - 空文字 (未分類) と TRADE_IDEA_OPTIONS 内の値は採用
-            # - リスト外でも現行レコードに既に入っている値は保持を許可 (旧自由記述の救済)
-            # - 純新規のリスト外値は ValueError
+            # trade_idea の値チェック (issue #335: shelve マスター参照に移行)
+            # - 空文字 (未分類) は常に許容
+            # - 現行レコードに既に入っている値は保持を許可 (旧自由記述の救済)
+            # - 純新規でマスター未登録の値は ValueError
             if "trade_idea" in normalized_fields:
                 idea = normalized_fields["trade_idea"]
                 current_idea = current_memo.get("trade_idea", "")
-                if idea and idea not in TRADE_IDEA_OPTIONS and idea != current_idea:
-                    raise ValueError(
-                        f"portfolio_shelve: trade_idea {idea!r} は定型リスト外のため"
-                        f"新規付与できません (許容値: {list(TRADE_IDEA_OPTIONS)})"
-                    )
+                if idea and idea != current_idea:
+                    master_names = {
+                        k[len(KEY_TRADE_IDEA_PREFIX):]
+                        for k in db.keys()
+                        if k.startswith(KEY_TRADE_IDEA_PREFIX)
+                    }
+                    if idea not in master_names:
+                        raise ValueError(
+                            f"portfolio_shelve: trade_idea {idea!r} はマスター未登録のため"
+                            f"新規付与できません"
+                        )
 
             changed = any(
                 current_memo.get(k, _current_default(k)) != v

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2023,8 +2023,12 @@ def _format_tags_tooltip(tags: str) -> str:
     if not tags or tags == "—":
         return ""
     lines = [tags]
+    if "売" in tags:
+        lines.append("売: RS高いのに売り圧力比率<45 かつ wma10割れ（2条件同時成立）")
+    elif "警" in tags:
+        lines.append("警: RS高いのに売り圧力比率<45 または wma10割れ（1条件のみ）")
     if "早売" in tags:
-        lines.append("早売: 急騰後の10ma利確ライン割れ")
+        lines.append("早売: 10ma維持実績あり→10ma割れ後に、最初に10ma割れした日の安値をさらに下回って確定")
     return "\n".join(lines)
 
 

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -1176,3 +1176,97 @@ def themes_delete(name: str):
         "info",
     )
     return redirect(url_for("portfolio.themes_index"))
+
+
+# ===========================================
+# 戦略マスター編集 (issue #335)
+# ===========================================
+
+@portfolio_bp.route("/portfolio/strategies", methods=["GET"])
+def strategies_index():
+    """戦略マスター一覧・編集画面を表示する。初回アクセス時にシードを自動投入する。"""
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+    ps.seed_trade_ideas()
+    strategies = ps.list_trade_ideas()
+    usage = ps.count_trade_idea_usage()
+    return render_template(
+        "portfolio_strategies.html",
+        strategies=strategies,
+        usage=usage,
+        strategy_name_max_len=ps.THEME_NAME_MAX_LEN,
+        valid_time_horizons=ps.VALID_TIME_HORIZONS,
+    )
+
+
+@portfolio_bp.route("/portfolio/strategies/create", methods=["POST"])
+def strategies_create():
+    """戦略を新規作成して /portfolio/strategies に戻る (PRG)。"""
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+    name = (request.form.get("name") or "").strip()
+    description = (request.form.get("description") or "").strip()
+    time_horizon = (request.form.get("time_horizon") or "").strip()
+    over_earnings = request.form.get("over_earnings") == "true"
+    try:
+        ps.create_trade_idea(name, description, time_horizon, over_earnings)
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return redirect(url_for("portfolio.strategies_index"))
+    flash(f"戦略「{name}」を作成しました", "info")
+    return redirect(url_for("portfolio.strategies_index"))
+
+
+@portfolio_bp.route("/portfolio/strategies/<name>/update", methods=["POST"])
+def strategies_update(name: str):
+    """戦略のリネーム / 説明文 / 時間軸 / 決算またぎ編集。"""
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+    new_name = (request.form.get("name") or "").strip()
+    description = request.form.get("description")
+    time_horizon = request.form.get("time_horizon")
+    over_earnings_raw = request.form.get("over_earnings")
+    over_earnings = (over_earnings_raw == "true") if over_earnings_raw is not None else None
+    try:
+        ps.update_trade_idea(
+            name,
+            new_name=new_name if new_name and new_name != name else None,
+            description=description if description is not None else None,
+            time_horizon=time_horizon if time_horizon is not None else None,
+            over_earnings=over_earnings,
+        )
+    except KeyError:
+        flash(f"戦略「{name}」が見つかりません", "error")
+        return redirect(url_for("portfolio.strategies_index"))
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return redirect(url_for("portfolio.strategies_index"))
+    if new_name and new_name != name:
+        flash(f"戦略を「{name}」→「{new_name}」にリネームしました", "info")
+    else:
+        flash(f"戦略「{name}」を更新しました", "info")
+    return redirect(url_for("portfolio.strategies_index"))
+
+
+@portfolio_bp.route("/portfolio/strategies/<name>/delete", methods=["POST"])
+def strategies_delete(name: str):
+    """戦略を削除し、全銘柄の trade_idea を空にリセットする。"""
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+    try:
+        affected = ps.delete_trade_idea(name)
+    except KeyError:
+        flash(f"戦略「{name}」が見つかりません", "error")
+        return redirect(url_for("portfolio.strategies_index"))
+    except (ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return redirect(url_for("portfolio.strategies_index"))
+    flash(
+        f"戦略「{name}」を削除しました (影響: {affected} 銘柄)",
+        "info",
+    )
+    return redirect(url_for("portfolio.strategies_index"))

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -856,6 +856,7 @@ def dashboard():
                 "qty_updated_at": ps.get_qty_global_updated_at(),
             }
 
+    trade_idea_master = ps.list_trade_ideas()
     return render_template(
         "portfolio_list.html",
         status_choices=STATUS_CHOICES,
@@ -874,8 +875,8 @@ def dashboard():
         fallback_mode=fallback_mode,
         theme_master=theme_master,
         gyoutai_themes_max_slots=ps.GYOUTAI_THEMES_MAX_SLOTS,
-        trade_idea_options=ps.TRADE_IDEA_OPTIONS,
-        trade_idea_descriptions=ps.TRADE_IDEA_DESCRIPTIONS,
+        trade_idea_options=[t["name"] for t in trade_idea_master],
+        trade_idea_descriptions={t["name"]: t["description"] for t in trade_idea_master},
         stage_options=ps.STAGE_OPTIONS,
         stage_t_options=ps.STAGE_T_OPTIONS,
         chart_style_options=ps.CHART_STYLE_OPTIONS,

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -207,7 +207,7 @@
     margin: 0; font-size: 0.85em;
   }
   .portfolio-add-form input[type="text"] { padding: 0.25em 0.4em; margin: 0; }
-  .portfolio-add-form button { padding: 0.3em 0.8em; margin: 0; }
+  .portfolio-add-form button { padding: 0.3em 0.8em; margin: 0; width: auto; }
   .portfolio-add-form .hint { color: #999; font-size: 0.85em; }
   /* 管理ボタン + 展開パネル */
   .dashboard-header { display: flex; justify-content: space-between; align-items: center; gap: 1em; flex-wrap: wrap; }
@@ -266,36 +266,47 @@
 {% endwith %}
 
 {# issue #215: フィルタは status / gyoutai_theme の単一選択 select 2 つ。onchange で即送信。 #}
-<form id="portfolio-filter-form" action="/portfolio" method="GET"
-      style="display:flex;flex-wrap:wrap;gap:1.2em;align-items:center;margin-bottom:0.6em;padding:0.5em 0.6em;background:#f5f7fa;border:1px solid #d8dee6;border-radius:4px;font-size:0.9em;">
-  {% if active_sort != default_sort %}
-  <input type="hidden" name="sort" value="{{ active_sort }}">
+<div style="display:flex;flex-wrap:wrap;gap:0.6em;align-items:center;margin-bottom:0.6em;padding:0.5em 0.6em;background:#f5f7fa;border:1px solid #d8dee6;border-radius:4px;font-size:0.9em;">
+  <form id="portfolio-filter-form" action="/portfolio" method="GET"
+        style="display:contents;">
+    {% if active_sort != default_sort %}
+    <input type="hidden" name="sort" value="{{ active_sort }}">
+    {% endif %}
+    <label style="display:inline-flex;align-items:center;gap:0.4em;margin:0;">
+      <span style="color:#666;">ステータス</span>
+      <select name="status" onchange="this.form.submit()" style="padding:0.2em 0.3em;font-size:0.9em;margin:0;">
+        <option value="">すべて</option>
+        {% for q, _, label in status_choices %}
+        <option value="{{ q }}" {% if q == active_status_query %}selected{% endif %}>{{ label }} ({{ counts[q] }})</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label style="display:inline-flex;align-items:center;gap:0.4em;margin:0;">
+      <span style="color:#666;">業態・テーマ</span>
+      <select name="gyoutai_theme" onchange="this.form.submit()" style="padding:0.2em 0.3em;font-size:0.9em;margin:0;max-width:18em;">
+        <option value="">すべて</option>
+        {% for theme in theme_master %}
+        <option value="{{ theme.name }}" {% if theme.name == active_gyoutai_theme %}selected{% endif %}>{{ theme.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <a href="{{ url_for('portfolio.charts') }}?status={{ active_status_query }}{% if active_gyoutai_theme %}&gyoutai_theme={{ active_gyoutai_theme|urlencode }}{% endif %}"
+       style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
+       title="現在のフィルタ結果をチャート一覧で確認">📊 チャート一覧</a>
+  </form>
+  {% if not fallback_mode %}
+  {# 追加フォームには return_query を入れない。
+     現在のフィルタが保有のみだと、追加された 3監 銘柄が見えなくなるため、
+     add() 側の default_status_query="watch" フォールバックを効かせる (codex 指摘 P2)。 #}
+  <form action="/portfolio/add" method="POST" class="portfolio-add-form" style="margin:0;display:inline-flex;align-items:center;gap:0.4em;">
+    <label style="margin:0;">コード追加 <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
+    <button type="submit" style="width:auto;">追加</button>
+  </form>
+  {% if delete_mode_allowed %}
+  <button type="button" id="toggle-delete-mode">一括変更モード</button>
   {% endif %}
-  <label style="display:inline-flex;align-items:center;gap:0.4em;margin:0;">
-    <span style="color:#666;">ステータス</span>
-    <select name="status" onchange="this.form.submit()" style="padding:0.2em 0.3em;font-size:0.9em;margin:0;">
-      <option value="">すべて</option>
-      {% for q, _, label in status_choices %}
-      <option value="{{ q }}" {% if q == active_status_query %}selected{% endif %}>{{ label }} ({{ counts[q] }})</option>
-      {% endfor %}
-    </select>
-  </label>
-  <label style="display:inline-flex;align-items:center;gap:0.4em;margin:0;">
-    <span style="color:#666;">業態・テーマ</span>
-    <select name="gyoutai_theme" onchange="this.form.submit()" style="padding:0.2em 0.3em;font-size:0.9em;margin:0;max-width:18em;">
-      <option value="">すべて</option>
-      {% for theme in theme_master %}
-      <option value="{{ theme.name }}" {% if theme.name == active_gyoutai_theme %}selected{% endif %}>{{ theme.name }}</option>
-      {% endfor %}
-    </select>
-  </label>
-  <a href="{{ url_for('portfolio.themes_index') }}"
-     style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
-     title="テーママスターを編集">✏️ テーマを編集</a>
-  <a href="{{ url_for('portfolio.charts') }}?status={{ active_status_query }}{% if active_gyoutai_theme %}&gyoutai_theme={{ active_gyoutai_theme|urlencode }}{% endif %}"
-     style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
-     title="現在のフィルタ結果をチャート一覧で確認">📊 チャート一覧</a>
-</form>
+  {% endif %}
+</div>
 
 <div style="display:flex;align-items:center;justify-content:space-between;gap:1em;flex-wrap:wrap;margin:0 0 0.4em 0;">
   <p style="font-size:0.85em;color:#666;margin:0;">
@@ -318,20 +329,20 @@
 
 {% if not fallback_mode %}
 <div id="manage-panel" style="display:none;">
-  {# 追加フォームには return_query を入れない。
-     現在のフィルタが保有のみだと、追加された 3監 銘柄が見えなくなるため、
-     add() 側の default_status_query="watch" フォールバックを効かせる (codex 指摘 P2)。 #}
-  <form action="/portfolio/add" method="POST" class="portfolio-add-form">
-    <label>コード <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
-    <button type="submit">追加</button>
-  </form>
-  <div style="margin-top:0.4em;">
+  <div>
+    <a href="{{ url_for('portfolio.themes_index') }}"
+       style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
+       title="テーママスターを編集">テーマ管理</a>
+  </div>
+  <div>
+    <a href="{{ url_for('portfolio.strategies_index') }}"
+       style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
+       title="売買戦略マスターを編集">戦略マスター管理</a>
+  </div>
+  <div>
     <a href="{{ url_for('portfolio.shikiho_page') }}?status={{ active_status_query }}{% if active_gyoutai_theme %}&gyoutai_theme={{ active_gyoutai_theme|urlencode }}{% endif %}"
        style="font-size:0.85em;color:#555;text-decoration:none;padding:0.2em 0.5em;border:1px solid #ccc;border-radius:3px;background:#fff;"
-       title="四季報コメントを順次更新">📝 四季報更新</a>
-    {% if delete_mode_allowed %}
-    <button type="button" id="toggle-delete-mode">一括変更モード</button>
-    {% endif %}
+       title="四季報コメントを順次更新">四季報更新</a>
   </div>
 </div>
 {% if delete_mode_allowed %}

--- a/scripts/webapp/templates/portfolio_strategies.html
+++ b/scripts/webapp/templates/portfolio_strategies.html
@@ -1,0 +1,174 @@
+{% extends "base.html" %}
+{% block title %}戦略マスター管理 | Shintakane Research{% endblock %}
+
+{% block content %}
+<style>
+  table.strategies-table { width: 100%; font-size: 0.9em; }
+  table.strategies-table th, table.strategies-table td { padding: 0.4em 0.6em; vertical-align: middle; }
+  table.strategies-table td.name-cell { font-weight: 600; max-width: 10em; word-break: break-word; }
+  table.strategies-table td.desc-cell { color: #555; max-width: 24em; word-break: break-word; }
+  table.strategies-table td.horizon-cell { white-space: nowrap; width: 6em; }
+  table.strategies-table td.earnings-cell { text-align: center; width: 5em; }
+  table.strategies-table td.usage-cell { text-align: right; color: #666; width: 4em; }
+  table.strategies-table td.op-cell { width: 14em; white-space: nowrap; }
+  table.strategies-table input[type="text"] { font-size: 0.9em; padding: 0.2em 0.4em; margin: 0; height: auto; width: 100%; }
+  table.strategies-table select { font-size: 0.9em; padding: 0.2em 0.4em; margin: 0; height: auto; }
+  table.strategies-table button { font-size: 0.85em; padding: 0.2em 0.6em; margin: 0 0.2em 0 0; height: auto; }
+  .strategies-create-form { background: #f5f7fa; border: 1px solid #d8dee6; border-radius: 4px; padding: 0.6em 0.8em; margin-bottom: 1em; }
+  .strategies-create-form input[type="text"] { font-size: 0.9em; padding: 0.3em 0.5em; margin: 0; height: auto; }
+  .strategies-create-form select { font-size: 0.9em; padding: 0.3em 0.5em; margin: 0; height: auto; }
+  .strategies-create-form button { font-size: 0.9em; padding: 0.3em 0.8em; margin: 0; height: auto; }
+  .principle-note { background: #f0f4ff; border-left: 3px solid #4a7adc; padding: 0.6em 1em; margin-bottom: 1em; font-size: 0.9em; color: #333; }
+</style>
+
+<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6em;">
+  <h2 style="margin:0;">戦略マスター管理</h2>
+  <div style="display:flex;gap:1em;align-items:center;font-size:0.9em;">
+    <a href="{{ url_for('portfolio.themes_index') }}">テーマ管理</a>
+    <a href="{{ url_for('portfolio.dashboard') }}">← ポートフォリオに戻る</a>
+  </div>
+</div>
+
+<div class="principle-note">
+  <strong>運用原則:</strong> 戦略は「銘柄の性質ラベル」ではなく「この銘柄の主たる出口ルールの宣言」。
+  テーマ・モメンタム・イベントは 1 銘柄で両立しがちだが、「何が崩れたら売るか」は 1 つに決められる。
+  判定に迷ったら「<em>何が崩れたら売るか</em>」を自問する。
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+  {% for category, message in messages %}
+  <div style="padding:0.5em 1em;margin-bottom:1em;border-radius:4px;font-size:0.9em;{% if category == 'error' %}background:#ffeaea;color:#c00;border:1px solid #fcc;{% else %}background:#eaffea;color:#060;border:1px solid #cfc;{% endif %}">{{ message }}</div>
+  {% endfor %}
+{% endif %}
+{% endwith %}
+
+<form method="POST" action="{{ url_for('portfolio.strategies_create') }}" class="strategies-create-form">
+  <div style="display:flex;gap:0.6em;align-items:center;flex-wrap:wrap;">
+    <label style="margin:0;">
+      <span style="color:#666;font-size:0.85em;">名前</span>
+      <input type="text" name="name" required maxlength="{{ strategy_name_max_len }}"
+             placeholder="例: 新戦略" style="width:10em;">
+    </label>
+    <label style="margin:0;flex:1;min-width:16em;">
+      <span style="color:#666;font-size:0.85em;">定義文</span>
+      <input type="text" name="description" placeholder="入口の例 + 出口基準" style="width:100%;">
+    </label>
+    <label style="margin:0;">
+      <span style="color:#666;font-size:0.85em;">時間軸</span>
+      <select name="time_horizon">
+        {% for h in valid_time_horizons %}
+        <option value="{{ h }}">{{ h if h else '(未設定)' }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label style="margin:0;">
+      <span style="color:#666;font-size:0.85em;">決算またぎ</span>
+      <select name="over_earnings">
+        <option value="false">不可</option>
+        <option value="true">可</option>
+      </select>
+    </label>
+    <button type="submit">+ 追加</button>
+  </div>
+</form>
+
+<p style="font-size:0.85em;color:#666;margin:0 0 0.4em 0;">戦略 {{ strategies|length }} 件</p>
+
+{# 各行の編集 / 削除フォームは HTML5 の form="id" 属性でセル横断的に関連付ける。 #}
+{% for strategy in strategies %}
+<form id="strategy-update-{{ loop.index }}" method="POST"
+      action="{{ url_for('portfolio.strategies_update', name=strategy.name) }}" style="display:none;"></form>
+<form id="strategy-delete-{{ loop.index }}" method="POST"
+      action="{{ url_for('portfolio.strategies_delete', name=strategy.name) }}" style="display:none;"></form>
+{% endfor %}
+
+<table class="strategies-table">
+  <thead>
+    <tr>
+      <th style="text-align:left;">名前</th>
+      <th style="text-align:left;">定義文</th>
+      <th style="text-align:center;">時間軸</th>
+      <th style="text-align:center;">決算またぎ</th>
+      <th style="text-align:right;">使用</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for strategy in strategies %}
+    {% set uses = usage.get(strategy.name, 0) %}
+    {% set fid = 'strategy-update-' ~ loop.index %}
+    {% set did = 'strategy-delete-' ~ loop.index %}
+    <tr data-name="{{ strategy.name }}" data-delete-form="{{ did }}">
+      <td class="name-cell">
+        <span class="display-name">{{ strategy.name }}</span>
+        <input type="text" name="name" value="{{ strategy.name }}" form="{{ fid }}"
+               required maxlength="{{ strategy_name_max_len }}"
+               class="edit-input edit-name" style="display:none;">
+      </td>
+      <td class="desc-cell">
+        <span class="display-desc">{{ strategy.description or '' }}</span>
+        <input type="text" name="description" value="{{ strategy.description or '' }}" form="{{ fid }}"
+               class="edit-input edit-desc" style="display:none;">
+      </td>
+      <td class="horizon-cell">
+        <span class="display-horizon">{{ strategy.time_horizon or '—' }}</span>
+        <select name="time_horizon" form="{{ fid }}" class="edit-input edit-horizon" style="display:none;">
+          {% for h in valid_time_horizons %}
+          <option value="{{ h }}" {% if strategy.time_horizon == h %}selected{% endif %}>
+            {{ h if h else '(未設定)' }}
+          </option>
+          {% endfor %}
+        </select>
+      </td>
+      <td class="earnings-cell">
+        <span class="display-earnings">{{ '可' if strategy.over_earnings else '不可' }}</span>
+        <select name="over_earnings" form="{{ fid }}" class="edit-input edit-earnings" style="display:none;">
+          <option value="false" {% if not strategy.over_earnings %}selected{% endif %}>不可</option>
+          <option value="true" {% if strategy.over_earnings %}selected{% endif %}>可</option>
+        </select>
+      </td>
+      <td class="usage-cell">{{ uses }}</td>
+      <td class="op-cell">
+        <span class="display-ops">
+          <button type="button" class="edit-btn" onclick="toggleEdit(this, true)">編集</button>
+          <button type="button" class="delete-btn"
+                  onclick="confirmDeleteStrategy({{ strategy.name|tojson }}, {{ uses }})">削除</button>
+        </span>
+        <span class="edit-ops" style="display:none;">
+          <button type="submit" form="{{ fid }}">保存</button>
+          <button type="button" onclick="toggleEdit(this, false)">キャンセル</button>
+        </span>
+      </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="6" style="text-align:center;color:#999;padding:1em;">登録済み戦略がありません。上のフォームから追加してください。</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<script>
+function toggleEdit(btn, openEdit) {
+  var tr = btn.closest('tr');
+  if (!tr) return;
+  tr.querySelectorAll('.display-name, .display-desc, .display-horizon, .display-earnings, .display-ops').forEach(function(el) {
+    el.style.display = openEdit ? 'none' : '';
+  });
+  tr.querySelectorAll('.edit-input, .edit-ops').forEach(function(el) {
+    el.style.display = openEdit ? '' : 'none';
+  });
+}
+
+function confirmDeleteStrategy(name, uses) {
+  var msg = uses > 0
+    ? '戦略「' + name + '」を削除しますか?\n' + uses + ' 銘柄の売買戦略が未分類になります。'
+    : '戦略「' + name + '」を削除しますか?';
+  if (!confirm(msg)) return;
+  var tr = document.querySelector('tr[data-name="' + CSS.escape(name) + '"]');
+  if (!tr) return;
+  var formId = tr.dataset.deleteForm;
+  var form = document.getElementById(formId);
+  if (form) form.submit();
+}
+</script>
+{% endblock %}

--- a/scripts/webapp/templates/portfolio_themes.html
+++ b/scripts/webapp/templates/portfolio_themes.html
@@ -18,7 +18,10 @@
 
 <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6em;">
   <h2 style="margin:0;">テーマ管理</h2>
-  <a href="{{ url_for('portfolio.dashboard') }}" style="font-size:0.9em;">← ポートフォリオに戻る</a>
+  <div style="display:flex;gap:1em;align-items:center;font-size:0.9em;">
+    <a href="{{ url_for('portfolio.strategies_index') }}">戦略マスター管理</a>
+    <a href="{{ url_for('portfolio.dashboard') }}">← ポートフォリオに戻る</a>
+  </div>
 </div>
 
 {% with messages = get_flashed_messages(with_categories=true) %}

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -400,6 +400,11 @@ class TestKeyNamespaceIsolation:
 # ==================================================
 class TestUpdateMemo:
 
+    @pytest.fixture(autouse=True)
+    def seed_strategies(self, db_path):
+        """trade_idea の shelve マスターをシード投入 (issue #335 移行後必須)"""
+        ps.seed_trade_ideas(db_path=db_path)
+
     def test_update_single_field(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
         rec = ps.update_memo("4377", {"trade_idea": "中期モメンタム"}, db_path=db_path)
@@ -434,7 +439,7 @@ class TestUpdateMemo:
             rec["memo"]["trade_idea"] = current
             ps.upsert_record(rec, db_path=db_path)
         if expect_error:
-            with pytest.raises(ValueError, match="定型リスト外"):
+            with pytest.raises(ValueError, match="マスター未登録"):
                 ps.update_memo("4377", {"trade_idea": new_value}, db_path=db_path)
         else:
             rec = ps.update_memo("4377", {"trade_idea": new_value}, db_path=db_path)
@@ -535,9 +540,10 @@ class TestGyoutaiThemesField:
 
     @pytest.fixture(autouse=True)
     def _seed_master(self, db_path):
-        """テストで使う name (半導体 / AI) をマスター登録しておく"""
+        """テストで使う name (半導体 / AI) をマスター登録し、戦略シードも投入する"""
         ps.create_theme("半導体", db_path=db_path)
         ps.create_theme("AI", db_path=db_path)
+        ps.seed_trade_ideas(db_path=db_path)
 
     def test_create_memo_defaults_empty_list(self):
         memo = ps.create_memo()
@@ -1076,3 +1082,93 @@ class TestThemeMaster:
         ps.update_memo("6324", {"gyoutai_themes": ["AI", "半導体"]}, db_path=db_path)
         ps.update_memo("9984", {"gyoutai_themes": ["AI"]}, db_path=db_path)
         assert ps.count_theme_usage(db_path=db_path) == {"AI": 2, "半導体": 1}
+
+
+@pytest.fixture
+def db_path_ti(tmp_path):
+    """戦略マスターテスト用の一時 DB パス。"""
+    return str(tmp_path / "test_portfolio_ti")
+
+
+class TestTradeIdeaMaster:
+    """戦略マスター CRUD + update_memo 整合性 (issue #335)"""
+
+    def test_create_and_list(self, db_path_ti):
+        """作成・一覧・get の基本動作。"""
+        ps.create_trade_idea("GARP", "説明A", "中長期", True, db_path=db_path_ti)
+        ps.create_trade_idea("夢枠", "説明B", "長期", False, db_path=db_path_ti)
+
+        items = ps.list_trade_ideas(db_path=db_path_ti)
+        assert len(items) == 2
+        names = [i["name"] for i in items]
+        assert names == sorted(names)
+
+        got = ps.get_trade_idea("GARP", db_path=db_path_ti)
+        assert got["time_horizon"] == "中長期"
+        assert got["over_earnings"] is True
+
+        # 重複は ValueError
+        with pytest.raises(ValueError):
+            ps.create_trade_idea("GARP", db_path=db_path_ti)
+
+    def test_update_renames_records(self, db_path_ti):
+        """リネームで全 record の memo[trade_idea] が追従し、delete で "" になること。"""
+        ps.create_trade_idea("中期モメンタム", "説明", "中期", False, db_path=db_path_ti)
+        ps.add_to_watch("6324", db_path=db_path_ti)
+        ps.update_memo("6324", {"trade_idea": "中期モメンタム"}, db_path=db_path_ti)
+
+        # リネーム
+        ps.update_trade_idea("中期モメンタム", new_name="モメンタム中期", db_path=db_path_ti)
+        rec = ps.get_record("6324", db_path=db_path_ti)
+        assert rec["memo"]["trade_idea"] == "モメンタム中期"
+
+        # 削除 → trade_idea が空文字にリセット
+        affected = ps.delete_trade_idea("モメンタム中期", db_path=db_path_ti)
+        assert affected == 1
+        rec = ps.get_record("6324", db_path=db_path_ti)
+        assert rec["memo"]["trade_idea"] == ""
+
+        # action_log に "メモ更新" が追記されている
+        logs = ps.list_action_logs("6324", db_path=db_path_ti)
+        memo_logs = [l for l in logs if l["action_type"] == "メモ更新"]
+        assert len(memo_logs) >= 2
+
+    @pytest.mark.parametrize(
+        "current_idea,posted,should_raise",
+        [
+            ("中期モメンタム", "中期モメンタム", False),  # マスター登録済み → OK
+            ("中期モメンタム", "",              False),  # 空文字（未分類）→ 常に許容
+            ("",              "未登録新規",     True),   # マスター未登録の純新規 → ValueError
+            ("旧自由記述",    "旧自由記述",     False),  # 現行レコードの未登録値は保持許可
+        ],
+    )
+    def test_update_memo_master_validation(
+        self, db_path_ti, current_idea, posted, should_raise
+    ):
+        """update_memo の trade_idea マスター未登録判定 (issue #335)"""
+        ps.create_trade_idea("中期モメンタム", db_path=db_path_ti)
+        ps.add_to_watch("6324", db_path=db_path_ti)
+        # 現行値を直書き込みで仕込む
+        rec = ps.get_record("6324", db_path=db_path_ti)
+        rec["memo"]["trade_idea"] = current_idea
+        ps.upsert_record(rec, db_path=db_path_ti)
+
+        if should_raise:
+            with pytest.raises(ValueError):
+                ps.update_memo("6324", {"trade_idea": posted}, db_path=db_path_ti)
+        else:
+            ps.update_memo("6324", {"trade_idea": posted}, db_path=db_path_ti)
+            after = ps.get_record("6324", db_path=db_path_ti)
+            assert after["memo"]["trade_idea"] == posted
+
+    def test_seed_trade_ideas_idempotent(self, db_path_ti):
+        """seed_trade_ideas() は空の場合のみ投入し、2回呼んでも件数が変わらないこと。"""
+        count = ps.seed_trade_ideas(db_path=db_path_ti)
+        assert count == len(ps._TRADE_IDEA_SEED)
+        items_after_first = ps.list_trade_ideas(db_path=db_path_ti)
+
+        # 2回目は 0 件投入（冪等）
+        count2 = ps.seed_trade_ideas(db_path=db_path_ti)
+        assert count2 == 0
+        items_after_second = ps.list_trade_ideas(db_path=db_path_ti)
+        assert len(items_after_first) == len(items_after_second)


### PR DESCRIPTION
## Summary

- `TRADE_IDEA_OPTIONS` Python定数をshelveマスターに移行し、`/portfolio/strategies` でCRUD管理できるようにした（テーママスターと同パターン）
- 戦略マスターに `time_horizon`（時間軸）・`over_earnings`（決算またぎ可否）フィールドを追加
- ポートフォリオ一覧の売買戦略ドロップダウンをshelve連動に切り替え（追加・リネームが即反映）
- manage-panelのUI整理：コード追加・一括変更モードをフィルタ行に移動、テーマ管理・戦略マスター管理をmanage-panel配下に整理
- 売/警/早売タグのtooltipに判定条件を追記

## Test plan

- [ ] `pytest tests/test_portfolio_shelve.py tests/test_webapp_routes.py -v` がすべてパスすること
- [ ] `/portfolio/strategies` にアクセスしてシード8件が自動投入されること
- [ ] 戦略の追加・リネーム・削除が `/portfolio` の売買戦略ドロップダウンに即反映されること
- [ ] テーマ管理 ↔ 戦略マスター管理の相互リンクが機能すること

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)