### PR TITLE
ポートフォリオのステータス編集を改善

### DIFF
--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -2,6 +2,7 @@
 
 GET  /portfolio?status=hold&gyoutai_theme=半導体 : フィルタ (issue #215)
 POST /portfolio/add                              : 3監 への新規追加 / 除外済みの復活
+POST /portfolio/status                           : コード指定の保有ステータス変更
 POST /portfolio/<code_s>/transition              : ステータス変更
 POST /portfolio/bulk-exclude                     : 2準/3監 銘柄をユニバースから除外 (一括)
 POST /portfolio/bulk-transition                  : ステータスを一括変更
@@ -743,6 +744,84 @@ def add():
     else:
         flash(f"{normalized} {name_for_flash} を監視に追加しました".rstrip(), "info")
     return _redirect_with_return_query(default_status_query="watch", code_s=normalized)
+
+
+@portfolio_bp.route("/portfolio/status", methods=["POST"])
+def set_status():
+    """コード指定で保有/準保有/監視へ変更する。
+
+    未登録コードは内部的に 3監 レコードを作ってから、選択された状態へ遷移する。
+    これにより画面上の操作を「ユニバース追加」ではなく状態の指定に統一する。
+    """
+    rejected = _reject_when_fallback()
+    if rejected is not None:
+        return rejected
+
+    code_s = (request.form.get("code_s") or "").strip()
+    new_status = (request.form.get("new_status") or "").strip()
+    reason = (request.form.get("reason") or "").strip() or "WebApp ステータス変更"
+    trade_idea = (request.form.get("trade_idea") or "").strip()
+    qty_raw = (request.form.get("qty") or "").strip()
+    if new_status not in ps.VALID_STATUSES:
+        flash(f"不正なステータス: {new_status!r}", "error")
+        return _redirect_with_return_query()
+    try:
+        ps.validate_code_s(code_s)
+    except (ValueError, TypeError) as e:
+        flash(f"不正な銘柄コード: {e}", "error")
+        return _redirect_with_return_query()
+    normalized = ps.normalize_code_s(code_s)
+
+    qty = None
+    if new_status == "1保":
+        try:
+            qty = int(qty_raw)
+        except ValueError:
+            flash("保有に変更するには株数を整数で入力してください", "error")
+            return _redirect_with_return_query()
+        if qty < 0:
+            flash("株数は 0 以上で入力してください", "error")
+            return _redirect_with_return_query()
+
+    record = ps.get_record(normalized)
+    if record is None:
+        if not get_stock_data(normalized):
+            flash(f"{normalized} は stocks_shelve に未登録のコードです", "error")
+            return _redirect_with_return_query()
+        try:
+            ps.add_to_watch(normalized, reason=reason)
+        except ValueError as e:
+            flash(str(e), "error")
+            return _redirect_with_return_query()
+        record = ps.get_record(normalized)
+    elif record.get("excluded"):
+        try:
+            ps.add_to_watch(normalized, reason=reason)
+        except ValueError as e:
+            flash(str(e), "error")
+            return _redirect_with_return_query()
+        record = ps.get_record(normalized)
+
+    old_status = (record or {}).get("status")
+    try:
+        if new_status == "1保" and old_status != "1保":
+            if not trade_idea:
+                flash("保有に変更するには売買戦略を選択してください", "error")
+                return _redirect_with_return_query()
+            ps.seed_trade_ideas()
+            ps.update_memo(normalized, {"trade_idea": trade_idea})
+        ps.transition_status(normalized, new_status, reason=reason, qty=qty)
+        if new_status == "1保" and qty is not None:
+            ps.update_qty(normalized, qty, reason=reason, log_action=old_status == "1保")
+    except (KeyError, ValueError, TypeError) as e:
+        flash(str(e), "error")
+        return _redirect_with_return_query()
+
+    _sync_txt_safely()
+    label = STATUS_VALUE_TO_LABEL[new_status]
+    _flash_stock_info(normalized, f" のステータスを {label} に変更しました")
+    return _redirect_with_return_query(
+        default_status_query=STATUS_VALUE_TO_QUERY[new_status], code_s=normalized)
 
 
 def _build_fallback_records() -> list[dict]:

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -230,6 +230,13 @@
     white-space: nowrap;
   }
   #toggle-manage-mode { padding: 0.3em 0.8em; font-size: 0.85em; margin: 0; }
+  #toggle-status-edit {
+    padding: 0; margin: 0; width: auto; border: none; background: transparent;
+    color: #555; font-size: 0.85em; font-weight: normal; text-decoration: underline;
+  }
+  #status-edit-panel {
+    display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap;
+  }
   #manage-panel {
     padding: 0.6em 0.8em; margin: 0.4em 0 0.6em 0;
     background: #f5f7fa; border: 1px solid #d8dee6; border-radius: 4px;
@@ -295,16 +302,27 @@
        title="現在のフィルタ結果をチャート一覧で確認">📊 チャート一覧</a>
   </form>
   {% if not fallback_mode %}
-  {# 追加フォームには return_query を入れない。
-     現在のフィルタが保有のみだと、追加された 3監 銘柄が見えなくなるため、
-     add() 側の default_status_query="watch" フォールバックを効かせる (codex 指摘 P2)。 #}
-  <form action="/portfolio/add" method="POST" class="portfolio-add-form" style="margin:0;display:inline-flex;align-items:center;gap:0.4em;">
-    <label style="margin:0;">コード追加 <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
-    <button type="submit" style="width:auto;">追加</button>
+  <button type="button" id="toggle-status-edit" aria-expanded="false">▷ ステータス編集</button>
+  <div id="status-edit-panel" style="display:none;">
+  {% if active_status_query %}
+  {% set add_status = {'hold': '1保', 'semi': '2準', 'watch': '3監'}[active_status_query] %}
+  {% set add_label = {'hold': '保有に追加', 'semi': '準保有に追加', 'watch': '監視に追加'}[active_status_query] %}
+  <form action="/portfolio/status" method="POST" id="portfolio-add-form" class="portfolio-add-form" style="margin:0;display:inline-flex;align-items:center;gap:0.4em;flex-wrap:wrap;">
+    <label style="margin:0;">コード <input type="text" name="code_s" required pattern="[0-9A-Za-z]+" maxlength="4" style="width:6em;"></label>
+    <input type="hidden" name="new_status" value="{{ add_status }}">
+    {% if add_status == '1保' %}
+    <button type="button" onclick="openPortfolioAddHoldModal()" style="width:auto;">{{ add_label }}</button>
+    {% else %}
+    <button type="submit" style="width:auto;">{{ add_label }}</button>
+    {% endif %}
   </form>
+  {% else %}
+  <span class="portfolio-add-form hint">追加先のステータスを選択してください</span>
+  {% endif %}
   {% if delete_mode_allowed %}
   <button type="button" id="toggle-delete-mode">一括変更モード</button>
   {% endif %}
+  </div>
   {% endif %}
 </div>
 
@@ -612,6 +630,39 @@
 </div>
 
 {% if not fallback_mode %}
+<div id="portfolio-add-hold-modal" class="portfolio-modal-overlay" style="display:none;" onclick="closePortfolioAddHoldModalOnOverlay(event)">
+  <div class="portfolio-modal-content" role="dialog" aria-labelledby="portfolio-add-hold-modal-title">
+    <div class="portfolio-modal-header">
+      <strong id="portfolio-add-hold-modal-title">保有に追加</strong>
+      <button type="button" class="portfolio-modal-close" onclick="closePortfolioAddHoldModal()" aria-label="閉じる">×</button>
+    </div>
+    <form method="POST" action="/portfolio/status" class="portfolio-modal-body" novalidate>
+      <input type="hidden" name="return_query" value="{{ return_query }}">
+      <input type="hidden" name="new_status" value="1保">
+      <input type="hidden" name="code_s" id="portfolio-add-hold-code">
+      <p style="margin:0 0 0.6em 0;">コード: <strong id="portfolio-add-hold-code-label"></strong></p>
+      <label style="display:block;margin-bottom:0.6em;">
+        株数:
+        <input type="number" name="qty" min="0" step="100" value="100" required
+               style="margin-left:0.4em;width:6em;text-align:right;padding:0.2em 0.3em;">
+        <span style="color:#888;font-size:0.85em;">株</span>
+      </label>
+      <label style="display:block;margin-bottom:0.6em;">
+        売買戦略 (必須):
+        <select name="trade_idea" required style="margin-left:0.4em;">
+          <option value="">-- 戦略を選択 --</option>
+          {% for idea in trade_idea_options %}
+          <option value="{{ idea }}">{{ idea }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <div class="portfolio-modal-actions">
+        <button type="button" class="secondary" onclick="closePortfolioAddHoldModal()">キャンセル</button>
+        <button type="submit">保有に追加</button>
+      </div>
+    </form>
+  </div>
+</div>
 <div id="portfolio-modal" class="portfolio-modal-overlay" style="display:none;" onclick="closePortfolioModalOnOverlay(event)">
   <div class="portfolio-modal-content" role="dialog" aria-labelledby="portfolio-modal-title">
     <div class="portfolio-modal-header">
@@ -740,6 +791,24 @@
 })();
 
 {% if not fallback_mode %}
+// ========== 表示ステータスへの追加 ==========
+function openPortfolioAddHoldModal() {
+  var addForm = document.getElementById('portfolio-add-form');
+  var codeInput = addForm ? addForm.querySelector('input[name="code_s"]') : null;
+  if (!codeInput || !codeInput.reportValidity()) return;
+  var code = codeInput.value.trim();
+  document.getElementById('portfolio-add-hold-code').value = code;
+  document.getElementById('portfolio-add-hold-code-label').textContent = code;
+  document.getElementById('portfolio-add-hold-modal').style.display = 'flex';
+}
+function closePortfolioAddHoldModal() {
+  var modal = document.getElementById('portfolio-add-hold-modal');
+  if (modal) modal.style.display = 'none';
+}
+function closePortfolioAddHoldModalOnOverlay(e) {
+  if (e.target.id === 'portfolio-add-hold-modal') closePortfolioAddHoldModal();
+}
+
 // ========== 保有状態モーダル ==========
 // issue #269: qty 欄は「変更先=1保」のときのみ表示する。
 // issue #363: 売買戦略欄は「新規1保遷移 (現在=非1保 → 変更先=1保)」のときのみ表示・必須化する。
@@ -1418,6 +1487,27 @@ function excludeFromUniverse(codeS) {
         alert('通信エラー: ' + err);
       });
     });
+  });
+})();
+
+// ========== ステータス編集パネル開閉 ==========
+(function() {
+  var toggle = document.getElementById('toggle-status-edit');
+  var panel = document.getElementById('status-edit-panel');
+  if (!toggle || !panel) return;
+  toggle.addEventListener('click', function() {
+    var open = panel.style.display !== 'none';
+    panel.style.display = open ? 'none' : '';
+    toggle.textContent = (open ? '▷' : '▽') + ' ステータス編集';
+    toggle.setAttribute('aria-expanded', open ? 'false' : 'true');
+    if (open) {
+      document.body.classList.remove('delete-mode');
+      document.querySelectorAll('.bulk-cb').forEach(function(c) { c.checked = false; });
+      var bar = document.getElementById('bulk-delete-bar');
+      if (bar) bar.style.display = 'none';
+      var cnt = document.getElementById('selected-count');
+      if (cnt) cnt.textContent = '0';
+    }
   });
 })();
 

--- a/tests/test_webapp_routes.py
+++ b/tests/test_webapp_routes.py
@@ -1352,6 +1352,61 @@ class TestTransitionRequiresStrategy:
         assert rec["qty"] == 300
         assert rec["memo"].get("trade_idea") == "GARP"
 
+    def test_code_status_endpoint_changes_watch_to_semi(self, portfolio_app):
+        """一覧上部のコード指定操作はユニバース追加でなくステータス変更を行う。"""
+        import portfolio_shelve as ps
+        app, portfolio_db = portfolio_app
+
+        resp = app.test_client().post(
+            "/portfolio/status",
+            data={"code_s": "3496", "new_status": "2準"},
+        )
+
+        assert resp.status_code == 302
+        assert ps.get_record("3496", db_path=portfolio_db)["status"] == "2準"
+
+    def test_code_status_endpoint_requires_strategy_for_hold(self, portfolio_app):
+        """コード指定の保有化でも売買戦略と株数を必須にする。"""
+        import portfolio_shelve as ps
+        app, portfolio_db = portfolio_app
+        client = app.test_client()
+
+        client.post("/portfolio/status", data={
+            "code_s": "3496", "new_status": "1保", "qty": "100",
+        })
+        assert ps.get_record("3496", db_path=portfolio_db)["status"] == "3監"
+
+        client.post("/portfolio/status", data={
+            "code_s": "3496", "new_status": "1保", "qty": "100",
+            "trade_idea": "GARP",
+        })
+        record = ps.get_record("3496", db_path=portfolio_db)
+        assert record["status"] == "1保"
+        assert record["qty"] == 100
+
+    @pytest.mark.parametrize(
+        "status_query, expected_label",
+        [
+            ("hold", "保有に追加"),
+            ("semi", "準保有に追加"),
+            ("watch", "監視に追加"),
+        ],
+    )
+    def test_code_add_button_follows_display_status(
+        self, portfolio_app, status_query, expected_label
+    ):
+        """コード追加の操作先は現在表示中のステータスに一致する。"""
+        app, _ = portfolio_app
+
+        html = app.test_client().get(
+            f"/portfolio?status={status_query}"
+        ).data.decode()
+
+        assert 'id="toggle-status-edit"' in html
+        assert '▷ ステータス編集</button>' in html
+        assert 'id="status-edit-panel" style="display:none;"' in html
+        assert f">{expected_label}</button>" in html
+
 
 class TestPortfolioHoldSummary:
     """保有 (status=hold) フィルタ表示時の運用総額 / 保有株数更新日サマリーの統合テスト"""


### PR DESCRIPTION
## 変更内容

- 一覧のコード追加を、表示中ステータスへの追加に変更
- 保有への追加時は株数・売買戦略をモーダルで入力
- コード追加と一括変更モードを「▷ ステータス編集」の折りたたみ内へ集約

## 確認

- `PYTHONPYCACHEPREFIX=/private/tmp/shintakane-pycache .venv/bin/python -m pytest tests/test_webapp_routes.py::TestTransitionRequiresStrategy -q`
- 9 passed
