### PR TITLE
feat(portfolio): 新規1保遷移で売買戦略を必須化 + 未分類ハイライト (issue #363)

### DIFF
--- a/scripts/webapp/routes/detail.py
+++ b/scripts/webapp/routes/detail.py
@@ -80,6 +80,11 @@ def stock_detail(code_s: str):
     portfolio_transitions = (
         _allowed_transitions_from(portfolio_status) if portfolio_status else []
     )
+    # issue #363: 遷移モーダルの売買戦略 select 用。未シード環境ではシード (冪等)。
+    ps.seed_trade_ideas()
+    trade_idea_master = ps.list_trade_ideas()
+    trade_idea_options = [t["name"] for t in trade_idea_master]
+    trade_idea_descriptions = {t["name"]: t["description"] for t in trade_idea_master}
 
     # issue #205: 業態・テーマ inline 編集用の context
     # memo は None や非 dict (旧データ等) を許容する仕様 (_normalize_loaded_memo)
@@ -152,6 +157,9 @@ def stock_detail(code_s: str):
         portfolio_status_query=portfolio_status_query,
         portfolio_fallback_mode=portfolio_fallback_mode,
         portfolio_transitions=portfolio_transitions,
+        # issue #363: 遷移モーダルの売買戦略 select 用
+        trade_idea_options=trade_idea_options,
+        trade_idea_descriptions=trade_idea_descriptions,
         # モーダルの株数欄初期値 (保有中のみ意味を持つ。未登録/フォールバックは 0)
         portfolio_qty=(portfolio_record or {}).get("qty") or 0,
         gyoutai_themes=gyoutai_themes,

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -485,6 +485,8 @@ def transition(code_s: str):
     new_status = (request.form.get("new_status") or "").strip()
     reason = (request.form.get("reason") or "").strip()
     action_date = (request.form.get("action_date") or "").strip() or None
+    # issue #363: 新規1保遷移時のエントリー宣言 (売買戦略を必須化)
+    trade_idea = (request.form.get("trade_idea") or "").strip()
 
     # issue #269: qty は任意。空文字/欠落は None (qty 変更なし)、
     # 整数パース失敗・負数は error flash で reject。
@@ -513,12 +515,23 @@ def transition(code_s: str):
     try:
         before = ps.get_record(code_s)
         old_status = (before or {}).get("status")
+        # issue #363: 新規1保遷移 (非1保→1保) は売買戦略の宣言を必須にする。
+        # 未分類のまま保有にできると出口ルール未宣言のポジションが生まれるため入口で弾く。
+        is_new_hold = new_status == "1保" and old_status != "1保"
+        if is_new_hold:
+            if not trade_idea:
+                flash("売買戦略を選択してください（未分類のまま保有にはできません）", "error")
+                return _redirect_with_return_query(code_s=code_s)
+            # 未シード環境でも transition POST 単体でバリデーションが成立するようシード (冪等)
+            ps.seed_trade_ideas()
+            # 戦略を先に保存 → 成功後に遷移。この順序なら戦略保存失敗時は元ステータスのままで
+            # 「1保かつ未分類」の中間状態が生まれない。マスター未登録値は update_memo が ValueError で弾く。
+            ps.update_memo(code_s, {"trade_idea": trade_idea})
         ps.transition_status(code_s, new_status, reason=reason, action_date=action_date, qty=qty if new_status == "1保" else None)
         # issue #269: 1保 のときだけ qty を反映する (他ステータスでは無視)
         # log_action=False は「非1保 → 1保」の遷移時のみ（IN株数は遷移ログに記録済み）
         # 既に1保の状態で株数のみ変更する場合は log_action=True のまま株数変更ログを残す
         if new_status == "1保" and qty is not None:
-            is_new_hold = old_status != "1保"
             ps.update_qty(code_s, qty, reason=reason, action_date=action_date, log_action=not is_new_hold)
     except KeyError as e:
         flash(f"レコード未登録: {e}", "error")
@@ -859,6 +872,8 @@ def dashboard():
                 "qty_updated_at": ps.get_qty_global_updated_at(),
             }
 
+    # issue #363: 遷移モーダルの戦略 select に選択肢を出すため、未シード環境ではシード (冪等)
+    ps.seed_trade_ideas()
     trade_idea_master = ps.list_trade_ideas()
     return render_template(
         "portfolio_list.html",

--- a/scripts/webapp/templates/detail.html
+++ b/scripts/webapp/templates/detail.html
@@ -672,6 +672,23 @@
           <span style="color:#888;font-size:0.85em;">株</span>
         </label>
       </div>
+      {# issue #363: 新規1保遷移 (現在=非1保→1保) のとき売買戦略を必須で選ばせ、出口基準を hint 表示 #}
+      {% if portfolio_status_query != 'hold' %}
+      <div id="detail-portfolio-strategy-row" style="display:none;margin-bottom:0.6em;">
+        <label style="display:block;">
+          売買戦略 (必須):
+          <select name="trade_idea" id="detail-portfolio-strategy"
+                  onchange="syncDetailPortfolioStrategyHint()" style="margin-left:0.4em;">
+            <option value="">-- 戦略を選択 --</option>
+            {% for idea in trade_idea_options %}
+            <option value="{{ idea }}">{{ idea }}</option>
+            {% endfor %}
+          </select>
+        </label>
+        <div id="detail-portfolio-strategy-hint" style="margin-top:0.3em;color:#666;font-size:0.85em;"></div>
+      </div>
+      <script id="detail-trade-idea-descriptions" type="application/json">{{ trade_idea_descriptions | tojson }}</script>
+      {% endif %}
       <label style="display:block;margin-bottom:0.6em;">
         アクション日付:
         <input type="date" name="action_date" value="{{ today_jst }}" max="{{ today_jst }}" required
@@ -891,8 +908,30 @@ function syncDetailPortfolioQtyVisibility() {
   var label = document.getElementById('detail-portfolio-reason-label');
   if (!sel || !row) return;
   var isQtyOnly = sel.value === '1保' && sel.options[sel.selectedIndex].text.indexOf('株数のみ変更') >= 0;
-  row.style.display = (sel.value === '1保') ? '' : 'none';
+  var toHold = (sel.value === '1保');
+  row.style.display = toHold ? '' : 'none';
   if (label) label.textContent = isQtyOnly ? '変更メモ (任意):' : '理由 (任意):';
+
+  // issue #363: 戦略行は「変更先=1保」のときのみ表示・必須化 (現在=非1保 はテンプレ条件で担保済み)
+  var strategyRow = document.getElementById('detail-portfolio-strategy-row');
+  var strategySelect = document.getElementById('detail-portfolio-strategy');
+  if (strategyRow && strategySelect) {
+    strategyRow.style.display = toHold ? '' : 'none';
+    strategySelect.required = toHold;
+    if (!toHold) syncDetailPortfolioStrategyHint();
+  }
+}
+
+// issue #363: 選択した戦略の出口基準 (description) を hint に出す。
+function syncDetailPortfolioStrategyHint() {
+  var strategySelect = document.getElementById('detail-portfolio-strategy');
+  var hint = document.getElementById('detail-portfolio-strategy-hint');
+  if (!strategySelect || !hint) return;
+  var descEl = document.getElementById('detail-trade-idea-descriptions');
+  var descs = {};
+  try { descs = JSON.parse(descEl ? descEl.textContent : '{}') || {}; } catch (e) { descs = {}; }
+  var val = strategySelect.value;
+  hint.textContent = val && descs[val] ? '出口の目安: ' + descs[val] : '';
 }
 
 function openPortfolioModal() {

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -549,13 +549,16 @@
       {# issue #327: 売買戦略 (定型リスト単一選択 + 色分けバッジ)。
          リスト外の旧自由記述値は ⚠️ 付き option を差し込んで保持し、再分類を促す #}
       {% set current_idea = row.memo.trade_idea or '' %}
+      {# issue #363: 1保 かつ戦略未分類 (空) は出口ルール未宣言。「未分類」option に ⚠️ を付けて
+         棚卸しを促す。2準/3監 の未分類は正常なので付けない (row.status で限定)。 #}
+      {% set unclassified_hold = (row.status == '1保' and not current_idea) %}
       <td data-page="2" style="padding:0 2px;">
         <select class="trade-idea-select"
                 data-code="{{ row.code_s }}"
                 data-idea="{{ current_idea }}"
                 title="{{ trade_idea_descriptions[current_idea] if current_idea in trade_idea_descriptions else '売買戦略 (選択で即保存)' }}"
                 {% if fallback_mode %}disabled{% endif %}>
-          <option value="">未分類</option>
+          <option value="">{% if unclassified_hold %}⚠️ 未分類{% else %}未分類{% endif %}</option>
           {% if current_idea and current_idea not in trade_idea_options %}
           <option value="{{ current_idea }}" selected>⚠️ {{ current_idea }}</option>
           {% endif %}
@@ -608,6 +611,20 @@
             <span style="color:#888;font-size:0.85em;">株</span>
           </label>
         </div>
+        {# issue #363: 新規1保遷移 (非1保→1保) のときのみ表示。売買戦略を必須で選ばせ、
+           選択した戦略の出口基準 (description) を hint に出して「出口を意識した買い」を促す。 #}
+        <div id="portfolio-modal-strategy-row" style="display:none;margin-bottom:0.6em;">
+          <label style="display:block;">
+            売買戦略 (必須):
+            <select name="trade_idea" id="portfolio-modal-strategy" style="margin-left:0.4em;">
+              <option value="">-- 戦略を選択 --</option>
+              {% for idea in trade_idea_options %}
+              <option value="{{ idea }}">{{ idea }}</option>
+              {% endfor %}
+            </select>
+          </label>
+          <div id="portfolio-modal-strategy-hint" style="margin-top:0.3em;color:#666;font-size:0.85em;"></div>
+        </div>
         <label style="display:block;margin-bottom:0.6em;">
           アクション日付:
           <input type="date" name="action_date" value="{{ today_jst }}" max="{{ today_jst }}" required
@@ -627,6 +644,8 @@
     </form>
   </div>
 </div>
+{# issue #363: 戦略の出口基準 (description) を JS の hint 表示に渡す #}
+<script id="trade-idea-descriptions" type="application/json">{{ trade_idea_descriptions | tojson }}</script>
 {% endif %}
 
 <style>
@@ -695,11 +714,35 @@
 {% if not fallback_mode %}
 // ========== 保有状態モーダル ==========
 // issue #269: qty 欄は「変更先=1保」のときのみ表示する。
+// issue #363: 売買戦略欄は「新規1保遷移 (現在=非1保 → 変更先=1保)」のときのみ表示・必須化する。
 function syncPortfolioQtyVisibility() {
   var select = document.getElementById('portfolio-modal-new-status');
   var qtyRow = document.getElementById('portfolio-modal-qty-row');
   if (!select || !qtyRow) return;
-  qtyRow.style.display = (select.value === '1保') ? '' : 'none';
+  var toHold = (select.value === '1保');
+  qtyRow.style.display = toHold ? '' : 'none';
+
+  var form = document.getElementById('portfolio-modal-form');
+  var strategyRow = document.getElementById('portfolio-modal-strategy-row');
+  var strategySelect = document.getElementById('portfolio-modal-strategy');
+  if (!strategyRow || !strategySelect) return;
+  // 現在が非1保 (statusQuery が 'hold' 以外) かつ 変更先=1保 のとき = 新規エントリー
+  var isNewHold = toHold && (form && form.dataset.statusQuery !== 'hold');
+  strategyRow.style.display = isNewHold ? '' : 'none';
+  strategySelect.required = isNewHold;
+  if (!isNewHold) syncPortfolioStrategyHint();  // 非表示時は hint もクリア
+}
+
+// issue #363: 選択した戦略の出口基準 (description) を hint に出す。
+function syncPortfolioStrategyHint() {
+  var strategySelect = document.getElementById('portfolio-modal-strategy');
+  var hint = document.getElementById('portfolio-modal-strategy-hint');
+  if (!strategySelect || !hint) return;
+  var descEl = document.getElementById('trade-idea-descriptions');
+  var descs = {};
+  try { descs = JSON.parse(descEl ? descEl.textContent : '{}') || {}; } catch (e) { descs = {}; }
+  var val = strategySelect.value;
+  hint.textContent = val && descs[val] ? '出口の目安: ' + descs[val] : '';
 }
 
 function openPortfolioModalFromBadge(btn) {
@@ -724,6 +767,8 @@ function openPortfolioModalFromBadge(btn) {
   var form = document.getElementById('portfolio-modal-form');
   form.action = '/portfolio/' + encodeURIComponent(code) + '/transition';
   form.dataset.code = code;
+  // issue #363: 戦略欄の表示判定 (新規1保遷移か) に現在ステータスを使う
+  form.dataset.statusQuery = statusQuery;
 
   var select = document.getElementById('portfolio-modal-new-status');
   select.innerHTML = '';
@@ -744,6 +789,9 @@ function openPortfolioModalFromBadge(btn) {
   if (qtyInput) {
     qtyInput.value = (statusQuery === 'hold' && currentQty > 0) ? currentQty : 100;
   }
+  // issue #363: 開くたびに戦略 select をリセット
+  var strategySelect = document.getElementById('portfolio-modal-strategy');
+  if (strategySelect) strategySelect.value = '';
   syncPortfolioQtyVisibility();
 
   var excludeBtn = document.getElementById('portfolio-modal-exclude');
@@ -757,6 +805,9 @@ function openPortfolioModalFromBadge(btn) {
 document.addEventListener('DOMContentLoaded', function() {
   var select = document.getElementById('portfolio-modal-new-status');
   if (select) select.addEventListener('change', syncPortfolioQtyVisibility);
+  // issue #363: 戦略選択で出口基準 hint を更新
+  var strategySelect = document.getElementById('portfolio-modal-strategy');
+  if (strategySelect) strategySelect.addEventListener('change', syncPortfolioStrategyHint);
 });
 function closePortfolioModal() {
   var modal = document.getElementById('portfolio-modal');

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1281,6 +1281,78 @@ class TestTransitionWithQty:
         assert rec["qty"] == 0
 
 
+class TestTransitionRequiresStrategy:
+    """issue #363: 新規1保遷移 (2準/3監→1保) は売買戦略 (trade_idea) を必須化する"""
+
+    @pytest.fixture
+    def portfolio_app(self, db_path, tmp_path, monkeypatch):
+        import portfolio_shelve as ps
+        portfolio_db = str(tmp_path / "test_portfolio_shelve")
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", db_path)
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+
+        rec = rs.create_research_record("3496", "アズーム", overall_rating="A")
+        rs.upsert_research_record(rec, db_path=db_path)
+        # 3496 を 3監 で登録 (add_to_watch は 3監 で登録)
+        ps.add_to_watch("3496", reason="テスト", db_path=portfolio_db)
+
+        app = create_app()
+        app.config["TESTING"] = True
+        return app, portfolio_db
+
+    @pytest.mark.parametrize(
+        "trade_idea_form, expect_status, expect_idea",
+        [
+            # 空 (未分類) のまま 1保 → 弾かれて 3監 のまま、戦略も空
+            ("", "3監", ""),
+            # 有効な戦略 (シードされる "GARP") → 1保 に遷移し戦略も保存
+            ("GARP", "1保", "GARP"),
+            # マスター未登録の戦略名 → update_memo が ValueError で弾き、3監 のまま
+            ("存在しない戦略", "3監", ""),
+        ],
+        ids=["empty-rejected", "valid-strategy-ok", "invalid-strategy-rejected"],
+    )
+    def test_new_hold_requires_strategy(
+        self, portfolio_app, trade_idea_form, expect_status, expect_idea
+    ):
+        import portfolio_shelve as ps
+        app, portfolio_db = portfolio_app
+        client = app.test_client()
+
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "1保", "trade_idea": trade_idea_form, "reason": ""},
+        )
+        assert resp.status_code in (200, 302)
+
+        rec = ps.get_record("3496", db_path=portfolio_db)
+        assert rec["status"] == expect_status
+        assert (rec["memo"].get("trade_idea") or "") == expect_idea
+
+    def test_existing_hold_qty_change_no_strategy_required(self, portfolio_app):
+        """既に1保の株数のみ変更は戦略必須化の対象外 (trade_idea なしでも成功)"""
+        import portfolio_shelve as ps
+        app, portfolio_db = portfolio_app
+        # 先に戦略マスターをシードし、戦略付きで 1保 にしておく
+        ps.seed_trade_ideas(db_path=portfolio_db)
+        ps.update_memo("3496", {"trade_idea": "GARP"}, db_path=portfolio_db)
+        ps.transition_status("3496", "1保", db_path=portfolio_db)
+        client = app.test_client()
+
+        # 1保 のまま株数のみ変更 (trade_idea 送信なし) → 成功、戦略は保持
+        resp = client.post(
+            "/portfolio/3496/transition",
+            data={"new_status": "1保", "qty": "300", "reason": ""},
+        )
+        assert resp.status_code in (200, 302)
+        rec = ps.get_record("3496", db_path=portfolio_db)
+        assert rec["status"] == "1保"
+        assert rec["qty"] == 300
+        assert rec["memo"].get("trade_idea") == "GARP"
+
+
 class TestPortfolioHoldSummary:
     """保有 (status=hold) フィルタ表示時の運用総額 / 保有株数更新日サマリーの統合テスト"""
 


### PR DESCRIPTION
## 概要

Closes #363

保有後の監視 (シグナル・早売・出口ルール) は充実している一方、**買う瞬間はノーガード**で出口ルール未宣言のポジションが発生しうる。新規エントリー (2準/3監→1保) の入口で未宣言ポジションを作らせないようガードを追加する。

## スコープの方針転換 (要件確定の結果)

issue 本文は「エントリー宣言4項目 (売買戦略・想定保有期間・サイズ根拠・無効化条件) の構造化必須化」を求めているが、ユーザーとの要件確定の結果 **新規フィールドは一切追加しない** 方針に転換。`less is more / Simplicity First` に沿い、既存の `trade_idea` (売買戦略) の必須化と、選択戦略の出口基準 (description) を遷移時に見せることで「出口を意識させる」中核目的を達成する。

## 変更内容

| # | 内容 | ファイル |
|---|---|---|
| ① | **戦略必須化 (サーバ側)**: 新規1保遷移で戦略未選択なら flash で reject。「戦略保存→遷移」の順で書き込み、「1保かつ未分類」の中間状態を作らない。未シード環境対策に transition ハンドラ内で `seed_trade_ideas()` (冪等) | `webapp/routes/portfolio.py` |
| ② | **出口注意書き**: 遷移モーダル (一覧・詳細) で戦略を選ぶと出口基準 (description) を hint 表示 | `portfolio_list.html` / `detail.html` / `detail.py` |
| ③ | **棚卸しハイライト**: 1保 かつ戦略未分類の売買戦略セルを「⚠️ 未分類」+ 警告色で目立たせる (2準/3監 の未分類は対象外) | `portfolio_list.html` |

## スコープ外 (今回やらない)

- 想定保有期間・サイズ根拠・無効化条件の新規フィールド化 → 戦略マスターの `time_horizon` / `description` に内包
- 売却モーダルでの出口照合 (issue 要件2 後半)
- inline 編集で既存1保を未分類に戻す経路の禁止 (棚卸しの逆行操作であり、ハイライトと両立するため塞がない)

## 検証

- ✅ `pytest tests/test_webapp_routes.py`: **107 passed** (新規4件: 空戦略→reject/1保にならない・有効戦略→1保・不正戦略→reject・既存1保の株数のみ変更は戦略不要)
- ✅ ブラウザ目視: 未分類1保 (フジクラ5803・タイミー215A・デクセリアルズ4980 = issue名指し銘柄) が売買戦略セルで「⚠️ 未分類」警告色表示。遷移モーダルで保有選択時に戦略 select が required 化・出口 hint 表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)