### PR TITLE
feat(signal): 週ブ (出来高dry up後の5日間出来高拡大ブレイク) を追加 (#384)

### DIFF
--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -1143,6 +1143,9 @@ def extract_signals(stock, max_delta_days=10, include_extended=False):
     breakout = stock.get("breakout", [])
     if breakout and not stage4:
         sources.append(("ブ", list(breakout)[:1], False))  # ブは最新1件のみ
+    vol_dryup_bo = stock.get("volume_dryup_breakout", [])
+    if vol_dryup_bo and not stage4:
+        sources.append(("週ブ", list(vol_dryup_bo)[:1], False))  # 週ブも最新1件のみ (issue #384)
     if include_extended and not stage4:
         breakout_ext = stock.get("breakout_extended", [])
         if breakout_ext:
@@ -1170,6 +1173,12 @@ def extract_signals(stock, max_delta_days=10, include_extended=False):
                 "kind": kind, "mmdd": spl[0], "num": num,
                 "sig_date": sig_date, "delta": delta,
             }
+            # 週ブは3要素目に dry up 比率% を持つ (tooltip 用, issue #384)。
+            if kind == "週ブ" and len(spl) >= 3:
+                try:
+                    entry["dryup"] = int(spl[2])
+                except ValueError:
+                    pass
             if extended:
                 entry["extended"] = True
                 # 3要素目があれば出来高超過率 (描画側のマーカー強度バケット用)。
@@ -1344,6 +1353,18 @@ def make_signal(stock, market_db=None, topix_map=None, rs_line=None):
                 log_warning("ブレイクアウト日付エラー", brkspl[0])
             signal += "[ブ]"
             signal += "%s(%s)," % (brkspl[0], brkspl[1])
+            break  # 一つにしておく(最新日)
+    # 週ブ (出来高dry up後の5日間出来高拡大ブレイクアウト, issue #384)
+    vol_dryup_bo = stock.get("volume_dryup_breakout", [])
+    if not stage4:
+        for vdb in vol_dryup_bo:
+            vdbspl = vdb.split(",")
+            try:
+                delta_day = get_recent_signal_delta(vdbspl[0])
+            except ValueError:
+                log_warning("週ブ日付エラー", vdbspl[0])
+            signal += "[週ブ]"
+            signal += "%s(%s)," % (vdbspl[0], vdbspl[1])
             break  # 一つにしておく(最新日)
     # 売り圧力レシオ(5日)による買われ過ぎ売われすぎ
     sell_ratio = stock.get("sell_pressure_ratio", [])

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -1857,6 +1857,105 @@ def parse_date_str(s):
         return None
 
 
+# ---- 週ブ (volume_dryup_breakout, issue #384) の判定パラメータ
+# 「乾(出来高dry up)→増(5日間の出来高拡大)→抜(価格上抜け)」を検知する。
+# 日次「ブ」(単日の出来高急増) と別軸で、複数営業日にわたる出来高拡大局面を拾う。
+VDB_EXPAND_DAYS = 5          # 拡大期間 (直近営業日数): 出来高拡大・価格上抜けを評価
+VDB_SETUP_DAYS = 20          # セットアップ期間 (拡大期間の直前): 通常出来高・dry up を評価
+VDB_DRYUP_LOOKBACK = 10      # セットアップ期間のうち dry up を探す直近日数
+VDB_MIN_DAYS = VDB_EXPAND_DAYS + VDB_SETUP_DAYS  # 必要データ数 (25営業日)
+VDB_DRYUP_RATIO = 0.60       # dry up 判定 (基準比): この比率以下が2日以上
+VDB_DRYUP_STRONG_RATIO = 0.45  # 強い dry up (基準比): この比率以下が1日以上でも可
+VDB_EXPAND_AVG_RATIO = 1.5   # 増: 5日平均出来高が基準比この倍以上
+VDB_EXPAND_DAY_RATIO = 1.2   # 増: 5日中この倍以上の日が
+VDB_EXPAND_DAY_COUNT = 3     # 増: 上記を満たす日が3日以上
+
+
+def _vdb_check(price_list, offset):
+    """price_list[offset:] を最新日とみなし週ブ条件 (乾→増→抜) を判定する。
+
+    Args:
+        price_list: [date_str, open, high, low, close, volume, adj_close] (新しい日が先頭)
+        offset: 最新日とみなす起点インデックス
+    Returns:
+        (per, dryup_pct) | None: 成立時は (5日平均出来高の基準比%, 最小出来高の基準比%)。
+        不成立・データ不足・基準出来高0 なら None。
+    """
+    from statistics import median
+
+    seg = price_list[offset:]
+    if len(seg) < VDB_MIN_DAYS:
+        return None
+    expand = seg[:VDB_EXPAND_DAYS]                       # 直近5日
+    setup = seg[VDB_EXPAND_DAYS:VDB_EXPAND_DAYS + VDB_SETUP_DAYS]  # 直前20日
+    dryup_window = setup[:VDB_DRYUP_LOOKBACK]            # セットアップの直近10日
+
+    setup_vols = [row[5] for row in setup]
+    base_vol = median(setup_vols)                        # 基準出来高 (中央値)
+    if base_vol <= 0:
+        return None
+
+    # 1. dry up (乾): 基準×0.60以下が2日以上、or 基準×0.45以下が1日以上
+    dryup_vols = [row[5] for row in dryup_window]
+    n_dryup = sum(1 for v in dryup_vols if v <= base_vol * VDB_DRYUP_RATIO)
+    n_strong = sum(1 for v in dryup_vols if v <= base_vol * VDB_DRYUP_STRONG_RATIO)
+    if not (n_dryup >= 2 or n_strong >= 1):
+        return None
+
+    # 2. 出来高拡大 (増): 5日平均≥基準×1.5 かつ 5日中3日以上が基準×1.2以上
+    expand_vols = [row[5] for row in expand]
+    avg5 = sum(expand_vols) / len(expand_vols)
+    if avg5 < base_vol * VDB_EXPAND_AVG_RATIO:
+        return None
+    n_expand = sum(1 for v in expand_vols if v >= base_vol * VDB_EXPAND_DAY_RATIO)
+    if n_expand < VDB_EXPAND_DAY_COUNT:
+        return None
+
+    # 3. 価格上抜け (抜): 直近5日終値高値 > セットアップ20日終値高値 かつ 最新終値≥MA10
+    expand_close_high = max(row[6] for row in expand)
+    setup_close_high = max(row[6] for row in setup)
+    if expand_close_high <= setup_close_high:
+        return None
+    ma10 = sum(seg[i][6] for i in range(10)) / 10        # 直近10日終値平均
+    if seg[0][6] < ma10:
+        return None
+
+    per = int(round(100 * avg5 / base_vol))
+    dryup_pct = int(round(100 * min(dryup_vols) / base_vol))
+    return per, dryup_pct
+
+
+def calc_volume_dryup_breakout(price_list):
+    """週ブ (出来高dry up後の5日間出来高拡大ブレイクアウト) を検知する (issue #384)。
+
+    直近10日を走査し、当日 (offset) で全条件が成立し、かつ前日 (offset+1) では
+    成立していなかった「初成立日」だけを記録する (連日成立時の重複記録を防ぐ)。
+
+    Returns:
+        list[str]: ["MM/DD,per,dryup_pct"] (新しい日が先頭)。per=5日平均出来高の
+            基準中央値比%、dryup_pct=セットアップ直近10日の最小出来高の基準比%。
+    """
+    out = []
+    # 各 ind で当日 (ind) と前日 (ind+1) を判定する。隣接 ind 間で ind+1 の判定が
+    # 重複するため、直前反復の当日結果を prev_res として持ち回し再計算を避ける。
+    prev_res = _vdb_check(price_list, 0)  # ind=0 の当日結果 (最新日)
+    for ind in range(10):
+        res = prev_res  # = _vdb_check(price_list, ind)
+        next_res = _vdb_check(price_list, ind + 1)  # 前日 (次反復では当日になる)
+        prev_res = next_res
+        if res is None:
+            continue
+        # 前日も成立していれば同一局面として重複記録しない (初成立日のみ)。
+        if next_res is not None:
+            continue
+        per, dryup_pct = res
+        dt = parse_date_str(price_list[ind][0])
+        day = dt.strftime("%m/%d") if dt else price_list[ind][0]
+        log_debug("週ブ:%s,%d,%d" % (day, per, dryup_pct))
+        out.append("%s,%d,%d" % (day, per, dryup_pct))
+    return out
+
+
 def parse_price_text_from_list(price_current, price_list):
     """パース済みprice_listから各種指標を計算する
     yfinanceパスとHTMLパースパス共通で使用。
@@ -2009,6 +2108,10 @@ def parse_price_text_from_list(price_current, price_list):
     price["breakout"] = breaks
     price["breakout_extended"] = breaks_ext
     # print breaks
+
+    # ---- 週ブ (出来高dry up後の5日間出来高拡大ブレイクアウト, issue #384)
+    price["volume_dryup_breakout"] = calc_volume_dryup_breakout(price_list)
+
     # ---- 過去価格
     past_prices = []
     # 20日前比較に必要な 21件 + バッファ

--- a/scripts/price.py
+++ b/scripts/price.py
@@ -1911,10 +1911,11 @@ def _vdb_check(price_list, offset):
     if n_expand < VDB_EXPAND_DAY_COUNT:
         return None
 
-    # 3. 価格上抜け (抜): 直近5日終値高値 > セットアップ20日終値高値 かつ 最新終値≥MA10
-    expand_close_high = max(row[6] for row in expand)
+    # 3. 価格上抜け (抜): 最新終値 (発生日) がセットアップ20日終値高値を上回り、
+    # かつ MA10 以上。5日中どこか1日が高値超えでは、その後レンジ内へ戻った銘柄を
+    # 発生日 (最新日) の上抜けとして誤検知するため、最新終値そのもので判定する。
     setup_close_high = max(row[6] for row in setup)
-    if expand_close_high <= setup_close_high:
+    if seg[0][6] <= setup_close_high:
         return None
     ma10 = sum(seg[i][6] for i in range(10)) / 10        # 直近10日終値平均
     if seg[0][6] < ma10:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2088,6 +2088,13 @@ def _signal_strength_bucket(kind: str, num: int) -> str:
         if num >= -3:
             return "中"
         return "弱"
+    if kind == "週ブ":
+        # num = 5日平均出来高の基準中央値比% (成立条件上 150 以上)。未較正 (issue #384)。
+        if num >= 250:
+            return "強"
+        if num >= 200:
+            return "中"
+        return "弱"
     # ブ
     if num >= 500:
         return "特強"
@@ -2126,7 +2133,16 @@ def _build_signal_display(stock: Dict[str, Any]) -> Dict[str, str]:
     max_alpha = 0.0
     for s in signals:
         bucket = _signal_strength_bucket(s["kind"], s["num"])
-        lines.append(tmpls[s["kind"]] % (s["mmdd"], bucket, s["num"], s["delta"]))
+        if s["kind"] == "週ブ":
+            # 週ブは dry up 比率も出す (issue #384)。旧データで dryup 欠落時は ? 表示。
+            dryup = s.get("dryup")
+            dryup_str = "%d" % dryup if dryup is not None else "?"
+            lines.append(
+                "[週ブ] %s %s 乾%s%%→5日出来高 中央値比%d%% 20日高値上抜け / %d日前"
+                % (s["mmdd"], bucket, dryup_str, s["num"], s["delta"])
+            )
+        else:
+            lines.append(tmpls[s["kind"]] % (s["mmdd"], bucket, s["num"], s["delta"]))
         max_alpha = max(max_alpha,
                         strength_alpha[bucket] * _signal_freshness_alpha(s["delta"]))
 
@@ -3294,6 +3310,11 @@ def build_price_rs_chart_full(
             if m["kind"] == "ポ":
                 parts.append(_svg_hover_rect(m["x"], y_po, 8.0, 8.0, title))
                 parts.append(_svg_triangle(m["x"], y_po, size * PO_SIZE_SCALE, "#2e7d32", 1.0, title))
+            elif m["kind"] == "週ブ":
+                # 週ブは通常ブ (橙) と区別して紫ダイヤ。ブと同発生週で重ならないよう上段 (issue #384)。
+                y_wbu = y_bu - 6
+                parts.append(_svg_hover_rect(m["x"], y_wbu, 8.0, 8.0, title))
+                parts.append(_svg_diamond(m["x"], y_wbu, size * BU_SIZE_SCALE, "#8e24aa", opa_map[m["strength"]], title))
             else:  # ブ
                 parts.append(_svg_hover_rect(m["x"], y_bu, 8.0, 8.0, title))
                 parts.append(_svg_diamond(m["x"], y_bu, size * BU_SIZE_SCALE, "#f57c00", opa_map[m["strength"]], title))

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -436,6 +436,10 @@ class TestExtractSignals:
                 "breakout": ["%s,180" % d(1), "%s,200" % d(2)]}, ["ブ"]),
             # delta>10 は除外
             ("stale_drop", lambda d: {"pocket_pivot": ["%s,2" % d(12)]}, []),
+            # 週ブは最新1件のみ (issue #384)
+            ("wbo_cap1", lambda d: {
+                "volume_dryup_breakout": ["%s,168,42" % d(1), "%s,150,50" % d(5)]},
+             ["週ブ"]),
         ],
     )
     def test_filter_matches_tags(self, case, kw_factory, expect_kinds):
@@ -450,6 +454,17 @@ class TestExtractSignals:
         """access_date_price 無し → 日付基準が立たず空 (tags と同じ)"""
         stock = {"pocket_pivot": ["06/03,2"], "trend_template": []}
         assert make_stock_db.extract_signals(stock) == []
+
+    def test_weekly_breakout_dryup_parsed(self):
+        """週ブは3要素目 (dry up比率%) を entry["dryup"] に読む (issue #384 tooltip 用)。"""
+        today = datetime.today()
+        d = (today - timedelta(days=2)).strftime("%m/%d")
+        stock, _ = self._stock(volume_dryup_breakout=["%s,168,42" % d])
+        signals = make_stock_db.extract_signals(stock)
+        assert len(signals) == 1
+        assert signals[0]["kind"] == "週ブ"
+        assert signals[0]["num"] == 168  # 5日平均出来高の中央値比%
+        assert signals[0]["dryup"] == 42  # dry up 比率%
 
     @pytest.mark.parametrize("suffix, expect_per", [
         (",13,256", 256),  # 3要素: per あり (マーカー強度バケット用)

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -1654,10 +1654,28 @@ class TestCalcVolumeDryupBreakout:
 
     def test_no_price_breakout_not_detected(self):
         """ケース4: dry up+出来高拡大があっても価格上抜けがなければ検出されない。"""
-        # 終値をフラット (1000) に保つ → expand高値 == setup高値で上抜けなし。
+        # 終値をフラット (1000) に保つ → 最新終値 == setup高値で上抜けなし。
         vols, closes = self._case(
             vol_head=self.DETECT_VOL, close_head=None, length=25
         )
+        price_list = _make_vdb_price_list(vols, closes)
+        assert price.calc_volume_dryup_breakout(price_list) == []
+
+    def test_intraweek_breakout_but_latest_back_in_range_not_detected(self):
+        """ケース6: 5日内に瞬間ブレイクがあっても最新終値がレンジ内なら検出しない。
+
+        直近5日のどこか1日が20日高値を超えても、発生日 (最新終値) が
+        setup 高値以下ならレンジ内へ戻ったとみなす (Codex P2 指摘)。
+        """
+        # setup に古い高値 (index24=2000) を置き setup_close_high=2000。
+        # expand は index1 で瞬間ブレイク (2100>2000) するが、最新 index0=1500 は
+        # setup 高値未満。ただし MA10 (直近10日平均≒1179) は上回るため、上抜け条件
+        # だけで弾かれることを確認する (MA10 条件では落ちない構成)。
+        close_head = [1500, 2100, 1080, 1060, 1050]
+        vols, closes = self._case(
+            vol_head=self.DETECT_VOL, close_head=close_head, length=25
+        )
+        closes[24] = 2000  # setup 期間の古い高値
         price_list = _make_vdb_price_list(vols, closes)
         assert price.calc_volume_dryup_breakout(price_list) == []
 

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -1573,3 +1573,105 @@ class TestMonthlyConvertAndCacheFresh:
             mock_dt.now.return_value = _dt(2026, 7, 12, 20, 0)
             mock_dt.side_effect = lambda *a, **kw: _dt(*a, **kw)
             assert price._is_monthly_cache_fresh([row]) is expected
+
+
+# ==================================================
+# calc_volume_dryup_breakout (週ブ, issue #384)
+# ==================================================
+def _make_vdb_price_list(volumes, closes):
+    """出来高・終値リスト (新しい日が先頭) から price_list を組み立てる。
+
+    calc_volume_dryup_breakout が参照するのは [5]=出来高 と [6]=終値のみ。
+    日付は最新を先頭に 1日刻みで降順に振る。
+    """
+    price_list = []
+    for i, (vol, close) in enumerate(zip(volumes, closes)):
+        day = 30 - i  # 先頭ほど新しい日
+        date_str = "2025年6月%d日" % day
+        # [date, open, high, low, close, volume, adj_close]。判定は [5],[6] のみ使用。
+        price_list.append([date_str, close, close, close, close, vol, close])
+    return price_list
+
+
+class TestCalcVolumeDryupBreakout:
+    """週ブ (出来高dry up後の5日間出来高拡大ブレイクアウト) 検知テスト。"""
+
+    # 基準となる setup 出来高・終値 (中央値=1000, 終値フラット=1000)。
+    # 各ケースは先頭 (expand=直近5日 / dry up窓=直近10日) だけを差し替える。
+    BASE_VOL = [1000] * 30
+    BASE_CLOSE = [1000] * 30
+
+    def _case(self, vol_head=None, close_head=None, length=26):
+        """先頭を差し替えた (volumes, closes) を返す。length で末尾を切る。"""
+        vols = list(self.BASE_VOL)
+        closes = list(self.BASE_CLOSE)
+        if vol_head:
+            vols[: len(vol_head)] = vol_head
+        if close_head:
+            closes[: len(close_head)] = close_head
+        return vols[:length], closes[:length]
+
+    # 検出成立の基本形: expand=出来高拡大(3日以上≥1200,平均≥1500)、
+    # index5 を強dry up(400≤450)、終値は expand が setup 20日高値(1000)を上抜け。
+    DETECT_VOL = [1800, 1600, 1300, 1000, 1900] + [400] + [1000] * 20
+    DETECT_CLOSE = [1100, 1080, 1070, 1060, 1050] + [1000] * 21
+
+    def test_detects_dryup_then_expansion_breakout(self):
+        """ケース1: dry up後の5日拡大+価格上抜けで検出され per/dryup 値も正しい。"""
+        vols, closes = self._case(
+            vol_head=self.DETECT_VOL, close_head=self.DETECT_CLOSE, length=25
+        )
+        price_list = _make_vdb_price_list(vols, closes)
+        result = price.calc_volume_dryup_breakout(price_list)
+        assert len(result) == 1
+        mmdd, per, dryup = result[0].split(",")
+        assert mmdd == "06/30"  # 最新日
+        # per = 5日平均(1520)/中央値(1000)*100 = 152
+        assert int(per) == 152
+        # dryup = 直近10日最小(400)/中央値(1000)*100 = 40
+        assert int(dryup) == 40
+
+    def test_single_big_volume_not_detected(self):
+        """ケース2: 直近5日で1日だけ極端な大商いでは検出されない (3日以上条件)。"""
+        # index0 だけ突出、他 expand は基準以下。平均は 1.5 倍を超えるが ≥1200 は1日のみ。
+        vol_head = [6000, 1000, 1000, 1000, 1000] + [400]
+        vols, closes = self._case(
+            vol_head=vol_head, close_head=self.DETECT_CLOSE, length=25
+        )
+        price_list = _make_vdb_price_list(vols, closes)
+        assert price.calc_volume_dryup_breakout(price_list) == []
+
+    def test_no_dryup_not_detected(self):
+        """ケース3: 出来高拡大+上抜けがあっても dry up がなければ検出されない。"""
+        # dry up 窓 (index5..14) を基準比 0.6 超に保つ (全て 1000)。
+        vols, closes = self._case(
+            vol_head=[1800, 1600, 1300, 1000, 1900],  # dry up 差し替えなし
+            close_head=self.DETECT_CLOSE,
+            length=25,
+        )
+        price_list = _make_vdb_price_list(vols, closes)
+        assert price.calc_volume_dryup_breakout(price_list) == []
+
+    def test_no_price_breakout_not_detected(self):
+        """ケース4: dry up+出来高拡大があっても価格上抜けがなければ検出されない。"""
+        # 終値をフラット (1000) に保つ → expand高値 == setup高値で上抜けなし。
+        vols, closes = self._case(
+            vol_head=self.DETECT_VOL, close_head=None, length=25
+        )
+        price_list = _make_vdb_price_list(vols, closes)
+        assert price.calc_volume_dryup_breakout(price_list) == []
+
+    def test_no_duplicate_on_consecutive_days(self):
+        """ケース5: 前日から条件継続でも重複発火せず、初成立日1件のみ記録される。"""
+        # 26本用意し index0,1 の両方が成立する構成にする。expand を1日ずらしても
+        # 拡大条件を満たすよう、先頭6日を出来高拡大帯にする。
+        vol_head = [1800, 1600, 1300, 1500, 1900, 1400] + [400] + [1000] * 19
+        close_head = [1120, 1100, 1080, 1070, 1060, 1050] + [1000] * 20
+        price_list = _make_vdb_price_list(vol_head, close_head[:26])
+        # index1 起点も成立することを確認 (前提の妥当性チェック)。
+        assert price._vdb_check(price_list, 1) is not None
+        assert price._vdb_check(price_list, 0) is not None
+        result = price.calc_volume_dryup_breakout(price_list)
+        # index0 は前日 (index1) も成立 → スキップ。index1 が初成立日として1件のみ。
+        assert len(result) == 1
+        assert result[0].split(",")[0] == "06/29"  # index1 の日付 (30-1)

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -3307,6 +3307,29 @@ class TestSignalDisplay:
         alpha = float(m.group(1))
         assert (alpha >= 0.8) is alpha_high
 
+    @pytest.mark.parametrize(
+        "num, expect_word, alpha_high",
+        [
+            (250, "強", True),    # 5日出来高中央値比>=250 強・直近 → 濃い
+            (200, "中", False),   # >=200 中 → 強より薄い
+            (168, "弱", False),   # 成立下限帯 弱
+        ],
+    )
+    def test_weekly_breakout_strength_and_tooltip(self, num, expect_word, alpha_high):
+        """週ブ (issue #384): 強度バケットと dry up 比率を含む tooltip。"""
+        anchor_now, anchor_day = self._anchor()
+        mmdd = anchor_day.strftime("%m/%d")  # 直近 (delta=0)
+        stock = {"volume_dryup_breakout": ["%s,%d,42" % (mmdd, num)],
+                 "trend_template": [], "access_date_price": anchor_now}
+        disp = helpers._build_signal_display(stock)
+        assert "[週ブ]" in disp["tooltip"]
+        assert expect_word in disp["tooltip"]
+        assert "乾42%" in disp["tooltip"]  # dry up 比率が出る
+        import re
+        m = re.search(r"rgba\(234,67,53,([0-9.]+)\)", disp["style"])
+        assert m is not None
+        assert (float(m.group(1)) >= 0.8) is alpha_high
+
     def test_format_signal_uses_recent_marks_only_but_keeps_full_title(self):
         """表示記号は直近ポ/ブのみ、title用全文は make_signal の signal を保持する"""
         from datetime import timedelta


### PR DESCRIPTION
Closes #384

## Summary
- 現行「ブ」(単日の出来高急増) と別軸で、出来高が枯れ (乾) た後に直近5営業日で複数日にわたり出来高が拡大 (増) し価格がレンジを上抜ける (抜) 局面を検知する「週ブ」シグナルを追加。
- 一般手法では Minervini の VDU→ブレイク / 持続的 RVOL / PVO(5,20) に相当。20日出来高**中央値**を基準に判定し、初成立日のみ記録 (連日成立時は重複記録しない)。
- 既存「ブ」「ポ」の判定・表示は不変。

## 実装
- `price.py`: `calc_volume_dryup_breakout` / `_vdb_check` を追加。保存形式 `"MM/DD,per,dryup_pct"` (例 `07/15,168,42`)。
- `make_stock_db.py`: `extract_signals` / `make_signal` に週ブを追加 (既存ブと同様 最新1件・stage4/staleガード・発生日から10日以内フィルタ)。
- `webapp/helpers.py`: 強度バケット・tooltip・詳細チャートの**紫ダイヤ**マーカー (既存ブの橙と色で区別)。

## Test plan
- [x] `pytest tests/test_price.py tests/test_make_stock_db.py tests/test_webapp_helpers.py` — 634 passed
- [x] テーブル駆動テスト5ケース (検出 / 単発大商い非検出 / dry upなし / 上抜けなし / 連日重複なし)
- [x] **278A 実データ検証**: 7/8 の dry up (出来高=中央値比52%) が乾条件に反映され、7/10 に週ブ発火することを確認
- [x] webapp (Playwright) で 2準4銘柄 (446A/3399/5138/9215) の一覧シグナル列「週ブ」表示・tooltip・詳細チャート紫ダイヤを確認

## リリース後の反映
`volume_dryup_breakout` は price 更新時に計算されるため、既存銘柄への反映は `python make_stock_db.py update <code>` または日次 cron の価格更新後。未反映レコードは空を返すだけで後方互換問題なし。

## 補足
- 強度バケット閾値 (250/200) は未較正。運用後に分布を見て別途調整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)