### PR TITLE
楽天CSV約定インポートで実現損益を計測 (issue #360 Phase2 (a)+(b)+(c))

### DIFF
--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -108,6 +108,16 @@ cd scripts && python backfill_price_proxy.py             # None のみ埋める 
 cd scripts && python backfill_price_proxy.py --overwrite # actual 以外を再取得
 ```
 
+### 楽天 取引履歴CSV → fill レイヤー取込 (issue #360 Phase2)
+
+楽天証券の取引履歴CSV (`tradehistory(JP)_YYYYMMDD.csv`, Shift-JIS) の実約定価格・株数を fill として取り込み、`--match` でエピソードへ自動マッチする。同一 dedup キーは冪等スキップ。曖昧なケース (同日同side複数注文・候補複数) は自動マッチせず確認リスト行き。
+
+```bash
+cd scripts && python import_rakuten_fills.py "<csv_path>" --dry-run                    # 読込・パース検証 (DB 非書込)
+cd scripts && python import_rakuten_fills.py "<csv_path>" --db-path /tmp/fills_verify   # 一時DBで取込確認
+cd scripts && python import_rakuten_fills.py "<csv_path>" --match                       # 本番取込 + 自動マッチ
+```
+
 ## 自動実行
 
 `shintakane_cron.sh` が `shintakane.py` → `make_stock_db.py` を逐次実行。macOS launchd（`com.k_sohara.shintakane.cron.plist`）で平日19:00に定期実行。

--- a/scripts/import_rakuten_fills.py
+++ b/scripts/import_rakuten_fills.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""楽天証券 取引履歴CSV → portfolio_shelve fill レイヤー 取込 (issue #360 Phase2)。
+
+二層モデル (GitHub コメント 2026-07-11 確定):
+- fill レイヤー (本スクリプトが書く): CSV 由来の約定事実。価格・株数・約定日の真実源。
+- 判断レイヤー (既存 action_log): ステータス・タグ・メモ。CSV では得られない情報。維持。
+
+本スクリプトのスコープ (issue #360 Phase2 (a)+(b)):
+- (a) fill 取込 + dedup 保存 (冪等)
+- (b) --match 指定時、エピソードへ自動マッチして matched_seq を書き戻す
+
+4 層構成 (migrate_portfolio_from_csv.py のパターン踏襲):
+    1. CSV 読込層 (read_csv_rows)
+    2. 行パース層 (parse_fill_row)
+    3. 統合層 (import_csv_to_fills)
+    4. 実行層 (main + argparse)
+
+入力: 楽天 取引履歴CSV `tradehistory(JP)_YYYYMMDD.csv` (Shift-JIS, 28列, ヘッダあり)。
+"""
+
+import argparse
+import csv
+import os
+import sys
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+# scripts/ を sys.path に追加 (直接実行時)
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+
+try:
+    from ks_util import log_print, log_warning
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+
+# ===========================================
+# 定数 (楽天 取引履歴CSV フォーマット)
+# ===========================================
+
+CSV_ENCODING = "shift_jis"
+EXPECTED_COL_COUNT = 28
+
+# 列インデックス (0-indexed、確認済みフォーマット)
+COL_TRADE_DATE = 0     # 約定日 (YYYY/M/D)
+COL_CODE_S = 2         # 銘柄コード
+COL_TRADE_KIND = 6     # 取引区分 (現物 / 信用新規 / 信用返済 / 現物(単元未満))
+COL_BAIBAI = 7         # 売買区分 (買付 / 売付 / 買建 / 売埋)
+COL_QTY = 10           # 数量[株]
+COL_PRICE = 11         # 単価[円]
+COL_AMOUNT = 16        # 受渡金額[円]
+
+HEADER_FIRST_COL = "約定日"  # ヘッダ検証用
+
+
+# ===========================================
+# 1. CSV 読込層
+# ===========================================
+
+def read_csv_rows(csv_path: str) -> List[List[str]]:
+    """楽天 取引履歴CSV を Shift-JIS で読み、ヘッダを除いたデータ行を返す。
+
+    先頭行が既知ヘッダ (約定日...) でなければ ValueError。
+    """
+    with open(csv_path, "r", encoding=CSV_ENCODING, newline="") as f:
+        rows = list(csv.reader(f))
+    if not rows:
+        raise ValueError(f"CSV が空です: {csv_path}")
+    header = rows[0]
+    if not header or header[0].strip() != HEADER_FIRST_COL:
+        raise ValueError(
+            f"想定外のヘッダです (先頭列={header[0]!r}, 期待={HEADER_FIRST_COL!r}): {csv_path}"
+        )
+    return rows[1:]
+
+
+# ===========================================
+# 2. 行パース層
+# ===========================================
+
+def _parse_num(raw: str) -> Optional[float]:
+    """カンマ区切り数値文字列を float に。空欄/"-" は None。"""
+    s = (raw or "").strip().replace(",", "")
+    if s in ("", "-"):
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _normalize_trade_date(raw: str) -> Optional[str]:
+    """約定日 "YYYY/M/D" を "YYYY-MM-DD" に正規化。パース不可なら None。"""
+    s = (raw or "").strip()
+    try:
+        d = datetime.strptime(s, "%Y/%m/%d").date()
+    except ValueError:
+        return None
+    return d.isoformat()
+
+
+class RowSkip(Exception):
+    """パース対象外の行 (無効コード・未知区分・数量欠落など)。理由を保持する。"""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def parse_fill_row(row: List[str]) -> Dict[str, Any]:
+    """CSV 1 行を fill 構築用の中間 dict に変換する。
+
+    現物・信用の両方に対応。対象外行は RowSkip を投げる (呼び出し側でカウント)。
+    dedup_key の occurrence は統合層で付与するため、ここでは素材のみ返す。
+    """
+    if len(row) < EXPECTED_COL_COUNT:
+        raise RowSkip(f"列数不足 ({len(row)})")
+
+    code_raw = (row[COL_CODE_S] or "").strip()
+    try:
+        ps.validate_code_s(code_raw)
+    except (ValueError, TypeError):
+        raise RowSkip(f"無効な銘柄コード: {code_raw!r}")
+    code_s = ps.normalize_code_s(code_raw)
+
+    trade_date = _normalize_trade_date(row[COL_TRADE_DATE])
+    if trade_date is None:
+        raise RowSkip(f"約定日パース不可: {row[COL_TRADE_DATE]!r}")
+
+    baibai = (row[COL_BAIBAI] or "").strip()
+    try:
+        side = ps.normalize_side(baibai)
+    except ValueError as e:
+        raise RowSkip(str(e))
+
+    qty_f = _parse_num(row[COL_QTY])
+    price_f = _parse_num(row[COL_PRICE])
+    if qty_f is None or qty_f <= 0:
+        raise RowSkip(f"数量欠落/不正: {row[COL_QTY]!r}")
+    if price_f is None or price_f <= 0:
+        raise RowSkip(f"単価欠落/不正: {row[COL_PRICE]!r}")
+    amount_f = _parse_num(row[COL_AMOUNT])
+
+    trade_kind = (row[COL_TRADE_KIND] or "").strip()
+
+    return {
+        "code_s": code_s,
+        "trade_date": trade_date,
+        "side": side,
+        "qty": int(qty_f),
+        "price": price_f,
+        "amount": int(amount_f) if amount_f is not None else 0,
+        "trade_kind": trade_kind,
+        "baibai": baibai,
+    }
+
+
+# ===========================================
+# 3. 統合層
+# ===========================================
+
+def import_csv_to_fills(
+    csv_path: str,
+    *,
+    dry_run: bool = False,
+    db_path: Optional[str] = None,
+) -> Dict[str, int]:
+    """CSV を読み、各行を fill として冪等取込する。
+
+    同一CSV内の同一 dedup 素材の出現順 (occurrence) を数えて dedup_key に含める
+    (同日同単価の別注文を別 fill として扱いつつ、再取込は冪等)。
+
+    Returns: {"rows", "imported", "skipped_dup", "skipped_invalid"}
+    """
+    rows = read_csv_rows(csv_path)
+    stats = {"rows": len(rows), "imported": 0, "skipped_dup": 0, "skipped_invalid": 0}
+    occurrence_counter: Dict[str, int] = {}
+    samples: List[Dict[str, Any]] = []
+
+    for row in rows:
+        try:
+            parsed = parse_fill_row(row)
+        except RowSkip as e:
+            stats["skipped_invalid"] += 1
+            log_print("import_rakuten_fills: スキップ", e.reason)
+            continue
+
+        # occurrence: 同一CSV内で dedup 素材が同一な行の出現順
+        occ_key = "|".join(
+            [
+                parsed["trade_date"],
+                parsed["code_s"],
+                parsed["trade_kind"],
+                parsed["baibai"],
+                str(parsed["qty"]),
+                f"{parsed['price']:.4f}",
+                str(parsed["amount"]),
+            ]
+        )
+        occurrence = occurrence_counter.get(occ_key, 0)
+        occurrence_counter[occ_key] = occurrence + 1
+
+        dedup_key = ps.make_dedup_key(
+            trade_date=parsed["trade_date"],
+            code_s=parsed["code_s"],
+            trade_kind=parsed["trade_kind"],
+            baibai_kubun=parsed["baibai"],
+            qty=parsed["qty"],
+            price=parsed["price"],
+            amount=parsed["amount"],
+            occurrence=occurrence,
+        )
+        fill = ps.create_fill(
+            parsed["code_s"],
+            trade_date=parsed["trade_date"],
+            side=parsed["side"],
+            qty=parsed["qty"],
+            price=parsed["price"],
+            amount=parsed["amount"],
+            trade_kind=parsed["trade_kind"],
+            dedup_key=dedup_key,
+        )
+
+        if dry_run:
+            if len(samples) < 3:
+                samples.append(fill)
+            stats["imported"] += 1
+            continue
+
+        _, is_new = ps.append_fill(fill, db_path=db_path)
+        if is_new:
+            stats["imported"] += 1
+        else:
+            stats["skipped_dup"] += 1
+
+    if dry_run and samples:
+        log_print("import_rakuten_fills: dry-run サンプル (先頭 3 件):")
+        for s in samples:
+            log_print(
+                f"  {s['code_s']} {s['trade_date']} {s['side']} "
+                f"qty={s['qty']} price={s['price']} kind={s['trade_kind']}"
+            )
+    return stats
+
+
+# ===========================================
+# 3b. (b) 自動マッチング — fill → action_log エピソード
+# ===========================================
+
+MATCH_WINDOW_DAYS = 3  # 約定日 ±3 暦日 (±5 は隣接エピソードを跨ぎやすいため縮小)
+
+
+def _build_episodes(logs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """action_log 群を trade_history.py と同じ走査でエピソード単位に再構築する。
+
+    各エピソード: {code_s, hold_seq, hold_date, sell_seq, sell_date, has_qty_changes}。
+    sell_seq/sell_date は未売却なら None。fill を「イベント」でなく「エピソードの
+    hold/sell スロット」へ割り当てるための土台。
+    """
+    episodes: List[Dict[str, Any]] = []
+    open_ep: Dict[str, Dict[str, Any]] = {}
+    for log in logs:
+        code_s = log["code_s"]
+        if log.get("status_to") == "1保":
+            if code_s in open_ep:
+                episodes.append(open_ep.pop(code_s))  # 未クローズ再購入 (異常系) を先に確定
+            open_ep[code_s] = {
+                "code_s": code_s,
+                "hold_seq": log["seq"],
+                "hold_date": log["timestamp"][:10],
+                "sell_seq": None,
+                "sell_date": None,
+                "has_qty_changes": False,
+            }
+        elif log.get("action_type") == "株数変更" and code_s in open_ep:
+            open_ep[code_s]["has_qty_changes"] = True
+        elif log.get("action_type") == "売却" and code_s in open_ep:
+            ep = open_ep.pop(code_s)
+            ep["sell_seq"] = log["seq"]
+            ep["sell_date"] = log["timestamp"][:10]
+            episodes.append(ep)
+    episodes.extend(open_ep.values())
+    return episodes
+
+
+def _days_between(a: str, b: str) -> Optional[int]:
+    try:
+        return (date.fromisoformat(a) - date.fromisoformat(b)).days
+    except (ValueError, TypeError):
+        return None
+
+
+def _candidate_slots(
+    fill: Dict[str, Any],
+    episodes: List[Dict[str, Any]],
+    consumed: set,
+) -> List[Tuple[int, int]]:
+    """fill が区間整合する (距離, スロットの seq) 候補を返す (単一 IN のみ、未消費のみ)。
+
+    区間整合 (codexレビュー指摘):
+    - buy fill → hold スロット: |約定日 - hold_date| <= W (端点窓)。
+      かつ 約定日 <= sell_date (このエピソードの sell を跨がない)。
+      かつ 約定日 < 直後エピソードの hold_date (次サイクルに食い込まない)。
+    - sell fill → sell スロット: |約定日 - sell_date| <= W (端点窓)。
+      かつ 約定日 >= hold_date (このエピソードの hold より前でない)。
+      かつ 約定日 > 直前エピソードの sell_date (前サイクルに食い込まない)。
+    距離 = 約定日とスロット端点 (hold_date / sell_date) の暦日差の絶対値。
+    """
+    fd = fill["trade_date"]
+    code_s = fill["code_s"]
+    W = MATCH_WINDOW_DAYS
+    # 同一コードのエピソードを hold_date 昇順に (前後境界の判定に使う)
+    same = sorted(
+        (e for e in episodes if e["code_s"] == code_s and not e["has_qty_changes"]),
+        key=lambda e: e["hold_date"],
+    )
+    slots: List[Tuple[int, int]] = []
+    for i, ep in enumerate(same):
+        if fill["side"] == ps.SIDE_BUY:
+            seq = ep["hold_seq"]
+            if (code_s, seq) in consumed:
+                continue
+            lo = _days_between(fd, ep["hold_date"])  # 約定日 - hold
+            if lo is None or abs(lo) > W:
+                continue  # hold から W 日を超えるものは対象外 (端点窓)
+            # このエピソードの sell_date (あれば) を跨がない
+            if ep["sell_date"] is not None:
+                hi = _days_between(fd, ep["sell_date"])
+                if hi is not None and hi > 0:
+                    continue  # sell を跨いだ買いは別サイクル
+            # 直後エピソードの hold_date に食い込まない
+            if i + 1 < len(same):
+                nxt = _days_between(fd, same[i + 1]["hold_date"])
+                if nxt is not None and nxt >= 0:
+                    continue
+            slots.append((abs(lo), seq))
+        else:  # sell
+            if ep["sell_date"] is None:
+                continue
+            seq = ep["sell_seq"]
+            if (code_s, seq) in consumed:
+                continue
+            hi = _days_between(fd, ep["sell_date"])  # 約定日 - sell
+            if hi is None or abs(hi) > W:
+                continue  # sell から W 日を超えるものは対象外 (端点窓)
+            # このエピソードの hold_date より前の売りは無効
+            lo = _days_between(fd, ep["hold_date"])
+            if lo is not None and lo < 0:
+                continue
+            # 直前エピソードの sell_date に食い込まない
+            if i - 1 >= 0 and same[i - 1]["sell_date"] is not None:
+                prev = _days_between(fd, same[i - 1]["sell_date"])
+                if prev is not None and prev <= 0:
+                    continue
+            slots.append((abs(hi), seq))
+    return slots
+
+
+def match_fills_to_episodes(*, db_path: Optional[str] = None) -> Dict[str, int]:
+    """未マッチ fill をエピソードの hold/sell スロットへ突合し matched_seq を書き戻す。
+
+    安全側の設計 (曖昧さゼロのケースだけ自動反映):
+    - 楽天CSVは注文番号を持たないため、同 (code_s, side, 約定日) の fill が 2 件以上ある
+      コードは「同一注文の分割」か「別イベント」か区別できない。よってその (code_s, side)
+      は丸ごと自動マッチ対象外 (全 fill 未マッチのまま)。
+    - 残った 1 fill = 1 イベントを、エピソード区間で候補を固定した上で最近接一意マッチ。
+      候補スロットのうち距離最小が一意 (2位と厳密に差) かつ未消費のときだけ確定。
+    - 1 スロット (エピソードの hold or sell) は高々 1 fill (二重消費防止)。
+
+    Returns: {"matched", "unmatched", "ambiguous"}
+    """
+    all_fills = ps.list_fills(db_path=db_path)
+    episodes = _build_episodes(ps.list_action_logs(db_path=db_path))
+
+    # (code_s, side, trade_date) ごとの件数 → 2 件以上は曖昧として除外
+    group_count: Dict[Tuple[str, str, str], int] = {}
+    for f in all_fills:
+        key = (f["code_s"], f["side"], f["trade_date"])
+        group_count[key] = group_count.get(key, 0) + 1
+
+    stats = {"matched": 0, "unmatched": 0, "ambiguous": 0}
+    consumed: set = set()  # (code_s, slot_seq) 消費済みスロット
+
+    # 約定日昇順で処理 (早い約定を優先確定)
+    for f in sorted(all_fills, key=lambda x: (x["code_s"], x["trade_date"], x["seq"])):
+        if f.get("matched_seq") is not None:
+            continue  # 既マッチは触らない (冪等)
+        key = (f["code_s"], f["side"], f["trade_date"])
+        if group_count.get(key, 0) >= 2:
+            stats["ambiguous"] += 1
+            log_print(
+                "import_rakuten_fills: 曖昧 (同日同side複数) 未マッチ",
+                f["code_s"], f["side"], f["trade_date"],
+            )
+            continue
+
+        slots = _candidate_slots(f, episodes, consumed)
+        slots.sort(key=lambda x: x[0])
+        # 距離最小が一意 (2位と厳密に差がある) のときだけ確定
+        if slots and (len(slots) == 1 or slots[0][0] < slots[1][0]):
+            _, seq = slots[0]
+            ps.set_fill_matched_seq(f["code_s"], f["seq"], seq, db_path=db_path)
+            consumed.add((f["code_s"], seq))
+            stats["matched"] += 1
+        else:
+            stats["unmatched"] += 1
+            log_print(
+                "import_rakuten_fills: 未マッチ (候補 %d 件)" % len(slots),
+                f["code_s"], f["side"], f["trade_date"],
+            )
+    return stats
+
+
+# ===========================================
+# 4. 実行層
+# ===========================================
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="楽天 取引履歴CSV を fill レイヤーへ取込 (issue #360 Phase2)",
+    )
+    parser.add_argument("csv_path", help="楽天 取引履歴CSV のパス (Shift-JIS)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="読込・パースまで行うが DB へは書かない",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="portfolio_shelve のパス上書き (検証用)",
+    )
+    parser.add_argument(
+        "--match",
+        action="store_true",
+        help="取込後にエピソードへの自動マッチを実行する",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    if not os.path.exists(args.csv_path):
+        log_warning(f"CSV が見つかりません: {args.csv_path}")
+        return 1
+
+    stats = import_csv_to_fills(
+        args.csv_path,
+        dry_run=args.dry_run,
+        db_path=args.db_path,
+    )
+    log_print(
+        "import_rakuten_fills: 取込完了",
+        f"rows={stats['rows']}",
+        f"imported={stats['imported']}",
+        f"skipped_dup={stats['skipped_dup']}",
+        f"skipped_invalid={stats['skipped_invalid']}",
+        "(dry-run)" if args.dry_run else "",
+    )
+
+    if args.match and not args.dry_run:
+        match_stats = match_fills_to_episodes(db_path=args.db_path)
+        log_print(
+            "import_rakuten_fills: マッチ完了",
+            f"matched={match_stats['matched']}",
+            f"unmatched={match_stats['unmatched']}",
+            f"ambiguous={match_stats['ambiguous']}",
+        )
+    elif args.match and args.dry_run:
+        log_warning("--match は --dry-run と併用できません (書き込みが必要)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import_rakuten_fills.py
+++ b/scripts/import_rakuten_fills.py
@@ -387,7 +387,13 @@ def match_fills_to_episodes(*, db_path: Optional[str] = None) -> Dict[str, int]:
         group_count[key] = group_count.get(key, 0) + 1
 
     stats = {"matched": 0, "unmatched": 0, "ambiguous": 0}
-    consumed: set = set()  # (code_s, slot_seq) 消費済みスロット
+    # (code_s, slot_seq) 消費済みスロット。増分取込に備え、既にマッチ済みの fill が
+    # 占有するスロットを先に投入する (別CSVの後日 fill が同一スロットへ再マッチするのを防ぐ)
+    consumed: set = {
+        (f["code_s"], f["matched_seq"])
+        for f in all_fills
+        if f.get("matched_seq") is not None
+    }
 
     # 約定日昇順で処理 (早い約定を優先確定)
     for f in sorted(all_fills, key=lambda x: (x["code_s"], x["trade_date"], x["seq"])):

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -29,6 +29,7 @@ shelve ベースのラッパー。
 
 import fcntl
 import glob
+import hashlib
 import os
 import re
 import threading
@@ -80,6 +81,9 @@ KEY_ACTION_LOG_PREFIX = "action_log:"
 KEY_SEQ_PREFIX = "_seq:"
 KEY_THEME_PREFIX = "theme:"
 KEY_TRADE_IDEA_PREFIX = "trade_idea:"
+# issue #360 Phase2: 楽天CSV 由来の約定事実 (fill レイヤー、イミュータブル)
+KEY_FILL_PREFIX = "fill:"
+KEY_FILL_SEQ_PREFIX = "_fill_seq:"
 
 # テーママスター (issue #282)
 THEME_FIELDS = frozenset({"name", "description", "created_at"})
@@ -193,6 +197,29 @@ ACTION_LOG_FIELDS = frozenset(
         "post_sell_returns",
     }
 )
+
+# issue #360 Phase2: fill レコードの既知フィールド。
+# CSV 由来の約定事実 (価格・株数・約定日) の真実源。イミュータブルに追記のみ。
+FILL_FIELDS = frozenset(
+    {
+        "code_s",
+        "seq",
+        "trade_date",     # 約定日 "YYYY-MM-DD"
+        "side",           # "buy" / "sell" (建玉方向を正規化)
+        "qty",            # 数量[株] (>0)
+        "price",          # 単価[円] (>0, float)
+        "amount",         # 受渡金額[円] (楽天符号のまま int)
+        "trade_kind",     # 元の取引区分 (現物 / 信用新規 / 信用返済 / 現物(単元未満))
+        "dedup_key",      # 冪等取込用ハッシュ
+        "matched_seq",    # マッチした action_log の seq (未マッチは None)
+        "imported_at",    # 取込時刻 ISO8601
+    }
+)
+
+# 建玉方向の正規化 (楽天 売買区分 → side)
+SIDE_BUY = "buy"
+SIDE_SELL = "sell"
+
 
 # 許可されるステータス遷移 (status_from, status_to)
 # (None, "3監") は新規追加。それ以外は (from, to) の組
@@ -427,6 +454,18 @@ def _seq_key(code_s: str) -> str:
 
 def _action_log_prefix_for(code_s: str) -> str:
     return f"{KEY_ACTION_LOG_PREFIX}{code_s}:"
+
+
+def _fill_key(code_s: str, seq: int) -> str:
+    return f"{KEY_FILL_PREFIX}{code_s}:{seq:06d}"
+
+
+def _fill_seq_key(code_s: str) -> str:
+    return f"{KEY_FILL_SEQ_PREFIX}{code_s}"
+
+
+def _fill_prefix_for(code_s: str) -> str:
+    return f"{KEY_FILL_PREFIX}{code_s}:"
 
 
 # ===========================================
@@ -865,6 +904,190 @@ def backfill_price_proxies(
         f"date_fixed={stats['date_fixed']}",
     )
     return stats
+
+
+# ===========================================
+# issue #360 Phase2: fill レイヤー (楽天CSV 由来の約定事実)
+# ===========================================
+
+# 楽天 売買区分 → side 正規化テーブル。買付/買建=buy、売付/売埋=sell。
+_SIDE_BY_BUY_SELL = {
+    "買付": SIDE_BUY,
+    "買建": SIDE_BUY,
+    "売付": SIDE_SELL,
+    "売埋": SIDE_SELL,
+}
+
+
+def normalize_side(baibai_kubun: str) -> str:
+    """楽天 売買区分文字列を side ("buy"/"sell") に正規化する。
+
+    未知の区分は ValueError (取込時に弾いて確認リスト行きにする)。
+    """
+    side = _SIDE_BY_BUY_SELL.get((baibai_kubun or "").strip())
+    if side is None:
+        raise ValueError(f"未知の売買区分: {baibai_kubun!r}")
+    return side
+
+
+def make_dedup_key(
+    *,
+    trade_date: str,
+    code_s: str,
+    trade_kind: str,
+    baibai_kubun: str,
+    qty: int,
+    price: float,
+    amount: int,
+    occurrence: int,
+) -> str:
+    """fill の冪等取込用ハッシュを生成する。
+
+    楽天CSVには注文番号列が無いため、行の内容 + 同一CSV内の出現順 (occurrence) で
+    一意キーを作る。同日同単価の別注文 (正当な重複) は occurrence 違いで別 fill になり、
+    再ダウンロードでは順序が保たれ同じ occurrence になるため冪等。
+    """
+    raw = "|".join(
+        [
+            trade_date,
+            code_s,
+            trade_kind,
+            baibai_kubun,
+            str(qty),
+            f"{price:.4f}",
+            str(amount),
+            str(occurrence),
+        ]
+    )
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def create_fill(
+    code_s: str,
+    *,
+    trade_date: str,
+    side: str,
+    qty: int,
+    price: float,
+    amount: int,
+    trade_kind: str,
+    dedup_key: str,
+    matched_seq: Optional[int] = None,
+) -> Dict[str, Any]:
+    """fill レコード dict を生成する (バリデーション付き)。"""
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    if side not in (SIDE_BUY, SIDE_SELL):
+        raise ValueError(f"invalid side: {side!r} (許容値: {SIDE_BUY!r}/{SIDE_SELL!r})")
+    if not _ACTION_DATE_RE.match(trade_date):
+        raise ValueError(f"trade_date は YYYY-MM-DD 形式で指定してください: {trade_date!r}")
+    if isinstance(qty, bool) or not isinstance(qty, int) or qty <= 0:
+        raise ValueError(f"qty must be a positive int, got {qty!r}")
+    if not isinstance(price, (int, float)) or price <= 0:
+        raise ValueError(f"price must be > 0, got {price!r}")
+    return {
+        "code_s": normalized,
+        "seq": None,          # append_fill で採番
+        "trade_date": trade_date,
+        "side": side,
+        "qty": int(qty),
+        "price": float(price),
+        "amount": int(amount),
+        "trade_kind": trade_kind,
+        "dedup_key": dedup_key,
+        "matched_seq": matched_seq,
+        "imported_at": now_iso(),
+    }
+
+
+def _next_fill_seq(db: ShelveDB, code_s: str) -> int:
+    """指定銘柄の次の fill seq を返し、カウンタを進める (action_log とは別系統)。"""
+    seq_k = _fill_seq_key(code_s)
+    current = db.get(seq_k, 0)
+    nxt = int(current) + 1
+    db[seq_k] = nxt
+    return nxt
+
+
+def append_fill(
+    fill: Dict[str, Any],
+    *,
+    db_path: Optional[str] = None,
+) -> tuple:
+    """fill を1件追記する (dedup_key で冪等)。
+
+    同一 code_s に同じ dedup_key の fill が既にあればスキップ (取込済み)。
+    新規なら _fill_seq を採番して保存する。
+
+    Returns: (fill, is_new: bool) — is_new=False は重複スキップ (既存 fill を返す)
+    """
+    if not isinstance(fill, dict):
+        raise TypeError(f"fill must be dict, got {type(fill).__name__}")
+    code_s = normalize_code_s(fill["code_s"])
+    dedup_key = fill["dedup_key"]
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            prefix = _fill_prefix_for(code_s)
+            for key, value in db.items():
+                if not key.startswith(prefix):
+                    continue
+                if isinstance(value, dict) and value.get("dedup_key") == dedup_key:
+                    return value, False  # 既に取込済み (冪等)
+            seq = _next_fill_seq(db, code_s)
+            stored = dict(fill)
+            stored["seq"] = seq
+            db[_fill_key(code_s, seq)] = stored
+    return stored, True
+
+
+def list_fills(
+    code_s: Optional[str] = None,
+    *,
+    db_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """fill を取得する。code_s 指定でその銘柄のみ、None で全銘柄。(code_s, seq) 昇順。"""
+    if code_s is not None:
+        validate_code_s(code_s)
+        prefix = _fill_prefix_for(normalize_code_s(code_s))
+    else:
+        prefix = KEY_FILL_PREFIX
+    path = _resolve_db_path(db_path)
+    results: List[Dict[str, Any]] = []
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(prefix):
+                continue
+            if not isinstance(value, dict):
+                continue
+            results.append(value)
+    results.sort(key=lambda r: (r.get("code_s", ""), r.get("seq", 0)))
+    return results
+
+
+def set_fill_matched_seq(
+    code_s: str,
+    seq: int,
+    matched_seq: Optional[int],
+    *,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """fill の matched_seq を更新する (マッチング結果の書き戻し)。
+
+    対象が無ければ KeyError。action_log 側は触らず fill 側にリンクを持たせる設計。
+    """
+    validate_code_s(code_s)
+    normalized = normalize_code_s(code_s)
+    key = _fill_key(normalized, seq)
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            entry = db.get(key)
+            if entry is None:
+                raise KeyError(f"fill not found: code_s={code_s!r}, seq={seq}")
+            entry["matched_seq"] = matched_seq
+            db[key] = entry
+    return entry
 
 
 # ===========================================

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4186,6 +4186,44 @@ def build_portfolio_theme_summary(
 
 
 # ===========================================
+# issue #360 Phase2: fill (実約定) の集約
+# ===========================================
+
+def _aggregate_fill_price(fills: list) -> Optional[dict]:
+    """マッチ済み fill 群を株数加重平均単価に畳む。
+
+    現状 (Phase2) は 1 イベント 1 fill だが、将来 (c) で分割約定の群マッチを許した際に
+    複数 fill を 1 価格へまとめられるよう前方互換な集約にする。要素1なら実質そのまま。
+
+    date は群の最も遅い約定日 (買い集め/売り切りの完了日) を代表日とする。
+    issue #360: 楽天の約定日を売買日の真実源として表示・保有日数計算に使う。
+
+    Returns: {"price": 加重平均単価, "qty": 合計株数, "date": 代表約定日} / 不正なら None
+    """
+    if not fills:
+        return None
+    total_qty = 0
+    total_amount = 0.0
+    dates = []
+    for f in fills:
+        qty = f.get("qty")
+        price = f.get("price")
+        if not isinstance(qty, int) or qty <= 0 or not isinstance(price, (int, float)) or price <= 0:
+            return None
+        total_qty += qty
+        total_amount += price * qty
+        if f.get("trade_date"):
+            dates.append(f["trade_date"])
+    if total_qty <= 0:
+        return None
+    return {
+        "price": total_amount / total_qty,
+        "qty": total_qty,
+        "date": max(dates) if dates else None,
+    }
+
+
+# ===========================================
 # issue #361: 売買エピソードの概算損益・成績サマリー
 # ===========================================
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4223,6 +4223,55 @@ def _aggregate_fill_price(fills: list) -> Optional[dict]:
     }
 
 
+_SIDE_LABELS = {"buy": "買", "sell": "売"}
+
+
+def list_unmatched_fills() -> List[Dict[str, Any]]:
+    """取込済みで未マッチ (matched_seq is None) の fill を表示用にまとめて返す (issue #360)。
+
+    エピソードへ自動マッチできなかった約定を /trade-history で可視化するためのリスト。
+    P/L には反映されていない fill を銘柄ごとに一覧して気づけるようにする (閲覧のみ)。
+
+    同日集約: (code_s, side, trade_date) が同じ fill (分割約定) は加重平均単価・合計株数で
+    1 行に畳む。2 件以上を畳んだ行には count と aggregated=True を付ける (可視化)。
+    集約は表示のみで、自動マッチ判定 (b) には影響しない。
+
+    Returns: [{code_s, stock_name, trade_date, side, side_label, qty, price,
+               trade_kind, count, aggregated}, ...] を code_s 昇順 → trade_date 昇順で。
+    """
+    import portfolio_shelve as ps  # 遅延 import (循環回避)
+
+    unmatched = [f for f in ps.list_fills() if f.get("matched_seq") is None]
+    if not unmatched:
+        return []
+
+    # (code_s, side, trade_date) で分割約定をグループ化
+    groups: Dict[Tuple[str, str, str], List[Dict[str, Any]]] = {}
+    for f in unmatched:
+        key = (f["code_s"], f["side"], f["trade_date"])
+        groups.setdefault(key, []).append(f)
+
+    rows: List[Dict[str, Any]] = []
+    for (code_s, side, trade_date), fills in groups.items():
+        agg = _aggregate_fill_price(fills)
+        # 取引区分はグループ内で通常単一。複数種混在時は "/" で併記 (稀)
+        kinds = sorted({f.get("trade_kind", "") for f in fills if f.get("trade_kind")})
+        rows.append({
+            "code_s": code_s,
+            "stock_name": resolve_stock_name(code_s),
+            "trade_date": trade_date,
+            "side": side,
+            "side_label": _SIDE_LABELS.get(side, side),
+            "qty": agg["qty"] if agg else sum(f["qty"] for f in fills),
+            "price": agg["price"] if agg else fills[0]["price"],
+            "trade_kind": " / ".join(kinds),
+            "count": len(fills),
+            "aggregated": len(fills) >= 2,
+        })
+    rows.sort(key=lambda r: (r["code_s"], r["trade_date"]))
+    return rows
+
+
 # ===========================================
 # issue #361: 売買エピソードの概算損益・成績サマリー
 # ===========================================

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -14,6 +14,7 @@ from webapp.helpers import (
     calc_episode_pl,
     calc_post_sell_returns,
     calc_trade_summary,
+    list_unmatched_fills,
     resolve_stock_name,
 )
 
@@ -274,12 +275,16 @@ def trade_history():
     # 年降順のリスト [(year, episodes), ...]
     past_years = sorted(past_by_year.items(), key=lambda x: x[0], reverse=True)
 
+    # issue #360 Phase2 (c): 取込済みで未マッチ (P/L 未反映) の fill を一覧表示 (閲覧のみ)
+    unmatched_fills = list_unmatched_fills()
+
     return render_template(
         "trade_history.html",
         recent=recent,
         past_years=past_years,
         summary=summary,
         closed_count=closed_count,
+        unmatched_fills=unmatched_fills,
     )
 
 

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -9,6 +9,7 @@ from flask import Blueprint, abort, jsonify, render_template, request
 
 import portfolio_shelve as ps
 from webapp.helpers import (
+    _aggregate_fill_price,
     _bulk_price_logs,
     calc_episode_pl,
     calc_post_sell_returns,
@@ -100,6 +101,50 @@ def _last_action_date(ep: dict) -> str:
     return max(dates)
 
 
+def _apply_fill_prices(episodes: list) -> None:
+    """マッチ済み fill (実約定) で hold_price/sell_price/qty/日付をエピソードへ上書きする。
+
+    issue #360 Phase2: fill 側 matched_seq が action_log の seq を指す。seq は code_s ごとの
+    連番なので (code_s, matched_seq) を複合キーにする。買い増し (qty_changes) 混在エピソードは
+    加重平均が proxy と混ざり歪むため対象外 (単一 IN のみ)。上書きは episodes を破壊的に更新。
+
+    日付 (hold_date/sell_date) も楽天の約定日を真実源として上書きする。手動 action_log の
+    timestamp は操作履歴として DB 側にそのまま残し、表示・保有日数計算は約定日を優先する。
+    マッチした側のみ差し替え、未マッチ側は手動日のまま (価格の上書きポリシーと一致)。
+    """
+    fills_by_key: dict = {}  # (code_s, matched_seq) -> [fill, ...]
+    for f in ps.list_fills():
+        matched = f.get("matched_seq")
+        if matched is None:
+            continue
+        fills_by_key.setdefault((f["code_s"], matched), []).append(f)
+
+    if not fills_by_key:
+        return
+
+    for ep in episodes:
+        if ep.get("qty_changes"):
+            continue  # 買い増し混在は proxy のまま (§3 の限定)
+        code_s = ep["code_s"]
+        # 保有開始 (buy fill) → hold_seq にマッチ
+        buy = _aggregate_fill_price(fills_by_key.get((code_s, ep.get("hold_seq")), []))
+        if buy is not None:
+            ep["hold_price"] = buy["price"]
+            if ep.get("hold_qty") is None:
+                ep["hold_qty"] = buy["qty"]
+            if buy.get("date"):
+                ep["hold_date"] = buy["date"]
+        # 売却 (sell fill) → sell_seq にマッチ
+        if ep.get("sell_seq") is not None:
+            sell = _aggregate_fill_price(fills_by_key.get((code_s, ep["sell_seq"]), []))
+            if sell is not None:
+                ep["sell_price"] = sell["price"]
+                if ep.get("sell_qty") is None:
+                    ep["sell_qty"] = sell["qty"]
+                if sell.get("date"):
+                    ep["sell_date"] = sell["date"]
+
+
 @trade_history_bp.route("/trade-history")
 def trade_history():
     """売買履歴ページ — 銘柄×保有エピソードをサブ行展開で表示。"""
@@ -126,6 +171,7 @@ def trade_history():
                 "sell_qty": None,
                 "sell_price": None,
                 "memo_seq": log["seq"],           # 1保ログの seq（未売却時のメモ保存先）
+                "hold_seq": log["seq"],           # 1保ログの seq（fill マッチ解決用、issue #360）
                 "sell_seq": None,
                 "review_memo": log.get("review_memo", ""),
                 "qty_changes": [],
@@ -170,6 +216,13 @@ def trade_history():
     episodes.extend(open_episodes.values())
 
     # エピソード内の最新アクション日 (売却 > 株数変更 > 保有) 降順
+    episodes.sort(key=_last_action_date, reverse=True)
+
+    # issue #360 Phase2: マッチ済み fill (実約定) で hold_price/sell_price/日付を上書きする。
+    # 買い増し (qty_changes) 混在エピソードは加重平均が proxy と混ざり歪むため対象外
+    # (単一 IN のみ)。未マッチ側は従来 price_proxy フォールバックのまま (既存挙動維持)。
+    _apply_fill_prices(episodes)
+    # 日付を約定日に上書きしたので、表示順を約定日基準に揃え直す
     episodes.sort(key=_last_action_date, reverse=True)
 
     # 銘柄名付与・サブ行組み立て・概算損益 (issue #361)

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -126,12 +126,12 @@ def _apply_fill_prices(episodes: list) -> None:
         if ep.get("qty_changes"):
             continue  # 買い増し混在は proxy のまま (§3 の限定)
         code_s = ep["code_s"]
-        # 保有開始 (buy fill) → hold_seq にマッチ
+        # 保有開始 (buy fill) → hold_seq にマッチ。
+        # fill を株数の真実源とするため、手入力 qty があっても実約定株数で置換する。
         buy = _aggregate_fill_price(fills_by_key.get((code_s, ep.get("hold_seq")), []))
         if buy is not None:
             ep["hold_price"] = buy["price"]
-            if ep.get("hold_qty") is None:
-                ep["hold_qty"] = buy["qty"]
+            ep["hold_qty"] = buy["qty"]
             if buy.get("date"):
                 ep["hold_date"] = buy["date"]
         # 売却 (sell fill) → sell_seq にマッチ
@@ -139,9 +139,12 @@ def _apply_fill_prices(episodes: list) -> None:
             sell = _aggregate_fill_price(fills_by_key.get((code_s, ep["sell_seq"]), []))
             if sell is not None:
                 ep["sell_price"] = sell["price"]
-                if ep.get("sell_qty") is None:
-                    ep["sell_qty"] = sell["qty"]
+                ep["sell_qty"] = sell["qty"]
                 if sell.get("date"):
+                    # 約定日で売却日を上書きした場合、保存済み売却後騰落率 (旧手動日基準)
+                    # を無効化する。後段で新約定日を起点に再計算される (issue #366 整合)
+                    if sell["date"] != ep.get("sell_date"):
+                        ep["post_sell_returns"] = {}
                     ep["sell_date"] = sell["date"]
 
 

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -148,6 +148,59 @@
 
 {% endif %}
 
+{# 取込済みで未反映の約定 (issue #360 Phase2 (c))。エピソードの有無に依存せず表示する #}
+{% if unmatched_fills %}
+<div style="margin-top:2em;">
+  <hr style="border:none;border-top:1px solid #333;margin-bottom:1em;">
+  <details>
+    <summary style="color:#c8a050;font-size:0.95em;cursor:pointer;">
+      取込済みで未反映の約定（{{ unmatched_fills|length }} 件）
+    </summary>
+    <p style="color:#888;font-size:0.82em;margin:0.5em 0;">
+      手動記録と対応付かなかった楽天の約定です。P/L には未反映です。
+      同じ日・同じ売買方向の分割約定は加重平均単価でまとめています（「N件集約」）。
+    </p>
+    <table class="trade-history-table">
+      <colgroup>
+        <col style="width:9em;"><col style="width:6em;"><col style="width:4em;">
+        <col style="width:5em;"><col style="width:6em;"><col>
+      </colgroup>
+      <thead>
+        <tr>
+          <th>銘柄</th>
+          <th style="white-space:nowrap;">約定日</th>
+          <th>売買</th>
+          <th style="white-space:nowrap;">株数</th>
+          <th style="white-space:nowrap;">単価</th>
+          <th>取引区分</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for f in unmatched_fills %}
+        <tr>
+          <td style="white-space:nowrap;"><a href="/stock/{{ f.code_s }}">{{ f.code_s }} {{ f.stock_name }}</a></td>
+          <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ f.trade_date[2:4] }}/{{ f.trade_date[5:7] }}/{{ f.trade_date[8:10] }}</td>
+          <td style="white-space:nowrap;">
+            {% if f.side == "buy" %}
+            <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#2e5a6e;color:#9ed8f0;">{{ f.side_label }}</span>
+            {% else %}
+            <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#5a2e2e;color:#f0a0a0;">{{ f.side_label }}</span>
+            {% endif %}
+            {% if f.aggregated %}
+            <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#3a3a2e;color:#c8c070;margin-left:0.2em;">{{ f.count }}件集約</span>
+            {% endif %}
+          </td>
+          <td style="text-align:right;color:#888;font-size:0.85em;">{{ f.qty }}</td>
+          <td style="text-align:right;color:#888;font-size:0.85em;white-space:nowrap;">{{ "{:,}".format(f.price|round|int) }}</td>
+          <td style="color:#777;font-size:0.85em;">{{ f.trade_kind }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </details>
+</div>
+{% endif %}
+
 <script>
 (function () {
   // 振り返りメモ編集

--- a/tests/test_import_rakuten_fills.py
+++ b/tests/test_import_rakuten_fills.py
@@ -1,0 +1,169 @@
+"""import_rakuten_fills.py のテスト (issue #360 Phase2)。
+
+楽天 取引履歴CSV の fill 取込・冪等 dedup・エピソード自動マッチを検証する。
+"""
+
+import csv
+
+import pytest
+
+import import_rakuten_fills as ir
+import portfolio_shelve as ps
+
+# 楽天 取引履歴CSV の実ヘッダ (28列)
+_HEADER = [
+    "約定日", "受渡日", "銘柄コード", "銘柄名", "市場名称", "口座区分", "取引区分",
+    "売買区分", "信用区分", "弁済期限", "数量［株］", "単価［円］", "手数料［円］",
+    "税金等［円］", "諸費用［円］", "税区分", "受渡金額［円］", "建約定日", "建単価［円］",
+    "建手数料［円］", "建手数料消費税［円］", "金利（支払）〔円〕", "金利（受取）〔円〕",
+    "逆日歩／特別空売り料（支払）〔円〕", "逆日歩（受取）〔円〕", "貸株料",
+    "事務管理費〔円〕（税抜）", "名義書換料〔円〕（税抜）",
+]
+
+
+def _row(code_s, trade_kind, baibai, qty, price, trade_date="2026/6/22", amount="0"):
+    """28列の取引行を組み立てる (未使用列は '0' / '-' で埋める)。"""
+    row = ["0"] * 28
+    row[ir.COL_TRADE_DATE] = trade_date
+    row[ir.COL_CODE_S] = code_s
+    row[ir.COL_TRADE_KIND] = trade_kind
+    row[ir.COL_BAIBAI] = baibai
+    row[ir.COL_QTY] = qty
+    row[ir.COL_PRICE] = price
+    row[ir.COL_AMOUNT] = amount
+    return row
+
+
+def _write_csv(path, data_rows):
+    """Shift-JIS で ヘッダ + データ行の CSV を書く。"""
+    with open(path, "w", encoding="shift_jis", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(_HEADER)
+        for r in data_rows:
+            w.writerow(r)
+    return str(path)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_fills_shelve")
+
+
+@pytest.mark.parametrize(
+    "trade_kind,baibai,qty,price,exp_side,exp_qty,exp_price",
+    [
+        ("現物", "買付", "100", "1,925.0", "buy", 100, 1925.0),
+        ("信用新規", "買建", "200", "1,440.0", "buy", 200, 1440.0),
+        ("信用返済", "売埋", "100", "7,590.0", "sell", 100, 7590.0),
+    ],
+)
+def test_parse_row(trade_kind, baibai, qty, price, exp_side, exp_qty, exp_price):
+    """現物買付 / 信用新規買建 / 信用返済売埋 の side/qty/price を検証。"""
+    parsed = ir.parse_fill_row(_row("6315", trade_kind, baibai, qty, price))
+    assert parsed["side"] == exp_side
+    assert parsed["qty"] == exp_qty
+    assert parsed["price"] == exp_price
+
+
+def test_dedup_idempotent(tmp_path, db_path):
+    """同一CSVを2回取込→1回目 imported、2回目 skipped_dup。occurrence違いは別件。"""
+    # 同日同単価の別注文 (occurrence 違い) を 2 行 + 別内容 1 行
+    rows = [
+        _row("6315", "信用新規", "買建", "100", "3,390.0"),
+        _row("6315", "信用新規", "買建", "100", "3,390.0"),  # occurrence=1 → 別 fill
+        _row("3496", "信用新規", "買建", "100", "4,140.0"),
+    ]
+    csv_path = _write_csv(tmp_path / "t.csv", rows)
+
+    s1 = ir.import_csv_to_fills(csv_path, db_path=db_path)
+    assert s1["imported"] == 3 and s1["skipped_dup"] == 0
+    # occurrence 違いで同日同単価が別 fill として 2 件残る
+    assert len(ps.list_fills("6315", db_path=db_path)) == 2
+
+    s2 = ir.import_csv_to_fills(csv_path, db_path=db_path)
+    assert s2["imported"] == 0 and s2["skipped_dup"] == 3
+    assert len(ps.list_fills(db_path=db_path)) == 3  # 総数不変 (冪等)
+
+
+def test_match_single_and_ambiguous(tmp_path, db_path):
+    """buy fill が ±5日内の1保ログに付く / 同日同side2行は曖昧で未マッチ。"""
+    # 6315: 単一 buy → 1保ログにマッチ確定
+    ps.add_to_watch("6315", db_path=db_path)
+    ps.transition_status("6315", "1保", action_date="2026-06-24", qty=100, db_path=db_path)
+    # 3496: 同日同side2行 → 曖昧で未マッチ
+    ps.add_to_watch("3496", db_path=db_path)
+    ps.transition_status("3496", "1保", action_date="2026-06-23", qty=100, db_path=db_path)
+
+    rows = [
+        _row("6315", "信用新規", "買建", "100", "3,390.0", trade_date="2026/6/23"),
+        _row("3496", "信用新規", "買建", "100", "4,140.0", trade_date="2026/6/23"),
+        _row("3496", "信用新規", "買建", "100", "4,200.0", trade_date="2026/6/23"),
+    ]
+    csv_path = _write_csv(tmp_path / "t.csv", rows)
+    ir.import_csv_to_fills(csv_path, db_path=db_path)
+
+    stats = ir.match_fills_to_episodes(db_path=db_path)
+    assert stats["matched"] == 1      # 6315 のみ
+    assert stats["ambiguous"] == 2    # 3496 の 2 行
+
+    matched = [f for f in ps.list_fills("6315", db_path=db_path) if f["matched_seq"] is not None]
+    assert len(matched) == 1
+    # 3496 は全て未マッチ
+    assert all(f["matched_seq"] is None for f in ps.list_fills("3496", db_path=db_path))
+
+
+def test_match_no_double_consume(tmp_path, db_path):
+    """1つの1保スロットに対し近接2 fill があっても、消費されるのは1件だけ。"""
+    ps.add_to_watch("6315", db_path=db_path)
+    ps.transition_status("6315", "1保", action_date="2026-06-24", qty=100, db_path=db_path)
+    # 別々の約定日 (曖昧集約は回避) だが両方が同じ1保スロットの±3日窓に入る buy 2 件
+    rows = [
+        _row("6315", "信用新規", "買建", "100", "3,390.0", trade_date="2026/6/23"),
+        _row("6315", "信用新規", "買建", "100", "3,400.0", trade_date="2026/6/25"),
+    ]
+    csv_path = _write_csv(tmp_path / "t.csv", rows)
+    ir.import_csv_to_fills(csv_path, db_path=db_path)
+
+    stats = ir.match_fills_to_episodes(db_path=db_path)
+    # 1保スロットは1つしかないので、マッチ確定は高々1件 (二重消費されない)
+    assert stats["matched"] == 1
+    matched = [f for f in ps.list_fills("6315", db_path=db_path) if f["matched_seq"] is not None]
+    assert len(matched) == 1
+
+
+def test_match_two_episodes_no_cross(tmp_path, db_path):
+    """同一コードで近接2エピソード時、buy/sell が各エピソードの最近接スロットにのみ付き跨がない。
+
+    6227 縮図: 保有(6/20)→売却(6/25) と 保有(7/01)→売却(7/06) の2サイクル。
+    各サイクルの実約定 buy/sell が、隣サイクルに吸着せず自分の区間に収まる。
+    """
+    ps.add_to_watch("6227", db_path=db_path)
+    # サイクル1
+    ps.transition_status("6227", "1保", action_date="2026-06-20", qty=100, db_path=db_path)
+    ps.transition_status("6227", "2準", action_date="2026-06-25", db_path=db_path)
+    # サイクル2
+    ps.transition_status("6227", "1保", action_date="2026-07-01", qty=100, db_path=db_path)
+    ps.transition_status("6227", "2準", action_date="2026-07-06", db_path=db_path)
+
+    rows = [
+        _row("6227", "信用新規", "買建", "100", "7,000.0", trade_date="2026/6/21"),  # cyc1 buy
+        _row("6227", "信用返済", "売埋", "100", "7,300.0", trade_date="2026/6/24"),  # cyc1 sell
+        _row("6227", "信用新規", "買建", "100", "6,800.0", trade_date="2026/7/02"),  # cyc2 buy
+        _row("6227", "信用返済", "売埋", "100", "7,100.0", trade_date="2026/7/05"),  # cyc2 sell
+    ]
+    csv_path = _write_csv(tmp_path / "t.csv", rows)
+    ir.import_csv_to_fills(csv_path, db_path=db_path)
+    stats = ir.match_fills_to_episodes(db_path=db_path)
+
+    assert stats["matched"] == 4  # 4件すべてが自分のサイクルにマッチ
+
+    logs = ps.list_action_logs("6227", db_path=db_path)
+    hold_seqs = sorted(l["seq"] for l in logs if l.get("status_to") == "1保")
+    sell_seqs = sorted(l["seq"] for l in logs if l.get("action_type") == "売却")
+    fills = {(f["side"], f["trade_date"]): f["matched_seq"]
+             for f in ps.list_fills("6227", db_path=db_path)}
+    # cyc1 buy(6/21) は早い方の1保、cyc2 buy(7/02) は遅い方の1保 (跨がない)
+    assert fills[("buy", "2026-06-21")] == hold_seqs[0]
+    assert fills[("buy", "2026-07-02")] == hold_seqs[1]
+    assert fills[("sell", "2026-06-24")] == sell_seqs[0]
+    assert fills[("sell", "2026-07-05")] == sell_seqs[1]

--- a/tests/test_import_rakuten_fills.py
+++ b/tests/test_import_rakuten_fills.py
@@ -113,7 +113,7 @@ def test_match_single_and_ambiguous(tmp_path, db_path):
 
 
 def test_match_no_double_consume(tmp_path, db_path):
-    """1つの1保スロットに対し近接2 fill があっても、消費されるのは1件だけ。"""
+    """1つの1保スロットに対し近接2 fill があっても消費は1件、増分取込でも再マッチしない。"""
     ps.add_to_watch("6315", db_path=db_path)
     ps.transition_status("6315", "1保", action_date="2026-06-24", qty=100, db_path=db_path)
     # 別々の約定日 (曖昧集約は回避) だが両方が同じ1保スロットの±3日窓に入る buy 2 件
@@ -129,6 +129,15 @@ def test_match_no_double_consume(tmp_path, db_path):
     assert stats["matched"] == 1
     matched = [f for f in ps.list_fills("6315", db_path=db_path) if f["matched_seq"] is not None]
     assert len(matched) == 1
+
+    # 増分取込: 後日の別CSVで同スロット近傍の buy を追加し再マッチしても、既マッチ
+    # スロットは消費済みとして除外され二重マッチしない (P1)
+    rows2 = [_row("6315", "信用新規", "買建", "100", "3,410.0", trade_date="2026/6/26")]
+    csv2 = _write_csv(tmp_path / "t2.csv", rows2)
+    ir.import_csv_to_fills(csv2, db_path=db_path)
+    ir.match_fills_to_episodes(db_path=db_path)
+    matched2 = [f for f in ps.list_fills("6315", db_path=db_path) if f["matched_seq"] is not None]
+    assert len(matched2) == 1  # 増分後もマッチは1件のまま
 
 
 def test_match_two_episodes_no_cross(tmp_path, db_path):

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -132,6 +132,62 @@ class TestTradeHistoryPage:
         assert "26/06/10" in html     # 約定日 (buy)
         assert "26/06/20" in html     # 約定日 (sell)
 
+    def test_unmatched_fills_listed(self, app, client):
+        """未マッチ fill が未反映セクションに一覧・同日集約され、マッチ済みは出ない (issue #360 (c))。
+
+        3496 に未マッチ buy を1件 + 同日同side2件 (分割約定) を足し、6324 にはマッチ済み fill を
+        足す。同日同side2件は加重平均単価・合計株数で1行に集約され「2件集約」バッジが出る。
+        6324 のマッチ済み単価はセクションに出ないことを確認する。
+        """
+        with app.app_context():
+            logs = ps.list_action_logs("6324")
+            hold_seq = next(l["seq"] for l in logs if l.get("status_to") == "1保")
+            matched = ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=100,
+                                     price=6990.0, amount=-699000, trade_kind="信用新規",
+                                     dedup_key="um-matched")
+            ps.append_fill(matched)
+            ps.set_fill_matched_seq("6324", ps.list_fills("6324")[0]["seq"], hold_seq)
+            # 3496: 未マッチ buy 1件 + 同日同side2件 (分割約定 → 加重平均集約)
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-15", side="buy", qty=100,
+                                          price=1234.0, amount=-123400, trade_kind="現物",
+                                          dedup_key="um-a"))
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-18", side="sell", qty=50,
+                                          price=1500.0, amount=75000, trade_kind="現物",
+                                          dedup_key="um-b1"))
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-18", side="sell", qty=50,
+                                          price=1510.0, amount=75500, trade_kind="現物",
+                                          dedup_key="um-b2"))
+
+        html = client.get("/trade-history").data.decode()
+        section = html.split("取込済みで未反映")[1]
+        assert "取込済みで未反映の約定" in html
+        assert "1,234" in section        # 未マッチ単発 buy の単価
+        assert "2件集約" in section       # 分割約定を集約したバッジ
+        assert "1,505" in section        # 集約後の加重平均単価 (50@1500 + 50@1510)
+        assert "6,990" not in section     # マッチ済みはセクション外
+
+    def test_unmatched_fills_shown_without_episodes(self, tmp_path, monkeypatch):
+        """action_log が空でも未マッチ fill セクションは表示される (codexレビュー指摘)。"""
+        portfolio_db = str(tmp_path / "pf_um")
+        stocks_db = str(tmp_path / "st_um")
+        research_db = str(tmp_path / "rs_um")
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db)
+        monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db)
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", research_db)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", research_db)
+        monkeypatch.setattr("portfolio_shelve.DATA_DIR", str(tmp_path))
+        ps.append_fill(ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=100,
+                                      price=5000.0, amount=-500000, trade_kind="信用新規",
+                                      dedup_key="um-noep"), db_path=portfolio_db)
+        app2 = create_app()
+        app2.config["TESTING"] = True
+        html = app2.test_client().get("/trade-history").data.decode()
+        assert "売買履歴がありません" in html
+        assert "取込済みで未反映の約定" in html
+        assert "5,000" in html
+
     def test_all_episodes_have_review_memo_textarea(self, client):
         """売却済み・未売却どちらのエピソードにも textarea が表示される。"""
         html = client.get("/trade-history").data.decode()

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -101,6 +101,37 @@ class TestTradeHistoryPage:
         saved = next(l for l in ps.list_action_logs("6324") if l["action_type"] == "売却")
         assert saved["post_sell_returns"].keys() == {"5d", "20d"}
 
+    def test_matched_fill_overrides_price_qty_date(self, app, client):
+        """マッチ済み fill があると 6324 の売却済みエピソードの株価・株数・日付が実約定で上書き。
+
+        1保ログ・売却ログには手入力の株数プロキシが無い代わりに、fill を株数の真実源として
+        置換する (P2a)。日付も約定日で上書きされる。
+        """
+        with app.app_context():
+            logs = ps.list_action_logs("6324")
+            hold_seq = next(l["seq"] for l in logs if l.get("status_to") == "1保")
+            sell_seq = next(l["seq"] for l in logs if l["action_type"] == "売却")
+            # buy fill (hold) と sell fill を作成し、対応ログへマッチ済みにする
+            buy = ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=300,
+                                 price=6990.0, amount=-2097000, trade_kind="信用新規",
+                                 dedup_key="th-buy")
+            _, _ = ps.append_fill(buy)
+            sell = ps.create_fill("6324", trade_date="2026-06-20", side="sell", qty=300,
+                                  price=7810.0, amount=2343000, trade_kind="信用返済",
+                                  dedup_key="th-sell")
+            _, _ = ps.append_fill(sell)
+            for f in ps.list_fills("6324"):
+                seq = hold_seq if f["side"] == "buy" else sell_seq
+                ps.set_fill_matched_seq("6324", f["seq"], seq)
+
+        html = client.get("/trade-history").data.decode()
+        # 実約定価格・株数・約定日が反映される (proxy 5,678 ではなく 6,990/7,810)
+        assert "6,990" in html
+        assert "7,810" in html
+        assert "300" in html          # 実約定株数
+        assert "26/06/10" in html     # 約定日 (buy)
+        assert "26/06/20" in html     # 約定日 (sell)
+
     def test_all_episodes_have_review_memo_textarea(self, client):
         """売却済み・未売却どちらのエピソードにも textarea が表示される。"""
         html = client.get("/trade-history").data.decode()


### PR DESCRIPTION
## 概要

issue #360 Phase 2 の (a)+(b)+(c)。二層モデル (約定=fill レイヤー / 判断=action_log) で楽天取引履歴CSVを取り込み、**実約定価格・株数・約定日**をエピソードへ対応付けてP/Lの精度を上げる。

Refs #360 (親 issue のため Closes は使わない)

## 実装

### (a) fill 取込 + dedup
- `portfolio_shelve.py` に fill レイヤーCRUD (`create_fill`/`append_fill`/`list_fills`/`set_fill_matched_seq`)。**既存関数は無変更**
- `dedup_key` で冪等取込 (楽天CSVに注文番号列が無いため occurrence index 込み)
- `import_rakuten_fills.py` (新規): Shift-JIS 28列パース、現物・信用両対応、`--dry-run`/`--db-path`/`--match`

### (b) 自動マッチ + P/L・日付上書き
- **エピソード区間ベースの最近接一意マッチ**: fill を「イベント」でなく「エピソードの hold/sell スロット」へ割当。区間整合 (sell を跨がない/隣サイクルに食い込まない) + 端点窓 ±3日 + 最近接一意で誤マッチを防ぐ
- 同日同side複数注文・候補曖昧は**未マッチ** (確認リスト行き = (c)で対応)。1スロット1fillで二重消費防止
- `trade_history.py`: マッチ済み fill で hold/sell の**価格・株数・日付**を上書き (単一INのみ)。日付は楽天約定日を真実源とし、action_log の timestamp は操作履歴として維持。上書き後に表示順を再ソート。未マッチは従来の `price_proxy` フォールバック

### (c) 未マッチ確認リストUI (同日集約)
- 取り込んだが自動マッチできず P/L 未反映の fill を `/trade-history` 末尾に折りたたみセクションで一覧表示 (閲覧のみ)
- 同日・同 side の分割約定は**加重平均単価・合計株数で1行に集約**し「N件集約」バッジで可視化 (集約は表示のみ、マッチ判定 (b) には影響しない)
- `helpers.list_unmatched_fills()` + テンプレート。エピソードの有無に依存せず表示

## スコープ外
- **(d) 株数突合警告は実装しない** (方針転換)。本実装を進める中で「楽天CSV (fill) を売買履歴の本体とし、手動メモは補助情報として本体に合流させる」方向が見えたため。fill 累計と手動株数の整合を取り続けると破綻するので、突合警告ではなく本体化で解決する → **別issueに切り出し**
- 手数料・金利は概算無視

## 検証
- 新規テスト (parametrize含む) green / 既存テスト green (回帰なし)
- 実CSV (73約定): imported=73、2回目 skipped_dup=73 (冪等)
- **厳格化マッチ10件すべて日付差2日以内** (誤マッチゼロ、頻度売買銘柄 6227 も破綻なし)
- (c) 本番DB目視: 未マッチ 63 fill → 56行に集約 (285A 8株@97,242 / 5243 300株@2,267 など加重平均が正確)
- 保有日数マイナス0件、時系列破綻なし

## 設計プロセス
「日付も楽天約定日を真実源に」という要望が ±5日窓による隣エピソード誤マッチを炙り出し、codex レビュー (複数系統) でエピソード区間ベースの最近接一意マッチに厳格化・窓±3日に絞って解決。(c) も codex レビューでセクション配置の欠陥 (エピソード無しで非表示) を修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
