### PR TITLE
適時開示の定型タイトルと英文IRを除外

### DIFF
--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -2339,6 +2339,27 @@ def _html_kessan(kessan_csv):
 # =HYPERLINK("url","text") パターン
 _RE_HYPERLINK = re.compile(r'^=HYPERLINK\("([^"]+)","([^"]+)"\)$')
 
+EXCLUDE_DISCLOSURE_KEYWORDS = [
+    "独立役員届出書",
+    "定時株主総会招集",
+    "コーポレート・ガバナンスに関する",
+]
+
+# ひらがな・カタカナ・漢字・全角英数/記号。含まなければ英文IRとして扱う。
+_RE_DISCLOSURE_CJK = re.compile(r'[\u3040-\u30ff\u3400-\u9fff\uff00-\uffef]')
+
+
+def _is_english_disclosure_heading(heading):
+    """見出しが英文IRか判定する。カーリークォート等の非ASCII約物は許容する。"""
+    return not _RE_DISCLOSURE_CJK.search(heading or "")
+
+
+def _should_exclude_disclosure_heading(heading):
+    """適時開示セクションから除外する見出しか判定する。"""
+    if _is_english_disclosure_heading(heading):
+        return True
+    return any(keyword in heading for keyword in EXCLUDE_DISCLOSURE_KEYWORDS)
+
 
 def _html_disclosure(disc_csv):
     """適宜開示セクションのHTMLを生成する
@@ -2364,10 +2385,9 @@ def _html_disclosure(disc_csv):
             continue
         if row[0] == "":  # 空行
             continue
-        # 見出しが ASCII のみ = 日本語IRの英語版重複なので除外
         body_match = _RE_HYPERLINK.match(str(row[4]))
         heading = body_match.group(2) if body_match else str(row[4])
-        if heading.isascii():
+        if _should_exclude_disclosure_heading(heading):
             continue
         data_rows.append(row)
 

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -1520,6 +1520,30 @@ class TestHtmlDisclosure:
         html = make_market_db._html_disclosure(rows)
         assert "Notice Concerning" not in html
 
+    @pytest.mark.parametrize("heading", [
+        "Notice Regarding Acquisition of Shares of Company’s Consolidated Subsidiary",
+        "(Correction) “Consolidated Financial Results for the Fiscal Year” (IFRS)",
+    ])
+    def test_非ASCII約物を含む英文見出しは除外される(self, heading):
+        rows = [self._row(heading)]
+        html = make_market_db._html_disclosure(rows)
+        assert html == ""
+
+    @pytest.mark.parametrize("heading", [
+        "独立役員届出書",
+        "第10回定時株主総会招集ご通知",
+        "コーポレート・ガバナンスに関する報告書",
+    ])
+    def test_定型キーワードを含む見出しは除外される(self, heading):
+        rows = [self._row(heading)]
+        html = make_market_db._html_disclosure(rows)
+        assert html == ""
+
+    def test_英字混在でも日本語を含む見出しは除外されない(self):
+        rows = [self._row("MUFGのIR資料")]
+        html = make_market_db._html_disclosure(rows)
+        assert "MUFGのIR資料" in html
+
     def test_日本語と英語混在で日本語のみ残る(self):
         rows = [
             self._row("決算短信"),


### PR DESCRIPTION
## 概要
- 適時開示一覧から英文のみの見出しを除外
- 独立役員届出書、定時株主総会招集、コーポレート・ガバナンス報告書を除外
- 全角引用符などを含む英文IRも日本語判定に誤分類しないようCJK文字ベースで判定

## 検証
- pytest tests/test_make_market_db.py -q

Refs #304