### PR TITLE
feat(webapp): 銘柄詳細ページに振り返りセクションを追加 (issue #172)

### DIFF
--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -61,7 +61,7 @@ VALID_STATUSES = frozenset({"1保", "2準", "3監"})
 
 # アクションログ種別
 VALID_ACTION_TYPES = frozenset(
-    {"初回登録", "ステータス変更", "売却", "削除", "メモ更新", "ユニバース除外"}
+    {"初回登録", "ステータス変更", "売却", "削除", "ユニバース除外", "株数変更"}
 )
 
 # キー名前空間プレフィックス
@@ -723,12 +723,12 @@ def update_qty(
     code_s: str,
     qty: int,
     *,
+    reason: str = "",
+    timestamp: Optional[str] = None,
     db_path: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """既存レコードの保有株数を更新する (issue #269)。
 
-    - 株数変更はアクションログを残さない (要件 §5)
-    - updated_at も触らない (株数変更は監査対象外、ファイル mtime の不要な変化を避ける)
     - 差分なしは no-op で early return (戻り値も現レコード)
     - レコード未登録は KeyError
     - 不正値 (非整数 / 負数) は TypeError / ValueError
@@ -756,6 +756,13 @@ def update_qty(
             db[key] = record
             db[KEY_QTY_GLOBAL_UPDATED_AT] = now_iso()
     log_print("portfolio_shelve: 株数更新", normalized, f"{current_qty} -> {qty_int}")
+    append_action_log(
+        code_s,
+        "株数変更",
+        reason=f"{current_qty} → {qty_int}" + (f" ({reason})" if reason else ""),
+        timestamp=timestamp,
+        db_path=db_path,
+    )
     return _normalize_loaded_record(record)
 
 
@@ -1078,9 +1085,6 @@ def update_theme(
                 db[old_key] = current
                 affected_codes = []
 
-            # 影響を受けた record の action_log は flock 内で追記 (リエントラント対応済み)
-            for code in affected_codes:
-                _append_action_log_inner(db, code, "メモ更新")
     if renaming:
         log_print(
             "portfolio_shelve: theme リネーム",
@@ -1106,8 +1110,6 @@ def delete_theme(name: str, *, db_path: Optional[str] = None) -> int:
                 raise KeyError(f"theme {normalized!r} は存在しません")
             del db[key]
             affected_codes = _rewrite_theme_in_records(db, normalized, None)
-            for code in affected_codes:
-                _append_action_log_inner(db, code, "メモ更新")
     log_print(
         "portfolio_shelve: theme 削除",
         normalized,
@@ -1327,8 +1329,6 @@ def update_trade_idea(
                 db[old_key] = current
                 affected_codes = []
 
-            for code in affected_codes:
-                _append_action_log_inner(db, code, "メモ更新")
     if renaming:
         log_print(
             "portfolio_shelve: strategy リネーム",
@@ -1354,8 +1354,6 @@ def delete_trade_idea(name: str, *, db_path: Optional[str] = None) -> int:
                 raise KeyError(f"strategy {normalized!r} は存在しません")
             del db[key]
             affected_codes = _rewrite_trade_idea_in_records(db, normalized, None)
-            for code in affected_codes:
-                _append_action_log_inner(db, code, "メモ更新")
     log_print(
         "portfolio_shelve: strategy 削除",
         normalized,
@@ -1483,8 +1481,7 @@ def update_memo(
     差分判定:
     - fields の各 key について現行値と完全一致すれば no-op
       (action_log 追記なし、updated_at 据え置き)
-    - 1 つでも変更があれば action_log に "メモ更新" を 1 件追加
-      (差分内容は記録しない、reason は空文字)
+    - 1 つでも変更があれば updated_at を更新 (action_log は記録しない)
 
     Returns: 更新後のレコード dict (no-op 時も現行 record を返す)
     """
@@ -1596,11 +1593,6 @@ def update_memo(
             record["memo"] = {**current_memo, **normalized_fields}
             record["updated_at"] = now_iso()
             db[key] = record
-        append_action_log(
-            normalized,
-            "メモ更新",
-            db_path=db_path,
-        )
     log_print(
         "portfolio_shelve: メモ更新",
         normalized,

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -724,7 +724,7 @@ def update_qty(
     qty: int,
     *,
     reason: str = "",
-    timestamp: Optional[str] = None,
+    action_date: Optional[str] = None,
     db_path: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """既存レコードの保有株数を更新する (issue #269)。
@@ -732,6 +732,8 @@ def update_qty(
     - 差分なしは no-op で early return (戻り値も現レコード)
     - レコード未登録は KeyError
     - 不正値 (非整数 / 負数) は TypeError / ValueError
+    - action_date (YYYY-MM-DD) を指定すると、action_log の timestamp を
+      JST 12:00 の ISO 8601 文字列に変換して記録する
 
     Returns: 更新後のレコード。差分なしの場合は現レコードをそのまま返す。
     """
@@ -739,6 +741,7 @@ def update_qty(
     normalized = normalize_code_s(code_s)
     _validate_qty(qty)
     qty_int = int(qty)
+    action_ts = _parse_action_date_to_iso(action_date) if action_date else None
 
     path = _resolve_db_path(db_path)
     with _flock(db_path):
@@ -760,7 +763,7 @@ def update_qty(
         code_s,
         "株数変更",
         reason=f"{current_qty} → {qty_int}" + (f" ({reason})" if reason else ""),
-        timestamp=timestamp,
+        timestamp=action_ts,
         db_path=db_path,
     )
     return _normalize_loaded_record(record)

--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -136,6 +136,9 @@ def stock_detail(code_s: str):
     except Exception:  # noqa: BLE001
         signal_display = {"tooltip": "", "style": ""}
 
+    # issue #172: 振り返りセクション用アクションログ (除外・削除済みでもログは表示する)
+    action_logs = list(reversed(ps.list_action_logs(code_s)))
+
     return render_template(
         "detail.html",
         record=record,
@@ -158,4 +161,5 @@ def stock_detail(code_s: str):
         signal_display=signal_display,
         gyoutai_themes_unset=gyoutai_themes_unset,
         has_business_text=has_business_text,
+        action_logs=action_logs,
     )

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -516,7 +516,7 @@ def transition(code_s: str):
         ps.transition_status(code_s, new_status, reason=reason, action_date=action_date)
         # issue #269: 1保 のときだけ qty を反映する (他ステータスでは無視)
         if new_status == "1保" and qty is not None:
-            ps.update_qty(code_s, qty, reason=reason, timestamp=action_date)
+            ps.update_qty(code_s, qty, reason=reason, action_date=action_date)
     except KeyError as e:
         flash(f"レコード未登録: {e}", "error")
         return _redirect_with_return_query(code_s=code_s)

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -516,7 +516,7 @@ def transition(code_s: str):
         ps.transition_status(code_s, new_status, reason=reason, action_date=action_date)
         # issue #269: 1保 のときだけ qty を反映する (他ステータスでは無視)
         if new_status == "1保" and qty is not None:
-            ps.update_qty(code_s, qty)
+            ps.update_qty(code_s, qty, reason=reason, timestamp=action_date)
     except KeyError as e:
         flash(f"レコード未登録: {e}", "error")
         return _redirect_with_return_query(code_s=code_s)

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -428,8 +428,8 @@ nav .quick-search {
 .kessan-history-table .col-date { width: 8em; white-space: nowrap; }
 .kessan-history-table .col-q { width: 3em; }
 .kessan-history-table .col-exp { width: 3.5em; }
-.kessan-history-table .col-change { width: 5em; white-space: nowrap; }
-.kessan-history-table .col-outlook { width: 18em; }
+.kessan-history-table .col-change { width: 12em; white-space: nowrap; }
+.kessan-history-table .col-outlook { width: 12em; }
 /* col-reaction は幅指定なし → 残り全幅に伸びる */
 /* Q セルは改行させず、1 行に収める */
 .kessan-history-table td.col-q { white-space: nowrap; color: #888; }

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -607,6 +607,34 @@
   {% endif %}
 </div>
 
+{# ===== 8. 振り返り (issue #172) ===== #}
+{% if action_logs %}
+<div class="memo-section" id="action-log-section">
+  <h3>振り返り</h3>
+  <table class="action-log-table">
+    <tbody>
+    {% for log in action_logs %}
+      {% if log.action_type != "メモ更新" %}
+      <tr>
+        <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ log.timestamp[:16] | replace("T", " ") }}</td>
+        <td>
+          {% if log.action_type == "ステータス変更" %}
+            ステータス変更 [{{ log.status_from or "—" }} → {{ log.status_to or "—" }}]
+          {% elif log.action_type == "売却" %}
+            <span style="color:#c00;">売却</span> [{{ log.status_from or "—" }} → {{ log.status_to or "—" }}]
+          {% else %}
+            {{ log.action_type }}{% if log.status_to %} [→ {{ log.status_to }}]{% endif %}
+          {% endif %}
+        </td>
+        <td style="color:#555;">{{ log.reason or "" }}</td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
 {# ===== 保有ステータス変更モーダル (issue #195) ===== #}
 {% if not portfolio_fallback_mode %}
 <div id="portfolio-modal" class="portfolio-modal-overlay" style="display:none;" onclick="closePortfolioModalOnOverlay(event)">

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -409,12 +409,10 @@ class TestUpdateMemo:
         ps.add_to_watch("4377", db_path=db_path)
         rec = ps.update_memo("4377", {"trade_idea": "中期モメンタム"}, db_path=db_path)
         assert rec["memo"]["trade_idea"] == "中期モメンタム"
-        # action_log に "メモ更新" 1 件 (初回登録 1 件 + メモ更新 1 件 = 計 2 件)
+        # メモ更新は action_log を記録しない (初回登録の 1 件のみ)
         logs = ps.list_action_logs("4377", db_path=db_path)
-        assert len(logs) == 2
-        assert logs[1]["action_type"] == "メモ更新"
-        assert logs[1]["status_from"] is None
-        assert logs[1]["status_to"] is None
+        assert len(logs) == 1
+        assert logs[0]["action_type"] == "初回登録"
 
     @pytest.mark.parametrize(
         "current, new_value, expect_error",
@@ -465,9 +463,9 @@ class TestUpdateMemo:
         ps.update_memo("4377", {"trade_idea": "中期モメンタム"}, db_path=db_path)
         rec = ps.update_memo("4377", {"trade_idea": ""}, db_path=db_path)
         assert rec["memo"]["trade_idea"] == ""
-        # action_log: 初回登録 + メモ更新×2 = 3 件
+        # メモ更新は action_log を記録しない (初回登録の 1 件のみ)
         logs = ps.list_action_logs("4377", db_path=db_path)
-        assert len(logs) == 3
+        assert len(logs) == 1
 
     def test_update_with_none_normalizes_to_empty_string(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
@@ -484,7 +482,7 @@ class TestUpdateMemo:
         for k, v in all_fields.items():
             assert rec["memo"][k] == v
         logs = ps.list_action_logs("4377", db_path=db_path)
-        assert len([log for log in logs if log["action_type"] == "メモ更新"]) == 1
+        assert not any(log["action_type"] == "メモ更新" for log in logs)
 
     def test_update_no_diff_is_noop(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
@@ -494,9 +492,9 @@ class TestUpdateMemo:
         rec_after = ps.get_record("4377", db_path=db_path)
         # updated_at が変わらない (no-op)
         assert rec_before["updated_at"] == rec_after["updated_at"]
-        # action_log: 初回登録 + メモ更新×1 のみ (no-op で増えない)
+        # メモ更新は action_log を記録しない (初回登録の 1 件のみ)
         logs = ps.list_action_logs("4377", db_path=db_path)
-        assert len([log for log in logs if log["action_type"] == "メモ更新"]) == 1
+        assert not any(log["action_type"] == "メモ更新" for log in logs)
 
     def test_update_empty_dict_is_noop(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
@@ -504,7 +502,7 @@ class TestUpdateMemo:
         # KeyError なし、no-op として現行 record を返す
         assert rec["code_s"] == "4377"
         logs = ps.list_action_logs("4377", db_path=db_path)
-        assert len([log for log in logs if log["action_type"] == "メモ更新"]) == 0
+        assert not any(log["action_type"] == "メモ更新" for log in logs)
 
     def test_update_unknown_field_raises(self, db_path):
         ps.add_to_watch("4377", db_path=db_path)
@@ -594,9 +592,8 @@ class TestGyoutaiThemesField:
         ps.update_memo("4377", {"gyoutai_themes": ["AI"]}, db_path=db_path)
         ps.update_memo("4377", {"gyoutai_themes": ["AI"]}, db_path=db_path)
         logs = ps.list_action_logs("4377", db_path=db_path)
-        memo_logs = [log for log in logs if log["action_type"] == "メモ更新"]
-        # 同じ値の更新は no-op、ログ追記は 1 回のみ
-        assert len(memo_logs) == 1
+        # メモ更新は action_log を記録しない
+        assert not any(log["action_type"] == "メモ更新" for log in logs)
 
     def test_legacy_record_without_gyoutai_themes_loads_as_empty_list(
         self, db_path
@@ -879,32 +876,32 @@ class TestQty:
     """update_qty / get_record の qty 補完を集約テスト"""
 
     @pytest.mark.parametrize(
-        "new_qty, expected, expect_log_count",
+        "new_qty, expected",
         [
-            (100, 100, 1),    # 新規セット
-            (250, 250, 1),    # 上書き
-            (0, 0, 1),        # 0 株 (利確直後の枠取り)
-            (0, 0, 0),        # 差分なし (no-op): 初期 qty=0 のまま 0 を入れる → 変化なし
+            (100, 100),   # 新規セット
+            (250, 250),   # 上書き
         ],
-        ids=["set-100", "overwrite-250", "set-zero", "noop-same"],
+        ids=["set-100", "overwrite-250"],
     )
-    def test_update_qty_writes_value_and_no_action_log(
-        self, db_path, new_qty, expected, expect_log_count
-    ):
-        """update_qty は qty を更新し、action_log は追記しない。差分なしは no-op。"""
+    def test_update_qty_writes_value_and_action_log(self, db_path, new_qty, expected):
+        """update_qty は qty を更新し action_log に「株数変更」を記録する。"""
         ps.add_to_watch("4377", db_path=db_path)
         ps.transition_status("4377", "1保", db_path=db_path)
         log_count_before = len(ps.list_action_logs("4377", db_path=db_path))
 
-        if expect_log_count == 0:
-            # 差分なしケース: 一度 0 にしてから 0 を入れる → 2 回目が no-op
-            ps.update_qty("4377", 0, db_path=db_path)
-
         rec = ps.update_qty("4377", new_qty, db_path=db_path)
         assert rec["qty"] == expected
-        # action_log は qty 更新で増えない (1保 遷移ログ +「初回登録」のみ)
-        log_count_after = len(ps.list_action_logs("4377", db_path=db_path))
-        assert log_count_after == log_count_before
+        logs = ps.list_action_logs("4377", db_path=db_path)
+        assert len(logs) == log_count_before + 1
+        assert logs[-1]["action_type"] == "株数変更"
+
+    def test_update_qty_noop_no_action_log(self, db_path):
+        """差分なし (初期 qty=0 に 0 を入れる) は no-op でログが増えない。"""
+        ps.add_to_watch("4377", db_path=db_path)
+        ps.transition_status("4377", "1保", db_path=db_path)
+        log_count_before = len(ps.list_action_logs("4377", db_path=db_path))
+        ps.update_qty("4377", 0, db_path=db_path)  # 初期値=0 なので no-op
+        assert len(ps.list_action_logs("4377", db_path=db_path)) == log_count_before
 
     @pytest.mark.parametrize(
         "bad_qty, exc",
@@ -1030,10 +1027,9 @@ class TestThemeMaster:
         rec = ps.get_record("6324", db_path=db_path)
         assert rec["memo"]["gyoutai_themes"] == ["AI"]
 
-        # action_log に "メモ更新" が 2 回 (リネーム + 削除) 追記されている
+        # メモ更新は action_log を記録しない
         logs = ps.list_action_logs("6324", db_path=db_path)
-        memo_logs = [l for l in logs if l["action_type"] == "メモ更新"]
-        assert len(memo_logs) >= 2
+        assert not any(l["action_type"] == "メモ更新" for l in logs)
 
     @pytest.mark.parametrize(
         "current,posted,expected,should_raise",
@@ -1128,10 +1124,9 @@ class TestTradeIdeaMaster:
         rec = ps.get_record("6324", db_path=db_path_ti)
         assert rec["memo"]["trade_idea"] == ""
 
-        # action_log に "メモ更新" が追記されている
+        # メモ更新は action_log を記録しない
         logs = ps.list_action_logs("6324", db_path=db_path_ti)
-        memo_logs = [l for l in logs if l["action_type"] == "メモ更新"]
-        assert len(memo_logs) >= 2
+        assert not any(l["action_type"] == "メモ更新" for l in logs)
 
     @pytest.mark.parametrize(
         "current_idea,posted,should_raise",

--- a/tests/test_webapp_detail_portfolio.py
+++ b/tests/test_webapp_detail_portfolio.py
@@ -1,0 +1,65 @@
+"""銘柄詳細ページの振り返りセクション (issue #172) ユニットテスト。"""
+
+import pytest
+import portfolio_shelve as ps
+import research_shelve as rs
+from webapp import create_app
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    portfolio_db = str(tmp_path / "portfolio")
+    stocks_db = str(tmp_path / "stocks")
+    research_db = str(tmp_path / "research")
+
+    monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+    monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+    monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db)
+    monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db)
+    monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", research_db)
+    monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", research_db)
+    monkeypatch.setattr("portfolio_shelve.DATA_DIR", str(tmp_path))
+
+    rec = rs.create_research_record("3496", "アズーム", overall_rating="A")
+    rs.upsert_research_record(rec, db_path=research_db)
+
+    ps.add_to_watch("3496", reason="初回監視", db_path=portfolio_db)
+    ps.transition_status("3496", "1保", reason="ブレイク確認", db_path=portfolio_db)
+
+    app = create_app()
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestDetailActionLog:
+    def test_action_log_section_shown(self, client):
+        """portfolio 登録済み銘柄は振り返りセクションが表示される。"""
+        assert "振り返り" in client.get("/stock/3496").data.decode()
+
+    @pytest.mark.parametrize("text", ["初回登録", "ステータス変更", "1保"])
+    def test_log_entries_shown(self, client, text):
+        """アクションログのエントリ内容が表示される。"""
+        assert text in client.get("/stock/3496").data.decode()
+
+    def test_unregistered_stock_no_section(self, tmp_path, monkeypatch):
+        """portfolio 未登録銘柄は振り返りセクションが非表示。"""
+        research_db = str(tmp_path / "research2")
+        portfolio_db = str(tmp_path / "portfolio2")
+        stocks_db = str(tmp_path / "stocks2")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", research_db)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", research_db)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db)
+        monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db)
+        monkeypatch.setattr("portfolio_shelve.DATA_DIR", str(tmp_path))
+        rec = rs.create_research_record("3496", "アズーム")
+        rs.upsert_research_record(rec, db_path=research_db)
+        app2 = create_app()
+        app2.config["TESTING"] = True
+        assert "振り返り" not in app2.test_client().get("/stock/3496").data.decode()

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -66,6 +66,9 @@ def app(portfolio_db_path, stocks_db_path, research_db_path, txt_path, monkeypat
         except ValueError:
             pass  # 重複は無視
 
+    # issue #335: 売買戦略マスターをシード (GARP 等の定型値を使うテストに必要)
+    ps.seed_trade_ideas(db_path=portfolio_db_path)
+
     # stocks_shelve にダミーデータ
     with ShelveDB(stocks_db_path) as db:
         db["6324"] = {

--- a/tests/test_webapp_portfolio_routes.py
+++ b/tests/test_webapp_portfolio_routes.py
@@ -602,9 +602,9 @@ class TestUpdateMemoPost:
         rec = ps.get_record("6324", db_path=portfolio_db_path)
         for field, expected in form_data.items():
             assert rec["memo"][field] == expected
-        # action_log に "メモ更新" が 1 件追加 (初回登録 + メモ更新 = 2 件)
+        # メモ更新は action_log を記録しない
         logs = ps.list_action_logs("6324", db_path=portfolio_db_path)
-        assert len([log for log in logs if log["action_type"] == "メモ更新"]) == 1
+        assert not any(log["action_type"] == "メモ更新" for log in logs)
 
     def test_memo_shows_linked_success_flash(self, client):
         """メモ保存後、銘柄コードリンク付きの完了メッセージを表示する"""


### PR DESCRIPTION
## Summary

- `/stock/<code_s>` にアクションログを時系列降順で表示する「振り返り」セクションを追加（ステータス変更・売却・株数変更・初回登録）
- 「メモ更新」アクションタイプを廃止（記録・表示とも停止）
- `update_qty()` に `reason` / `timestamp` 引数を追加し、株数変更をログ記録。`action_date` 指定時はステータス変更ログと同一日時で記録
- 除外・削除済み銘柄でもアクションログがあれば振り返りセクションを表示
- 決算コメント履歴テーブルの変動/見通し列幅を調整（文字重なりを解消）

Closes #172

## Test plan

- [ ] `pytest tests/test_portfolio_shelve.py tests/test_webapp_detail_portfolio.py tests/test_webapp_portfolio_routes.py -v` が全 pass
- [ ] `/stock/<実在code_s>` にアクセスし「振り返り」セクションが表示される
- [ ] 株数変更後、振り返りセクションに「株数変更」ログが表示される
- [ ] portfolio 未登録銘柄では振り返りセクションが非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)