### PR TITLE
売却後騰落を記録

### DIFF
--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -189,6 +189,8 @@ ACTION_LOG_FIELDS = frozenset(
         # 入れば price_source="actual" で上書きできる構造。旧ログは list 側で None 補完。
         "price_proxy",   # イベント日 (直前営業日) の終値 (int) or None
         "price_source",  # "close" (終値プロキシ) / 将来 "actual" (実約定)
+        # issue #366: 売却後5/20営業日の騰落率。売買履歴表示時に確定分のみ保存する。
+        "post_sell_returns",
     }
 )
 
@@ -728,6 +730,7 @@ def list_action_logs(
             # issue #361: 旧ログの後方互換補完 (物理スキーマ変更なし・マイグレーション不要)
             value.setdefault("price_proxy", None)
             value.setdefault("price_source", None)
+            value.setdefault("post_sell_returns", {})
             results.append(value)
     results.sort(
         key=lambda r: (r.get("code_s", ""), r.get("seq", 0)),
@@ -760,6 +763,37 @@ def update_action_log_review_memo(
             if entry is None:
                 raise KeyError(f"action_log not found: code_s={code_s!r}, seq={seq}")
             entry["review_memo"] = review_memo
+            db[key] = entry
+    return entry
+
+
+def update_action_log_post_sell_returns(
+    code_s: str,
+    seq: int,
+    returns: Dict[str, float],
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """売却ログの確定済み売却後騰落率を保存する (issue #366)。"""
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    if not isinstance(returns, dict) or not all(
+        key in {"5d", "20d"} and isinstance(value, (int, float))
+        for key, value in returns.items()
+    ):
+        raise TypeError("returns must be a dict of 5d/20d numeric values")
+    key = _action_log_key(normalized, seq)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            entry = db.get(key)
+            if entry is None:
+                raise KeyError(f"action_log not found: code_s={code_s!r}, seq={seq}")
+            if entry.get("action_type") != "売却":
+                raise ValueError("post_sell_returns can only be saved for sell logs")
+            saved = entry.get("post_sell_returns") or {}
+            saved.update(returns)
+            entry["post_sell_returns"] = saved
             db[key] = entry
     return entry
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -896,7 +896,6 @@ def _price_reactions_from_log(
         result[key] = _format_reaction(before_price, after_entries[n - 1][1])
     return result
 
-
 def calc_price_reactions(code_s: str, kessanbi: str) -> Dict[str, str]:
     """決算日前営業日終値と複数期間後の終値から株価変動率を算出する。
 
@@ -4305,3 +4304,49 @@ def calc_trade_summary(episode_pls: list) -> Optional[dict]:
         "n_win": len(wins),
         "n_lose": len(loses),
     }
+
+
+# ===========================================
+# issue #366: 売却後騰落率
+# ===========================================
+
+POST_SELL_RETURN_PERIODS = (("5d", 5), ("20d", 20))
+
+
+def calc_post_sell_returns(ep: dict, price_log: List) -> Dict[str, dict]:
+    """売却日終値から5/20営業日後の騰落率と経過営業日数を返す。
+
+    売却日以前の価格履歴が窓外なら、後続日数を正確に数えられないため未計測扱いにする。
+    """
+    result = {
+        key: {"days": days, "return_pct": None, "elapsed_days": None}
+        for key, days in POST_SELL_RETURN_PERIODS
+    }
+    sell_price = ep.get("sell_price")
+    try:
+        sell_date = date.fromisoformat(ep.get("sell_date", ""))
+        sell_price = float(sell_price)
+    except (TypeError, ValueError):
+        return result
+    if sell_price <= 0:
+        return result
+
+    try:
+        sorted_log = sorted(
+            (entry[0], entry[1]) for entry in price_log
+            if isinstance(entry[0], date) and entry[1] is not None
+        )
+    except (IndexError, TypeError):
+        return result
+    if not any(entry_date <= sell_date for entry_date, _ in sorted_log):
+        return result
+
+    after_entries = [entry for entry in sorted_log if entry[0] > sell_date]
+    for key, days in POST_SELL_RETURN_PERIODS:
+        result[key]["elapsed_days"] = min(len(after_entries), days)
+        if len(after_entries) >= days:
+            result[key]["return_pct"] = round(
+                (float(after_entries[days - 1][1]) / sell_price - 1.0) * 100.0,
+                6,
+            )
+    return result

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -8,7 +8,13 @@ POST /trade-history/<code_s>/<int:seq>/review-memo : 振り返りメモを保存
 from flask import Blueprint, abort, jsonify, render_template, request
 
 import portfolio_shelve as ps
-from webapp.helpers import calc_episode_pl, calc_trade_summary, resolve_stock_name
+from webapp.helpers import (
+    _bulk_price_logs,
+    calc_episode_pl,
+    calc_post_sell_returns,
+    calc_trade_summary,
+    resolve_stock_name,
+)
 
 trade_history_bp = Blueprint("trade_history", __name__)
 
@@ -157,6 +163,7 @@ def trade_history():
             # 空文字（明示削除）はそのまま優先する
             sell_memo = log.get("review_memo")
             ep["review_memo"] = sell_memo if sell_memo is not None else ep.get("review_memo", "")
+            ep["post_sell_returns"] = log.get("post_sell_returns") or {}
             episodes.append(ep)
 
     # 未売却（保有中）エピソードを追加
@@ -166,6 +173,8 @@ def trade_history():
     episodes.sort(key=_last_action_date, reverse=True)
 
     # 銘柄名付与・サブ行組み立て・概算損益 (issue #361)
+    # 売却後騰落率は表示時に計算し、確定した値だけ売却ログへ保存する (issue #366)。
+    price_logs = _bulk_price_logs([ep["code_s"] for ep in episodes if ep["sell_date"]])
     episode_pls = []
     for ep in episodes:
         ep["stock_name"] = resolve_stock_name(ep["code_s"])
@@ -174,6 +183,24 @@ def trade_history():
         ep["pl"] = calc_episode_pl(ep)  # 算出不可なら None (行は「—」表示)
         if ep["pl"] is not None:
             episode_pls.append(ep["pl"])
+        if ep["sell_date"]:
+            calculated = calc_post_sell_returns(ep, price_logs.get(ep["code_s"], []))
+            saved = ep.get("post_sell_returns", {})
+            newly_confirmed = {
+                key: value["return_pct"]
+                for key, value in calculated.items()
+                if value["return_pct"] is not None and key not in saved
+            }
+            if newly_confirmed:
+                ps.update_action_log_post_sell_returns(ep["code_s"], ep["sell_seq"], newly_confirmed)
+                saved = {**saved, **newly_confirmed}
+            for key, value in calculated.items():
+                if key in saved:
+                    value["return_pct"] = saved[key]
+            ep["post_sell"] = calculated
+            ep["review_prompt"] = any(
+                value["return_pct"] is not None for value in calculated.values()
+            ) and not ep["review_memo"]
 
     # 売却済み全体の成績サマリー (issue #361)。母数0/算出不可のみなら None
     closed_count = sum(1 for ep in episodes if ep["sell_date"])

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -17,9 +17,8 @@
     <span style="color:#9ef0aa;margin-left:0.3em;">{% if summary.avg_hold_win is not none %}{{ "%.0f"|format(summary.avg_hold_win) }}日{% else %}—{% endif %}</span></div>
   <div><span style="color:#888;font-size:0.8em;">平均保有(負)</span>
     <span style="color:#f0a0a0;margin-left:0.3em;">{% if summary.avg_hold_lose is not none %}{{ "%.0f"|format(summary.avg_hold_lose) }}日{% else %}—{% endif %}</span></div>
-  <div style="color:#777;font-size:0.78em;margin-left:auto;">
-    算出 {{ summary.n_total }} 件 / 売却済み {{ closed_count }} 件<br>
-    ※終値プロキシによる概算（手数料・配当は無視）
+  <div title="終値プロキシによる概算（手数料・配当は無視）" style="color:#777;font-size:0.78em;margin-left:auto;cursor:help;">
+    算出 {{ summary.n_total }} 件 / 売却済み {{ closed_count }} 件
   </div>
 </div>
 {% endif %}
@@ -72,6 +71,17 @@
         {% elif ep.sell_date %}
         <div style="font-size:0.82em;margin-top:2px;color:#666;">損益 —</div>
         {% endif %}
+        {% if ep.post_sell %}
+        <div style="font-size:0.78em;margin-top:3px;color:#888;">
+          {% for item in ep.post_sell.values() %}
+          <span style="margin-right:0.45em;">後{{ item.days }}:
+            {% if item.return_pct is not none %}<b style="color:{{ '#f0a0a0' if item.return_pct >= 0 else '#9ef0aa' }};">{{ '+' if item.return_pct >= 0 else '' }}{{ "%.1f"|format(item.return_pct) }}%</b>
+            {% elif item.elapsed_days is not none %}{{ item.elapsed_days }}/{{ item.days }}日
+            {% else %}—{% endif %}
+          </span>
+          {% endfor %}
+        </div>
+        {% endif %}
       </td>
       {% endif %}
       <td style="white-space:nowrap;">
@@ -94,7 +104,7 @@
       </td>
       <td style="color:#555;">{{ row.reason }}</td>
       {% if loop.first %}
-      <td rowspan="{{ ep.rowspan }}" style="vertical-align:top;">
+      <td rowspan="{{ ep.rowspan }}" style="vertical-align:top;{% if ep.review_prompt %}background:rgba(210,170,70,0.10);{% endif %}">
         <div class="review-memo-cell"
              data-url="/trade-history/{{ ep.code_s }}/{{ ep.memo_seq }}/review-memo"
              data-memo="{{ ep.review_memo or '' | e }}">

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -3507,3 +3507,15 @@ def test_calc_trade_summary(pls, checks):
 
 def test_calc_trade_summary_empty_returns_none():
     assert helpers.calc_trade_summary([]) is None
+
+
+def test_calc_post_sell_returns_uses_business_day_count():
+    ep = {"sell_date": "2026-05-01", "sell_price": 1000}
+    log = [(date(2026, 5, 1), 1000)] + [
+        (date(2026, 5, day), 1000 + day * 10) for day in range(2, 23)
+    ]
+
+    result = helpers.calc_post_sell_returns(ep, log)
+
+    assert result["5d"] == {"days": 5, "return_pct": 6.0, "elapsed_days": 5}
+    assert result["20d"] == {"days": 20, "return_pct": 21.0, "elapsed_days": 20}

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -1,6 +1,7 @@
 """売買履歴ページ (issue #351, #357) ルートテスト。"""
 
 import pytest
+from datetime import date, timedelta
 import portfolio_shelve as ps
 import research_shelve as rs
 from webapp import create_app
@@ -82,6 +83,23 @@ class TestTradeHistoryPage:
         assert "GARP確認" in html
         assert "目標達成" in html
         assert "売却" in html
+
+    def test_post_sell_returns_are_displayed_and_saved(self, client, monkeypatch):
+        """売却後5/20営業日騰落率を表示時に確定・保存する。"""
+        sell_log = next(l for l in ps.list_action_logs("6324") if l["action_type"] == "売却")
+        sell_day = date.fromisoformat(sell_log["timestamp"][:10])
+        log = [(sell_day, 5678)] + [
+            (sell_day + timedelta(days=offset), 5678 + offset * 10)
+            for offset in range(1, 22)
+        ]
+        monkeypatch.setattr("webapp.routes.trade_history._bulk_price_logs", lambda codes: {"6324": log})
+
+        html = client.get("/trade-history").data.decode()
+
+        assert "後5:" in html
+        assert "後20:" in html
+        saved = next(l for l in ps.list_action_logs("6324") if l["action_type"] == "売却")
+        assert saved["post_sell_returns"].keys() == {"5d", "20d"}
 
     def test_all_episodes_have_review_memo_textarea(self, client):
         """売却済み・未売却どちらのエピソードにも textarea が表示される。"""


### PR DESCRIPTION
## 変更内容
- 売却後5営業日・20営業日の騰落率を売買履歴表示時に算出し、確定値を売却ログへ保存
- 売買履歴に期間別の騰落率、計測中の経過営業日、振り返りメモ未記入のハイライトを追加
- 概算損益の注意書きをツールチップへ移動

## 背景
専用の日次バッチを追加せず、既存の直近30営業日価格履歴を使って売却後の値動きを記録するため。

## 確認
- `.venv/bin/python -m pytest tests/test_webapp_trade_history_routes.py tests/test_webapp_helpers.py -q -k 'post_sell or trade_history'`
- 21 passed