### PR TITLE
feat(trade-history): 売買日終値プロキシで概算損益・成績サマリーを計測 (issue #361)

### DIFF
--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -99,6 +99,15 @@ cd scripts && python migrate_kessan_comments_from_log.py ../data/kessan_comments
 cd scripts && python migrate_kessan_comments_from_log.py ../data/kessan_comments_log.txt                                             # 本番移行
 ```
 
+### action_log に売買日終値プロキシを付与 (issue #361)
+
+売買履歴の概算損益・成績サマリー用。既存 DB の price_log (直近30営業日) の範囲のみ終値を埋め、土日の売買日を直前営業日に補正する。夜間 price 更新後に叩くと当日 None が埋まる。
+
+```bash
+cd scripts && python backfill_price_proxy.py             # None のみ埋める (冪等)
+cd scripts && python backfill_price_proxy.py --overwrite # actual 以外を再取得
+```
+
 ## 自動実行
 
 `shintakane_cron.sh` が `shintakane.py` → `make_stock_db.py` を逐次実行。macOS launchd（`com.k_sohara.shintakane.cron.plist`）で平日19:00に定期実行。

--- a/scripts/backfill_price_proxy.py
+++ b/scripts/backfill_price_proxy.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""action_log の売買日イベントに終値プロキシを一括付与する CLI (issue #361)。
+
+既存 DB の price_log (直近30営業日) の範囲のみ終値を埋める。窓外は None のまま。
+同時に土日 timestamp を直前営業日に正規化する。
+
+使い方:
+    cd scripts && python backfill_price_proxy.py             # None のみ埋める (冪等)
+    cd scripts && python backfill_price_proxy.py --overwrite # actual 以外を再取得
+
+夜間の price 更新後に叩くと、記録時に終値未確定だった当日イベントの None が埋まる。
+"""
+
+import argparse
+import os
+import sys
+
+# scripts/ を sys.path に追加(直接実行時)
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import log_print
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="price_source != 'actual' のイベントを全て再取得する (既存プロキシも上書き)",
+    )
+    args = parser.parse_args()
+
+    stats = ps.backfill_price_proxies(overwrite=args.overwrite)
+    log_print(
+        "backfill_price_proxy 完了:",
+        f"updated={stats['updated']}",
+        f"skipped={stats['skipped']}",
+        f"no_price={stats['no_price']}",
+        f"date_fixed={stats['date_fixed']}",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -33,7 +33,7 @@ import os
 import re
 import threading
 from contextlib import contextmanager
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional
 
 from db_shelve import PORTFOLIO_SHELVE, ShelveDB
@@ -185,6 +185,10 @@ ACTION_LOG_FIELDS = frozenset(
         "reason",
         "review_memo",
         "qty",
+        # issue #361: 売買イベント日の終値プロキシ。実約定価格 (#360 Phase2) が
+        # 入れば price_source="actual" で上書きできる構造。旧ログは list 側で None 補完。
+        "price_proxy",   # イベント日 (直前営業日) の終値 (int) or None
+        "price_source",  # "close" (終値プロキシ) / 将来 "actual" (実約定)
     }
 )
 
@@ -310,6 +314,97 @@ def _parse_action_date_to_iso(action_date: str) -> str:
             f"action_date に未来日は指定できません: {action_date} (今日={today.isoformat()})"
         )
     return datetime(parsed.year, parsed.month, parsed.day, 12, 0, 0, tzinfo=JST).isoformat()
+
+
+# ===========================================
+# issue #361: 売買日の営業日正規化 + 終値プロキシ取得
+# ===========================================
+
+def _weekday_date(d: date) -> date:
+    """土(weekday=5)/日(6)なら直前金曜に丸める。平日はそのまま。
+
+    ks_util.recent_weekday は内部の get_price_day が 17:00 境界で 12:00 の
+    timestamp を前日化してしまうため使わず、date だけを見て土日を丸める。
+    祝日は考慮しない (終値は _close_on_or_before が直前営業日を返すため概算許容)。
+    """
+    wd = d.weekday()
+    if wd == 5:
+        return d - timedelta(days=1)
+    if wd == 6:
+        return d - timedelta(days=2)
+    return d
+
+
+def _normalize_weekend_iso(iso_timestamp: str) -> str:
+    """timestamp の日付が土日なら直前金曜の JST 12:00 ISO 文字列を返す。平日は元のまま。
+
+    timestamp = ユーザーが意図した「売買日」。土日値は入力ミスであり、営業日への
+    正規化は改ざんではなく訂正 (issue #361)。新規記録・バックフィルで共有する。
+    """
+    try:
+        d = date.fromisoformat(iso_timestamp[:10])
+    except (ValueError, TypeError):
+        return iso_timestamp
+    fixed = _weekday_date(d)
+    if fixed == d:
+        return iso_timestamp
+    return datetime(fixed.year, fixed.month, fixed.day, 12, 0, 0, tzinfo=JST).isoformat()
+
+
+def _close_on_or_before(price_log: list, target_dt: date) -> Optional[int]:
+    """price_log から target_dt 以下の最新営業日終値を返す。無ければ None。
+
+    price_log: [(date, int終値), ...] (順序非依存)。
+    webapp.helpers._split_log_around_kessanbi と同ロジック (逆依存を避け内製)。
+    """
+    if not price_log:
+        return None
+    try:
+        sorted_log = sorted(price_log, key=lambda x: x[0])  # 昇順
+    except (TypeError, IndexError):
+        return None
+    before: Optional[int] = None
+    for entry in sorted_log:
+        try:
+            entry_dt, entry_pr = entry[0], entry[1]
+        except (IndexError, TypeError):
+            continue
+        if not isinstance(entry_dt, date):
+            continue
+        if entry_dt <= target_dt:
+            before = entry_pr  # 昇順なので最後に上書きされた値が「以下の最新営業日」
+    return before
+
+
+def _fetch_price_proxy(code_s: str, iso_timestamp: str) -> Optional[int]:
+    """stocks_shelve の price_log から timestamp 日付以下の最新営業日終値を引く。
+
+    price_log 窓外 (直近30営業日より古い) ・未取得 (当日終値未確定) なら None。
+    DB 無し等の例外は握りつぶして None。循環回避のため遅延 import。
+    """
+    try:
+        target_dt = date.fromisoformat(iso_timestamp[:10])
+    except (ValueError, TypeError):
+        return None
+    try:
+        from db_shelve import STOCKS_SHELVE
+        with ShelveDB(STOCKS_SHELVE) as db:
+            rec = db.get(normalize_code_s(code_s))
+        price_log = (rec or {}).get("price_log") or []
+    except Exception:
+        return None
+    return _close_on_or_before(price_log, target_dt)
+
+
+def _needs_price_proxy(action_type: Optional[str], status_to: Optional[str]) -> bool:
+    """終値プロキシ付与・土日補正の対象イベントか判定する。
+
+    対象 = 売買日の意味を持つ 1保 (保有開始) / 株数変更 / 売却。
+    初回登録(3監)・監視系ステータス変更・ユニバース除外は対象外。
+    """
+    if status_to == "1保":
+        return True
+    return action_type in {"株数変更", "売却"}
 
 
 # ===========================================
@@ -570,6 +665,14 @@ def append_action_log(
         raise TypeError(f"review_memo must be str, got {type(review_memo).__name__}")
     ts = timestamp or now_iso()
 
+    # issue #361: 売買日イベント (1保/株数変更/売却) は終値プロキシを自動付与する。
+    # 土日 timestamp は入力ミスとして直前営業日に正規化 (新規記録・バックフィルで統一)。
+    extra: Dict[str, Any] = {}
+    if _needs_price_proxy(action_type, status_to):
+        ts = _normalize_weekend_iso(ts)
+        extra["price_proxy"] = _fetch_price_proxy(normalized, ts)
+        extra["price_source"] = "close"
+
     path = _resolve_db_path(db_path)
     with _flock(db_path):
         with ShelveDB(path) as db:
@@ -584,6 +687,7 @@ def append_action_log(
                 "reason": reason,
                 "review_memo": review_memo,
                 "qty": qty,
+                **extra,
             }
             db[_action_log_key(normalized, seq)] = entry
     log_print(
@@ -621,6 +725,9 @@ def list_action_logs(
                 continue
             value.setdefault("review_memo", "")
             value.setdefault("qty", None)
+            # issue #361: 旧ログの後方互換補完 (物理スキーマ変更なし・マイグレーション不要)
+            value.setdefault("price_proxy", None)
+            value.setdefault("price_source", None)
             results.append(value)
     results.sort(
         key=lambda r: (r.get("code_s", ""), r.get("seq", 0)),
@@ -655,6 +762,75 @@ def update_action_log_review_memo(
             entry["review_memo"] = review_memo
             db[key] = entry
     return entry
+
+
+def backfill_price_proxies(
+    *,
+    overwrite: bool = False,
+    db_path: Optional[str] = None,
+) -> Dict[str, int]:
+    """全 action_log の売買日イベント (1保/株数変更/売却) に終値プロキシを一括付与する。
+
+    同時に土日 timestamp を直前営業日に正規化する (issue #361)。
+    終値は既存 DB の price_log (直近30営業日) の範囲のみ。窓外は price_proxy=None のまま。
+
+    overwrite=False: price_proxy が既に非 None のイベントはスキップ (冪等)。None のみ再取得。
+    overwrite=True:  price_source != "actual" のイベントを全て再取得。
+    実約定 (price_source="actual", #360 Phase2) は overwrite でも timestamp/proxy とも触らない。
+
+    Returns: {"updated", "skipped", "no_price", "date_fixed"}
+    """
+    path = _resolve_db_path(db_path)
+    stats = {"updated": 0, "skipped": 0, "no_price": 0, "date_fixed": 0}
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            for key in [k for k in db.keys() if k.startswith(KEY_ACTION_LOG_PREFIX)]:
+                entry = db[key]
+                if not isinstance(entry, dict):
+                    continue
+                if not _needs_price_proxy(entry.get("action_type"), entry.get("status_to")):
+                    continue
+                # 実約定は不可侵 (プロキシが実約定に負ける構造)
+                if entry.get("price_source") == "actual":
+                    stats["skipped"] += 1
+                    continue
+                # 冪等: overwrite でなければ既に埋まっているものはスキップ
+                if not overwrite and entry.get("price_proxy") is not None:
+                    stats["skipped"] += 1
+                    continue
+
+                ts = entry.get("timestamp", "")
+                fixed_ts = _normalize_weekend_iso(ts)
+                date_changed = fixed_ts != ts
+                proxy = _fetch_price_proxy(entry.get("code_s", ""), fixed_ts)
+
+                if not date_changed and proxy == entry.get("price_proxy") \
+                        and entry.get("price_source") == "close":
+                    # 変化なし (窓外で None のまま等)
+                    if proxy is None:
+                        stats["no_price"] += 1
+                    else:
+                        stats["skipped"] += 1
+                    continue
+
+                entry["timestamp"] = fixed_ts
+                entry["price_proxy"] = proxy
+                entry["price_source"] = "close"
+                db[key] = entry
+                if date_changed:
+                    stats["date_fixed"] += 1
+                if proxy is None:
+                    stats["no_price"] += 1
+                else:
+                    stats["updated"] += 1
+    log_print(
+        "portfolio_shelve: backfill_price_proxies",
+        f"updated={stats['updated']}",
+        f"skipped={stats['skipped']}",
+        f"no_price={stats['no_price']}",
+        f"date_fixed={stats['date_fixed']}",
+    )
+    return stats
 
 
 # ===========================================

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4123,11 +4123,13 @@ def calc_episode_pl(ep: dict) -> Optional[dict]:
     return_pct = (sell_price / avg_cost - 1) * 100
     hold_days  = (sell_date - hold_date).days (暦日)
     amount     = 金額加重ペイオフの重み
+    profit_amount = 概算実現損益額。株数不明なら None
+    profit_per_share = 1株あたり概算損益。株数不明時の検算表示に使う
 
     取得単価 avg_cost の求め方:
     - 株数変更がない単一 IN: hold_price をそのまま取得単価とする。株数は損益率に
       不要なので hold_qty=None でも算出する (旧ログは IN 株数を持たないため救済)。
-      amount は hold_qty があれば hold_price*hold_qty、なければ hold_price (1株相当)。
+      amount は hold_qty/sell_qty があれば hold_price*qty、なければ hold_price (1株相当)。
     - 買い増し (株数変更) がある: 加重平均が必要。全 IN の株数と価格が揃っている
       場合のみ Σ(IN終値×IN株数)/Σ(IN株数) を算出。数量不明を混ぜると取得単価が
       逆方向に飛び符号反転しうるため、揃わなければ None (母数除外)。
@@ -4175,10 +4177,19 @@ def calc_episode_pl(ep: dict) -> Optional[dict]:
             return None
         avg_cost = sum(p * q for p, q in in_price_qty) / total_in_qty
         amount = avg_cost * total_in_qty
+        profit_per_share = sell_price - avg_cost
+        profit_amount = profit_per_share * total_in_qty
     else:
         # 単一 IN: 株数不要で損益率が出せる
         avg_cost = hold_price
-        amount = hold_price * hold_qty if hold_qty else hold_price
+        qty_for_profit = hold_qty if hold_qty is not None else ep.get("sell_qty")
+        profit_per_share = sell_price - avg_cost
+        if qty_for_profit and qty_for_profit > 0:
+            amount = hold_price * qty_for_profit
+            profit_amount = profit_per_share * qty_for_profit
+        else:
+            amount = hold_price
+            profit_amount = None
 
     if avg_cost <= 0:
         return None
@@ -4194,6 +4205,8 @@ def calc_episode_pl(ep: dict) -> Optional[dict]:
         "hold_days": hold_days,
         "avg_cost": avg_cost,
         "amount": amount,
+        "profit_amount": profit_amount,
+        "profit_per_share": profit_per_share,
     }
 
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4111,3 +4111,128 @@ def build_portfolio_theme_summary(
         r["theme"],
     ))
     return result
+
+
+# ===========================================
+# issue #361: 売買エピソードの概算損益・成績サマリー
+# ===========================================
+
+def calc_episode_pl(ep: dict) -> Optional[dict]:
+    """売却済みエピソードの概算実現損益を終値プロキシから計算する。
+
+    return_pct = (sell_price / avg_cost - 1) * 100
+    hold_days  = (sell_date - hold_date).days (暦日)
+    amount     = 金額加重ペイオフの重み
+
+    取得単価 avg_cost の求め方:
+    - 株数変更がない単一 IN: hold_price をそのまま取得単価とする。株数は損益率に
+      不要なので hold_qty=None でも算出する (旧ログは IN 株数を持たないため救済)。
+      amount は hold_qty があれば hold_price*hold_qty、なければ hold_price (1株相当)。
+    - 買い増し (株数変更) がある: 加重平均が必要。全 IN の株数と価格が揃っている
+      場合のみ Σ(IN終値×IN株数)/Σ(IN株数) を算出。数量不明を混ぜると取得単価が
+      逆方向に飛び符号反転しうるため、揃わなければ None (母数除外)。
+
+    None (母数除外) の条件:
+    - 未売却 / sell_price None / hold_price None
+    - 減玉 (株数変更の after_qty < 直前株数) がある
+    - 買い増しがあるのに IN の株数 (qty) or 価格 (price_proxy) が欠ける
+    - 取得単価が 0 以下
+    """
+    sell_date = ep.get("sell_date")
+    sell_price = ep.get("sell_price")
+    hold_price = ep.get("hold_price")
+    if not sell_date or sell_price is None or hold_price is None:
+        return None
+
+    hold_qty = ep.get("hold_qty")
+
+    # 買い増し (増加分) を収集。減玉があれば概算対象外。
+    buy_ups = []  # [(price, added), ...]
+    prev_qty = hold_qty
+    for qc in ep.get("qty_changes", []):
+        after_qty = qc.get("after_qty")
+        if after_qty is None or prev_qty is None:
+            # 株数変更があるのに数量が不明 → 加重平均が組めない
+            return None
+        if after_qty < prev_qty:
+            return None  # 減玉ありは概算対象外
+        added = after_qty - prev_qty
+        prev_qty = after_qty
+        if added == 0:
+            continue  # 数量据え置き (メモのみ変更) は取得に影響しない
+        price = qc.get("price")
+        if price is None:
+            return None  # 買い増しの終値が欠けると加重平均が歪む
+        buy_ups.append((price, added))
+
+    if buy_ups:
+        # 加重平均には 1保 IN の株数も必要
+        if hold_qty is None:
+            return None
+        in_price_qty = [(hold_price, hold_qty)] + buy_ups
+        total_in_qty = sum(q for _, q in in_price_qty)
+        if total_in_qty <= 0:
+            return None
+        avg_cost = sum(p * q for p, q in in_price_qty) / total_in_qty
+        amount = avg_cost * total_in_qty
+    else:
+        # 単一 IN: 株数不要で損益率が出せる
+        avg_cost = hold_price
+        amount = hold_price * hold_qty if hold_qty else hold_price
+
+    if avg_cost <= 0:
+        return None
+
+    return_pct = (sell_price / avg_cost - 1) * 100
+    try:
+        hold_days = (date.fromisoformat(sell_date) - date.fromisoformat(ep["hold_date"])).days
+    except (ValueError, TypeError, KeyError):
+        return None
+
+    return {
+        "return_pct": return_pct,
+        "hold_days": hold_days,
+        "avg_cost": avg_cost,
+        "amount": amount,
+    }
+
+
+def calc_trade_summary(episode_pls: list) -> Optional[dict]:
+    """calc_episode_pl の非 None 結果リストから成績サマリーを算出する。
+
+    勝ち = return_pct > 0、負け = return_pct <= 0 (0% は負け)。
+    ペイオフレシオは金額加重: 勝ち群 Σ(return_pct×amount)/Σamount ÷ |負け群同値|。
+    母数0 → None (サマリー非表示)。
+    """
+    if not episode_pls:
+        return None
+
+    wins = [p for p in episode_pls if p["return_pct"] > 0]
+    loses = [p for p in episode_pls if p["return_pct"] <= 0]
+    n_total = len(episode_pls)
+
+    def _weighted_avg_return(group):
+        total_amount = sum(p["amount"] for p in group)
+        if total_amount <= 0:
+            return None
+        return sum(p["return_pct"] * p["amount"] for p in group) / total_amount
+
+    def _avg_hold(group):
+        return sum(p["hold_days"] for p in group) / len(group) if group else None
+
+    win_weighted = _weighted_avg_return(wins)
+    lose_weighted = _weighted_avg_return(loses)
+    if win_weighted is None or lose_weighted is None or lose_weighted == 0:
+        payoff_ratio = None
+    else:
+        payoff_ratio = win_weighted / abs(lose_weighted)
+
+    return {
+        "win_rate": len(wins) / n_total * 100,
+        "payoff_ratio": payoff_ratio,
+        "avg_hold_win": _avg_hold(wins),
+        "avg_hold_lose": _avg_hold(loses),
+        "n_total": n_total,
+        "n_win": len(wins),
+        "n_lose": len(loses),
+    }

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -8,7 +8,7 @@ POST /trade-history/<code_s>/<int:seq>/review-memo : 振り返りメモを保存
 from flask import Blueprint, abort, jsonify, render_template, request
 
 import portfolio_shelve as ps
-from webapp.helpers import resolve_stock_name
+from webapp.helpers import calc_episode_pl, calc_trade_summary, resolve_stock_name
 
 trade_history_bp = Blueprint("trade_history", __name__)
 
@@ -85,8 +85,10 @@ def trade_history():
                 "sell_date": "",
                 "hold_reason": log.get("reason", ""),
                 "hold_qty": log.get("qty"),       # 1保遷移時のIN株数 (issue #357)
+                "hold_price": log.get("price_proxy"),  # 保有開始日の終値プロキシ (issue #361)
                 "sell_reason": "",
                 "sell_qty": None,
+                "sell_price": None,
                 "memo_seq": log["seq"],           # 1保ログの seq（未売却時のメモ保存先）
                 "sell_seq": None,
                 "review_memo": log.get("review_memo", ""),
@@ -99,16 +101,25 @@ def trade_history():
             memo = ""
             if "(" in raw_reason and raw_reason.endswith(")"):
                 memo = raw_reason[raw_reason.index("(") + 1:-1].strip()
+            # 変更後株数 (右辺) を int パース。加重平均取得単価の計算に使う (issue #361)
+            after_qty = None
+            if "→" in diff:
+                right = diff.split("→", 1)[1].strip()
+                if right.isdigit():
+                    after_qty = int(right)
             open_episodes[code_s]["qty_changes"].append({
                 "date": log["timestamp"][:10],
                 "reason": diff,
                 "memo": memo,
+                "price": log.get("price_proxy"),  # 株数変更日の終値プロキシ (issue #361)
+                "after_qty": after_qty,
             })
         elif log.get("action_type") == "売却" and code_s in open_episodes:
             ep = open_episodes.pop(code_s)
             ep["sell_date"] = log["timestamp"][:10]
             ep["sell_reason"] = log.get("reason", "")
             ep["sell_qty"] = log.get("qty")       # 売却時の保有株数（旧ログは None）
+            ep["sell_price"] = log.get("price_proxy")  # 売却日の終値プロキシ (issue #361)
             ep["sell_seq"] = log["seq"]
             ep["memo_seq"] = log["seq"]           # 売却済みはこちらがメモ保存先
             # 保有中に入力したメモを引き継ぐ
@@ -124,11 +135,19 @@ def trade_history():
     # 保有日降順
     episodes.sort(key=lambda r: r["hold_date"], reverse=True)
 
-    # 銘柄名付与・サブ行組み立て
+    # 銘柄名付与・サブ行組み立て・概算損益 (issue #361)
+    episode_pls = []
     for ep in episodes:
         ep["stock_name"] = resolve_stock_name(ep["code_s"])
         ep["rows"] = _build_rows(ep)
         ep["rowspan"] = len(ep["rows"])
+        ep["pl"] = calc_episode_pl(ep)  # 算出不可なら None (行は「—」表示)
+        if ep["pl"] is not None:
+            episode_pls.append(ep["pl"])
+
+    # 売却済み全体の成績サマリー (issue #361)。母数0/算出不可のみなら None
+    closed_count = sum(1 for ep in episodes if ep["sell_date"])
+    summary = calc_trade_summary(episode_pls)
 
     # 直近30件と過去ログに分割
     recent = episodes[:30]
@@ -142,7 +161,13 @@ def trade_history():
     # 年降順のリスト [(year, episodes), ...]
     past_years = sorted(past_by_year.items(), key=lambda x: x[0], reverse=True)
 
-    return render_template("trade_history.html", recent=recent, past_years=past_years)
+    return render_template(
+        "trade_history.html",
+        recent=recent,
+        past_years=past_years,
+        summary=summary,
+        closed_count=closed_count,
+    )
 
 
 @trade_history_bp.route(

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -38,17 +38,34 @@ def _build_rows(ep: dict) -> list:
         "kind":   "保有",
         "date":   ep["hold_date"],
         "qty":    in_qty,
+        "price":  ep.get("hold_price"),
         "reason": ep["hold_reason"],
     })
 
     for qc in qty_changes:
         reason = qc.get("reason", "")
-        after = reason.split("→", 1)[1].strip() if "→" in reason else ""
+        before = ""
+        after = ""
+        if "→" in reason:
+            before, after = [part.strip() for part in reason.split("→", 1)]
+        before_qty = int(before) if before.isdigit() else None
+        after_qty = qc.get("after_qty")
+        if after_qty is None and after.isdigit():
+            after_qty = int(after)
+        if before_qty is None or after_qty is None:
+            kind = "株数修正"
+        elif after_qty > before_qty:
+            kind = "買増"
+        elif after_qty < before_qty:
+            kind = "一部売却"
+        else:
+            kind = "株数修正"
         memo = qc.get("memo", "")
         rows.append({
-            "kind":   "株数変更",
+            "kind":   kind,
             "date":   qc["date"],
             "qty":    after,
+            "price":  qc.get("price"),
             "reason": memo,  # issue #356: 株数変更メモ（なければ空欄）
         })
 
@@ -58,6 +75,7 @@ def _build_rows(ep: dict) -> list:
             "kind":   "売却",
             "date":   ep["sell_date"],
             "qty":    str(sell_qty) if sell_qty is not None else "",
+            "price":  ep.get("sell_price"),
             "reason": ep["sell_reason"],
         })
 

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -5,6 +5,25 @@
 <h2>売買履歴</h2>
 <p style="color:#888;font-size:0.85em;">保有エピソード単位で表示。保有日降順。</p>
 
+{# 成績サマリー (issue #361): 売却済みエピソードのうち終値プロキシで概算できた分 #}
+{% if summary %}
+<div style="display:flex;gap:1.5em;flex-wrap:wrap;align-items:baseline;margin:0.5em 0 1em;padding:0.7em 1em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:5px;">
+  <div><span style="color:#888;font-size:0.8em;">勝率</span>
+    <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{{ "%.0f"|format(summary.win_rate) }}%</span>
+    <span style="color:#888;font-size:0.8em;">({{ summary.n_win }}勝{{ summary.n_lose }}敗)</span></div>
+  <div><span style="color:#888;font-size:0.8em;">ペイオフレシオ</span>
+    <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{% if summary.payoff_ratio is not none %}{{ "%.2f"|format(summary.payoff_ratio) }}{% else %}—{% endif %}</span></div>
+  <div><span style="color:#888;font-size:0.8em;">平均保有(勝)</span>
+    <span style="color:#9ef0aa;margin-left:0.3em;">{% if summary.avg_hold_win is not none %}{{ "%.0f"|format(summary.avg_hold_win) }}日{% else %}—{% endif %}</span></div>
+  <div><span style="color:#888;font-size:0.8em;">平均保有(負)</span>
+    <span style="color:#f0a0a0;margin-left:0.3em;">{% if summary.avg_hold_lose is not none %}{{ "%.0f"|format(summary.avg_hold_lose) }}日{% else %}—{% endif %}</span></div>
+  <div style="color:#777;font-size:0.78em;margin-left:auto;">
+    算出 {{ summary.n_total }} 件 / 売却済み {{ closed_count }} 件<br>
+    ※終値プロキシによる概算（手数料・配当は無視）
+  </div>
+</div>
+{% endif %}
+
 {% macro episode_table(episodes) %}
 {% if episodes %}
 <table class="trade-history-table">
@@ -34,6 +53,16 @@
       {% if loop.first %}
       <td rowspan="{{ ep.rowspan }}" style="vertical-align:top;white-space:nowrap;">
         <a href="/stock/{{ ep.code_s }}">{{ ep.code_s }} {{ ep.stock_name }}</a>
+        {# 概算損益 (issue #361): 算出できたエピソードのみ。None は非表示 #}
+        {% if ep.pl %}
+        <div style="font-size:0.82em;margin-top:2px;">
+          <span style="color:{{ '#9ef0aa' if ep.pl.return_pct >= 0 else '#f0a0a0' }};font-weight:600;">
+            {{ '+' if ep.pl.return_pct >= 0 else '' }}{{ "%.1f"|format(ep.pl.return_pct) }}%</span>
+          <span style="color:#888;margin-left:0.4em;">{{ ep.pl.hold_days }}日</span>
+        </div>
+        {% elif ep.sell_date %}
+        <div style="font-size:0.82em;margin-top:2px;color:#666;">損益 —</div>
+        {% endif %}
       </td>
       {% endif %}
       <td style="white-space:nowrap;">

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -32,6 +32,7 @@
     <col style="width:5em;">
     <col style="width:7em;">
     <col style="width:4em;">
+    <col style="width:6em;">
     <col>
     <col style="width:22em;">
   </colgroup>
@@ -41,6 +42,7 @@
       <th>種類</th>
       <th style="white-space:nowrap;">日付</th>
       <th style="white-space:nowrap;">株数</th>
+      <th style="white-space:nowrap;">株価</th>
       <th>理由</th>
       <th>振り返りメモ</th>
     </tr>
@@ -58,6 +60,13 @@
         <div style="font-size:0.82em;margin-top:2px;">
           <span style="color:{{ '#9ef0aa' if ep.pl.return_pct >= 0 else '#f0a0a0' }};font-weight:600;">
             {{ '+' if ep.pl.return_pct >= 0 else '' }}{{ "%.1f"|format(ep.pl.return_pct) }}%</span>
+          {% if ep.pl.profit_amount is not none %}
+          <span style="color:{{ '#9ef0aa' if ep.pl.profit_amount >= 0 else '#f0a0a0' }};margin-left:0.4em;">
+            {{ "{:+,}".format(ep.pl.profit_amount|round|int) }}円</span>
+          {% elif ep.pl.profit_per_share is not none %}
+          <span style="color:{{ '#9ef0aa' if ep.pl.profit_per_share >= 0 else '#f0a0a0' }};margin-left:0.4em;" title="株数不明のため1株あたり損益">
+            {{ "{:+,}".format(ep.pl.profit_per_share|round|int) }}円/株</span>
+          {% endif %}
           <span style="color:#888;margin-left:0.4em;">{{ ep.pl.hold_days }}日</span>
         </div>
         {% elif ep.sell_date %}
@@ -70,12 +79,19 @@
           <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#2e6e3e;color:#9ef0aa;">保有</span>
         {% elif row.kind == "売却" %}
           <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#5a2e2e;color:#f0a0a0;">売却</span>
+        {% elif row.kind == "一部売却" %}
+          <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#5a2e2e;color:#f0a0a0;">一部売却</span>
+        {% elif row.kind == "買増" %}
+          <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#2e5a6e;color:#9ed8f0;">買増</span>
         {% else %}
-          <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#3a3a2e;color:#c8c070;">株数変更</span>
+          <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#3a3a2e;color:#c8c070;">株数修正</span>
         {% endif %}
       </td>
       <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ row.date[2:4] }}/{{ row.date[5:7] }}/{{ row.date[8:10] }}</td>
       <td style="text-align:right;color:#888;font-size:0.85em;">{{ row.qty }}</td>
+      <td style="text-align:right;color:#888;font-size:0.85em;white-space:nowrap;">
+        {% if row.price is not none %}{{ "{:,}".format(row.price|int) }}{% else %}—{% endif %}
+      </td>
       <td style="color:#555;">{{ row.reason }}</td>
       {% if loop.first %}
       <td rowspan="{{ ep.rowspan }}" style="vertical-align:top;">

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1183,3 +1183,113 @@ class TestTradeIdeaMaster:
         assert count2 == 0
         items_after_second = ps.list_trade_ideas(db_path=db_path_ti)
         assert len(items_after_first) == len(items_after_second)
+
+
+# ==================================================
+# issue #361: 終値プロキシ自動付与・バックフィル・土日補正
+# ==================================================
+
+from datetime import date as _date  # noqa: E402
+
+
+@pytest.fixture
+def stocks_with_price_log(tmp_path, monkeypatch):
+    """_fetch_price_proxy が引く stocks_shelve に price_log を仕込む。
+
+    price_log は [(date, int終値), ...]。5/8(金)=3000, 5/11(月)=3200。
+    5/9(土)・5/10(日) は無い → 土日補正で 5/8 の終値が引ける。
+    """
+    from db_shelve import ShelveDB
+
+    stocks_path = str(tmp_path / "test_stocks_shelve")
+    monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_path)
+    with ShelveDB(stocks_path) as db:
+        db["6324"] = {"price_log": [
+            (_date(2026, 5, 8), 3000),
+            (_date(2026, 5, 11), 3200),
+        ]}
+    return stocks_path
+
+
+@pytest.mark.parametrize("action, expect_proxy", [
+    ("hold", True),      # 1保遷移 → 付与
+    ("qty_change", True),  # 株数変更 → 付与
+    ("sell", True),      # 売却 → 付与
+    ("watch", False),    # 初回登録(3監) → 未付与
+])
+def test_append_action_log_price_proxy(db_path, stocks_with_price_log, action, expect_proxy):
+    """売買日イベントのみ price_proxy が自動付与される (issue #361)。"""
+    if action == "watch":
+        ps.add_to_watch("6324", db_path=db_path)
+        logs = ps.list_action_logs("6324", db_path=db_path)
+        assert logs[-1]["price_proxy"] is None
+        assert logs[-1]["price_source"] is None
+        return
+
+    ps.add_to_watch("6324", db_path=db_path)
+    ps.transition_status("6324", "2準", db_path=db_path)
+    ps.transition_status("6324", "1保", action_date="2026-05-11", qty=500, db_path=db_path)
+    if action == "qty_change":
+        ps.update_qty("6324", 700, action_date="2026-05-11", db_path=db_path)
+    if action == "sell":
+        ps.transition_status("6324", "2準", action_date="2026-05-11", db_path=db_path)
+
+    logs = ps.list_action_logs("6324", db_path=db_path)
+    latest = logs[-1]
+    assert latest["price_source"] == "close"
+    assert latest["price_proxy"] == 3200  # 5/11 の終値
+
+
+def test_append_action_log_weekend_normalized(db_path, stocks_with_price_log):
+    """土日 (5/9土) の売買日は直前営業日 (5/8金) に正規化され、終値も 5/8 のものになる。"""
+    ps.add_to_watch("6324", db_path=db_path)
+    ps.transition_status("6324", "2準", db_path=db_path)
+    ps.transition_status("6324", "1保", action_date="2026-05-09", qty=500, db_path=db_path)
+
+    logs = ps.list_action_logs("6324", db_path=db_path)
+    hold = [l for l in logs if l.get("status_to") == "1保"][0]
+    assert hold["timestamp"][:10] == "2026-05-08"  # 土→金に補正
+    assert hold["price_proxy"] == 3000             # 5/8 の終値
+
+
+@pytest.mark.parametrize("scenario", ["fill_none", "skip_existing", "protect_actual", "overwrite"])
+def test_backfill_price_proxies(db_path, stocks_with_price_log, monkeypatch, scenario):
+    """backfill の冪等/overwrite/actual保護/土日補正 (issue #361)。"""
+    ps.add_to_watch("6324", db_path=db_path)
+    ps.transition_status("6324", "2準", db_path=db_path)
+    ps.transition_status("6324", "1保", action_date="2026-05-11", qty=500, db_path=db_path)
+    hold = [l for l in ps.list_action_logs("6324", db_path=db_path) if l.get("status_to") == "1保"][0]
+    seq = hold["seq"]
+    key = ps._action_log_key("6324", seq)
+
+    if scenario == "fill_none":
+        # price_proxy を手動で None に戻して backfill で埋め直す
+        with ps.ShelveDB(db_path) as db:
+            e = db[key]; e["price_proxy"] = None; db[key] = e
+        stats = ps.backfill_price_proxies(db_path=db_path)
+        assert stats["updated"] == 1
+        after = [l for l in ps.list_action_logs("6324", db_path=db_path) if l["seq"] == seq][0]
+        assert after["price_proxy"] == 3200
+
+    elif scenario == "skip_existing":
+        # 既に付与済み → overwrite なしでスキップ
+        stats = ps.backfill_price_proxies(db_path=db_path)
+        assert stats["updated"] == 0
+        assert stats["skipped"] >= 1
+
+    elif scenario == "protect_actual":
+        # 実約定は overwrite でも触らない
+        with ps.ShelveDB(db_path) as db:
+            e = db[key]; e["price_source"] = "actual"; e["price_proxy"] = 9999; db[key] = e
+        ps.backfill_price_proxies(overwrite=True, db_path=db_path)
+        after = [l for l in ps.list_action_logs("6324", db_path=db_path) if l["seq"] == seq][0]
+        assert after["price_proxy"] == 9999
+        assert after["price_source"] == "actual"
+
+    elif scenario == "overwrite":
+        # price_log を書き換えて overwrite すると再取得される
+        with ps.ShelveDB(stocks_with_price_log) as db:
+            db["6324"] = {"price_log": [(_date(2026, 5, 11), 5555)]}
+        ps.backfill_price_proxies(overwrite=True, db_path=db_path)
+        after = [l for l in ps.list_action_logs("6324", db_path=db_path) if l["seq"] == seq][0]
+        assert after["price_proxy"] == 5555

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -3406,3 +3406,68 @@ class TestBuildTrendInfoMa10:
         # tooltip に10日MA乖離行が入る
         assert "10日MA乖離:" in info["tooltip"]
         assert ("赤太点線: 10ma 30日維持中" in info["tooltip"]) is streak
+
+
+# ==================================================
+# issue #361: 概算損益・成績サマリー
+# ==================================================
+
+def _ep(hold_date="2026-05-01", sell_date="2026-05-11", hold_price=1000,
+        hold_qty=100, sell_price=1200, sell_qty=100, qty_changes=None):
+    return {
+        "hold_date": hold_date, "sell_date": sell_date,
+        "hold_price": hold_price, "hold_qty": hold_qty,
+        "sell_price": sell_price, "sell_qty": sell_qty,
+        "qty_changes": qty_changes or [],
+    }
+
+
+@pytest.mark.parametrize("ep, expect", [
+    # 単純: 1000→1200 = +20%、暦日10日
+    (_ep(), {"return_pct": 20.0, "hold_days": 10}),
+    # 単一 IN で hold_qty=None (旧ログ救済): 株数なしでも損益率は出る
+    (_ep(hold_qty=None), {"return_pct": 20.0, "hold_days": 10}),
+    # 買い増し加重: 100株@1000 + 100株@1400 → 平均1200、売値1200 = 0%
+    (_ep(hold_qty=100, sell_price=1200, sell_qty=200,
+         qty_changes=[{"price": 1400, "after_qty": 200}]),
+     {"return_pct": 0.0, "hold_days": 10}),
+    # 減玉あり (200→100) → None
+    (_ep(hold_qty=200, qty_changes=[{"price": 1100, "after_qty": 100}]), None),
+    # 買い増しがあるのに hold_qty=None (加重不能) → None
+    (_ep(hold_qty=None, qty_changes=[{"price": 1400, "after_qty": 200}]), None),
+    # 買い増しの price 欠損 → None
+    (_ep(hold_qty=100, qty_changes=[{"price": None, "after_qty": 200}]), None),
+    # 売却価格なし → None
+    (_ep(sell_price=None), None),
+])
+def test_calc_episode_pl(ep, expect):
+    result = helpers.calc_episode_pl(ep)
+    if expect is None:
+        assert result is None
+    else:
+        assert result is not None
+        assert round(result["return_pct"], 4) == expect["return_pct"]
+        assert result["hold_days"] == expect["hold_days"]
+
+
+@pytest.mark.parametrize("pls, checks", [
+    # 勝ち負け混在: +20%(amt100) 勝ち, -10%(amt100) 負け → win_rate50, payoff 20/10=2.0
+    ([{"return_pct": 20, "hold_days": 5, "amount": 100},
+      {"return_pct": -10, "hold_days": 15, "amount": 100}],
+     {"win_rate": 50.0, "payoff_ratio": 2.0, "n_win": 1, "n_lose": 1}),
+    # 0% は負け扱い
+    ([{"return_pct": 0, "hold_days": 3, "amount": 100}],
+     {"win_rate": 0.0, "n_win": 0, "n_lose": 1}),
+    # 負け0件 → payoff None
+    ([{"return_pct": 20, "hold_days": 5, "amount": 100}],
+     {"win_rate": 100.0, "payoff_ratio": None, "n_win": 1, "n_lose": 0}),
+])
+def test_calc_trade_summary(pls, checks):
+    s = helpers.calc_trade_summary(pls)
+    assert s is not None
+    for k, v in checks.items():
+        assert s[k] == v
+
+
+def test_calc_trade_summary_empty_returns_none():
+    assert helpers.calc_trade_summary([]) is None

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -3424,13 +3424,15 @@ def _ep(hold_date="2026-05-01", sell_date="2026-05-11", hold_price=1000,
 
 @pytest.mark.parametrize("ep, expect", [
     # 単純: 1000→1200 = +20%、暦日10日
-    (_ep(), {"return_pct": 20.0, "hold_days": 10}),
-    # 単一 IN で hold_qty=None (旧ログ救済): 株数なしでも損益率は出る
-    (_ep(hold_qty=None), {"return_pct": 20.0, "hold_days": 10}),
+    (_ep(), {"return_pct": 20.0, "hold_days": 10, "profit_amount": 20000, "profit_per_share": 200}),
+    # 単一 IN で hold_qty=None でも sell_qty があれば概算損益額を出す
+    (_ep(hold_qty=None), {"return_pct": 20.0, "hold_days": 10, "profit_amount": 20000, "profit_per_share": 200}),
+    # 株数が全く無い旧ログは損益率のみ出し、損益額は出さない
+    (_ep(hold_qty=None, sell_qty=None), {"return_pct": 20.0, "hold_days": 10, "profit_amount": None, "profit_per_share": 200}),
     # 買い増し加重: 100株@1000 + 100株@1400 → 平均1200、売値1200 = 0%
     (_ep(hold_qty=100, sell_price=1200, sell_qty=200,
          qty_changes=[{"price": 1400, "after_qty": 200}]),
-     {"return_pct": 0.0, "hold_days": 10}),
+     {"return_pct": 0.0, "hold_days": 10, "profit_amount": 0, "profit_per_share": 0}),
     # 減玉あり (200→100) → None
     (_ep(hold_qty=200, qty_changes=[{"price": 1100, "after_qty": 100}]), None),
     # 買い増しがあるのに hold_qty=None (加重不能) → None
@@ -3448,6 +3450,8 @@ def test_calc_episode_pl(ep, expect):
         assert result is not None
         assert round(result["return_pct"], 4) == expect["return_pct"]
         assert result["hold_days"] == expect["hold_days"]
+        assert result["profit_amount"] == expect["profit_amount"]
+        assert result["profit_per_share"] == expect["profit_per_share"]
 
 
 @pytest.mark.parametrize("pls, checks", [

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -19,6 +19,10 @@ def app(tmp_path, monkeypatch):
     monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", research_db)
     monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", research_db)
     monkeypatch.setattr("portfolio_shelve.DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        "portfolio_shelve._fetch_price_proxy",
+        lambda code_s, timestamp: {"3496": 1234, "6324": 5678}.get(code_s),
+    )
 
     # 銘柄 3496: 3監 → 1保（未売却）
     rec = rs.create_research_record("3496", "アズーム", overall_rating="A")
@@ -49,13 +53,20 @@ class TestTradeHistoryPage:
         assert client.get("/trade-history").status_code == 200
 
     def test_column_headers_shown(self, client):
-        """種類・日付・株数・理由・振り返りメモのヘッダが表示される。"""
+        """種類・日付・株数・株価・理由・振り返りメモのヘッダが表示される。"""
         html = client.get("/trade-history").data.decode()
         assert "種類" in html
         assert "日付" in html
         assert "株数" in html
+        assert "株価" in html
         assert "理由" in html
         assert "振り返りメモ" in html
+
+    def test_price_proxy_column_shown(self, client):
+        """保有・売却イベント日の終値プロキシが株価列に表示される。"""
+        html = client.get("/trade-history").data.decode()
+        assert "1,234" in html
+        assert "5,678" in html
 
     def test_unsold_episode_shown(self, client):
         """未売却エピソード（3496）が保有サブ行で表示される。"""
@@ -111,10 +122,17 @@ class TestTradeHistoryPage:
         assert "保有中メモ" in html
 
     def test_qty_changes_subrow(self, client):
-        """株数変更があるエピソードは「株数変更」サブ行が出る。"""
+        """株数増加は「買増」サブ行として表示される。"""
         ps.update_qty("3496", 50)
         html = client.get("/trade-history").data.decode()
-        assert "株数変更" in html
+        assert "買増" in html
+
+    def test_qty_decrease_subrow(self, client):
+        """株数減少は「一部売却」サブ行として表示される。"""
+        ps.update_qty("3496", 100)
+        ps.update_qty("3496", 50)
+        html = client.get("/trade-history").data.decode()
+        assert "一部売却" in html
 
     def test_rowspan_present_when_qty_changes(self, client):
         """株数変更があるエピソードは銘柄セルに rowspan="2" が付く（保有+株数変更=2行）。"""


### PR DESCRIPTION
## 概要

issue #360 の暫定実装として、売買イベント日の終値をプロキシ約定価格として自動付与し、手入力なしで概算損益・保有日数・成績サマリーを計測する (#361)。

概算値のため個別トレードの精密な損益額には使えないが、「利を伸ばせているか / 損切りが早いか」という**売買の傾向評価**（勝率・ペイオフレシオ・利小損大の検出）に機能する。実約定価格 (#360 Phase2) が入れば `price_source="actual"` で上書きできる構造。

Closes #361
Refs #360

## 変更内容

- **`portfolio_shelve.py`**: action_log に `price_proxy`/`price_source` を追加。売買日イベント (1保/株数変更/売却) の記録時に、既存 price_log から終値を自動付与。土日の売買日を直前営業日に正規化 (timestamp=売買日として訂正)。旧ログは `setdefault` で後方互換 (マイグレーション不要)。
- **`backfill_price_proxy.py`** (新規): 既存 price_log (直近30営業日) の範囲で終値を一括付与する CLI。実約定 (`source=actual`) は保護。土日補正も同時実行。冪等/`--overwrite`。
- **`webapp/helpers.py`**: `calc_episode_pl` (加重平均取得単価で損益率算出)、`calc_trade_summary` (勝率・金額加重ペイオフレシオ・勝ち負け平均保有日数)。減玉・買い増し価格欠損・複数INの数量欠損は母数除外して符号反転を回避。単一INは株数がなくても損益率を算出 (旧ログ救済)。
- **`trade_history.py` / `trade_history.html`**: エピソード単位の損益率・保有日数を表示、ページ上部にサマリーセクション。概算値である旨 (終値プロキシ・手数料/配当無視) を明示。

## 設計判断

| 論点 | 方針 |
|---|---|
| 終値の保持 | action_log に永続化 (#360 Phase2 で実約定に上書き可能) |
| バックフィル | 既存 price_log の範囲のみ。窓外は `price_proxy=None` |
| 土日の売買日 | timestamp を直前営業日に正規化 (入力ミスの訂正)。新規記録・バックフィルで統一 |
| 0% 境界 | 負けに含める |
| ペイオフレシオ | 金額加重 |
| 取得単価 | 加重平均。減玉/数量欠損エピソードは母数除外 |

## テスト

- 追加: `calc_episode_pl`/`calc_trade_summary`/自動付与/バックフィル/土日補正 (parametrize 集約)
- `pytest tests/test_portfolio_shelve.py tests/test_webapp_helpers.py tests/test_webapp_routes.py tests/test_webapp_trade_history_routes.py` — 追加分含め全 pass
- 実運用DBでバックフィル実行 (バックアップ取得済み): updated=48 / no_price=60(窓外) / date_fixed=16(土日補正)
- ブラウザで /trade-history 目視確認: 勝率29%・ペイオフ0.78・利小損大の傾向が可視化

🤖 Generated with [Claude Code](https://claude.com/claude-code)