### PR TITLE
feat(trade-history): 株数変更履歴をアコーディオン表示 (issue #354)

### DIFF
--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -12,6 +12,22 @@ from webapp.helpers import resolve_stock_name
 trade_history_bp = Blueprint("trade_history", __name__)
 
 
+def _extract_initial_qty(qty_changes: list) -> str:
+    """qty_changes の最初のエントリの reason から IN 時の株数を取り出す。
+
+    reason 形式: "0 → 100" or "0 → 100 (買い増し)" → "100"
+    取り出せない場合は空文字。
+    """
+    if not qty_changes:
+        return ""
+    reason = qty_changes[0].get("reason", "")
+    # "→" の右側を取り、末尾の括弧注釈を除去
+    if "→" not in reason:
+        return ""
+    after = reason.split("→", 1)[1].strip()
+    return after.split("(")[0].strip()
+
+
 @trade_history_bp.route("/trade-history")
 def trade_history():
     """売買履歴ページ — 銘柄×保有エピソード単位で1行表示。"""
@@ -56,9 +72,10 @@ def trade_history():
     # 保有日降順
     episodes.sort(key=lambda r: r["hold_date"], reverse=True)
 
-    # 銘柄名付与
+    # 銘柄名付与・初期株数抽出
     for ep in episodes:
         ep["stock_name"] = resolve_stock_name(ep["code_s"])
+        ep["initial_qty"] = _extract_initial_qty(ep["qty_changes"])
 
     return render_template("trade_history.html", episodes=episodes)
 

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -54,9 +54,12 @@ def trade_history():
                 "qty_changes": [],
             }
         elif log.get("action_type") == "株数変更" and code_s in open_episodes:
+            # reason 形式 "500 → 700 (保有理由の流用)" の括弧内は除去して差分のみ表示
+            raw_reason = log.get("reason", "")
+            diff = raw_reason.split("(")[0].strip()
             open_episodes[code_s]["qty_changes"].append({
                 "date": log["timestamp"][:10],
-                "reason": log.get("reason", ""),
+                "reason": diff,
             })
         elif log.get("action_type") == "売却" and code_s in open_episodes:
             ep = open_episodes.pop(code_s)

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -24,8 +24,8 @@ def _extract_initial_qty(qty_changes: list) -> str:
     # "→" の右側を取り、末尾の括弧注釈を除去
     if "→" not in reason:
         return ""
-    after = reason.split("→", 1)[1].strip()
-    return after.split("(")[0].strip()
+    before = reason.split("→", 1)[0].strip()
+    return before
 
 
 @trade_history_bp.route("/trade-history")

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -35,7 +35,13 @@ def trade_history():
                 "sell_reason": "",
                 "sell_seq": None,
                 "review_memo": "",
+                "qty_changes": [],
             }
+        elif log.get("action_type") == "株数変更" and code_s in open_episodes:
+            open_episodes[code_s]["qty_changes"].append({
+                "date": log["timestamp"][:10],
+                "reason": log.get("reason", ""),
+            })
         elif log.get("action_type") == "売却" and code_s in open_episodes:
             ep = open_episodes.pop(code_s)
             ep["sell_date"] = log["timestamp"][:10]
@@ -64,6 +70,10 @@ def save_review_memo(code_s: str, seq: int):
     """売却ログの振り返りメモを上書き保存する (fetch POST / JSON レスポンス)。"""
     review_memo = request.form.get("review_memo", "")
     try:
+        logs = ps.list_action_logs(code_s)
+        target = next((l for l in logs if l["seq"] == seq), None)
+        if target is None or target.get("action_type") != "売却":
+            abort(404)
         ps.update_action_log_review_memo(code_s, seq, review_memo)
     except KeyError:
         abort(404)

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -7,6 +7,14 @@
 
 {% if episodes %}
 <table class="trade-history-table">
+  <colgroup>
+    <col style="width:10em;">
+    <col style="width:7em;">
+    <col>
+    <col style="width:7em;">
+    <col>
+    <col style="width:22em;">
+  </colgroup>
   <thead>
     <tr>
       <th>銘柄</th>
@@ -21,7 +29,23 @@
   {% for ep in episodes %}
     <tr>
       <td style="white-space:nowrap;">
+        {% if ep.qty_changes %}
+        <details>
+          <summary style="cursor:pointer;"><a href="/stock/{{ ep.code_s }}">{{ ep.code_s }} {{ ep.stock_name }}</a></summary>
+          <table style="margin:0.4em 0 0 1em;font-size:0.85em;border:none;">
+            <tbody>
+            {% for qc in ep.qty_changes %}
+              <tr>
+                <td style="color:#888;white-space:nowrap;padding:0 0.6em 0 0;">{{ qc.date }}</td>
+                <td style="color:#555;">{{ qc.reason }}</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </details>
+        {% else %}
         <a href="/stock/{{ ep.code_s }}">{{ ep.code_s }} {{ ep.stock_name }}</a>
+        {% endif %}
       </td>
       <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ ep.hold_date }}</td>
       <td style="color:#555;">{{ ep.hold_reason or "" }}</td>
@@ -48,11 +72,12 @@
     var initial = ta.value;
     ta.addEventListener('blur', function () {
       if (ta.value === initial) return;
-      initial = ta.value;
+      var next = ta.value;
       var fd = new FormData();
-      fd.append('review_memo', ta.value);
+      fd.append('review_memo', next);
       fetch(ta.dataset.url, { method: 'POST', body: fd })
-        .catch(function () { /* ネットワーク失敗時は静かに無視 */ });
+        .then(function (r) { if (r.ok) initial = next; })
+        .catch(function () { /* ネットワーク失敗時は初期値を据え置き、再試行可能にする */ });
     });
   });
 }());

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -8,9 +8,10 @@
 {% if episodes %}
 <table class="trade-history-table">
   <colgroup>
-    <col style="width:10em;">
+    <col style="width:8em;">
     <col style="width:7em;">
-    <col>
+    <col style="width:4em;">
+    <col style="width:18em;">
     <col style="width:7em;">
     <col>
     <col style="width:22em;">
@@ -19,6 +20,7 @@
     <tr>
       <th>銘柄</th>
       <th style="white-space:nowrap;">保有日</th>
+      <th style="white-space:nowrap;">株数</th>
       <th>保有理由</th>
       <th style="white-space:nowrap;">売却日</th>
       <th>売却理由</th>
@@ -50,6 +52,7 @@
         {% endif %}
       </td>
       <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ ep.hold_date }}</td>
+      <td style="color:#888;font-size:0.85em;text-align:right;">{{ ep.initial_qty or "" }}</td>
       <td style="color:#555;">{{ ep.hold_reason or "" }}</td>
       <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ ep.sell_date or "" }}</td>
       <td style="color:#555;">{{ ep.sell_reason or "" }}</td>

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -31,7 +31,9 @@
       <td style="white-space:nowrap;">
         {% if ep.qty_changes %}
         <details>
-          <summary style="cursor:pointer;"><a href="/stock/{{ ep.code_s }}">{{ ep.code_s }} {{ ep.stock_name }}</a></summary>
+          <summary style="cursor:pointer;">
+            <a href="/stock/{{ ep.code_s }}" onclick="event.stopPropagation();">{{ ep.code_s }} {{ ep.stock_name }}</a>
+          </summary>
           <table style="margin:0.4em 0 0 1em;font-size:0.85em;border:none;">
             <tbody>
             {% for qc in ep.qty_changes %}

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -84,6 +84,30 @@ class TestTradeHistoryPage:
         html = client.get("/trade-history").data.decode()
         assert "上値で薄く売り過ぎた" in html
 
+    def test_qty_changes_shown_in_accordion(self, client):
+        """株数変更があるエピソードは details/summary アコーディオンで表示される。"""
+        logs = ps.list_action_logs("6324")
+        sell_log = next(l for l in logs if l["action_type"] == "売却")
+        seq = sell_log["seq"]
+        # 振り返りメモを保存して再表示
+        client.post(f"/trade-history/6324/{seq}/review-memo", data={"review_memo": "test"})
+
+        # 株数変更ログを直接追加（update_qty 経由）
+        ps.update_qty("6324", 100)
+        html = client.get("/trade-history").data.decode()
+        # 株数変更がある銘柄は details タグが出る（6324は売却済みなのでqty_changesは空のはず）
+        # 未売却の 3496 に株数変更を加える
+        ps.update_qty("3496", 50)
+        html = client.get("/trade-history").data.decode()
+        assert "<details>" in html
+        assert "0 → 50" in html
+
+    def test_no_qty_changes_no_accordion(self, client):
+        """株数変更がないエピソードは details タグが出ない（通常リンク）。"""
+        html = client.get("/trade-history").data.decode()
+        # 6324 は株数変更なし → details なし、直接 a タグ
+        assert "6324" in html
+
     def test_empty_portfolio_shows_no_entries(self, tmp_path, monkeypatch):
         """portfolio が空の場合はエントリなしメッセージが表示される。"""
         portfolio_db = str(tmp_path / "portfolio2")


### PR DESCRIPTION
## Summary

- 保有エピソード行の銘柄列に、保有期間中の株数変更履歴を `<details>/<summary>` アコーディオンで折りたたみ表示
- 株数変更がないエピソードは通常リンク表示のまま（アコーディオンなし）
- 振り返りメモ blur 保存を `response.ok` 確認後にのみ `initial` を更新し、失敗時に再試行可能にする
- `save_review_memo` エンドポイントで `action_type == "売却"` を事前確認し、売却ログ以外への書き込みを拒否
- 銘柄列幅 `10em` / 振り返りメモ列幅 `22em` に調整

## Test plan

- [x] `pytest tests/test_webapp_trade_history_routes.py -v` — 8件 PASS
- [ ] ブラウザで `/trade-history` を開き、株数変更ありの銘柄のアコーディオンを確認

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)