### PR TITLE
売買履歴とアクションログを分離し fill 基準のエピソード損益・振り返りメモに一本化 (issue #387 Phase1-4b + Phase2)

### DIFF
--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -139,6 +139,15 @@ cd scripts && python import_sbi_fills.py "<csv_path>" --dry-run       # 読込�
 cd scripts && python import_sbi_fills.py "<csv_path>"                 # 本番取込
 ```
 
+取込後の建玉ラウンド (エピソード) 損益・保有中の含み損益・振り返りメモの紐付けをターミナルで確認する (DB 非更新)。
+
+```bash
+cd scripts && python show_fill_episodes.py            # 全エピソード (最新約定日降順)
+cd scripts && python show_fill_episodes.py 6324       # 特定銘柄のみ (内訳 fill も表示)
+cd scripts && python show_fill_episodes.py --open     # 保有中のみ (残株数・実現/含み損益)
+cd scripts && python show_fill_episodes.py --memo     # 振り返りメモ付きのみ
+```
+
 ## 自動実行
 
 `shintakane_cron.sh` が `shintakane.py` → `make_stock_db.py` を逐次実行。macOS launchd（`com.k_sohara.shintakane.cron.plist`）で平日19:00に定期実行。

--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -125,14 +125,18 @@ cd scripts && python backfill_price_proxy.py             # None のみ埋める 
 cd scripts && python backfill_price_proxy.py --overwrite # actual 以外を再取得
 ```
 
-### 楽天 取引履歴CSV → fill レイヤー取込 (issue #360, #387)
+### 証券会社CSV → fill レイヤー取込 (issue #360, #387)
 
-楽天証券の取引履歴CSV (`tradehistory(JP)_YYYYMMDD.csv`, Shift-JIS) の実約定価格・株数を fill として取り込む。同一 dedup キーは冪等スキップ。取り込んだ fill は `/trade-history` の「売買履歴」タブに約定日降順で一覧表示される (issue #387 で action_log との突合は廃止)。
+楽天・SBI証券の約定CSVの実約定価格・株数を fill として取り込む。同一 dedup キーは冪等スキップ。取り込んだ fill は `/trade-history` の「売買履歴」タブに約定日降順で一覧表示される (issue #387 で action_log との突合は廃止)。SBI は個別株のみ取込 (ETF/投信=ウォッチリスト外は自動除外)。信用返済行の決済損益は fill に保存する。
 
 ```bash
-cd scripts && python import_rakuten_fills.py "<csv_path>" --dry-run                    # 読込・パース検証 (DB 非書込)
-cd scripts && python import_rakuten_fills.py "<csv_path>" --db-path /tmp/fills_verify   # 一時DBで取込確認
-cd scripts && python import_rakuten_fills.py "<csv_path>"                               # 本番取込
+# 楽天 (tradehistory(JP)_YYYYMMDD.csv, Shift-JIS, 28列)
+cd scripts && python import_rakuten_fills.py "<csv_path>" --dry-run   # 読込・パース検証 (DB 非書込)
+cd scripts && python import_rakuten_fills.py "<csv_path>"             # 本番取込
+
+# SBI (SaveFile_*.csv, Shift-JIS, 冒頭メタ行あり)
+cd scripts && python import_sbi_fills.py "<csv_path>" --dry-run       # 読込・パース検証 (DB 非書込)
+cd scripts && python import_sbi_fills.py "<csv_path>"                 # 本番取込
 ```
 
 ## 自動実行

--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -127,7 +127,7 @@ cd scripts && python backfill_price_proxy.py --overwrite # actual 以外を再�
 
 ### 証券会社CSV → fill レイヤー取込 (issue #360, #387)
 
-楽天・SBI証券の約定CSVの実約定価格・株数を fill として取り込む。同一 dedup キーは冪等スキップ。取り込んだ fill は `/trade-history` の「売買履歴」タブに約定日降順で一覧表示される (issue #387 で action_log との突合は廃止)。SBI は個別株のみ取込 (ETF/投信=ウォッチリスト外は自動除外)。信用返済行の決済損益は fill に保存する。
+楽天・SBI証券の約定CSVの実約定価格・株数を fill として取り込む。同一 dedup キーは冪等スキップ。取り込んだ fill は `/trade-history` の「売買履歴」タブに建玉ラウンド単位のエピソードとして表示され、勝率・ペイオフレシオも fill 側で計算される (issue #387 Phase4b)。SBI は個別株のみ取込 (ETF/投信=ウォッチリスト外は自動除外)。楽天は信用返済行の建約定日・建単価と現引行 (建玉の現物化) も取込む (信用/現物のエピソード損益計算に使用)。SBI 信用返済行の決済損益は fill に保存する。既存 fill への建単価・決済損益は再取込時に後付けされる (None→非None のみ)。
 
 ```bash
 # 楽天 (tradehistory(JP)_YYYYMMDD.csv, Shift-JIS, 28列)

--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -125,14 +125,14 @@ cd scripts && python backfill_price_proxy.py             # None のみ埋める 
 cd scripts && python backfill_price_proxy.py --overwrite # actual 以外を再取得
 ```
 
-### 楽天 取引履歴CSV → fill レイヤー取込 (issue #360 Phase2)
+### 楽天 取引履歴CSV → fill レイヤー取込 (issue #360, #387)
 
-楽天証券の取引履歴CSV (`tradehistory(JP)_YYYYMMDD.csv`, Shift-JIS) の実約定価格・株数を fill として取り込み、`--match` でエピソードへ自動マッチする。同一 dedup キーは冪等スキップ。曖昧なケース (同日同side複数注文・候補複数) は自動マッチせず確認リスト行き。
+楽天証券の取引履歴CSV (`tradehistory(JP)_YYYYMMDD.csv`, Shift-JIS) の実約定価格・株数を fill として取り込む。同一 dedup キーは冪等スキップ。取り込んだ fill は `/trade-history` の「売買履歴」タブに約定日降順で一覧表示される (issue #387 で action_log との突合は廃止)。
 
 ```bash
 cd scripts && python import_rakuten_fills.py "<csv_path>" --dry-run                    # 読込・パース検証 (DB 非書込)
 cd scripts && python import_rakuten_fills.py "<csv_path>" --db-path /tmp/fills_verify   # 一時DBで取込確認
-cd scripts && python import_rakuten_fills.py "<csv_path>" --match                       # 本番取込 + 自動マッチ
+cd scripts && python import_rakuten_fills.py "<csv_path>"                               # 本番取込
 ```
 
 ## 自動実行

--- a/scripts/import_rakuten_fills.py
+++ b/scripts/import_rakuten_fills.py
@@ -61,11 +61,22 @@ COL_PRICE = 11         # 単価[円]
 COL_AMOUNT = 16        # 受渡金額[円]
 
 HEADER_FIRST_COL = "約定日"  # ヘッダ検証用
+BROKER = "楽天"
 
 
 # ===========================================
 # 1. CSV 読込層
 # ===========================================
+
+def is_rakuten_csv(csv_path: str) -> bool:
+    """CSV が楽天 取引履歴CSV 形式か判定する (先頭行が約定日ヘッダで28列)。"""
+    try:
+        with open(csv_path, "r", encoding=CSV_ENCODING, newline="") as f:
+            first = next(csv.reader(f), [])
+    except (OSError, UnicodeDecodeError):
+        return False
+    return bool(first) and first[0].strip() == HEADER_FIRST_COL and len(first) >= EXPECTED_COL_COUNT
+
 
 def read_csv_rows(csv_path: str) -> List[List[str]]:
     """楽天 取引履歴CSV を Shift-JIS で読み、ヘッダを除いたデータ行を返す。

--- a/scripts/import_rakuten_fills.py
+++ b/scripts/import_rakuten_fills.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """楽天証券 取引履歴CSV → portfolio_shelve fill レイヤー 取込 (issue #360 Phase2)。
 
-二層モデル (GitHub コメント 2026-07-11 確定):
-- fill レイヤー (本スクリプトが書く): CSV 由来の約定事実。価格・株数・約定日の真実源。
-- 判断レイヤー (既存 action_log): ステータス・タグ・メモ。CSV では得られない情報。維持。
+売買履歴とアクションログを独立させる方針 (issue #387) により、fill は action_log と
+突合しない。本スクリプトは CSV 由来の約定事実 (価格・株数・約定日) を fill として
+取り込むだけで、fill は売買履歴タブで一級の表示要素になる。
 
-本スクリプトのスコープ (issue #360 Phase2 (a)+(b)):
-- (a) fill 取込 + dedup 保存 (冪等)
-- (b) --match 指定時、エピソードへ自動マッチして matched_seq を書き戻す
+- fill レイヤー (本スクリプトが書く): CSV 由来の約定事実。価格・株数・約定日の真実源。
+- 判断レイヤー (既存 action_log): ステータス・タグ・メモ。手動記録。両者は独立。
+
+本スクリプトのスコープ:
+- fill 取込 + dedup 保存 (冪等)
 
 4 層構成 (migrate_portfolio_from_csv.py のパターン踏襲):
     1. CSV 読込層 (read_csv_rows)
@@ -22,8 +24,8 @@ import argparse
 import csv
 import os
 import sys
-from datetime import date, datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 # scripts/ を sys.path に追加 (直接実行時)
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -252,180 +254,6 @@ def import_csv_to_fills(
 
 
 # ===========================================
-# 3b. (b) 自動マッチング — fill → action_log エピソード
-# ===========================================
-
-MATCH_WINDOW_DAYS = 3  # 約定日 ±3 暦日 (±5 は隣接エピソードを跨ぎやすいため縮小)
-
-
-def _build_episodes(logs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """action_log 群を trade_history.py と同じ走査でエピソード単位に再構築する。
-
-    各エピソード: {code_s, hold_seq, hold_date, sell_seq, sell_date, has_qty_changes}。
-    sell_seq/sell_date は未売却なら None。fill を「イベント」でなく「エピソードの
-    hold/sell スロット」へ割り当てるための土台。
-    """
-    episodes: List[Dict[str, Any]] = []
-    open_ep: Dict[str, Dict[str, Any]] = {}
-    for log in logs:
-        code_s = log["code_s"]
-        if log.get("status_to") == "1保":
-            if code_s in open_ep:
-                episodes.append(open_ep.pop(code_s))  # 未クローズ再購入 (異常系) を先に確定
-            open_ep[code_s] = {
-                "code_s": code_s,
-                "hold_seq": log["seq"],
-                "hold_date": log["timestamp"][:10],
-                "sell_seq": None,
-                "sell_date": None,
-                "has_qty_changes": False,
-            }
-        elif log.get("action_type") == "株数変更" and code_s in open_ep:
-            open_ep[code_s]["has_qty_changes"] = True
-        elif log.get("action_type") == "売却" and code_s in open_ep:
-            ep = open_ep.pop(code_s)
-            ep["sell_seq"] = log["seq"]
-            ep["sell_date"] = log["timestamp"][:10]
-            episodes.append(ep)
-    episodes.extend(open_ep.values())
-    return episodes
-
-
-def _days_between(a: str, b: str) -> Optional[int]:
-    try:
-        return (date.fromisoformat(a) - date.fromisoformat(b)).days
-    except (ValueError, TypeError):
-        return None
-
-
-def _candidate_slots(
-    fill: Dict[str, Any],
-    episodes: List[Dict[str, Any]],
-    consumed: set,
-) -> List[Tuple[int, int]]:
-    """fill が区間整合する (距離, スロットの seq) 候補を返す (単一 IN のみ、未消費のみ)。
-
-    区間整合 (codexレビュー指摘):
-    - buy fill → hold スロット: |約定日 - hold_date| <= W (端点窓)。
-      かつ 約定日 <= sell_date (このエピソードの sell を跨がない)。
-      かつ 約定日 < 直後エピソードの hold_date (次サイクルに食い込まない)。
-    - sell fill → sell スロット: |約定日 - sell_date| <= W (端点窓)。
-      かつ 約定日 >= hold_date (このエピソードの hold より前でない)。
-      かつ 約定日 > 直前エピソードの sell_date (前サイクルに食い込まない)。
-    距離 = 約定日とスロット端点 (hold_date / sell_date) の暦日差の絶対値。
-    """
-    fd = fill["trade_date"]
-    code_s = fill["code_s"]
-    W = MATCH_WINDOW_DAYS
-    # 同一コードのエピソードを hold_date 昇順に (前後境界の判定に使う)
-    same = sorted(
-        (e for e in episodes if e["code_s"] == code_s and not e["has_qty_changes"]),
-        key=lambda e: e["hold_date"],
-    )
-    slots: List[Tuple[int, int]] = []
-    for i, ep in enumerate(same):
-        if fill["side"] == ps.SIDE_BUY:
-            seq = ep["hold_seq"]
-            if (code_s, seq) in consumed:
-                continue
-            lo = _days_between(fd, ep["hold_date"])  # 約定日 - hold
-            if lo is None or abs(lo) > W:
-                continue  # hold から W 日を超えるものは対象外 (端点窓)
-            # このエピソードの sell_date (あれば) を跨がない
-            if ep["sell_date"] is not None:
-                hi = _days_between(fd, ep["sell_date"])
-                if hi is not None and hi > 0:
-                    continue  # sell を跨いだ買いは別サイクル
-            # 直後エピソードの hold_date に食い込まない
-            if i + 1 < len(same):
-                nxt = _days_between(fd, same[i + 1]["hold_date"])
-                if nxt is not None and nxt >= 0:
-                    continue
-            slots.append((abs(lo), seq))
-        else:  # sell
-            if ep["sell_date"] is None:
-                continue
-            seq = ep["sell_seq"]
-            if (code_s, seq) in consumed:
-                continue
-            hi = _days_between(fd, ep["sell_date"])  # 約定日 - sell
-            if hi is None or abs(hi) > W:
-                continue  # sell から W 日を超えるものは対象外 (端点窓)
-            # このエピソードの hold_date より前の売りは無効
-            lo = _days_between(fd, ep["hold_date"])
-            if lo is not None and lo < 0:
-                continue
-            # 直前エピソードの sell_date に食い込まない
-            if i - 1 >= 0 and same[i - 1]["sell_date"] is not None:
-                prev = _days_between(fd, same[i - 1]["sell_date"])
-                if prev is not None and prev <= 0:
-                    continue
-            slots.append((abs(hi), seq))
-    return slots
-
-
-def match_fills_to_episodes(*, db_path: Optional[str] = None) -> Dict[str, int]:
-    """未マッチ fill をエピソードの hold/sell スロットへ突合し matched_seq を書き戻す。
-
-    安全側の設計 (曖昧さゼロのケースだけ自動反映):
-    - 楽天CSVは注文番号を持たないため、同 (code_s, side, 約定日) の fill が 2 件以上ある
-      コードは「同一注文の分割」か「別イベント」か区別できない。よってその (code_s, side)
-      は丸ごと自動マッチ対象外 (全 fill 未マッチのまま)。
-    - 残った 1 fill = 1 イベントを、エピソード区間で候補を固定した上で最近接一意マッチ。
-      候補スロットのうち距離最小が一意 (2位と厳密に差) かつ未消費のときだけ確定。
-    - 1 スロット (エピソードの hold or sell) は高々 1 fill (二重消費防止)。
-
-    Returns: {"matched", "unmatched", "ambiguous"}
-    """
-    all_fills = ps.list_fills(db_path=db_path)
-    episodes = _build_episodes(ps.list_action_logs(db_path=db_path))
-
-    # (code_s, side, trade_date) ごとの件数 → 2 件以上は曖昧として除外
-    group_count: Dict[Tuple[str, str, str], int] = {}
-    for f in all_fills:
-        key = (f["code_s"], f["side"], f["trade_date"])
-        group_count[key] = group_count.get(key, 0) + 1
-
-    stats = {"matched": 0, "unmatched": 0, "ambiguous": 0}
-    # (code_s, slot_seq) 消費済みスロット。増分取込に備え、既にマッチ済みの fill が
-    # 占有するスロットを先に投入する (別CSVの後日 fill が同一スロットへ再マッチするのを防ぐ)
-    consumed: set = {
-        (f["code_s"], f["matched_seq"])
-        for f in all_fills
-        if f.get("matched_seq") is not None
-    }
-
-    # 約定日昇順で処理 (早い約定を優先確定)
-    for f in sorted(all_fills, key=lambda x: (x["code_s"], x["trade_date"], x["seq"])):
-        if f.get("matched_seq") is not None:
-            continue  # 既マッチは触らない (冪等)
-        key = (f["code_s"], f["side"], f["trade_date"])
-        if group_count.get(key, 0) >= 2:
-            stats["ambiguous"] += 1
-            log_print(
-                "import_rakuten_fills: 曖昧 (同日同side複数) 未マッチ",
-                f["code_s"], f["side"], f["trade_date"],
-            )
-            continue
-
-        slots = _candidate_slots(f, episodes, consumed)
-        slots.sort(key=lambda x: x[0])
-        # 距離最小が一意 (2位と厳密に差がある) のときだけ確定
-        if slots and (len(slots) == 1 or slots[0][0] < slots[1][0]):
-            _, seq = slots[0]
-            ps.set_fill_matched_seq(f["code_s"], f["seq"], seq, db_path=db_path)
-            consumed.add((f["code_s"], seq))
-            stats["matched"] += 1
-        else:
-            stats["unmatched"] += 1
-            log_print(
-                "import_rakuten_fills: 未マッチ (候補 %d 件)" % len(slots),
-                f["code_s"], f["side"], f["trade_date"],
-            )
-    return stats
-
-
-# ===========================================
 # 4. 実行層
 # ===========================================
 
@@ -443,11 +271,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--db-path",
         default=None,
         help="portfolio_shelve のパス上書き (検証用)",
-    )
-    parser.add_argument(
-        "--match",
-        action="store_true",
-        help="取込後にエピソードへの自動マッチを実行する",
     )
     return parser
 
@@ -471,18 +294,6 @@ def main(argv: Optional[List[str]] = None) -> int:
         f"skipped_invalid={stats['skipped_invalid']}",
         "(dry-run)" if args.dry_run else "",
     )
-
-    if args.match and not args.dry_run:
-        match_stats = match_fills_to_episodes(db_path=args.db_path)
-        log_print(
-            "import_rakuten_fills: マッチ完了",
-            f"matched={match_stats['matched']}",
-            f"unmatched={match_stats['unmatched']}",
-            f"ambiguous={match_stats['ambiguous']}",
-        )
-    elif args.match and args.dry_run:
-        log_warning("--match は --dry-run と併用できません (書き込みが必要)")
-
     return 0
 
 

--- a/scripts/import_rakuten_fills.py
+++ b/scripts/import_rakuten_fills.py
@@ -59,9 +59,16 @@ COL_BAIBAI = 7         # 売買区分 (買付 / 売付 / 買建 / 売埋)
 COL_QTY = 10           # 数量[株]
 COL_PRICE = 11         # 単価[円]
 COL_AMOUNT = 16        # 受渡金額[円]
+COL_TATE_DATE = 17     # 建約定日 (信用返済行のみ、それ以外は空) (issue #387 Phase4b)
+COL_TATE_PRICE = 18    # 建単価[円] (信用返済行のみ) (issue #387 Phase4b)
 
 HEADER_FIRST_COL = "約定日"  # ヘッダ検証用
 BROKER = "楽天"
+
+# 取引区分=現引 は建玉の現物化。売買区分が空 (買/売でない) だが、単価[円](COL_PRICE)
+# に現引時の実質取得原価が入るため buy 扱いで取込み、後続の現物売とラウンドを組む
+# (issue #387 Phase4b: 現引ブリッジ)。
+TRADE_KIND_GENBIKI = "現引"
 
 
 # ===========================================
@@ -148,11 +155,17 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
     if trade_date is None:
         raise RowSkip(f"約定日パース不可: {row[COL_TRADE_DATE]!r}")
 
+    trade_kind = (row[COL_TRADE_KIND] or "").strip()
     baibai = (row[COL_BAIBAI] or "").strip()
-    try:
-        side = ps.normalize_side(baibai)
-    except ValueError as e:
-        raise RowSkip(str(e))
+
+    # 現引 (建玉の現物化) は売買区分が空だが、buy 扱いで取込む (Phase4b 現引ブリッジ)。
+    if trade_kind == TRADE_KIND_GENBIKI:
+        side = "buy"
+    else:
+        try:
+            side = ps.normalize_side(baibai)
+        except ValueError as e:
+            raise RowSkip(str(e))
 
     qty_f = _parse_num(row[COL_QTY])
     price_f = _parse_num(row[COL_PRICE])
@@ -162,7 +175,10 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
         raise RowSkip(f"単価欠落/不正: {row[COL_PRICE]!r}")
     amount_f = _parse_num(row[COL_AMOUNT])
 
-    trade_kind = (row[COL_TRADE_KIND] or "").strip()
+    # 建約定日・建単価 (信用返済行のみ。信用P/Lのペアリングに使う) (Phase4b)
+    tate_date = _normalize_trade_date(row[COL_TATE_DATE]) if len(row) > COL_TATE_DATE else None
+    tate_price_f = _parse_num(row[COL_TATE_PRICE]) if len(row) > COL_TATE_PRICE else None
+    tate_price = tate_price_f if (tate_price_f is not None and tate_price_f > 0) else None
 
     return {
         "code_s": code_s,
@@ -173,6 +189,8 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
         "amount": int(amount_f) if amount_f is not None else 0,
         "trade_kind": trade_kind,
         "baibai": baibai,
+        "tate_date": tate_date,
+        "tate_price": tate_price,
     }
 
 
@@ -241,6 +259,8 @@ def import_csv_to_fills(
             trade_kind=parsed["trade_kind"],
             dedup_key=dedup_key,
             broker="楽天",
+            tate_date=parsed.get("tate_date"),
+            tate_price=parsed.get("tate_price"),
         )
 
         if dry_run:

--- a/scripts/import_rakuten_fills.py
+++ b/scripts/import_rakuten_fills.py
@@ -151,6 +151,10 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
         raise RowSkip(f"無効な銘柄コード: {code_raw!r}")
     code_s = ps.normalize_code_s(code_raw)
 
+    # ETF は株式分析の対象外なので取込まない (issue #387)
+    if ps.is_etf_code(code_s):
+        raise RowSkip(f"ETF のため対象外: {code_s}")
+
     trade_date = _normalize_trade_date(row[COL_TRADE_DATE])
     if trade_date is None:
         raise RowSkip(f"約定日パース不可: {row[COL_TRADE_DATE]!r}")

--- a/scripts/import_sbi_fills.py
+++ b/scripts/import_sbi_fills.py
@@ -70,9 +70,35 @@ _ACTION_MAP = {
 _SETTLE_ACTIONS = frozenset({"信用返済買", "信用返済売"})
 
 
+BROKER = "SBI"
+
+
 # ===========================================
 # 1. CSV 読込層
 # ===========================================
+
+def _find_header_row(rows: List[List[str]]) -> int:
+    """ヘッダ行 (`約定日,...,銘柄コード,...`) の index を返す。無ければ -1。"""
+    for i, row in enumerate(rows):
+        if row and row[0].strip() == HEADER_FIRST_COL and HEADER_MARKER in [c.strip() for c in row]:
+            return i
+    return -1
+
+
+def is_sbi_csv(csv_path: str) -> bool:
+    """CSV が SBI 約定履歴CSV 形式か判定する。
+
+    SBI はヘッダの前に冒頭メタ行を持つ (ヘッダ行 index > 0)。楽天も同名の
+    銘柄コード列を持つがヘッダは先頭行 (index 0) なので、メタ行の有無で区別する。
+    """
+    try:
+        with open(csv_path, "r", encoding=CSV_ENCODING, newline="") as f:
+            rows = list(csv.reader(f))
+    except (OSError, UnicodeDecodeError):
+        return False
+    hi = _find_header_row(rows)
+    return hi > 0 and len(rows[hi]) == EXPECTED_COL_COUNT
+
 
 def read_csv_rows(csv_path: str) -> List[List[str]]:
     """SBI 約定履歴CSV を Shift-JIS で読み、ヘッダ行以降のデータ行を返す。
@@ -82,10 +108,10 @@ def read_csv_rows(csv_path: str) -> List[List[str]]:
     """
     with open(csv_path, "r", encoding=CSV_ENCODING, newline="") as f:
         rows = list(csv.reader(f))
-    for i, row in enumerate(rows):
-        if row and row[0].strip() == HEADER_FIRST_COL and HEADER_MARKER in [c.strip() for c in row]:
-            return rows[i + 1:]
-    raise ValueError(f"ヘッダ行 (約定日...銘柄コード) が見つかりません: {csv_path}")
+    hi = _find_header_row(rows)
+    if hi < 0:
+        raise ValueError(f"ヘッダ行 (約定日...銘柄コード) が見つかりません: {csv_path}")
+    return rows[hi + 1:]
 
 
 # ===========================================

--- a/scripts/import_sbi_fills.py
+++ b/scripts/import_sbi_fills.py
@@ -135,7 +135,11 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
         raise RowSkip(f"無効な銘柄コード: {code_raw!r}")
     code_s = ps.normalize_code_s(code_raw)
 
-    # ETF/投信除外: 成長株ウォッチリスト (stocks_shelve) に無い銘柄はスキップ (issue #387)
+    # ETF は株式分析の対象外なので取込まない (issue #387)
+    if ps.is_etf_code(code_s):
+        raise RowSkip(f"ETF のため対象外: {code_s}")
+
+    # 投信等の除外: 成長株ウォッチリスト (stocks_shelve) に無い銘柄はスキップ (issue #387)
     if not resolve_stock_name(code_s):
         raise RowSkip(f"ウォッチリスト外 (ETF/投信の可能性): {code_s}")
 

--- a/scripts/import_sbi_fills.py
+++ b/scripts/import_sbi_fills.py
@@ -1,38 +1,31 @@
 #!/usr/bin/env python3
-"""楽天証券 取引履歴CSV → portfolio_shelve fill レイヤー 取込 (issue #360 Phase2)。
+"""SBI証券 約定履歴CSV → portfolio_shelve fill レイヤー 取込 (issue #387 Phase3)。
 
-売買履歴とアクションログを独立させる方針 (issue #387) により、fill は action_log と
-突合しない。本スクリプトは CSV 由来の約定事実 (価格・株数・約定日) を fill として
-取り込むだけで、fill は売買履歴タブで一級の表示要素になる。
+楽天と同じ fill レイヤーへ取り込むが、SBI の CSV は列構成・語彙・冒頭メタ行が異なる。
 
-- fill レイヤー (本スクリプトが書く): CSV 由来の約定事実。価格・株数・約定日の真実源。
-- 判断レイヤー (既存 action_log): ステータス・タグ・メモ。手動記録。両者は独立。
+SBI CSV の特徴 (`SaveFile_*.csv`, Shift-JIS):
+- 冒頭に「約定履歴照会」等のメタ行があり、ヘッダは `約定日,銘柄,銘柄コード,...` の行
+- 14列。`取引` 列に 信用返済売 / 信用新規買 / 株式現物売 / 株式現物買 が入る
+- 建約定日・建単価の列は無い。代わりに末尾 `受渡金額/決済損益` に信用返済の損益が入る
+- ETF/投信 (成長株ウォッチリスト外) は取込対象外 (issue #387: 個別株のみ)
 
-本スクリプトのスコープ:
-- fill 取込 + dedup 保存 (冪等)
-
-4 層構成 (migrate_portfolio_from_csv.py のパターン踏襲):
-    1. CSV 読込層 (read_csv_rows)
-    2. 行パース層 (parse_fill_row)
-    3. 統合層 (import_csv_to_fills)
-    4. 実行層 (main + argparse)
-
-入力: 楽天 取引履歴CSV `tradehistory(JP)_YYYYMMDD.csv` (Shift-JIS, 28列, ヘッダあり)。
+楽天との共通処理 (_parse_num / _normalize_trade_date / RowSkip / create_fill / dedup) は
+import_rakuten_fills から再利用する。
 """
 
 import argparse
 import csv
 import os
 import sys
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-# scripts/ を sys.path に追加 (直接実行時)
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _THIS_DIR not in sys.path:
     sys.path.insert(0, _THIS_DIR)
 
 import portfolio_shelve as ps  # noqa: E402
+from import_rakuten_fills import RowSkip, _normalize_trade_date, _parse_num  # noqa: E402
+from webapp.helpers import resolve_stock_name  # noqa: E402
 
 try:
     from ks_util import log_print, log_warning
@@ -45,22 +38,36 @@ except ImportError:
 
 
 # ===========================================
-# 定数 (楽天 取引履歴CSV フォーマット)
+# 定数 (SBI 約定履歴CSV フォーマット)
 # ===========================================
 
 CSV_ENCODING = "shift_jis"
-EXPECTED_COL_COUNT = 28
+EXPECTED_COL_COUNT = 14
 
-# 列インデックス (0-indexed、確認済みフォーマット)
-COL_TRADE_DATE = 0     # 約定日 (YYYY/M/D)
+# 列インデックス (0-indexed、ヘッダ行を基準に確認済み)
+COL_TRADE_DATE = 0     # 約定日 (YYYY/MM/DD)
 COL_CODE_S = 2         # 銘柄コード
-COL_TRADE_KIND = 6     # 取引区分 (現物 / 信用新規 / 信用返済 / 現物(単元未満))
-COL_BAIBAI = 7         # 売買区分 (買付 / 売付 / 買建 / 売埋)
-COL_QTY = 10           # 数量[株]
-COL_PRICE = 11         # 単価[円]
-COL_AMOUNT = 16        # 受渡金額[円]
+COL_TRADE_ACTION = 4   # 取引 (信用返済売 / 信用新規買 / 株式現物売 / 株式現物買)
+COL_QTY = 8            # 約定数量
+COL_PRICE = 9          # 約定単価
+COL_AMOUNT = 13        # 受渡金額/決済損益 (信用返済は決済損益、それ以外は受渡金額)
 
-HEADER_FIRST_COL = "約定日"  # ヘッダ検証用
+HEADER_FIRST_COL = "約定日"
+HEADER_MARKER = "銘柄コード"  # メタ行と本ヘッダを区別する目印
+
+# SBI 取引区分 → (side, 楽天互換の trade_kind)。
+# trade_kind を楽天語彙に合わせることで売買履歴タブの集約・表示を一貫させる。
+_ACTION_MAP = {
+    "株式現物買": ("buy", "現物"),
+    "株式現物売": ("sell", "現物"),
+    "信用新規買": ("buy", "信用新規"),
+    "信用新規売": ("sell", "信用新規"),
+    "信用返済買": ("buy", "信用返済"),
+    "信用返済売": ("sell", "信用返済"),
+}
+
+# 決済損益を持つ取引区分 (信用返済のみ)
+_SETTLE_ACTIONS = frozenset({"信用返済買", "信用返済売"})
 
 
 # ===========================================
@@ -68,61 +75,30 @@ HEADER_FIRST_COL = "約定日"  # ヘッダ検証用
 # ===========================================
 
 def read_csv_rows(csv_path: str) -> List[List[str]]:
-    """楽天 取引履歴CSV を Shift-JIS で読み、ヘッダを除いたデータ行を返す。
+    """SBI 約定履歴CSV を Shift-JIS で読み、ヘッダ行以降のデータ行を返す。
 
-    先頭行が既知ヘッダ (約定日...) でなければ ValueError。
+    冒頭のメタ情報行を読み飛ばし、`約定日,銘柄,銘柄コード,...` のヘッダ行を探す。
+    ヘッダが見つからなければ ValueError。
     """
     with open(csv_path, "r", encoding=CSV_ENCODING, newline="") as f:
         rows = list(csv.reader(f))
-    if not rows:
-        raise ValueError(f"CSV が空です: {csv_path}")
-    header = rows[0]
-    if not header or header[0].strip() != HEADER_FIRST_COL:
-        raise ValueError(
-            f"想定外のヘッダです (先頭列={header[0]!r}, 期待={HEADER_FIRST_COL!r}): {csv_path}"
-        )
-    return rows[1:]
+    for i, row in enumerate(rows):
+        if row and row[0].strip() == HEADER_FIRST_COL and HEADER_MARKER in [c.strip() for c in row]:
+            return rows[i + 1:]
+    raise ValueError(f"ヘッダ行 (約定日...銘柄コード) が見つかりません: {csv_path}")
 
 
 # ===========================================
 # 2. 行パース層
 # ===========================================
 
-def _parse_num(raw: str) -> Optional[float]:
-    """カンマ区切り数値文字列を float に。空欄/"-" は None。"""
-    s = (raw or "").strip().replace(",", "")
-    if s in ("", "-"):
-        return None
-    try:
-        return float(s)
-    except ValueError:
-        return None
-
-
-def _normalize_trade_date(raw: str) -> Optional[str]:
-    """約定日 "YYYY/M/D" を "YYYY-MM-DD" に正規化。パース不可なら None。"""
-    s = (raw or "").strip()
-    try:
-        d = datetime.strptime(s, "%Y/%m/%d").date()
-    except ValueError:
-        return None
-    return d.isoformat()
-
-
-class RowSkip(Exception):
-    """パース対象外の行 (無効コード・未知区分・数量欠落など)。理由を保持する。"""
-
-    def __init__(self, reason: str):
-        super().__init__(reason)
-        self.reason = reason
-
-
 def parse_fill_row(row: List[str]) -> Dict[str, Any]:
-    """CSV 1 行を fill 構築用の中間 dict に変換する。
+    """SBI CSV 1 行を fill 構築用の中間 dict に変換する。
 
-    現物・信用の両方に対応。対象外行は RowSkip を投げる (呼び出し側でカウント)。
-    dedup_key の occurrence は統合層で付与するため、ここでは素材のみ返す。
+    ETF/投信 (銘柄名が解決できない = ウォッチリスト外) は RowSkip。空行・列数不足も RowSkip。
     """
+    if not any(c.strip() for c in row):
+        raise RowSkip("空行")
     if len(row) < EXPECTED_COL_COUNT:
         raise RowSkip(f"列数不足 ({len(row)})")
 
@@ -133,15 +109,19 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
         raise RowSkip(f"無効な銘柄コード: {code_raw!r}")
     code_s = ps.normalize_code_s(code_raw)
 
+    # ETF/投信除外: 成長株ウォッチリスト (stocks_shelve) に無い銘柄はスキップ (issue #387)
+    if not resolve_stock_name(code_s):
+        raise RowSkip(f"ウォッチリスト外 (ETF/投信の可能性): {code_s}")
+
     trade_date = _normalize_trade_date(row[COL_TRADE_DATE])
     if trade_date is None:
         raise RowSkip(f"約定日パース不可: {row[COL_TRADE_DATE]!r}")
 
-    baibai = (row[COL_BAIBAI] or "").strip()
-    try:
-        side = ps.normalize_side(baibai)
-    except ValueError as e:
-        raise RowSkip(str(e))
+    action = (row[COL_TRADE_ACTION] or "").strip()
+    mapped = _ACTION_MAP.get(action)
+    if mapped is None:
+        raise RowSkip(f"未知の取引区分: {action!r}")
+    side, trade_kind = mapped
 
     qty_f = _parse_num(row[COL_QTY])
     price_f = _parse_num(row[COL_PRICE])
@@ -149,9 +129,11 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
         raise RowSkip(f"数量欠落/不正: {row[COL_QTY]!r}")
     if price_f is None or price_f <= 0:
         raise RowSkip(f"単価欠落/不正: {row[COL_PRICE]!r}")
-    amount_f = _parse_num(row[COL_AMOUNT])
 
-    trade_kind = (row[COL_TRADE_KIND] or "").strip()
+    amount_f = _parse_num(row[COL_AMOUNT])
+    amount = int(amount_f) if amount_f is not None else 0
+    # 信用返済行の受渡金額列は「決済損益」。それを settle_pl に持たせる (P/L の真実源)
+    settle_pl = amount if action in _SETTLE_ACTIONS else None
 
     return {
         "code_s": code_s,
@@ -159,9 +141,10 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
         "side": side,
         "qty": int(qty_f),
         "price": price_f,
-        "amount": int(amount_f) if amount_f is not None else 0,
+        "amount": amount,
         "trade_kind": trade_kind,
-        "baibai": baibai,
+        "action": action,       # dedup 素材 (元の取引区分)
+        "settle_pl": settle_pl,
     }
 
 
@@ -175,10 +158,7 @@ def import_csv_to_fills(
     dry_run: bool = False,
     db_path: Optional[str] = None,
 ) -> Dict[str, int]:
-    """CSV を読み、各行を fill として冪等取込する。
-
-    同一CSV内の同一 dedup 素材の出現順 (occurrence) を数えて dedup_key に含める
-    (同日同単価の別注文を別 fill として扱いつつ、再取込は冪等)。
+    """SBI CSV を読み、各行を fill として冪等取込する。
 
     Returns: {"rows", "imported", "skipped_dup", "skipped_invalid"}
     """
@@ -192,16 +172,16 @@ def import_csv_to_fills(
             parsed = parse_fill_row(row)
         except RowSkip as e:
             stats["skipped_invalid"] += 1
-            log_print("import_rakuten_fills: スキップ", e.reason)
+            log_print("import_sbi_fills: スキップ", e.reason)
             continue
 
-        # occurrence: 同一CSV内で dedup 素材が同一な行の出現順
+        # occurrence: 同一CSV内で dedup 素材が同一な行の出現順 (分割約定を別 fill に)
         occ_key = "|".join(
             [
                 parsed["trade_date"],
                 parsed["code_s"],
                 parsed["trade_kind"],
-                parsed["baibai"],
+                parsed["action"],
                 str(parsed["qty"]),
                 f"{parsed['price']:.4f}",
                 str(parsed["amount"]),
@@ -210,11 +190,12 @@ def import_csv_to_fills(
         occurrence = occurrence_counter.get(occ_key, 0)
         occurrence_counter[occ_key] = occurrence + 1
 
+        # baibai_kubun には SBI の元区分 (action) を渡し、楽天と dedup 空間を分ける
         dedup_key = ps.make_dedup_key(
             trade_date=parsed["trade_date"],
             code_s=parsed["code_s"],
             trade_kind=parsed["trade_kind"],
-            baibai_kubun=parsed["baibai"],
+            baibai_kubun=parsed["action"],
             qty=parsed["qty"],
             price=parsed["price"],
             amount=parsed["amount"],
@@ -229,7 +210,8 @@ def import_csv_to_fills(
             amount=parsed["amount"],
             trade_kind=parsed["trade_kind"],
             dedup_key=dedup_key,
-            broker="楽天",
+            broker="SBI",
+            settle_pl=parsed["settle_pl"],
         )
 
         if dry_run:
@@ -245,11 +227,12 @@ def import_csv_to_fills(
             stats["skipped_dup"] += 1
 
     if dry_run and samples:
-        log_print("import_rakuten_fills: dry-run サンプル (先頭 3 件):")
+        log_print("import_sbi_fills: dry-run サンプル (先頭 3 件):")
         for s in samples:
             log_print(
                 f"  {s['code_s']} {s['trade_date']} {s['side']} "
-                f"qty={s['qty']} price={s['price']} kind={s['trade_kind']}"
+                f"qty={s['qty']} price={s['price']} kind={s['trade_kind']} "
+                f"settle_pl={s['settle_pl']}"
             )
     return stats
 
@@ -260,9 +243,9 @@ def import_csv_to_fills(
 
 def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="楽天 取引履歴CSV を fill レイヤーへ取込 (issue #360 Phase2)",
+        description="SBI証券 約定履歴CSV を fill レイヤーへ取込 (issue #387 Phase3)",
     )
-    parser.add_argument("csv_path", help="楽天 取引履歴CSV のパス (Shift-JIS)")
+    parser.add_argument("csv_path", help="SBI 約定履歴CSV のパス (Shift-JIS)")
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -288,7 +271,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         db_path=args.db_path,
     )
     log_print(
-        "import_rakuten_fills: 取込完了",
+        "import_sbi_fills: 取込完了",
         f"rows={stats['rows']}",
         f"imported={stats['imported']}",
         f"skipped_dup={stats['skipped_dup']}",

--- a/scripts/migrate_review_memo_to_fill_episode.py
+++ b/scripts/migrate_review_memo_to_fill_episode.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""アクションログの振り返りメモ (review_memo) を fill エピソード側へ移行する (issue #387 Phase2)。
+
+振り返りメモは判断の記録として売買履歴 (fill=真実源) タブへ一本化した。
+アクションログの売却ログ (または1保遷移ログ) が持つ review_memo を、対応する
+fill 建玉ラウンド (エピソード) の fill_memo レイヤーへ移す。
+
+対応付け:
+    - review_memo を持つ action_log を列挙 (通常は売却ログ)。
+    - その銘柄の fill エピソードのうち、クローズ日 (close_date) が action_log の
+      売却日と近いものを対応先とする。決算返済ラグ等で数日ずれるため許容差は
+      ±MATCH_TOLERANCE_DAYS 日。最も近い候補が1つに絞れるものだけ自動移行する。
+    - 複数候補 or 候補なしは手動判断が必要として skipped に積み、警告表示する。
+
+冪等: fill_memo に既にメモがある場合は上書きしない (既存優先)。dry-run で対応表確認可。
+"""
+
+import argparse
+import os
+import sys
+from datetime import date, timedelta
+from typing import Any, Dict, List, Optional
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+from webapp import helpers  # noqa: E402
+
+try:
+    from ks_util import log_print, log_warning
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+
+# 売却日と fill エピソードのクローズ日のずれ許容 (決算返済ラグ等)
+MATCH_TOLERANCE_DAYS = 3
+
+
+def _to_date(s: str) -> Optional[date]:
+    try:
+        return date.fromisoformat(s[:10])
+    except (ValueError, TypeError):
+        return None
+
+
+def _match_episode(
+    memo_log: Dict[str, Any],
+    episodes: List[Dict[str, Any]],
+) -> tuple[Optional[Dict[str, Any]], str]:
+    """review_memo を持つ action_log に対応する fill エピソードを1つ選ぶ。
+
+    Returns: (episode or None, 理由文字列)
+    """
+    code_s = memo_log["code_s"]
+    sell_date = _to_date(memo_log.get("timestamp", ""))
+    if sell_date is None:
+        return None, "売却日が不正"
+
+    code_eps = [e for e in episodes if e["code_s"] == code_s and e["closed"]]
+    if not code_eps:
+        return None, f"{code_s} にクローズ済みエピソードが無い"
+
+    # クローズ日が売却日と一致 (±1日許容) するエピソードを候補にする
+    def close_dist(ep):
+        cd = _to_date(ep.get("close_date") or "")
+        if cd is None:
+            return None
+        return abs((cd - sell_date).days)
+
+    scored = [(close_dist(e), e) for e in code_eps]
+    scored = [(d, e) for d, e in scored if d is not None and d <= MATCH_TOLERANCE_DAYS]
+    if not scored:
+        return None, f"{code_s} 売却日 {sell_date} に一致するクローズ日が無い"
+    scored.sort(key=lambda x: x[0])
+    best_dist = scored[0][0]
+    best = [e for d, e in scored if d == best_dist]
+    if len(best) > 1:
+        return None, f"{code_s} 売却日 {sell_date} に候補が複数 ({len(best)})"
+    return best[0], f"close_date={best[0]['close_date']} (差{best_dist}日)"
+
+
+def migrate(*, db_path: Optional[str] = None, dry_run: bool = False) -> Dict[str, Any]:
+    logs = ps.list_action_logs(db_path=db_path)
+    memo_logs = [l for l in logs if (l.get("review_memo") or "").strip()]
+    episodes = helpers.build_fill_episodes(db_path=db_path)
+    existing = ps.list_fill_memos(db_path=db_path)
+
+    log_print(f"[migrate_review_memo] 対象 review_memo: {len(memo_logs)} 件")
+
+    migrated: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
+    already: List[Dict[str, Any]] = []
+
+    for ml in memo_logs:
+        ep, reason = _match_episode(ml, episodes)
+        memo = (ml.get("review_memo") or "").strip()
+        if ep is None:
+            skipped.append({"code_s": ml["code_s"], "reason": reason, "memo": memo})
+            log_warning(f"[migrate_review_memo] SKIP {ml['code_s']}: {reason}")
+            continue
+        key = ep["episode_key"]
+        if existing.get(key):
+            already.append({"code_s": ml["code_s"], "episode_key": key})
+            log_print(f"[migrate_review_memo] 既存あり (上書きしない) {ml['code_s']} {key}")
+            continue
+        log_print(f"[migrate_review_memo] {ml['code_s']} → {key} : {reason}")
+        log_print(f"    memo: {memo[:60]}")
+        if not dry_run:
+            ps.set_fill_memo(key, memo, db_path=db_path)
+        migrated.append({"code_s": ml["code_s"], "episode_key": key, "memo": memo})
+
+    log_print(
+        f"[migrate_review_memo] 完了: 移行 {len(migrated)} / "
+        f"既存 {len(already)} / スキップ {len(skipped)}"
+        + (" (dry-run)" if dry_run else "")
+    )
+    return {"migrated": migrated, "skipped": skipped, "already": already, "dry_run": dry_run}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="action_log の review_memo を fill エピソードへ移行する (issue #387 Phase2)"
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="DB に書き込まず対応表のみ表示")
+    parser.add_argument("--db-path", default=None, help="書き込み先 DB パス")
+    args = parser.parse_args()
+    summary = migrate(db_path=args.db_path, dry_run=args.dry_run)
+    return 1 if summary["skipped"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -1104,16 +1104,19 @@ def list_fills(
 # fill 建玉ラウンド (エピソード) 単位の振り返りメモ (issue #387 Phase2)
 # ===========================================
 
-def fill_episode_key(code_s: str, kind: str, open_date: str,
-                     close_date: Optional[str]) -> str:
+def fill_episode_key(code_s: str, kind: str, first_seq: int) -> str:
     """fill エピソード (建玉ラウンド) を一意に識別するキーを組み立てる。
 
-    fill は再取込で作り直されるが、同一ラウンドは 銘柄+口座種別+建日+返済日 が
-    変わらないためメモが維持される。保有中 (close_date=None) は "open" を使う。
+    キーは 銘柄+口座種別+ラウンド先頭 fill の seq。first_seq は建玉開始時に
+    確定し、その後の買い増し・部分売り・返済・売却で fill が増えても不変。
+    これにより:
+      - 保有中に付けたメモが売却後 (close_date 確定) も同じキーで追える。
+      - 同一銘柄・同一区分で同日に複数回ラウンドトリップしても、各ラウンドの
+        先頭 seq は異なるためキーが衝突しない。
+    fill の seq は銘柄内で単調増加する固有値 (append_fill が採番)。
     """
     normalized = normalize_code_s(code_s)
-    close_part = close_date or "open"
-    return f"{normalized}|{kind}|{open_date}|{close_part}"
+    return f"{normalized}|{kind}|{first_seq}"
 
 
 def _fill_memo_storage_key(episode_key: str) -> str:

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -274,6 +274,36 @@ def validate_code_s(code_s: Any) -> None:
         )
 
 
+_etf_codes_cache: Optional[frozenset] = None
+
+
+def load_etf_code_set() -> frozenset:
+    """ETF コード集合を `DATA_DIR/ETF_code.txt` から読む (issue #387)。
+
+    ファイルはタブ区切り (`1357\t日経Ｄインバ`) でコードは先頭列。
+    株式売買の分析対象外なので、fill 取込時に除外するのに使う。
+    プロセス内でキャッシュする (取込ループから毎行呼ばれるため)。
+    """
+    global _etf_codes_cache
+    if _etf_codes_cache is None:
+        codes = set()
+        try:
+            with open(os.path.join(DATA_DIR, "ETF_code.txt"), "r") as f:
+                for line in f:
+                    code = line.strip().split("\t")[0].strip()
+                    if code:
+                        codes.add(normalize_code_s(code))
+        except OSError as e:
+            log_warning(f"ETF_code.txt を読めませんでした (ETF除外をスキップ): {e}")
+        _etf_codes_cache = frozenset(codes)
+    return _etf_codes_cache
+
+
+def is_etf_code(code_s: Any) -> bool:
+    """銘柄コードが ETF (ETF_code.txt 掲載) かどうか。"""
+    return normalize_code_s(code_s) in load_etf_code_set()
+
+
 def validate_status(status: Any) -> None:
     """ステータスを検証する。"""
     if status not in VALID_STATUSES:

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -1065,31 +1065,6 @@ def list_fills(
     return results
 
 
-def set_fill_matched_seq(
-    code_s: str,
-    seq: int,
-    matched_seq: Optional[int],
-    *,
-    db_path: Optional[str] = None,
-) -> Dict[str, Any]:
-    """fill の matched_seq を更新する (マッチング結果の書き戻し)。
-
-    対象が無ければ KeyError。action_log 側は触らず fill 側にリンクを持たせる設計。
-    """
-    validate_code_s(code_s)
-    normalized = normalize_code_s(code_s)
-    key = _fill_key(normalized, seq)
-    path = _resolve_db_path(db_path)
-    with _flock(db_path):
-        with ShelveDB(path) as db:
-            entry = db.get(key)
-            if entry is None:
-                raise KeyError(f"fill not found: code_s={code_s!r}, seq={seq}")
-            entry["matched_seq"] = matched_seq
-            db[key] = entry
-    return entry
-
-
 # ===========================================
 # 高レベル操作
 # ===========================================

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -213,6 +213,8 @@ FILL_FIELDS = frozenset(
         "dedup_key",      # 冪等取込用ハッシュ
         "matched_seq",    # マッチした action_log の seq (未マッチは None)
         "imported_at",    # 取込時刻 ISO8601
+        "broker",         # 取込元証券会社 ("楽天" / "SBI")。issue #387 Phase3
+        "settle_pl",      # 決済損益[円] (SBI 信用返済行のみ。無ければ None)。issue #387 Phase3
     }
 )
 
@@ -973,8 +975,13 @@ def create_fill(
     trade_kind: str,
     dedup_key: str,
     matched_seq: Optional[int] = None,
+    broker: Optional[str] = None,
+    settle_pl: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """fill レコード dict を生成する (バリデーション付き)。"""
+    """fill レコード dict を生成する (バリデーション付き)。
+
+    broker: 取込元証券会社 ("楽天"/"SBI")。settle_pl: 決済損益[円] (SBI 信用返済のみ)。
+    """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
     if side not in (SIDE_BUY, SIDE_SELL):
@@ -997,6 +1004,8 @@ def create_fill(
         "dedup_key": dedup_key,
         "matched_seq": matched_seq,
         "imported_at": now_iso(),
+        "broker": broker,
+        "settle_pl": int(settle_pl) if settle_pl is not None else None,
     }
 
 

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -215,6 +215,8 @@ FILL_FIELDS = frozenset(
         "imported_at",    # 取込時刻 ISO8601
         "broker",         # 取込元証券会社 ("楽天" / "SBI")。issue #387 Phase3
         "settle_pl",      # 決済損益[円] (SBI 信用返済行のみ。無ければ None)。issue #387 Phase3
+        "tate_date",      # 建約定日 "YYYY-MM-DD" (楽天 信用返済行のみ)。issue #387 Phase4b
+        "tate_price",     # 建単価[円] (楽天 信用返済行のみ、float)。issue #387 Phase4b
     }
 )
 
@@ -977,10 +979,13 @@ def create_fill(
     matched_seq: Optional[int] = None,
     broker: Optional[str] = None,
     settle_pl: Optional[int] = None,
+    tate_date: Optional[str] = None,
+    tate_price: Optional[float] = None,
 ) -> Dict[str, Any]:
     """fill レコード dict を生成する (バリデーション付き)。
 
     broker: 取込元証券会社 ("楽天"/"SBI")。settle_pl: 決済損益[円] (SBI 信用返済のみ)。
+    tate_date/tate_price: 建約定日/建単価 (楽天 信用返済のみ)。issue #387 Phase4b。
     """
     validate_code_s(code_s)
     normalized = normalize_code_s(code_s)
@@ -1006,6 +1011,8 @@ def create_fill(
         "imported_at": now_iso(),
         "broker": broker,
         "settle_pl": int(settle_pl) if settle_pl is not None else None,
+        "tate_date": tate_date,
+        "tate_price": float(tate_price) if tate_price is not None else None,
     }
 
 
@@ -1018,6 +1025,11 @@ def _next_fill_seq(db: ShelveDB, code_s: str) -> int:
     return nxt
 
 
+# 再取込時に既存 fill へ後付けで埋めてよいフィールド (dedup_key に含まれず、
+# 古い取込では欠けている派生情報)。値が None→非None のときだけ埋める。issue #387 Phase4b
+_FILL_BACKFILL_FIELDS = ("tate_date", "tate_price", "settle_pl", "broker")
+
+
 def append_fill(
     fill: Dict[str, Any],
     *,
@@ -1025,7 +1037,9 @@ def append_fill(
 ) -> tuple:
     """fill を1件追記する (dedup_key で冪等)。
 
-    同一 code_s に同じ dedup_key の fill が既にあればスキップ (取込済み)。
+    同一 code_s に同じ dedup_key の fill が既にあればスキップ (取込済み)。ただし
+    tate_date/tate_price/settle_pl/broker が既存で None かつ新 fill で埋まっていれば
+    既存レコードに後付けする (Phase4b で列を追加したための移行、None→非None のみ)。
     新規なら _fill_seq を採番して保存する。
 
     Returns: (fill, is_new: bool) — is_new=False は重複スキップ (既存 fill を返す)
@@ -1042,6 +1056,14 @@ def append_fill(
                 if not key.startswith(prefix):
                     continue
                 if isinstance(value, dict) and value.get("dedup_key") == dedup_key:
+                    # 既存 fill に欠けた派生情報を後付け (None→非None のみ)
+                    updated = False
+                    for f in _FILL_BACKFILL_FIELDS:
+                        if value.get(f) is None and fill.get(f) is not None:
+                            value[f] = fill[f]
+                            updated = True
+                    if updated:
+                        db[key] = value
                     return value, False  # 既に取込済み (冪等)
             seq = _next_fill_seq(db, code_s)
             stored = dict(fill)

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -84,6 +84,10 @@ KEY_TRADE_IDEA_PREFIX = "trade_idea:"
 # issue #360 Phase2: 楽天CSV 由来の約定事実 (fill レイヤー、イミュータブル)
 KEY_FILL_PREFIX = "fill:"
 KEY_FILL_SEQ_PREFIX = "_fill_seq:"
+# issue #387 Phase2: fill 建玉ラウンド (エピソード) 単位の振り返りメモ。
+# fill は再取込で作り直されるため、メモは別レイヤーに独立保存し
+# エピソードキー (code_s|kind|open_date|close_date) で紐付ける。
+KEY_FILL_MEMO_PREFIX = "fill_memo:"
 
 # テーママスター (issue #282)
 THEME_FIELDS = frozenset({"name", "description", "created_at"})
@@ -1093,6 +1097,73 @@ def list_fills(
                 continue
             results.append(value)
     results.sort(key=lambda r: (r.get("code_s", ""), r.get("seq", 0)))
+    return results
+
+
+# ===========================================
+# fill 建玉ラウンド (エピソード) 単位の振り返りメモ (issue #387 Phase2)
+# ===========================================
+
+def fill_episode_key(code_s: str, kind: str, open_date: str,
+                     close_date: Optional[str]) -> str:
+    """fill エピソード (建玉ラウンド) を一意に識別するキーを組み立てる。
+
+    fill は再取込で作り直されるが、同一ラウンドは 銘柄+口座種別+建日+返済日 が
+    変わらないためメモが維持される。保有中 (close_date=None) は "open" を使う。
+    """
+    normalized = normalize_code_s(code_s)
+    close_part = close_date or "open"
+    return f"{normalized}|{kind}|{open_date}|{close_part}"
+
+
+def _fill_memo_storage_key(episode_key: str) -> str:
+    return f"{KEY_FILL_MEMO_PREFIX}{episode_key}"
+
+
+def get_fill_memo(episode_key: str, *, db_path: Optional[str] = None) -> str:
+    """fill エピソードの振り返りメモを取得する。未設定は空文字。"""
+    path = _resolve_db_path(db_path)
+    with ShelveDB(path) as db:
+        value = db.get(_fill_memo_storage_key(episode_key))
+    if isinstance(value, dict):
+        return value.get("review_memo", "") or ""
+    return ""
+
+
+def set_fill_memo(episode_key: str, review_memo: str, *,
+                  db_path: Optional[str] = None) -> None:
+    """fill エピソードの振り返りメモを上書き保存する。空文字は削除扱い。"""
+    if not isinstance(review_memo, str):
+        raise TypeError(f"review_memo must be str, got {type(review_memo).__name__}")
+    path = _resolve_db_path(db_path)
+    storage_key = _fill_memo_storage_key(episode_key)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            if review_memo.strip() == "":
+                if storage_key in db:
+                    del db[storage_key]
+            else:
+                db[storage_key] = {
+                    "episode_key": episode_key,
+                    "review_memo": review_memo,
+                    "updated_at": now_iso(),
+                }
+    log_print("portfolio_shelve: fill_memo 更新", episode_key)
+
+
+def list_fill_memos(*, db_path: Optional[str] = None) -> Dict[str, str]:
+    """全 fill エピソードメモを {episode_key: review_memo} で一括取得する。"""
+    path = _resolve_db_path(db_path)
+    results: Dict[str, str] = {}
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_FILL_MEMO_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            memo = value.get("review_memo", "") or ""
+            if memo:
+                results[value.get("episode_key", key[len(KEY_FILL_MEMO_PREFIX):])] = memo
     return results
 
 

--- a/scripts/show_fill_episodes.py
+++ b/scripts/show_fill_episodes.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""fill 建玉ラウンド (エピソード) を確認する開発補助CLI (issue #387)。
+
+build_fill_episodes (webapp.helpers) を呼んで、取込後の検算・保有中確認・
+現引や信用の損益・振り返りメモの紐付けをターミナルで確認する。DB は更新しない。
+
+使い方:
+    cd scripts && python show_fill_episodes.py            # 全エピソード (最新約定日降順)
+    cd scripts && python show_fill_episodes.py 6324       # 特定銘柄のみ
+    cd scripts && python show_fill_episodes.py --open     # 保有中のみ
+    cd scripts && python show_fill_episodes.py --memo     # 振り返りメモ付きのみ
+    cd scripts && python show_fill_episodes.py --fills 6324  # 内訳 fill も表示
+"""
+
+import argparse
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+from webapp import helpers  # noqa: E402
+
+
+def _fmt_pl(ep: Dict[str, Any]) -> str:
+    """損益列の文字列を組み立てる (クローズ=実現、保有中=実現+含み)。"""
+    if ep["closed"]:
+        pl = ep.get("pl")
+        if not pl or pl.get("profit_amount") is None:
+            return "損益 —"
+        return f"実現 {pl['profit_amount']:+,}円 ({pl['return_pct']:+.1f}%)"
+    op = ep.get("open_pl") or {}
+    parts = []
+    if op.get("held_qty"):
+        parts.append(f"残 {op['held_qty']}株")
+    if op.get("realized"):
+        parts.append(f"実現 {op['realized']:+,}円")
+    if op.get("unrealized") is not None:
+        parts.append(f"含み {op['unrealized']:+,}円")
+    return " / ".join(parts) if parts else "—"
+
+
+def _print_episode(ep: Dict[str, Any], show_fills: bool) -> None:
+    held = " [保有中]" if not ep["closed"] else ""
+    period = ep["open_date"]
+    if ep.get("close_date") and ep["close_date"] != ep["open_date"]:
+        period += f"〜{ep['close_date']}"
+    print(f"{ep['code_s']:>5} {ep['kind']}{held} {ep['stock_name']}")
+    print(f"      期間 {period}  最大建玉 {ep['qty_peak']}株  {_fmt_pl(ep)}")
+    if ep.get("review_memo"):
+        first_line = ep["review_memo"].splitlines()[0]
+        print(f"      📝 {first_line}")
+    if show_fills:
+        for f in ep["fills"]:
+            tate = f" 建{f['tate_price']:,.0f}" if f.get("tate_price") else ""
+            print(f"        {f['trade_date']} {f['side_label']:>4} {f['trade_kind']:<6}"
+                  f" {f['qty']:>5}株 @{f['price']:,.0f}{tate} [{f['broker']}]")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="fill 建玉ラウンド (エピソード) を確認する (DB非更新)"
+    )
+    parser.add_argument("code_s", nargs="?", default=None,
+                        help="銘柄コード (省略時は全銘柄)")
+    parser.add_argument("--open", action="store_true", help="保有中のみ表示")
+    parser.add_argument("--memo", action="store_true", help="振り返りメモ付きのみ表示")
+    parser.add_argument("--fills", action="store_true", help="内訳の個別 fill も表示")
+    parser.add_argument("--db-path", default=None, help="portfolio DB パス")
+    args = parser.parse_args()
+
+    episodes: List[Dict[str, Any]] = helpers.build_fill_episodes(db_path=args.db_path)
+
+    if args.code_s:
+        code = args.code_s.upper()
+        episodes = [e for e in episodes if e["code_s"] == code]
+    if args.open:
+        episodes = [e for e in episodes if not e["closed"]]
+    if args.memo:
+        episodes = [e for e in episodes if e.get("review_memo")]
+
+    if not episodes:
+        print("該当するエピソードがありません。")
+        return 0
+
+    for ep in episodes:
+        _print_episode(ep, show_fills=args.fills or bool(args.code_s))
+        print()
+
+    print(f"--- {len(episodes)} エピソード "
+          f"(クローズ済 {sum(1 for e in episodes if e['closed'])} / "
+          f"保有中 {sum(1 for e in episodes if not e['closed'])})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/show_fill_episodes.py
+++ b/scripts/show_fill_episodes.py
@@ -44,10 +44,11 @@ def _fmt_pl(ep: Dict[str, Any]) -> str:
 
 def _print_episode(ep: Dict[str, Any], show_fills: bool) -> None:
     held = " [保有中]" if not ep["closed"] else ""
+    carry_over = " [期首持越し]" if ep.get("carry_over") else ""
     period = ep["open_date"]
     if ep.get("close_date") and ep["close_date"] != ep["open_date"]:
         period += f"〜{ep['close_date']}"
-    print(f"{ep['code_s']:>5} {ep['kind']}{held} {ep['stock_name']}")
+    print(f"{ep['code_s']:>5} {ep['kind']}{held}{carry_over} {ep['stock_name']}")
     print(f"      期間 {period}  最大建玉 {ep['qty_peak']}株  {_fmt_pl(ep)}")
     if ep.get("review_memo"):
         first_line = ep["review_memo"].splitlines()[0]

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4584,6 +4584,25 @@ def _build_code_episodes(code_s: str, stock_name: str,
     return episodes
 
 
+def latest_fill_dates_by_broker(db_path: Optional[str] = None) -> Dict[str, str]:
+    """証券会社別の取込済み fill の最新約定日を返す (issue #387、取込タイミング参考)。
+
+    Returns: {"楽天": "2026-07-31", "SBI": "2026-07-21", ...}。broker 未設定の
+    既存 fill は「楽天」に寄せる (表示補完と整合)。取込 fill が無ければ空 dict。
+    """
+    import portfolio_shelve as ps  # 遅延 import (循環回避)
+
+    latest: Dict[str, str] = {}
+    for f in ps.list_fills(db_path=db_path):
+        td = f.get("trade_date")
+        if not td:
+            continue
+        broker = f.get("broker") or "楽天"
+        if broker not in latest or td > latest[broker]:
+            latest[broker] = td
+    return latest
+
+
 def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
     """全 fill を建玉ラウンド単位のエピソードに再構成する (issue #387 Phase4b)。
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4610,6 +4610,15 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
         if not ep["closed"]:
             ep["open_pl"] = _episode_open_pl(ep, latest_prices.get(ep["code_s"]))
 
+    # 建玉ラウンド単位の振り返りメモ (issue #387 Phase2) を一括で紐付ける。
+    # メモは fill と独立レイヤーに保存され、エピソードキーで対応する。
+    memos = ps.list_fill_memos(db_path=db_path)
+    for ep in episodes:
+        ep["episode_key"] = ps.fill_episode_key(
+            ep["code_s"], ep["kind"], ep["open_date"], ep["close_date"]
+        )
+        ep["review_memo"] = memos.get(ep["episode_key"], "")
+
     # 最終約定日 (最新の取引がある順) 降順、同日は銘柄コード昇順
     episodes.sort(key=lambda e: e["code_s"])
     episodes.sort(key=lambda e: e["last_trade_date"], reverse=True)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4584,23 +4584,27 @@ def _build_code_episodes(code_s: str, stock_name: str,
     return episodes
 
 
-def latest_fill_dates_by_broker(db_path: Optional[str] = None) -> Dict[str, str]:
-    """証券会社別の取込済み fill の最新約定日を返す (issue #387、取込タイミング参考)。
+def fill_date_range_by_broker(db_path: Optional[str] = None) -> Dict[str, Dict[str, str]]:
+    """証券会社別の取込済み fill の最古・最新約定日を返す (issue #387、取込タイミング参考)。
 
-    Returns: {"楽天": "2026-07-31", "SBI": "2026-07-21", ...}。broker 未設定の
-    既存 fill は「楽天」に寄せる (表示補完と整合)。取込 fill が無ければ空 dict。
+    Returns: {"楽天": {"first": "2026-01-05", "last": "2026-07-31"}, "SBI": {...}}。
+    broker 未設定の既存 fill は「楽天」に寄せる (表示補完と整合)。
+    取込 fill が無ければ空 dict。
     """
     import portfolio_shelve as ps  # 遅延 import (循環回避)
 
-    latest: Dict[str, str] = {}
+    ranges: Dict[str, Dict[str, str]] = {}
     for f in ps.list_fills(db_path=db_path):
         td = f.get("trade_date")
         if not td:
             continue
         broker = f.get("broker") or "楽天"
-        if broker not in latest or td > latest[broker]:
-            latest[broker] = td
-    return latest
+        r = ranges.setdefault(broker, {"first": td, "last": td})
+        if td < r["first"]:
+            r["first"] = td
+        if td > r["last"]:
+            r["last"] = td
+    return ranges
 
 
 def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4839,9 +4839,14 @@ def calc_trade_summary(episode_pls: list) -> Optional[dict]:
     else:
         payoff_ratio = win_weighted / abs(lose_weighted)
 
+    # 期待値 = 1 トレードあたりの平均リターン% (全トレードの金額加重平均)。
+    # 勝率とペイオフを統合した手法の総合的な優位性。プラスならトータルで優位。
+    expectancy = _weighted_avg_return(episode_pls)
+
     return {
         "win_rate": len(wins) / n_total * 100,
         "payoff_ratio": payoff_ratio,
+        "expectancy": expectancy,
         # 勝ち/負けの金額加重平均リターン% (ペイオフレシオの分子・分母)
         "avg_return_win": win_weighted,
         "avg_return_lose": lose_weighted,

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4247,49 +4247,50 @@ def _aggregate_fill_price(fills: list) -> Optional[dict]:
 _SIDE_LABELS = {"buy": "買", "sell": "売"}
 
 
-def list_unmatched_fills() -> List[Dict[str, Any]]:
-    """取込済みで未マッチ (matched_seq is None) の fill を表示用にまとめて返す (issue #360)。
+def list_trade_fills() -> List[Dict[str, Any]]:
+    """取込済みの全 fill (実約定) を売買履歴タブ用にまとめて返す (issue #387)。
 
-    エピソードへ自動マッチできなかった約定を /trade-history で可視化するためのリスト。
-    P/L には反映されていない fill を銘柄ごとに一覧して気づけるようにする (閲覧のみ)。
+    楽天CSVを売買履歴の真実源とし、約定日降順で一覧表示する。matched_seq の有無は
+    問わない (突合を廃止したため。既存 DB の matched_seq 値は参照しない)。
 
     同日集約: (code_s, side, trade_date) が同じ fill (分割約定) は加重平均単価・合計株数で
     1 行に畳む。2 件以上を畳んだ行には count と aggregated=True を付ける (可視化)。
-    集約は表示のみで、自動マッチ判定 (b) には影響しない。
 
     Returns: [{code_s, stock_name, trade_date, side, side_label, qty, price,
-               trade_kind, count, aggregated}, ...] を code_s 昇順 → trade_date 昇順で。
+               trade_kind, count, aggregated}, ...] を約定日降順 → code_s 昇順で。
     """
     import portfolio_shelve as ps  # 遅延 import (循環回避)
 
-    unmatched = [f for f in ps.list_fills() if f.get("matched_seq") is None]
-    if not unmatched:
+    fills = ps.list_fills()
+    if not fills:
         return []
 
     # (code_s, side, trade_date) で分割約定をグループ化
     groups: Dict[Tuple[str, str, str], List[Dict[str, Any]]] = {}
-    for f in unmatched:
+    for f in fills:
         key = (f["code_s"], f["side"], f["trade_date"])
         groups.setdefault(key, []).append(f)
 
     rows: List[Dict[str, Any]] = []
-    for (code_s, side, trade_date), fills in groups.items():
-        agg = _aggregate_fill_price(fills)
+    for (code_s, side, trade_date), group in groups.items():
+        agg = _aggregate_fill_price(group)
         # 取引区分はグループ内で通常単一。複数種混在時は "/" で併記 (稀)
-        kinds = sorted({f.get("trade_kind", "") for f in fills if f.get("trade_kind")})
+        kinds = sorted({f.get("trade_kind", "") for f in group if f.get("trade_kind")})
         rows.append({
             "code_s": code_s,
             "stock_name": resolve_stock_name(code_s),
             "trade_date": trade_date,
             "side": side,
             "side_label": _SIDE_LABELS.get(side, side),
-            "qty": agg["qty"] if agg else sum(f["qty"] for f in fills),
-            "price": agg["price"] if agg else fills[0]["price"],
+            "qty": agg["qty"] if agg else sum(f["qty"] for f in group),
+            "price": agg["price"] if agg else group[0]["price"],
             "trade_kind": " / ".join(kinds),
-            "count": len(fills),
-            "aggregated": len(fills) >= 2,
+            "count": len(group),
+            "aggregated": len(group) >= 2,
         })
-    rows.sort(key=lambda r: (r["code_s"], r["trade_date"]))
+    # 約定日降順、同日内は銘柄コード昇順
+    rows.sort(key=lambda r: r["code_s"])
+    rows.sort(key=lambda r: r["trade_date"], reverse=True)
     return rows
 
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4300,6 +4300,178 @@ def list_trade_fills() -> List[Dict[str, Any]]:
 
 
 # ===========================================
+# issue #387 Phase4b: fill 基準の建玉ラウンド・エピソード再構成
+# ===========================================
+
+# trade_kind → 口座種別 ("現物" / "信用")。現引は現物ラウンドに合流させる。
+def _fill_account_kind(trade_kind: str) -> str:
+    tk = trade_kind or ""
+    if tk.startswith("信用"):
+        return "信用"
+    return "現物"  # 現物 / 現物(単元未満) / 現引
+
+
+def _episode_pl_from_round(rnd: dict) -> Optional[dict]:
+    """クローズ済み建玉ラウンドから calc_trade_summary 互換の損益 dict を作る。
+
+    現物: 平均取得単価法。買い (buy=買付/現引) で加重平均取得単価を積み、売り (sell) で
+      実現損益 = Σ(sell_price - avg_cost) * sell_qty。amount = 総取得コスト (金額加重の重み)。
+    信用: 各返済 fill が単独で損益確定。楽天=約定単価-建単価(tate_price)、SBI=settle_pl。
+      amount = 建玉コスト (Σ tate_price*qty、無ければ約定金額)。
+
+    Returns: {return_pct, hold_days, avg_cost, amount, profit_amount, ...} / 算出不能なら None
+    """
+    fills = rnd["fills"]
+    if not fills:
+        return None
+    kind = rnd["kind"]
+    total_cost = 0.0        # 取得コスト合計 (現物=買い金額, 信用=建玉金額) → 金額加重の重み
+    realized = 0.0          # 実現損益額
+
+    if kind == "現物":
+        held_qty = 0
+        avg_cost = 0.0
+        cost_basis_total = 0.0  # 買いで積んだ延べ取得コスト (return_pct の分母 amount)
+        for f in fills:
+            qty = f["qty"]
+            price = f["price"]
+            if f["side"] == "buy":
+                new_qty = held_qty + qty
+                avg_cost = (avg_cost * held_qty + price * qty) / new_qty if new_qty else 0.0
+                held_qty = new_qty
+                cost_basis_total += price * qty
+            else:  # sell
+                sell_qty = min(qty, held_qty) if held_qty > 0 else qty
+                realized += (price - avg_cost) * sell_qty
+                held_qty -= qty
+        total_cost = cost_basis_total
+    else:  # 信用
+        for f in fills:
+            if f["side"] != "sell":
+                continue  # 信用新規買建は建玉、損益は返済 fill 側で確定
+            qty = f["qty"]
+            price = f["price"]
+            settle_pl = f.get("settle_pl")
+            tate_price = f.get("tate_price")
+            if settle_pl is not None:
+                realized += settle_pl
+                total_cost += (tate_price or price) * qty
+            elif tate_price is not None:
+                realized += (price - tate_price) * qty
+                total_cost += tate_price * qty
+            else:
+                # 建単価も決済損益も無い → 損益不能
+                return None
+
+    if total_cost <= 0:
+        return None
+    return_pct = realized / total_cost * 100
+    try:
+        hold_days = (date.fromisoformat(rnd["close_date"])
+                     - date.fromisoformat(rnd["open_date"])).days
+    except (ValueError, TypeError, KeyError):
+        hold_days = None
+    return {
+        "return_pct": return_pct,
+        "hold_days": hold_days if hold_days is not None else 0,
+        "avg_cost": total_cost / max(sum(f["qty"] for f in fills if f["side"] == "buy"), 1),
+        "amount": total_cost,
+        "profit_amount": round(realized),
+    }
+
+
+def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
+    """全 fill を建玉ラウンド単位のエピソードに再構成する (issue #387 Phase4b)。
+
+    銘柄コード × 口座種別 (現物/信用) ごとに約定日昇順で fill を並べ、保有 (建玉) 株数が
+    0 → 建 → 0 に戻る 1 サイクルを 1 エピソードとする。現引は現物ラウンドの buy として
+    合流させ (現引ブリッジ)、信用は返済 fill の建単価/決済損益で損益確定する。
+
+    各エピソード dict:
+      code_s, stock_name, kind ("現物"/"信用"), open_date, close_date,
+      qty_peak (最大建玉), closed (bool), fills (内部の個別 fill 明細リスト),
+      pl (クローズ済みのみ: _episode_pl_from_round の結果, 未クローズは None)
+
+    Returns: close_date (未クローズは open_date) 降順のエピソードリスト。
+    """
+    import portfolio_shelve as ps  # 遅延 import (循環回避)
+
+    all_fills = ps.list_fills(db_path=db_path)
+    if not all_fills:
+        return []
+
+    # (code_s, 口座種別) でグループ化し、約定日→seq 昇順に
+    groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for f in all_fills:
+        key = (f["code_s"], _fill_account_kind(f.get("trade_kind", "")))
+        groups.setdefault(key, []).append(f)
+
+    names = _bulk_resolve_stock_names(list({k[0] for k in groups}))
+
+    episodes: List[Dict[str, Any]] = []
+    for (code_s, kind), fills in groups.items():
+        fills = sorted(fills, key=lambda f: (f.get("trade_date") or "", f.get("seq") or 0))
+        held_qty = 0
+        cur: List[Dict[str, Any]] = []  # 現ラウンドの fill
+        qty_peak = 0
+        for f in fills:
+            if not cur:
+                # ラウンド開始
+                qty_peak = 0
+            cur.append(f)
+            if f["side"] == "buy":
+                held_qty += f["qty"]
+            else:
+                held_qty -= f["qty"]
+            qty_peak = max(qty_peak, held_qty)
+            if held_qty <= 0 and cur:
+                # ラウンドクローズ (保有 0 以下に戻った)
+                episodes.append(_finalize_round(code_s, kind, names.get(code_s, ""), cur, qty_peak))
+                cur = []
+                held_qty = 0
+        if cur:
+            # 未クローズ (保有中)
+            episodes.append(_finalize_round(code_s, kind, names.get(code_s, ""), cur, qty_peak, closed=False))
+
+    # close_date (未クローズは open_date) 降順、同日は銘柄コード昇順
+    episodes.sort(key=lambda e: e["code_s"])
+    episodes.sort(key=lambda e: e.get("close_date") or e["open_date"], reverse=True)
+    return episodes
+
+
+def _finalize_round(code_s: str, kind: str, stock_name: str,
+                    round_fills: List[Dict[str, Any]], qty_peak: int,
+                    closed: bool = True) -> Dict[str, Any]:
+    """建玉ラウンドの fill リストからエピソード dict を組み立てる。"""
+    dates = [f["trade_date"] for f in round_fills if f.get("trade_date")]
+    ep = {
+        "code_s": code_s,
+        "stock_name": stock_name,
+        "kind": kind,
+        "open_date": min(dates) if dates else "",
+        "close_date": max(dates) if (dates and closed) else None,
+        "qty_peak": qty_peak,
+        "closed": closed,
+        "fills": [
+            {
+                "trade_date": f.get("trade_date"),
+                "side": f["side"],
+                "side_label": _SIDE_LABELS.get(f["side"], f["side"]),
+                "qty": f["qty"],
+                "price": f["price"],
+                "trade_kind": f.get("trade_kind", ""),
+                "broker": f.get("broker") or "",
+                "tate_price": f.get("tate_price"),
+                "settle_pl": f.get("settle_pl"),
+            }
+            for f in round_fills
+        ],
+    }
+    ep["pl"] = _episode_pl_from_round(ep) if closed else None
+    return ep
+
+
+# ===========================================
 # issue #361: 売買エピソードの概算損益・成績サマリー
 # ===========================================
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4471,18 +4471,105 @@ def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict
     }
 
 
+def _build_code_episodes(code_s: str, stock_name: str,
+                         fills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """1銘柄の fill (信用+現物混在、約定日昇順) を建玉ラウンドのエピソードに分ける。
+
+    信用ラウンドと現物ラウンドを並行管理し、**現引で信用→現物へ建玉を振り替える**:
+      - 信用新規買 (buy): 信用建玉を積む
+      - 信用返済売 (sell): 信用建玉を減らし、建玉0で信用ラウンドをクローズ (損益確定)
+      - 現引 (buy): 信用建玉が残っていればその分を信用ラウンドから抜き (振替、信用側は
+        損益計上しない=現物へ持ち越し)、現物ラウンドに現引 buy を積む。信用建玉が0に
+        なれば信用ラウンドをクローズ
+      - 現物買 (buy): 現物建玉を積む
+      - 現物売 (sell): 現物建玉を減らし、建玉0で現物ラウンドをクローズ
+    保有0に戻らず残った建玉は保有中エピソードになる。
+    """
+    # 約定日昇順。同日内は 建玉を作る側 (buy=新規買・現引) を先に、玉を減らす側
+    # (sell=売り・返済) を後に処理する。現引で現物化してから同日に売るケースで、売りが
+    # 先に来て期首持ち越し扱いになる誤検出を防ぐ (6366 相当)。
+    def _sort_key(f):
+        return (f.get("trade_date") or "", 0 if f["side"] == "buy" else 1, f.get("seq") or 0)
+    fills = sorted(fills, key=_sort_key)
+    episodes: List[Dict[str, Any]] = []
+
+    shinyo_fills: List[Dict[str, Any]] = []  # 現ラウンドの信用 fill
+    shinyo_qty = 0
+    shinyo_peak = 0
+    genbutsu_fills: List[Dict[str, Any]] = []  # 現ラウンドの現物 fill
+    genbutsu_qty = 0
+    genbutsu_peak = 0
+
+    def close_shinyo():
+        nonlocal shinyo_fills, shinyo_qty, shinyo_peak
+        if shinyo_fills:
+            episodes.append(_finalize_round(code_s, "信用", stock_name, shinyo_fills, shinyo_peak))
+        shinyo_fills = []
+        shinyo_qty = 0
+        shinyo_peak = 0
+
+    def close_genbutsu():
+        nonlocal genbutsu_fills, genbutsu_qty, genbutsu_peak
+        if genbutsu_fills:
+            episodes.append(_finalize_round(code_s, "現物", stock_name, genbutsu_fills, genbutsu_peak))
+        genbutsu_fills = []
+        genbutsu_qty = 0
+        genbutsu_peak = 0
+
+    for f in fills:
+        tk = f.get("trade_kind") or ""
+        qty = f["qty"]
+        if tk == "現引":
+            # 信用建玉 → 現物へ振替。信用側は残っていれば現引分だけ減らす。
+            if shinyo_qty > 0:
+                shinyo_qty -= qty
+                if shinyo_qty <= 0:
+                    close_shinyo()  # 現引で信用建玉が尽きたらクローズ (損益は現物へ)
+            # 現物ラウンドに現引 buy を積む (price=実質取得原価)
+            genbutsu_fills.append(f)
+            genbutsu_qty += qty
+            genbutsu_peak = max(genbutsu_peak, genbutsu_qty)
+        elif tk.startswith("信用"):
+            shinyo_fills.append(f)
+            if f["side"] == "buy":
+                shinyo_qty += qty
+            else:
+                shinyo_qty -= qty
+            shinyo_peak = max(shinyo_peak, shinyo_qty)
+            if shinyo_qty <= 0:
+                close_shinyo()
+        else:  # 現物 / 現物(単元未満)
+            genbutsu_fills.append(f)
+            if f["side"] == "buy":
+                genbutsu_qty += qty
+            else:
+                genbutsu_qty -= qty
+            genbutsu_peak = max(genbutsu_peak, genbutsu_qty)
+            if genbutsu_qty <= 0:
+                close_genbutsu()
+
+    # 保有中 (残った建玉)
+    if shinyo_fills:
+        episodes.append(_finalize_round(code_s, "信用", stock_name, shinyo_fills, shinyo_peak, closed=False))
+    if genbutsu_fills:
+        episodes.append(_finalize_round(code_s, "現物", stock_name, genbutsu_fills, genbutsu_peak, closed=False))
+
+    return episodes
+
+
 def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
     """全 fill を建玉ラウンド単位のエピソードに再構成する (issue #387 Phase4b)。
 
-    銘柄コード × 口座種別 (現物/信用) ごとに約定日昇順で fill を並べ、保有 (建玉) 株数が
-    0 → 建 → 0 に戻る 1 サイクルを 1 エピソードとする。現引は現物ラウンドの buy として
-    合流させ (現引ブリッジ)、信用は返済 fill の建単価/決済損益で損益確定する。
+    銘柄ごとに信用・現物を同一時系列で処理し、保有 (建玉) 株数が 0 → 建 → 0 に戻る
+    1 サイクルを 1 エピソードとする。**現引は信用建玉を現物へ振り替える** (信用側の
+    建玉を減らし現物側に取得原価で積む)。信用は返済 fill の建単価/決済損益で損益確定。
 
     各エピソード dict:
       code_s, stock_name, kind ("現物"/"信用"), open_date, close_date,
       last_trade_date (ラウンド内の最終約定日), qty_peak (最大建玉),
       closed (bool), fills (内部の個別 fill 明細リスト),
-      pl (クローズ済みのみ: _episode_pl_from_round の結果, 未クローズは None)
+      pl (クローズ済みのみ: _episode_pl_from_round の結果, 未クローズは None),
+      open_pl (保有中のみ: realized/unrealized/held_qty/avg_cost)
 
     Returns: 最終約定日 (買い増し・部分売り含むラウンド内の最新の取引日) 降順の
     エピソードリスト。保有中エピソードも最後に約定した日で並ぶ。
@@ -4493,38 +4580,16 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
     if not all_fills:
         return []
 
-    # (code_s, 口座種別) でグループ化し、約定日→seq 昇順に
-    groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    # 銘柄コードでグループ化 (信用・現物を同一時系列で処理するため口座種別で分けない)
+    by_code: Dict[str, List[Dict[str, Any]]] = {}
     for f in all_fills:
-        key = (f["code_s"], _fill_account_kind(f.get("trade_kind", "")))
-        groups.setdefault(key, []).append(f)
+        by_code.setdefault(f["code_s"], []).append(f)
 
-    names = _bulk_resolve_stock_names(list({k[0] for k in groups}))
+    names = _bulk_resolve_stock_names(list(by_code.keys()))
 
     episodes: List[Dict[str, Any]] = []
-    for (code_s, kind), fills in groups.items():
-        fills = sorted(fills, key=lambda f: (f.get("trade_date") or "", f.get("seq") or 0))
-        held_qty = 0
-        cur: List[Dict[str, Any]] = []  # 現ラウンドの fill
-        qty_peak = 0
-        for f in fills:
-            if not cur:
-                # ラウンド開始
-                qty_peak = 0
-            cur.append(f)
-            if f["side"] == "buy":
-                held_qty += f["qty"]
-            else:
-                held_qty -= f["qty"]
-            qty_peak = max(qty_peak, held_qty)
-            if held_qty <= 0 and cur:
-                # ラウンドクローズ (保有 0 以下に戻った)
-                episodes.append(_finalize_round(code_s, kind, names.get(code_s, ""), cur, qty_peak))
-                cur = []
-                held_qty = 0
-        if cur:
-            # 未クローズ (保有中)
-            episodes.append(_finalize_round(code_s, kind, names.get(code_s, ""), cur, qty_peak, closed=False))
+    for code_s, fills in by_code.items():
+        episodes.extend(_build_code_episodes(code_s, names.get(code_s, ""), fills))
 
     # 保有中エピソードに実現損益 (部分売り分) と含み損益 (残玉評価) を付与 (issue #387 Phase4b)。
     # 含みは price_log の直近終値を現在値とする。銘柄をバルク取得して N+1 を避ける。

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4380,6 +4380,97 @@ def _episode_pl_from_round(rnd: dict) -> Optional[dict]:
     }
 
 
+def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict]:
+    """保有中 (未クローズ) 建玉ラウンドの実現損益 (部分売り分) と含み損益を計算する。
+
+    実現損益: ラウンド内で既に売った分の確定損益 (現物=平均取得単価法、信用=建単価/settle_pl)。
+    含み損益: 残っている建玉 × (current_price - 取得基準単価)。current_price は price_log の
+      直近終値。取得基準は 現物=平均取得単価、信用=平均建単価。current_price が無ければ
+      含みは None (実現分は出す)。
+
+    Returns: {realized, unrealized, held_qty, avg_cost} / 建玉も売りも無ければ None。
+      unrealized は current_price 不明なら None。
+    """
+    fills = rnd["fills"]
+    if not fills:
+        return None
+    kind = rnd["kind"]
+
+    if kind == "現物":
+        held_qty = 0
+        avg_cost = 0.0
+        realized = 0.0
+        for f in fills:
+            qty = f["qty"]
+            price = f["price"]
+            if f["side"] == "buy":
+                new_qty = held_qty + qty
+                avg_cost = (avg_cost * held_qty + price * qty) / new_qty if new_qty else 0.0
+                held_qty = new_qty
+            else:  # sell (部分売り)
+                sell_qty = min(qty, held_qty) if held_qty > 0 else qty
+                realized += (price - avg_cost) * sell_qty
+                held_qty -= qty
+        cost_basis = avg_cost
+    else:  # 信用
+        # 建玉 (buy=信用新規) の平均建単価を取得基準に、返済 (sell=信用返済) 分を実現に。
+        # 信用返済 buy (建玉方向と逆の返済買=空売り決済等) が混ざると held_qty が実態とずれ
+        # 含み評価が不正確になるため、そのラウンドは含みを算出しない (安全側)。
+        has_reverse_settle = any(
+            f["side"] == "buy" and (f.get("trade_kind") or "").startswith("信用返済")
+            for f in fills
+        )
+        held_qty = 0
+        avg_cost = 0.0
+        realized = 0.0
+        for f in fills:
+            qty = f["qty"]
+            price = f["price"]
+            if f["side"] == "buy" and (f.get("trade_kind") or "").startswith("信用新規"):
+                new_qty = held_qty + qty
+                avg_cost = (avg_cost * held_qty + price * qty) / new_qty if new_qty else 0.0
+                held_qty = new_qty
+            elif f["side"] == "sell":  # 信用返済 (部分返済)
+                settle_pl = f.get("settle_pl")
+                tate_price = f.get("tate_price")
+                if settle_pl is not None:
+                    realized += settle_pl
+                elif tate_price is not None:
+                    realized += (price - tate_price) * qty
+                else:
+                    realized += (price - avg_cost) * qty  # 建単価不明時は平均建単価で近似
+                held_qty -= qty
+            # 信用返済 buy は held_qty を触らない (has_reverse_settle で含みは無効化)
+        cost_basis = avg_cost
+        if has_reverse_settle:
+            return {
+                "realized": round(realized),
+                "unrealized": None,  # 建玉方向が交錯し含み評価不能
+                "held_qty": held_qty if held_qty > 0 else 0,
+                "avg_cost": cost_basis,
+            }
+
+    if held_qty <= 0:
+        # 保有中扱いだが実質建玉が残っていない (空売り等) → 含み対象なし
+        return {
+            "realized": round(realized),
+            "unrealized": None,
+            "held_qty": held_qty if held_qty > 0 else 0,
+            "avg_cost": cost_basis,
+        }
+
+    unrealized = None
+    if current_price is not None and cost_basis > 0:
+        unrealized = round((current_price - cost_basis) * held_qty)
+
+    return {
+        "realized": round(realized),
+        "unrealized": unrealized,
+        "held_qty": held_qty,
+        "avg_cost": cost_basis,
+    }
+
+
 def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
     """全 fill を建玉ラウンド単位のエピソードに再構成する (issue #387 Phase4b)。
 
@@ -4434,6 +4525,20 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
         if cur:
             # 未クローズ (保有中)
             episodes.append(_finalize_round(code_s, kind, names.get(code_s, ""), cur, qty_peak, closed=False))
+
+    # 保有中エピソードに実現損益 (部分売り分) と含み損益 (残玉評価) を付与 (issue #387 Phase4b)。
+    # 含みは price_log の直近終値を現在値とする。銘柄をバルク取得して N+1 を避ける。
+    open_codes = {e["code_s"] for e in episodes if not e["closed"]}
+    latest_prices: Dict[str, Optional[float]] = {}
+    if open_codes:
+        price_logs = _bulk_price_logs(list(open_codes))
+        for code_s, log in price_logs.items():
+            if log:
+                latest = max(log, key=lambda x: x[0])  # (date, close) の最新
+                latest_prices[code_s] = float(latest[1])
+    for ep in episodes:
+        if not ep["closed"]:
+            ep["open_pl"] = _episode_open_pl(ep, latest_prices.get(ep["code_s"]))
 
     # 最終約定日 (最新の取引がある順) 降順、同日は銘柄コード昇順
     episodes.sort(key=lambda e: e["code_s"])

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4346,9 +4346,13 @@ def _episode_pl_from_round(rnd: dict) -> Optional[dict]:
                 held_qty -= qty
         total_cost = cost_basis_total
     else:  # 信用
+        # 買建は返済 sell で、売建 (空売り) は返済 buy で損益が確定する。
+        # 売建は「高く売って安く買い戻す」ので損益の符号が買建と逆になる。
+        is_short = rnd.get("is_short", False)
+        settle_side = "buy" if is_short else "sell"
         for f in fills:
-            if f["side"] != "sell":
-                continue  # 信用新規買建は建玉、損益は返済 fill 側で確定
+            if f["side"] != settle_side:
+                continue  # 建玉側の fill。損益は返済 fill 側で確定
             qty = f["qty"]
             price = f["price"]
             settle_pl = f.get("settle_pl")
@@ -4357,7 +4361,9 @@ def _episode_pl_from_round(rnd: dict) -> Optional[dict]:
                 realized += settle_pl
                 total_cost += (tate_price or price) * qty
             elif tate_price is not None:
-                realized += (price - tate_price) * qty
+                # 売建は (建単価 - 買戻単価)、買建は (返済単価 - 建単価)
+                realized += ((tate_price - price) if is_short
+                             else (price - tate_price)) * qty
                 total_cost += tate_price * qty
             else:
                 # 建単価も決済損益も無い → 損益不能
@@ -4371,10 +4377,13 @@ def _episode_pl_from_round(rnd: dict) -> Optional[dict]:
                      - date.fromisoformat(rnd["open_date"])).days
     except (ValueError, TypeError, KeyError):
         hold_days = None
+    # 建玉側の株数で割る (買建/現物=buy、売建=sell が建玉側)
+    open_side = "sell" if rnd.get("is_short") else "buy"
     return {
         "return_pct": return_pct,
         "hold_days": hold_days if hold_days is not None else 0,
-        "avg_cost": total_cost / max(sum(f["qty"] for f in fills if f["side"] == "buy"), 1),
+        "avg_cost": total_cost / max(
+            sum(f["qty"] for f in fills if f["side"] == open_side), 1),
         "amount": total_cost,
         "profit_amount": round(realized),
     }
@@ -4413,11 +4422,15 @@ def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict
                 held_qty -= qty
         cost_basis = avg_cost
     else:  # 信用
-        # 建玉 (buy=信用新規) の平均建単価を取得基準に、返済 (sell=信用返済) 分を実現に。
-        # 信用返済 buy (建玉方向と逆の返済買=空売り決済等) が混ざると held_qty が実態とずれ
-        # 含み評価が不正確になるため、そのラウンドは含みを算出しない (安全側)。
+        # 建玉側と決済側は買建/売建で逆になる。売建 (空売り) は新規売で建て返済買で閉じる。
+        is_short = rnd.get("is_short", False)
+        open_side = "sell" if is_short else "buy"
+        settle_side = "buy" if is_short else "sell"
+        # 建玉方向と逆の返済が混ざると held_qty が実態とずれ含み評価が不正確になるため、
+        # そのラウンドは含みを算出しない (安全側)。売建ラウンドを分離した今、これは
+        # 「売建が無いのに返済買がある」等の想定外パターンのみが該当する。
         has_reverse_settle = any(
-            f["side"] == "buy" and (f.get("trade_kind") or "").startswith("信用返済")
+            f["side"] == open_side and (f.get("trade_kind") or "").startswith("信用返済")
             for f in fills
         )
         held_qty = 0
@@ -4426,21 +4439,24 @@ def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict
         for f in fills:
             qty = f["qty"]
             price = f["price"]
-            if f["side"] == "buy" and (f.get("trade_kind") or "").startswith("信用新規"):
+            if f["side"] == open_side and (f.get("trade_kind") or "").startswith("信用新規"):
                 new_qty = held_qty + qty
                 avg_cost = (avg_cost * held_qty + price * qty) / new_qty if new_qty else 0.0
                 held_qty = new_qty
-            elif f["side"] == "sell":  # 信用返済 (部分返済)
+            elif f["side"] == settle_side:  # 信用返済 (部分返済)
                 settle_pl = f.get("settle_pl")
                 tate_price = f.get("tate_price")
                 if settle_pl is not None:
                     realized += settle_pl
                 elif tate_price is not None:
-                    realized += (price - tate_price) * qty
+                    # 売建は (建単価 - 買戻単価)、買建は (返済単価 - 建単価)
+                    realized += ((tate_price - price) if is_short
+                                 else (price - tate_price)) * qty
                 else:
-                    realized += (price - avg_cost) * qty  # 建単価不明時は平均建単価で近似
+                    # 建単価不明時は平均建単価で近似
+                    realized += ((avg_cost - price) if is_short
+                                 else (price - avg_cost)) * qty
                 held_qty -= qty
-            # 信用返済 buy は held_qty を触らない (has_reverse_settle で含みは無効化)
         cost_basis = avg_cost
         if has_reverse_settle:
             return {
@@ -4461,7 +4477,10 @@ def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict
 
     unrealized = None
     if current_price is not None and cost_basis > 0:
-        unrealized = round((current_price - cost_basis) * held_qty)
+        # 売建 (空売り) は現在値が下がるほど含み益なので符号が逆になる
+        diff = ((cost_basis - current_price) if rnd.get("is_short")
+                else (current_price - cost_basis))
+        unrealized = round(diff * held_qty)
 
     return {
         "realized": round(realized),
@@ -4497,6 +4516,12 @@ def _build_code_episodes(code_s: str, stock_name: str,
     shinyo_fills: List[Dict[str, Any]] = []  # 現ラウンドの信用 fill
     shinyo_qty = 0
     shinyo_peak = 0
+    # 信用売建 (空売り) は買建とは別ラウンドで追跡する。新規売で建て、返済買で閉じる。
+    # 同一銘柄で買建と売建を同時に持ちうる (両建て) ため、状態を分けないと
+    # 売建が買建の建玉を打ち消してラウンドが誤って閉じる (issue #387 レビュー対応)。
+    short_fills: List[Dict[str, Any]] = []
+    short_qty = 0
+    short_peak = 0
     genbutsu_fills: List[Dict[str, Any]] = []  # 現ラウンドの現物 fill
     genbutsu_qty = 0
     genbutsu_peak = 0
@@ -4517,6 +4542,15 @@ def _build_code_episodes(code_s: str, stock_name: str,
         shinyo_fills = []
         shinyo_qty = 0
         shinyo_peak = 0
+
+    def close_short():
+        nonlocal short_fills, short_qty, short_peak
+        if short_fills:
+            episodes.append(_finalize_round(
+                code_s, "信用", stock_name, short_fills, short_peak, is_short=True))
+        short_fills = []
+        short_qty = 0
+        short_peak = 0
 
     def close_genbutsu():
         nonlocal genbutsu_fills, genbutsu_qty, genbutsu_peak
@@ -4546,6 +4580,24 @@ def _build_code_episodes(code_s: str, stock_name: str,
             genbutsu_peak = max(genbutsu_peak, genbutsu_qty)
         elif tk.startswith("信用"):
             tate_date = f.get("tate_date")
+            # 売建 (新規売) と、それを閉じる返済買は空売りラウンド側で処理する。
+            # ただし売建が一度も無い銘柄の返済買は、買建ラウンドの部分返済とみなす
+            # (旧来の挙動を維持。楽天の返済は原則 sell なのでここには来ない)。
+            is_short_side = (
+                (tk.startswith("信用新規") and f["side"] == "sell")
+                or (tk.startswith("信用返済") and f["side"] == "buy"
+                    and (short_qty > 0 or short_fills))
+            )
+            if is_short_side:
+                short_fills.append(f)
+                if f["side"] == "sell":
+                    short_qty += qty      # 新規売 = 建てる
+                else:
+                    short_qty -= qty      # 返済買 = 閉じる
+                short_peak = max(short_peak, short_qty)
+                if short_qty <= 0:
+                    close_short()
+                continue
             if (tk.startswith("信用返済") and f["side"] == "sell"
                     and tate_date and tate_date not in shinyo_open_dates):
                 # 当期に対応する信用新規が無い返済は、当期の建玉を減らしてはいけない。
@@ -4573,6 +4625,9 @@ def _build_code_episodes(code_s: str, stock_name: str,
     # 保有中 (残った建玉)
     if shinyo_fills:
         episodes.append(_finalize_round(code_s, "信用", stock_name, shinyo_fills, shinyo_peak, closed=False))
+    if short_fills:
+        episodes.append(_finalize_round(
+            code_s, "信用", stock_name, short_fills, short_peak, closed=False, is_short=True))
     if genbutsu_fills:
         episodes.append(_finalize_round(code_s, "現物", stock_name, genbutsu_fills, genbutsu_peak, closed=False))
     for tate_date, carry_over_fills in carry_over_shinyo.items():
@@ -4674,8 +4729,13 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
 def _finalize_round(code_s: str, kind: str, stock_name: str,
                     round_fills: List[Dict[str, Any]], qty_peak: int,
                     closed: bool = True, carry_over: bool = False,
-                    open_date: Optional[str] = None) -> Dict[str, Any]:
-    """建玉ラウンドの fill リストからエピソード dict を組み立てる。"""
+                    open_date: Optional[str] = None,
+                    is_short: bool = False) -> Dict[str, Any]:
+    """建玉ラウンドの fill リストからエピソード dict を組み立てる。
+
+    is_short=True は信用売建 (空売り) のラウンド。建玉は新規売、決済は返済買で、
+    損益の符号が買建と逆になる (_episode_pl_from_round で分岐)。
+    """
     dates = [f["trade_date"] for f in round_fills if f.get("trade_date")]
     # ラウンド固有のキー用に先頭 fill の seq を取る (建玉開始時に確定し不変)。
     seqs = [f.get("seq") for f in round_fills if f.get("seq") is not None]
@@ -4691,6 +4751,7 @@ def _finalize_round(code_s: str, kind: str, stock_name: str,
         "qty_peak": qty_peak,
         "closed": closed,
         "carry_over": carry_over,
+        "is_short": is_short,
         "fills": [
             {
                 "trade_date": f.get("trade_date"),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4522,6 +4522,11 @@ def _build_code_episodes(code_s: str, stock_name: str,
         if tk == "現引":
             # 信用建玉 → 現物へ振替。信用側は残っていれば現引分だけ減らす。
             if shinyo_qty > 0:
+                # 現引を信用ラウンドの「終了イベント」として明細・日付に反映する。
+                # 損益 (_episode_pl_from_round) は返済 sell のみ集計するので side=buy の
+                # 現引を加えても損益は不変。close_date/last_trade_date が最後の信用新規日
+                # ではなく現引日になる (P2 レビュー対応)。
+                shinyo_fills.append(f)
                 shinyo_qty -= qty
                 if shinyo_qty <= 0:
                     close_shinyo()  # 現引で信用建玉が尽きたらクローズ (損益は現物へ)
@@ -4633,7 +4638,9 @@ def _finalize_round(code_s: str, kind: str, stock_name: str,
                 "qty": f["qty"],
                 "price": f["price"],
                 "trade_kind": f.get("trade_kind", ""),
-                "broker": f.get("broker") or "",
+                # 既存の楽天取込 fill は broker 追加前で未設定 (None)。未設定は「楽天」で
+                # 補完する (SBI取込は必ず broker="SBI" を持つ、P2 レビュー対応)。
+                "broker": f.get("broker") or "楽天",
                 "tate_price": f.get("tate_price"),
                 "settle_pl": f.get("settle_pl"),
             }

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4274,12 +4274,15 @@ def list_trade_fills() -> List[Dict[str, Any]]:
                f.get("trade_kind", ""), f.get("broker") or "")
         groups.setdefault(key, []).append(f)
 
+    # 銘柄名は distinct code をバルク解決 (fill ごとに開くと N+1 で重い)
+    names = _bulk_resolve_stock_names(list({k[0] for k in groups}))
+
     rows: List[Dict[str, Any]] = []
     for (code_s, side, trade_date, trade_kind, broker), group in groups.items():
         agg = _aggregate_fill_price(group)
         rows.append({
             "code_s": code_s,
-            "stock_name": resolve_stock_name(code_s),
+            "stock_name": names.get(code_s, ""),
             "trade_date": trade_date,
             "side": side,
             "side_label": _SIDE_LABELS.get(side, side),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4389,10 +4389,12 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
 
     各エピソード dict:
       code_s, stock_name, kind ("現物"/"信用"), open_date, close_date,
-      qty_peak (最大建玉), closed (bool), fills (内部の個別 fill 明細リスト),
+      last_trade_date (ラウンド内の最終約定日), qty_peak (最大建玉),
+      closed (bool), fills (内部の個別 fill 明細リスト),
       pl (クローズ済みのみ: _episode_pl_from_round の結果, 未クローズは None)
 
-    Returns: close_date (未クローズは open_date) 降順のエピソードリスト。
+    Returns: 最終約定日 (買い増し・部分売り含むラウンド内の最新の取引日) 降順の
+    エピソードリスト。保有中エピソードも最後に約定した日で並ぶ。
     """
     import portfolio_shelve as ps  # 遅延 import (循環回避)
 
@@ -4433,9 +4435,9 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
             # 未クローズ (保有中)
             episodes.append(_finalize_round(code_s, kind, names.get(code_s, ""), cur, qty_peak, closed=False))
 
-    # close_date (未クローズは open_date) 降順、同日は銘柄コード昇順
+    # 最終約定日 (最新の取引がある順) 降順、同日は銘柄コード昇順
     episodes.sort(key=lambda e: e["code_s"])
-    episodes.sort(key=lambda e: e.get("close_date") or e["open_date"], reverse=True)
+    episodes.sort(key=lambda e: e["last_trade_date"], reverse=True)
     return episodes
 
 
@@ -4450,6 +4452,7 @@ def _finalize_round(code_s: str, kind: str, stock_name: str,
         "kind": kind,
         "open_date": min(dates) if dates else "",
         "close_date": max(dates) if (dates and closed) else None,
+        "last_trade_date": max(dates) if dates else "",  # ラウンド内の最新約定日 (並び順の基準)
         "qty_peak": qty_peak,
         "closed": closed,
         "fills": [

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4615,7 +4615,7 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
     memos = ps.list_fill_memos(db_path=db_path)
     for ep in episodes:
         ep["episode_key"] = ps.fill_episode_key(
-            ep["code_s"], ep["kind"], ep["open_date"], ep["close_date"]
+            ep["code_s"], ep["kind"], ep["first_seq"]
         )
         ep["review_memo"] = memos.get(ep["episode_key"], "")
 
@@ -4630,10 +4630,14 @@ def _finalize_round(code_s: str, kind: str, stock_name: str,
                     closed: bool = True) -> Dict[str, Any]:
     """建玉ラウンドの fill リストからエピソード dict を組み立てる。"""
     dates = [f["trade_date"] for f in round_fills if f.get("trade_date")]
+    # ラウンド固有のキー用に先頭 fill の seq を取る (建玉開始時に確定し不変)。
+    seqs = [f.get("seq") for f in round_fills if f.get("seq") is not None]
+    first_seq = min(seqs) if seqs else 0
     ep = {
         "code_s": code_s,
         "stock_name": stock_name,
         "kind": kind,
+        "first_seq": first_seq,
         "open_date": min(dates) if dates else "",
         "close_date": max(dates) if (dates and closed) else None,
         "last_trade_date": max(dates) if dates else "",  # ラウンド内の最新約定日 (並び順の基準)

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4483,7 +4483,8 @@ def _build_code_episodes(code_s: str, stock_name: str,
         なれば信用ラウンドをクローズ
       - 現物買 (buy): 現物建玉を積む
       - 現物売 (sell): 現物建玉を減らし、建玉0で現物ラウンドをクローズ
-    保有0に戻らず残った建玉は保有中エピソードになる。
+    保有0に戻らず残った建玉は保有中エピソードになる。取込対象期間より前に建てた
+    信用玉の返済は建約定日で判別し、当期の信用新規と相殺せず期首持越しとして分ける。
     """
     # 約定日昇順。同日内は 建玉を作る側 (buy=新規買・現引) を先に、玉を減らす側
     # (sell=売り・返済) を後に処理する。現引で現物化してから同日に売るケースで、売りが
@@ -4499,6 +4500,15 @@ def _build_code_episodes(code_s: str, stock_name: str,
     genbutsu_fills: List[Dict[str, Any]] = []  # 現ラウンドの現物 fill
     genbutsu_qty = 0
     genbutsu_peak = 0
+    # 取込済みの信用新規日。これに無い建約定日の返済は、取込前からの持越し玉である。
+    shinyo_open_dates = {
+        f.get("trade_date")
+        for f in fills
+        if (f.get("trade_kind") or "").startswith("信用新規")
+        and f["side"] == "buy"
+        and f.get("trade_date")
+    }
+    carry_over_shinyo: Dict[str, List[Dict[str, Any]]] = {}
 
     def close_shinyo():
         nonlocal shinyo_fills, shinyo_qty, shinyo_peak
@@ -4535,6 +4545,13 @@ def _build_code_episodes(code_s: str, stock_name: str,
             genbutsu_qty += qty
             genbutsu_peak = max(genbutsu_peak, genbutsu_qty)
         elif tk.startswith("信用"):
+            tate_date = f.get("tate_date")
+            if (tk.startswith("信用返済") and f["side"] == "sell"
+                    and tate_date and tate_date not in shinyo_open_dates):
+                # 当期に対応する信用新規が無い返済は、当期の建玉を減らしてはいけない。
+                # 同一建約定日の分割返済は一つの期首持越しエピソードにまとめる。
+                carry_over_shinyo.setdefault(tate_date, []).append(f)
+                continue
             shinyo_fills.append(f)
             if f["side"] == "buy":
                 shinyo_qty += qty
@@ -4558,6 +4575,11 @@ def _build_code_episodes(code_s: str, stock_name: str,
         episodes.append(_finalize_round(code_s, "信用", stock_name, shinyo_fills, shinyo_peak, closed=False))
     if genbutsu_fills:
         episodes.append(_finalize_round(code_s, "現物", stock_name, genbutsu_fills, genbutsu_peak, closed=False))
+    for tate_date, carry_over_fills in carry_over_shinyo.items():
+        episodes.append(_finalize_round(
+            code_s, "信用", stock_name, carry_over_fills, 0,
+            carry_over=True, open_date=tate_date,
+        ))
 
     return episodes
 
@@ -4573,6 +4595,7 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
       code_s, stock_name, kind ("現物"/"信用"), open_date, close_date,
       last_trade_date (ラウンド内の最終約定日), qty_peak (最大建玉),
       closed (bool), fills (内部の個別 fill 明細リスト),
+      carry_over (bool: 取込対象期間より前の信用建玉の返済),
       pl (クローズ済みのみ: _episode_pl_from_round の結果, 未クローズは None),
       open_pl (保有中のみ: realized/unrealized/held_qty/avg_cost)
 
@@ -4627,7 +4650,8 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
 
 def _finalize_round(code_s: str, kind: str, stock_name: str,
                     round_fills: List[Dict[str, Any]], qty_peak: int,
-                    closed: bool = True) -> Dict[str, Any]:
+                    closed: bool = True, carry_over: bool = False,
+                    open_date: Optional[str] = None) -> Dict[str, Any]:
     """建玉ラウンドの fill リストからエピソード dict を組み立てる。"""
     dates = [f["trade_date"] for f in round_fills if f.get("trade_date")]
     # ラウンド固有のキー用に先頭 fill の seq を取る (建玉開始時に確定し不変)。
@@ -4638,11 +4662,12 @@ def _finalize_round(code_s: str, kind: str, stock_name: str,
         "stock_name": stock_name,
         "kind": kind,
         "first_seq": first_seq,
-        "open_date": min(dates) if dates else "",
+        "open_date": open_date or (min(dates) if dates else ""),
         "close_date": max(dates) if (dates and closed) else None,
         "last_trade_date": max(dates) if dates else "",  # ラウンド内の最新約定日 (並び順の基準)
         "qty_peak": qty_peak,
         "closed": closed,
+        "carry_over": carry_over,
         "fills": [
             {
                 "trade_date": f.get("trade_date"),

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4842,6 +4842,9 @@ def calc_trade_summary(episode_pls: list) -> Optional[dict]:
     return {
         "win_rate": len(wins) / n_total * 100,
         "payoff_ratio": payoff_ratio,
+        # 勝ち/負けの金額加重平均リターン% (ペイオフレシオの分子・分母)
+        "avg_return_win": win_weighted,
+        "avg_return_lose": lose_weighted,
         "avg_hold_win": _avg_hold(wins),
         "avg_hold_lose": _avg_hold(loses),
         "n_total": n_total,

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4250,14 +4250,16 @@ _SIDE_LABELS = {"buy": "買", "sell": "売"}
 def list_trade_fills() -> List[Dict[str, Any]]:
     """取込済みの全 fill (実約定) を売買履歴タブ用にまとめて返す (issue #387)。
 
-    楽天CSVを売買履歴の真実源とし、約定日降順で一覧表示する。matched_seq の有無は
-    問わない (突合を廃止したため。既存 DB の matched_seq 値は参照しない)。
+    楽天・SBI証券CSVを売買履歴の真実源とし、約定日降順で一覧表示する。matched_seq の
+    有無は問わない (突合を廃止したため。既存 DB の matched_seq 値は参照しない)。
 
-    同日集約: (code_s, side, trade_date) が同じ fill (分割約定) は加重平均単価・合計株数で
-    1 行に畳む。2 件以上を畳んだ行には count と aggregated=True を付ける (可視化)。
+    同日集約: (code_s, side, trade_date, trade_kind, broker) が同じ fill (分割約定) だけを
+    加重平均単価・合計株数で 1 行に畳む。取引区分 (現物/信用新規/信用返済) や証券会社が
+    違う約定は別行に保つ (別々の取引事実を混ぜない、PR #388 レビュー対応)。2 件以上を
+    畳んだ行には count と aggregated=True を付ける (可視化)。
 
     Returns: [{code_s, stock_name, trade_date, side, side_label, qty, price,
-               trade_kind, count, aggregated}, ...] を約定日降順 → code_s 昇順で。
+               trade_kind, broker, count, aggregated}, ...] を約定日降順 → code_s 昇順で。
     """
     import portfolio_shelve as ps  # 遅延 import (循環回避)
 
@@ -4265,17 +4267,16 @@ def list_trade_fills() -> List[Dict[str, Any]]:
     if not fills:
         return []
 
-    # (code_s, side, trade_date) で分割約定をグループ化
-    groups: Dict[Tuple[str, str, str], List[Dict[str, Any]]] = {}
+    # (code_s, side, trade_date, trade_kind, broker) で分割約定のみグループ化
+    groups: Dict[Tuple[str, str, str, str, str], List[Dict[str, Any]]] = {}
     for f in fills:
-        key = (f["code_s"], f["side"], f["trade_date"])
+        key = (f["code_s"], f["side"], f["trade_date"],
+               f.get("trade_kind", ""), f.get("broker") or "")
         groups.setdefault(key, []).append(f)
 
     rows: List[Dict[str, Any]] = []
-    for (code_s, side, trade_date), group in groups.items():
+    for (code_s, side, trade_date, trade_kind, broker), group in groups.items():
         agg = _aggregate_fill_price(group)
-        # 取引区分はグループ内で通常単一。複数種混在時は "/" で併記 (稀)
-        kinds = sorted({f.get("trade_kind", "") for f in group if f.get("trade_kind")})
         rows.append({
             "code_s": code_s,
             "stock_name": resolve_stock_name(code_s),
@@ -4284,7 +4285,8 @@ def list_trade_fills() -> List[Dict[str, Any]]:
             "side_label": _SIDE_LABELS.get(side, side),
             "qty": agg["qty"] if agg else sum(f["qty"] for f in group),
             "price": agg["price"] if agg else group[0]["price"],
-            "trade_kind": " / ".join(kinds),
+            "trade_kind": trade_kind,
+            "broker": broker,
             "count": len(group),
             "aggregated": len(group) >= 2,
         })

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -30,6 +30,7 @@ from webapp.helpers import (
     build_fill_episodes,
     calc_post_sell_returns,
     calc_trade_summary,
+    latest_fill_dates_by_broker,
     resolve_stock_name,
 )
 
@@ -248,6 +249,9 @@ def trade_history():
         p["profit_amount"] for p in fill_pls if p["profit_amount"] is not None
     )
 
+    # 証券会社別の取込済み最新約定日 (次回インポートの参考、取込のたびに更新される)
+    broker_latest = latest_fill_dates_by_broker()
+
     return render_template(
         "trade_history.html",
         recent=recent,
@@ -257,6 +261,7 @@ def trade_history():
         fill_closed_count=fill_closed_count,
         fill_priced_count=fill_priced_count,
         fill_total_pl=fill_total_pl,
+        broker_latest=broker_latest,
     )
 
 

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -27,10 +27,9 @@ import portfolio_shelve as ps
 from ks_util import DATA_DIR
 from webapp.helpers import (
     _bulk_price_logs,
-    calc_episode_pl,
+    build_fill_episodes,
     calc_post_sell_returns,
     calc_trade_summary,
-    list_trade_fills,
     resolve_stock_name,
 )
 
@@ -198,17 +197,15 @@ def trade_history():
     # エピソード内の最新アクション日 (売却 > 株数変更 > 保有) 降順
     episodes.sort(key=_last_action_date, reverse=True)
 
-    # 銘柄名付与・サブ行組み立て・概算損益 (issue #361)
+    # 銘柄名付与・サブ行組み立て (issue #361)
+    # 成績サマリー・概算損益は fill 側 (売買履歴タブ) に一本化したため、
+    # アクションログ側では計算しない (issue #387 Phase4b)。
     # 売却後騰落率は表示時に計算し、確定した値だけ売却ログへ保存する (issue #366)。
     price_logs = _bulk_price_logs([ep["code_s"] for ep in episodes if ep["sell_date"]])
-    episode_pls = []
     for ep in episodes:
         ep["stock_name"] = resolve_stock_name(ep["code_s"])
         ep["rows"] = _build_rows(ep)
         ep["rowspan"] = len(ep["rows"])
-        ep["pl"] = calc_episode_pl(ep)  # 算出不可なら None (行は「—」表示)
-        if ep["pl"] is not None:
-            episode_pls.append(ep["pl"])
         if ep["sell_date"]:
             calculated = calc_post_sell_returns(ep, price_logs.get(ep["code_s"], []))
             saved = ep.get("post_sell_returns", {})
@@ -228,10 +225,6 @@ def trade_history():
                 value["return_pct"] is not None for value in calculated.values()
             ) and not ep["review_memo"]
 
-    # 売却済み全体の成績サマリー (issue #361)。母数0/算出不可のみなら None
-    closed_count = sum(1 for ep in episodes if ep["sell_date"])
-    summary = calc_trade_summary(episode_pls)
-
     # 直近30件と過去ログに分割
     recent = episodes[:30]
     past = episodes[30:]
@@ -244,16 +237,26 @@ def trade_history():
     # 年降順のリスト [(year, episodes), ...]
     past_years = sorted(past_by_year.items(), key=lambda x: x[0], reverse=True)
 
-    # issue #387: 売買履歴タブ用の実約定一覧 (楽天CSV=真実源、約定日降順)
-    trade_fills = list_trade_fills()
+    # issue #387 Phase4b: 売買履歴タブ = fill 基準の建玉ラウンド・エピソード。
+    # 成績サマリー (勝率/ペイオフ) はクローズ済みで損益算出できたエピソードから算出。
+    fill_episodes = build_fill_episodes()
+    fill_pls = [ep["pl"] for ep in fill_episodes if ep["closed"] and ep["pl"]]
+    fill_summary = calc_trade_summary(fill_pls)
+    fill_closed_count = sum(1 for ep in fill_episodes if ep["closed"])
+    fill_priced_count = len(fill_pls)
+    fill_total_pl = sum(
+        p["profit_amount"] for p in fill_pls if p["profit_amount"] is not None
+    )
 
     return render_template(
         "trade_history.html",
         recent=recent,
         past_years=past_years,
-        summary=summary,
-        closed_count=closed_count,
-        trade_fills=trade_fills,
+        fill_episodes=fill_episodes,
+        fill_summary=fill_summary,
+        fill_closed_count=fill_closed_count,
+        fill_priced_count=fill_priced_count,
+        fill_total_pl=fill_total_pl,
     )
 
 

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -1,13 +1,30 @@
-"""売買履歴ページルート (issue #351, #357)。
+"""売買履歴ページルート (issue #351, #357, #387)。
 
-GET  /trade-history                          : 保有エピソード単位でサブ行展開表示
+GET  /trade-history                          : 売買履歴/アクションログの2タブ表示
+POST /trade-history/import                    : 楽天/SBI CSV をアップロード取込 (issue #387 4a)
 POST /trade-history/<code_s>/<int:seq>/review-memo : 振り返りメモを保存
      seq は売却ログまたは1保遷移ログの seq。どちらも review_memo に保存可能。
 """
 
-from flask import Blueprint, abort, jsonify, render_template, request
+import os
+import shutil
+import tempfile
 
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+
+import import_rakuten_fills as rakuten
+import import_sbi_fills as sbi
 import portfolio_shelve as ps
+from ks_util import DATA_DIR
 from webapp.helpers import (
     _bulk_price_logs,
     calc_episode_pl,
@@ -18,6 +35,9 @@ from webapp.helpers import (
 )
 
 trade_history_bp = Blueprint("trade_history", __name__)
+
+# 取込成功CSVの保存先 (取引履歴の原本置き場)。issue #387 4a
+TRADE_HISTORY_DIR = os.path.join(DATA_DIR, "trade_history")
 
 
 def _build_rows(ep: dict) -> list:
@@ -235,6 +255,58 @@ def trade_history():
         closed_count=closed_count,
         trade_fills=trade_fills,
     )
+
+
+@trade_history_bp.route("/trade-history/import", methods=["POST"])
+def import_trade_csv():
+    """楽天/SBI の約定CSVをアップロード取込する (issue #387 4a)。
+
+    ヘッダで証券会社を自動判定 → 該当パーサーで取込 → 成功時のみ原本を
+    TRADE_HISTORY_DIR へ同名上書きコピー。結果を flash して /trade-history へ戻る。
+    dedup があるため再取込は冪等 (重複はスキップされる)。
+    """
+    file = request.files.get("csv_file")
+    if file is None or not file.filename:
+        flash("CSVファイルが選択されていません。", "error")
+        return redirect(url_for("trade_history.trade_history"))
+
+    filename = os.path.basename(file.filename)
+    # 一時ファイルに保存 (パーサーはパス受け取りのため)
+    fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    try:
+        file.save(tmp_path)
+
+        # ヘッダ自動判定 (楽天=先頭行が約定日ヘッダ / SBI=冒頭メタ行+銘柄コード列)
+        if rakuten.is_rakuten_csv(tmp_path):
+            module = rakuten
+        elif sbi.is_sbi_csv(tmp_path):
+            module = sbi
+        else:
+            flash(f"楽天/SBI の取引履歴CSVとして認識できませんでした: {filename}", "error")
+            return redirect(url_for("trade_history.trade_history"))
+
+        try:
+            stats = module.import_csv_to_fills(tmp_path)
+        except Exception as e:  # noqa: BLE001 - パース例外はユーザーへ提示
+            flash(f"取込中にエラーが発生しました ({filename}): {e}", "error")
+            return redirect(url_for("trade_history.trade_history"))
+
+        # 成功: 原本を正式置き場へ同名上書きコピー
+        os.makedirs(TRADE_HISTORY_DIR, exist_ok=True)
+        shutil.copy2(tmp_path, os.path.join(TRADE_HISTORY_DIR, filename))
+
+        flash(
+            f"{module.BROKER} CSV 取込完了: {filename} — "
+            f"新規 {stats['imported']} 件 / 重複スキップ {stats['skipped_dup']} 件 / "
+            f"対象外 {stats['skipped_invalid']} 件",
+            "success",
+        )
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    return redirect(url_for("trade_history.trade_history"))
 
 
 @trade_history_bp.route(

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -312,26 +312,17 @@ def import_trade_csv():
     return redirect(url_for("trade_history.trade_history"))
 
 
-@trade_history_bp.route(
-    "/trade-history/<code_s>/<int:seq>/review-memo", methods=["POST"]
-)
-def save_review_memo(code_s: str, seq: int):
-    """振り返りメモを上書き保存する (fetch POST / JSON レスポンス)。
+@trade_history_bp.route("/trade-history/fill-memo", methods=["POST"])
+def save_fill_memo():
+    """fill 建玉ラウンド (エピソード) の振り返りメモを保存する (issue #387 Phase2)。
 
-    seq は売却ログまたは1保遷移ログの seq。
-    どちらも review_memo を持つため同じエンドポイントで処理する。
+    エピソードキー (code_s|kind|open_date|close_date) を受け取り上書き保存する。
+    空文字は削除扱い。fetch POST / JSON レスポンス。
+    振り返りメモはアクションログ側から売買履歴 (fill=真実源) 側へ一本化した。
     """
+    episode_key = request.form.get("episode_key", "")
     review_memo = request.form.get("review_memo", "")
-    try:
-        logs = ps.list_action_logs(code_s)
-        target = next((l for l in logs if l["seq"] == seq), None)
-        if target is None:
-            abort(404)
-        action_type = target.get("action_type")
-        status_to = target.get("status_to")
-        if not (action_type == "売却" or (action_type == "ステータス変更" and status_to == "1保")):
-            abort(404)
-        ps.update_action_log_review_memo(code_s, seq, review_memo)
-    except KeyError:
-        abort(404)
+    if not episode_key:
+        abort(400)
+    ps.set_fill_memo(episode_key, review_memo)
     return jsonify({"ok": True})

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -30,7 +30,7 @@ from webapp.helpers import (
     build_fill_episodes,
     calc_post_sell_returns,
     calc_trade_summary,
-    latest_fill_dates_by_broker,
+    fill_date_range_by_broker,
     resolve_stock_name,
 )
 
@@ -249,8 +249,8 @@ def trade_history():
         p["profit_amount"] for p in fill_pls if p["profit_amount"] is not None
     )
 
-    # 証券会社別の取込済み最新約定日 (次回インポートの参考、取込のたびに更新される)
-    broker_latest = latest_fill_dates_by_broker()
+    # 証券会社別の取込済み約定日レンジ (次回インポートの参考、取込のたびに更新される)
+    broker_ranges = fill_date_range_by_broker()
 
     return render_template(
         "trade_history.html",
@@ -261,7 +261,7 @@ def trade_history():
         fill_closed_count=fill_closed_count,
         fill_priced_count=fill_priced_count,
         fill_total_pl=fill_total_pl,
-        broker_latest=broker_latest,
+        broker_ranges=broker_ranges,
     )
 
 

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -9,12 +9,11 @@ from flask import Blueprint, abort, jsonify, render_template, request
 
 import portfolio_shelve as ps
 from webapp.helpers import (
-    _aggregate_fill_price,
     _bulk_price_logs,
     calc_episode_pl,
     calc_post_sell_returns,
     calc_trade_summary,
-    list_unmatched_fills,
+    list_trade_fills,
     resolve_stock_name,
 )
 
@@ -102,56 +101,13 @@ def _last_action_date(ep: dict) -> str:
     return max(dates)
 
 
-def _apply_fill_prices(episodes: list) -> None:
-    """マッチ済み fill (実約定) で hold_price/sell_price/qty/日付をエピソードへ上書きする。
-
-    issue #360 Phase2: fill 側 matched_seq が action_log の seq を指す。seq は code_s ごとの
-    連番なので (code_s, matched_seq) を複合キーにする。買い増し (qty_changes) 混在エピソードは
-    加重平均が proxy と混ざり歪むため対象外 (単一 IN のみ)。上書きは episodes を破壊的に更新。
-
-    日付 (hold_date/sell_date) も楽天の約定日を真実源として上書きする。手動 action_log の
-    timestamp は操作履歴として DB 側にそのまま残し、表示・保有日数計算は約定日を優先する。
-    マッチした側のみ差し替え、未マッチ側は手動日のまま (価格の上書きポリシーと一致)。
-    """
-    fills_by_key: dict = {}  # (code_s, matched_seq) -> [fill, ...]
-    for f in ps.list_fills():
-        matched = f.get("matched_seq")
-        if matched is None:
-            continue
-        fills_by_key.setdefault((f["code_s"], matched), []).append(f)
-
-    if not fills_by_key:
-        return
-
-    for ep in episodes:
-        if ep.get("qty_changes"):
-            continue  # 買い増し混在は proxy のまま (§3 の限定)
-        code_s = ep["code_s"]
-        # 保有開始 (buy fill) → hold_seq にマッチ。
-        # fill を株数の真実源とするため、手入力 qty があっても実約定株数で置換する。
-        buy = _aggregate_fill_price(fills_by_key.get((code_s, ep.get("hold_seq")), []))
-        if buy is not None:
-            ep["hold_price"] = buy["price"]
-            ep["hold_qty"] = buy["qty"]
-            if buy.get("date"):
-                ep["hold_date"] = buy["date"]
-        # 売却 (sell fill) → sell_seq にマッチ
-        if ep.get("sell_seq") is not None:
-            sell = _aggregate_fill_price(fills_by_key.get((code_s, ep["sell_seq"]), []))
-            if sell is not None:
-                ep["sell_price"] = sell["price"]
-                ep["sell_qty"] = sell["qty"]
-                if sell.get("date"):
-                    # 約定日で売却日を上書きした場合、保存済み売却後騰落率 (旧手動日基準)
-                    # を無効化する。後段で新約定日を起点に再計算される (issue #366 整合)
-                    if sell["date"] != ep.get("sell_date"):
-                        ep["post_sell_returns"] = {}
-                    ep["sell_date"] = sell["date"]
-
-
 @trade_history_bp.route("/trade-history")
 def trade_history():
-    """売買履歴ページ — 銘柄×保有エピソードをサブ行展開で表示。"""
+    """売買履歴ページ — 2タブ構成 (issue #387)。
+
+    - 売買履歴タブ: 楽天CSVの実約定 (fill) を約定日降順で一覧
+    - アクションログタブ: 手動記録の保有エピソードをサブ行展開で表示
+    """
     all_logs = ps.list_action_logs()  # (code_s, seq) 昇順
 
     episodes = []
@@ -222,13 +178,6 @@ def trade_history():
     # エピソード内の最新アクション日 (売却 > 株数変更 > 保有) 降順
     episodes.sort(key=_last_action_date, reverse=True)
 
-    # issue #360 Phase2: マッチ済み fill (実約定) で hold_price/sell_price/日付を上書きする。
-    # 買い増し (qty_changes) 混在エピソードは加重平均が proxy と混ざり歪むため対象外
-    # (単一 IN のみ)。未マッチ側は従来 price_proxy フォールバックのまま (既存挙動維持)。
-    _apply_fill_prices(episodes)
-    # 日付を約定日に上書きしたので、表示順を約定日基準に揃え直す
-    episodes.sort(key=_last_action_date, reverse=True)
-
     # 銘柄名付与・サブ行組み立て・概算損益 (issue #361)
     # 売却後騰落率は表示時に計算し、確定した値だけ売却ログへ保存する (issue #366)。
     price_logs = _bulk_price_logs([ep["code_s"] for ep in episodes if ep["sell_date"]])
@@ -275,8 +224,8 @@ def trade_history():
     # 年降順のリスト [(year, episodes), ...]
     past_years = sorted(past_by_year.items(), key=lambda x: x[0], reverse=True)
 
-    # issue #360 Phase2 (c): 取込済みで未マッチ (P/L 未反映) の fill を一覧表示 (閲覧のみ)
-    unmatched_fills = list_unmatched_fills()
+    # issue #387: 売買履歴タブ用の実約定一覧 (楽天CSV=真実源、約定日降順)
+    trade_fills = list_trade_fills()
 
     return render_template(
         "trade_history.html",
@@ -284,7 +233,7 @@ def trade_history():
         past_years=past_years,
         summary=summary,
         closed_count=closed_count,
-        unmatched_fills=unmatched_fills,
+        trade_fills=trade_fills,
     )
 
 

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -96,6 +96,9 @@
         {% if not ep.closed %}
         <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#3a3a4a;color:#a0a0d0;margin-left:0.2em;">保有中</span>
         {% endif %}
+        {% if ep.carry_over %}
+        <span title="取込対象期間より前に建てた信用玉の返済" style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#4a4a3a;color:#c8c890;margin-left:0.2em;">期首持越し</span>
+        {% endif %}
         {% if ep.review_memo %}
         <span title="振り返りメモあり" style="margin-left:0.2em;">📝</span>
         {% endif %}

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -32,12 +32,13 @@
 <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1em;margin-bottom:0.6em;">
   <p style="color:#888;font-size:0.85em;margin:0;">楽天・SBI証券CSVの実約定を建玉ラウンド単位のエピソードにまとめています。行をクリックで内訳の個別約定を展開。損益は現物=平均取得単価法、信用=建単価/決済損益。</p>
   <div style="flex-shrink:0;display:flex;flex-direction:column;align-items:flex-end;gap:0.3em;">
-    {# 取込済み最新約定日 (次回インポートの参考、取込のたびに更新) issue #387 #}
-    {% if broker_latest %}
-    <div title="取込済み約定の最新日。この翌営業日以降の約定をCSVで取り込む" style="color:#888;font-size:0.76em;white-space:nowrap;">
+    {# 取込済み最新約定日 (次回インポートの参考、取込のたびに更新) issue #387。
+       title に最古〜最新のフルレンジをツールチップ表示 #}
+    {% if broker_ranges %}
+    <div style="color:#888;font-size:0.76em;white-space:nowrap;">
       取込済み最新:
       {% for broker in ["楽天", "SBI"] %}
-        {% if broker_latest.get(broker) %}<span style="color:#aaa;">{{ broker }} {{ broker_latest[broker][5:] }}</span>{% if not loop.last %} / {% endif %}{% endif %}
+        {% if broker_ranges.get(broker) %}<span style="color:#aaa;" title="取込済み: {{ broker_ranges[broker].first }} 〜 {{ broker_ranges[broker].last }} (この翌営業日以降をCSVで取り込む)">{{ broker }} {{ broker_ranges[broker].last[5:] }}</span>{% if not loop.last %} / {% endif %}{% endif %}
       {% endfor %}
     </div>
     {% endif %}

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -30,7 +30,7 @@
 
 {# 説明 + CSV取込 (issue #387 4a): 普段は「＋CSV取込」リンクのみ、クリックで展開 (details) #}
 <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1em;margin-bottom:0.6em;">
-  <p style="color:#888;font-size:0.85em;margin:0;">楽天・SBI証券CSVの実約定を建玉ラウンド単位のエピソードにまとめています。行をクリックで内訳の個別約定を展開。損益は現物=平均取得単価法、信用=建単価/決済損益。</p>
+  <p style="color:#888;font-size:0.85em;margin:0;cursor:help;" title="損益は現物=平均取得単価法、信用=建単価/決済損益。">楽天・SBI証券CSVの実約定を建玉ラウンド単位のエピソードにまとめています。行をクリックで内訳の個別約定を展開。</p>
   <div style="flex-shrink:0;display:flex;flex-direction:column;align-items:flex-end;gap:0.3em;">
     {# 取込済み最新約定日 (次回インポートの参考、取込のたびに更新) issue #387。
        title に最古〜最新のフルレンジをツールチップ表示 #}
@@ -38,7 +38,7 @@
     <div style="color:#888;font-size:0.76em;white-space:nowrap;">
       取込済み最新:
       {% for broker in ["楽天", "SBI"] %}
-        {% if broker_ranges.get(broker) %}<span style="color:#aaa;" title="取込済み: {{ broker_ranges[broker].first }} 〜 {{ broker_ranges[broker].last }} (この翌営業日以降をCSVで取り込む)">{{ broker }} {{ broker_ranges[broker].last[5:] }}</span>{% if not loop.last %} / {% endif %}{% endif %}
+        {% if broker_ranges.get(broker) %}<span style="color:#aaa;" title="取込済み: {{ broker_ranges[broker].first }} 〜 {{ broker_ranges[broker].last }}">{{ broker }} {{ broker_ranges[broker].last[5:] }}</span>{% if not loop.last %} / {% endif %}{% endif %}
       {% endfor %}
     </div>
     {% endif %}

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -3,7 +3,64 @@
 {% block content %}
 
 <h2>売買履歴</h2>
-<p style="color:#888;font-size:0.85em;">保有エピソード単位で表示。保有日降順。</p>
+
+{# issue #387: 2タブ構成。売買履歴=楽天CSVの実約定 / アクションログ=手動記録のエピソード #}
+<div class="th-tabs" style="display:flex;gap:0.5em;border-bottom:1px solid #333;margin-bottom:1.2em;">
+  <button class="th-tab-btn active" data-tab="tab-fills"
+          style="background:none;border:none;border-bottom:2px solid transparent;color:#aaa;font-size:0.95em;cursor:pointer;padding:0.5em 0.9em;">売買履歴</button>
+  <button class="th-tab-btn" data-tab="tab-actions"
+          style="background:none;border:none;border-bottom:2px solid transparent;color:#aaa;font-size:0.95em;cursor:pointer;padding:0.5em 0.9em;">アクションログ</button>
+</div>
+
+{# ============ タブ1: 売買履歴 (楽天CSVの実約定) ============ #}
+<div id="tab-fills" class="th-tab-panel">
+<p style="color:#888;font-size:0.85em;">楽天CSVの実約定。約定日降順。同じ日・同じ売買方向の分割約定は加重平均単価でまとめています（「N件集約」）。</p>
+{% if trade_fills %}
+<table class="trade-history-table">
+  <colgroup>
+    <col style="width:6em;"><col style="width:9em;"><col style="width:4em;">
+    <col style="width:5em;"><col style="width:6em;"><col>
+  </colgroup>
+  <thead>
+    <tr>
+      <th style="white-space:nowrap;">約定日</th>
+      <th>銘柄</th>
+      <th>売買</th>
+      <th style="white-space:nowrap;">株数</th>
+      <th style="white-space:nowrap;">株価</th>
+      <th>取引区分</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for f in trade_fills %}
+    <tr>
+      <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ f.trade_date[2:4] }}/{{ f.trade_date[5:7] }}/{{ f.trade_date[8:10] }}</td>
+      <td style="white-space:nowrap;"><a href="/stock/{{ f.code_s }}">{{ f.code_s }} {{ f.stock_name }}</a></td>
+      <td style="white-space:nowrap;">
+        {% if f.side == "buy" %}
+        <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#2e5a6e;color:#9ed8f0;">{{ f.side_label }}</span>
+        {% else %}
+        <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#5a2e2e;color:#f0a0a0;">{{ f.side_label }}</span>
+        {% endif %}
+        {% if f.aggregated %}
+        <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#3a3a2e;color:#c8c070;margin-left:0.2em;">{{ f.count }}件集約</span>
+        {% endif %}
+      </td>
+      <td style="text-align:right;color:#888;font-size:0.85em;">{{ f.qty }}</td>
+      <td style="text-align:right;color:#888;font-size:0.85em;white-space:nowrap;">{{ "{:,}".format(f.price|round|int) }}</td>
+      <td style="color:#777;font-size:0.85em;">{{ f.trade_kind }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p style="color:#888;">取り込まれた約定がありません。<code>import_rakuten_fills.py</code> で楽天CSVを取り込んでください。</p>
+{% endif %}
+</div>
+
+{# ============ タブ2: アクションログ (手動記録のエピソード) ============ #}
+<div id="tab-actions" class="th-tab-panel" style="display:none;">
+<p style="color:#888;font-size:0.85em;">保有エピソード単位で表示。保有日降順。株価は保有開始日の終値プロキシ（概算）。</p>
 
 {# 成績サマリー (issue #361): 売却済みエピソードのうち終値プロキシで概算できた分 #}
 {% if summary %}
@@ -121,7 +178,7 @@
 {% endmacro %}
 
 {% if not recent and not past_years %}
-<p style="color:#888;">売買履歴がありません。</p>
+<p style="color:#888;">アクションログがありません。</p>
 {% else %}
 
 {# 直近30件 #}
@@ -147,62 +204,35 @@
 {% endif %}
 
 {% endif %}
-
-{# 取込済みで未反映の約定 (issue #360 Phase2 (c))。エピソードの有無に依存せず表示する #}
-{% if unmatched_fills %}
-<div style="margin-top:2em;">
-  <hr style="border:none;border-top:1px solid #333;margin-bottom:1em;">
-  <details>
-    <summary style="color:#c8a050;font-size:0.95em;cursor:pointer;">
-      取込済みで未反映の約定（{{ unmatched_fills|length }} 件）
-    </summary>
-    <p style="color:#888;font-size:0.82em;margin:0.5em 0;">
-      手動記録と対応付かなかった楽天の約定です。P/L には未反映です。
-      同じ日・同じ売買方向の分割約定は加重平均単価でまとめています（「N件集約」）。
-    </p>
-    <table class="trade-history-table">
-      <colgroup>
-        <col style="width:9em;"><col style="width:6em;"><col style="width:4em;">
-        <col style="width:5em;"><col style="width:6em;"><col>
-      </colgroup>
-      <thead>
-        <tr>
-          <th>銘柄</th>
-          <th style="white-space:nowrap;">約定日</th>
-          <th>売買</th>
-          <th style="white-space:nowrap;">株数</th>
-          <th style="white-space:nowrap;">単価</th>
-          <th>取引区分</th>
-        </tr>
-      </thead>
-      <tbody>
-      {% for f in unmatched_fills %}
-        <tr>
-          <td style="white-space:nowrap;"><a href="/stock/{{ f.code_s }}">{{ f.code_s }} {{ f.stock_name }}</a></td>
-          <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ f.trade_date[2:4] }}/{{ f.trade_date[5:7] }}/{{ f.trade_date[8:10] }}</td>
-          <td style="white-space:nowrap;">
-            {% if f.side == "buy" %}
-            <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#2e5a6e;color:#9ed8f0;">{{ f.side_label }}</span>
-            {% else %}
-            <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#5a2e2e;color:#f0a0a0;">{{ f.side_label }}</span>
-            {% endif %}
-            {% if f.aggregated %}
-            <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#3a3a2e;color:#c8c070;margin-left:0.2em;">{{ f.count }}件集約</span>
-            {% endif %}
-          </td>
-          <td style="text-align:right;color:#888;font-size:0.85em;">{{ f.qty }}</td>
-          <td style="text-align:right;color:#888;font-size:0.85em;white-space:nowrap;">{{ "{:,}".format(f.price|round|int) }}</td>
-          <td style="color:#777;font-size:0.85em;">{{ f.trade_kind }}</td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  </details>
 </div>
-{% endif %}
 
 <script>
 (function () {
+  // タブ切替 (issue #387)
+  var tabBtns = document.querySelectorAll('.th-tab-btn');
+  var panels = document.querySelectorAll('.th-tab-panel');
+  tabBtns.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      tabBtns.forEach(function (b) {
+        b.classList.remove('active');
+        b.style.borderBottomColor = 'transparent';
+        b.style.color = '#aaa';
+      });
+      panels.forEach(function (p) { p.style.display = 'none'; });
+      btn.classList.add('active');
+      btn.style.borderBottomColor = '#9ed8f0';
+      btn.style.color = '#ddd';
+      var panel = document.getElementById(btn.dataset.tab);
+      if (panel) panel.style.display = '';
+    });
+  });
+  // 初期タブ (売買履歴) のアクティブ表示
+  var first = document.querySelector('.th-tab-btn.active');
+  if (first) {
+    first.style.borderBottomColor = '#9ed8f0';
+    first.style.color = '#ddd';
+  }
+
   // 振り返りメモ編集
   document.querySelectorAll('.review-memo-cell').forEach(function (cell) {
     var url = cell.dataset.url;

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -28,15 +28,14 @@
 {# ============ タブ1: 売買履歴 (楽天/SBI CSVの実約定) ============ #}
 <div id="tab-fills" class="th-tab-panel">
 
-{# CSV取込フォーム (issue #387 4a): 楽天/SBI をヘッダ自動判定 #}
+{# CSV取込フォーム (issue #387 4a): 楽天/SBI をヘッダ自動判定。コンパクトに収める #}
 <form method="post" action="/trade-history/import" enctype="multipart/form-data"
-      style="display:flex;align-items:center;gap:0.6em;margin-bottom:0.9em;padding:0.6em 0.8em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:5px;">
-  <span style="color:#aaa;font-size:0.85em;">CSV取込</span>
+      title="楽天・SBI の取引履歴CSVを自動判別して取り込みます"
+      style="display:inline-flex;align-items:center;gap:0.5em;margin-bottom:0.9em;padding:0.35em 0.6em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:5px;">
   <input type="file" name="csv_file" accept=".csv" required
-         style="font-size:0.82em;color:#aaa;">
+         style="font-size:0.78em;color:#aaa;max-width:16em;">
   <button type="submit"
-          style="padding:0.3em 0.9em;font-size:0.85em;background:#2e5a6e;color:#9ed8f0;border:1px solid #3a6a80;border-radius:4px;cursor:pointer;">取り込む</button>
-  <span style="color:#666;font-size:0.78em;">楽天・SBI を自動判別</span>
+          style="padding:0.25em 0.7em;font-size:0.82em;white-space:nowrap;background:#2e5a6e;color:#9ed8f0;border:1px solid #3a6a80;border-radius:4px;cursor:pointer;">CSV取込</button>
 </form>
 
 <p style="color:#888;font-size:0.85em;">楽天・SBI証券CSVの実約定。約定日降順。同じ日・同じ売買方向・同じ取引区分の分割約定は加重平均単価でまとめています（「N件集約」）。</p>

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -28,17 +28,21 @@
 {# ============ タブ1: 売買履歴 (楽天/SBI CSVの実約定) ============ #}
 <div id="tab-fills" class="th-tab-panel">
 
-{# CSV取込フォーム (issue #387 4a): 楽天/SBI をヘッダ自動判定。コンパクトに収める #}
-<form method="post" action="/trade-history/import" enctype="multipart/form-data"
-      title="楽天・SBI の取引履歴CSVを自動判別して取り込みます"
-      style="display:inline-flex;align-items:center;gap:0.5em;margin-bottom:0.9em;padding:0.35em 0.6em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:5px;">
-  <input type="file" name="csv_file" accept=".csv" required
-         style="font-size:0.78em;color:#aaa;max-width:16em;">
-  <button type="submit"
-          style="padding:0.25em 0.7em;font-size:0.82em;white-space:nowrap;background:#2e5a6e;color:#9ed8f0;border:1px solid #3a6a80;border-radius:4px;cursor:pointer;">CSV取込</button>
-</form>
-
-<p style="color:#888;font-size:0.85em;">楽天・SBI証券CSVの実約定。約定日降順。同じ日・同じ売買方向・同じ取引区分の分割約定は加重平均単価でまとめています（「N件集約」）。</p>
+{# 説明 + CSV取込 (issue #387 4a): 普段は「＋CSV取込」リンクのみ、クリックで展開 (details) #}
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1em;margin-bottom:0.6em;">
+  <p style="color:#888;font-size:0.85em;margin:0;">楽天・SBI証券CSVの実約定。約定日降順。同じ日・同じ売買方向・同じ取引区分の分割約定は加重平均単価でまとめています（「N件集約」）。</p>
+  <details style="flex-shrink:0;">
+    <summary style="color:#9ed8f0;font-size:0.82em;cursor:pointer;white-space:nowrap;list-style:none;">＋ CSV取込</summary>
+    <form method="post" action="/trade-history/import" enctype="multipart/form-data"
+          title="楽天・SBI の取引履歴CSVを自動判別して取り込みます"
+          style="display:flex;align-items:center;gap:0.5em;margin-top:0.5em;padding:0.4em 0.6em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:5px;">
+      <input type="file" name="csv_file" accept=".csv" required
+             style="font-size:0.78em;color:#aaa;width:18em;">
+      <button type="submit"
+              style="padding:0.25em 0.7em;font-size:0.82em;white-space:nowrap;background:#2e5a6e;color:#9ed8f0;border:1px solid #3a6a80;border-radius:4px;cursor:pointer;">取込</button>
+    </form>
+  </details>
+</div>
 {% if trade_fills %}
 <table class="trade-history-table">
   <colgroup>

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -56,28 +56,39 @@
   </div>
 </div>
 
-{# 成績サマリー (issue #387 Phase4b): fill 基準。クローズ済みで損益算出できたエピソードから #}
+{# 成績サマリー (issue #387 Phase4b): fill 基準。クローズ済みで損益算出できたエピソードから。
+   主要指標を上段、勝ち/負けの内訳を下段の2段構成にまとめる #}
 {% if fill_summary %}
-<div style="display:flex;gap:1.4em;align-items:baseline;flex-wrap:wrap;padding:0.6em 0.8em;margin-bottom:0.8em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:6px;">
-  <div><span style="color:#888;font-size:0.8em;">勝率</span>
-    <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{{ "%.0f"|format(fill_summary.win_rate) }}%</span>
-    <span style="color:#888;font-size:0.8em;">({{ fill_summary.n_win }}勝{{ fill_summary.n_lose }}敗)</span></div>
-  <div title="勝ちトレードの平均リターン ÷ 負けトレードの平均リターン (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">ペイオフレシオ</span>
-    <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{% if fill_summary.payoff_ratio is not none %}{{ "%.2f"|format(fill_summary.payoff_ratio) }}{% else %}—{% endif %}</span></div>
-  <div title="1トレードあたりの平均リターン% (勝率とペイオフを統合した総合的な優位性。プラスならトータルで優位)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">期待値</span>
-    <span style="font-size:1.1em;font-weight:600;color:{{ '#9ef0aa' if fill_summary.expectancy is not none and fill_summary.expectancy >= 0 else '#f0a0a0' }};margin-left:0.3em;">{% if fill_summary.expectancy is not none %}{{ '+' if fill_summary.expectancy >= 0 else '' }}{{ "%.1f"|format(fill_summary.expectancy) }}%{% else %}—{% endif %}</span></div>
-  <div title="勝ちトレードの平均リターン% (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">平均リターン(勝)</span>
-    <span style="color:#9ef0aa;font-weight:600;margin-left:0.3em;">{% if fill_summary.avg_return_win is not none %}+{{ "%.1f"|format(fill_summary.avg_return_win) }}%{% else %}—{% endif %}</span></div>
-  <div title="負けトレードの平均リターン% (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">平均リターン(負)</span>
-    <span style="color:#f0a0a0;font-weight:600;margin-left:0.3em;">{% if fill_summary.avg_return_lose is not none %}{{ "%.1f"|format(fill_summary.avg_return_lose) }}%{% else %}—{% endif %}</span></div>
-  <div><span style="color:#888;font-size:0.8em;">実現損益</span>
-    <span style="font-size:1.1em;font-weight:600;color:{{ '#9ef0aa' if fill_total_pl >= 0 else '#f0a0a0' }};margin-left:0.3em;">{{ "{:+,}".format(fill_total_pl) }}円</span></div>
-  <div><span style="color:#888;font-size:0.8em;">平均保有(勝)</span>
-    <span style="color:#9ef0aa;margin-left:0.3em;">{% if fill_summary.avg_hold_win is not none %}{{ "%.0f"|format(fill_summary.avg_hold_win) }}日{% else %}—{% endif %}</span></div>
-  <div><span style="color:#888;font-size:0.8em;">平均保有(負)</span>
-    <span style="color:#f0a0a0;margin-left:0.3em;">{% if fill_summary.avg_hold_lose is not none %}{{ "%.0f"|format(fill_summary.avg_hold_lose) }}日{% else %}—{% endif %}</span></div>
-  <div title="信用は建単価/決済損益、現物は平均取得単価法。期首持越し・空売りは損益算出対象外" style="color:#777;font-size:0.78em;margin-left:auto;cursor:help;">
-    算出 {{ fill_priced_count }} 件 / クローズ済 {{ fill_closed_count }} 件</div>
+<div style="padding:0.7em 0.9em;margin-bottom:0.8em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:6px;">
+  {# 上段: 主要指標 #}
+  <div style="display:flex;gap:1.8em;align-items:baseline;flex-wrap:wrap;">
+    <div><span style="color:#888;font-size:0.8em;">勝率</span>
+      <span style="font-size:1.15em;font-weight:600;color:#ddd;margin-left:0.35em;">{{ "%.0f"|format(fill_summary.win_rate) }}%</span>
+      <span style="color:#888;font-size:0.78em;">({{ fill_summary.n_win }}勝{{ fill_summary.n_lose }}敗)</span></div>
+    <div title="勝ちトレードの平均リターン ÷ 負けトレードの平均リターン (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">ペイオフレシオ</span>
+      <span style="font-size:1.15em;font-weight:600;color:#ddd;margin-left:0.35em;">{% if fill_summary.payoff_ratio is not none %}{{ "%.2f"|format(fill_summary.payoff_ratio) }}{% else %}—{% endif %}</span></div>
+    <div title="1トレードあたりの平均リターン% (勝率とペイオフを統合した総合的な優位性。プラスならトータルで優位)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">期待値</span>
+      <span style="font-size:1.15em;font-weight:600;color:{{ '#9ef0aa' if fill_summary.expectancy is not none and fill_summary.expectancy >= 0 else '#f0a0a0' }};margin-left:0.35em;">{% if fill_summary.expectancy is not none %}{{ '+' if fill_summary.expectancy >= 0 else '' }}{{ "%.1f"|format(fill_summary.expectancy) }}%{% else %}—{% endif %}</span></div>
+    <div><span style="color:#888;font-size:0.8em;">実現損益</span>
+      <span style="font-size:1.15em;font-weight:600;color:{{ '#9ef0aa' if fill_total_pl >= 0 else '#f0a0a0' }};margin-left:0.35em;">{{ "{:+,}".format(fill_total_pl) }}円</span></div>
+    <div title="信用は建単価/決済損益、現物は平均取得単価法。期首持越し・空売りは損益算出対象外" style="color:#777;font-size:0.78em;margin-left:auto;cursor:help;">
+      算出 {{ fill_priced_count }} 件 / クローズ済 {{ fill_closed_count }} 件</div>
+  </div>
+  {# 下段: 勝ち/負けの内訳 (平均リターン・平均保有) #}
+  <div style="display:flex;gap:2em;align-items:baseline;flex-wrap:wrap;margin-top:0.5em;padding-top:0.5em;border-top:1px solid #2a2a2a;font-size:0.85em;">
+    <div title="勝ちトレードの平均リターン% (金額加重) と平均保有日数">
+      <span style="color:#9ef0aa;font-weight:600;">勝ち</span>
+      <span style="color:#888;margin-left:0.5em;">平均リターン</span>
+      <span style="color:#9ef0aa;font-weight:600;margin-left:0.25em;">{% if fill_summary.avg_return_win is not none %}+{{ "%.1f"|format(fill_summary.avg_return_win) }}%{% else %}—{% endif %}</span>
+      <span style="color:#888;margin-left:0.8em;">平均保有</span>
+      <span style="color:#9ef0aa;margin-left:0.25em;">{% if fill_summary.avg_hold_win is not none %}{{ "%.0f"|format(fill_summary.avg_hold_win) }}日{% else %}—{% endif %}</span></div>
+    <div title="負けトレードの平均リターン% (金額加重) と平均保有日数">
+      <span style="color:#f0a0a0;font-weight:600;">負け</span>
+      <span style="color:#888;margin-left:0.5em;">平均リターン</span>
+      <span style="color:#f0a0a0;font-weight:600;margin-left:0.25em;">{% if fill_summary.avg_return_lose is not none %}{{ "%.1f"|format(fill_summary.avg_return_lose) }}%{% else %}—{% endif %}</span>
+      <span style="color:#888;margin-left:0.8em;">平均保有</span>
+      <span style="color:#f0a0a0;margin-left:0.25em;">{% if fill_summary.avg_hold_lose is not none %}{{ "%.0f"|format(fill_summary.avg_hold_lose) }}日{% else %}—{% endif %}</span></div>
+  </div>
 </div>
 {% endif %}
 

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -96,6 +96,9 @@
         {% if not ep.closed %}
         <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#3a3a4a;color:#a0a0d0;margin-left:0.2em;">保有中</span>
         {% endif %}
+        {% if ep.review_memo %}
+        <span title="振り返りメモあり" style="margin-left:0.2em;">📝</span>
+        {% endif %}
       </td>
       <td style="white-space:nowrap;color:#888;font-size:0.82em;">{{ ep.open_date[2:] }}{% if ep.close_date and ep.close_date != ep.open_date %} 〜 {{ ep.close_date[2:] }}{% endif %}</td>
       <td style="text-align:right;color:#888;font-size:0.85em;">{{ ep.qty_peak }}</td>
@@ -145,6 +148,16 @@
           </tr>
           {% endfor %}
         </table>
+        {# エピソード単位の振り返りメモ (issue #387 Phase2)。アクションログ側から一本化 #}
+        <div style="margin-top:0.6em;max-width:44em;">
+          <div style="color:#888;font-size:0.78em;margin-bottom:0.2em;">振り返りメモ</div>
+          <div class="review-memo-cell"
+               data-url="{{ url_for('trade_history.save_fill_memo') }}"
+               data-episode-key="{{ ep.episode_key }}"
+               data-memo="{{ ep.review_memo or '' | e }}">
+            <span class="review-memo-display">{{ ep.review_memo or "クリックして入力" }}</span>
+          </div>
+        </div>
       </td>
     </tr>
   {% endfor %}
@@ -157,7 +170,7 @@
 
 {# ============ タブ2: アクションログ (手動記録のエピソード) ============ #}
 <div id="tab-actions" class="th-tab-panel" style="display:none;">
-<p style="color:#888;font-size:0.85em;">判断の記録 (保有理由・売却理由・振り返りメモ)。保有日降順。成績・実現損益は「売買履歴」タブ (実約定=真実源) に一本化しました。</p>
+<p style="color:#888;font-size:0.85em;">判断の記録 (保有理由・売却理由)。保有日降順。成績・実現損益は「売買履歴」タブ (実約定=真実源) に一本化しました。振り返りメモも「売買履歴」タブのエピソード展開へ移行しました。</p>
 
 {% macro episode_table(episodes) %}
 {% if episodes %}
@@ -169,7 +182,6 @@
     <col style="width:4em;">
     <col style="width:6em;">
     <col>
-    <col style="width:22em;">
   </colgroup>
   <thead>
     <tr>
@@ -179,7 +191,6 @@
       <th style="white-space:nowrap;">株数</th>
       <th style="white-space:nowrap;">株価</th>
       <th>理由</th>
-      <th>振り返りメモ</th>
     </tr>
   </thead>
   <tbody>
@@ -224,15 +235,6 @@
         {% if row.price is not none %}{{ "{:,}".format(row.price|int) }}{% else %}—{% endif %}
       </td>
       <td style="color:#555;">{{ row.reason }}</td>
-      {% if loop.first %}
-      <td rowspan="{{ ep.rowspan }}" style="vertical-align:top;{% if ep.review_prompt %}background:rgba(210,170,70,0.10);{% endif %}">
-        <div class="review-memo-cell"
-             data-url="/trade-history/{{ ep.code_s }}/{{ ep.memo_seq }}/review-memo"
-             data-memo="{{ ep.review_memo or '' | e }}">
-          <span class="review-memo-display">{{ ep.review_memo or "クリックして入力" }}</span>
-        </div>
-      </td>
-      {% endif %}
     </tr>
     {% endfor %}
   {% endfor %}
@@ -333,6 +335,10 @@
         }
         var fd = new FormData();
         fd.append('review_memo', next);
+        // 売買履歴タブ (fill エピソード) はエピソードキーで保存 (issue #387 Phase2)
+        if (cell.dataset.episodeKey) {
+          fd.append('episode_key', cell.dataset.episodeKey);
+        }
         fetch(url, { method: 'POST', body: fd })
           .then(function (r) {
             if (r.ok) {

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -67,7 +67,8 @@
 <table class="trade-history-table">
   <colgroup>
     <col style="width:1.5em;"><col style="width:11em;"><col style="width:4em;">
-    <col style="width:9em;"><col style="width:4.5em;"><col style="width:6em;"><col>
+    <col style="width:9em;"><col style="width:4.5em;"><col style="width:5em;">
+    <col style="width:7em;"><col style="width:7em;">
   </colgroup>
   <thead>
     <tr>
@@ -78,6 +79,7 @@
       <th style="text-align:right;white-space:nowrap;">株数</th>
       <th style="text-align:right;white-space:nowrap;">リターン</th>
       <th style="text-align:right;white-space:nowrap;">実現損益</th>
+      <th style="text-align:right;white-space:nowrap;">含み損益</th>
     </tr>
   </thead>
   <tbody>
@@ -100,21 +102,34 @@
       <td style="text-align:right;white-space:nowrap;">
         {% if ep.pl %}
         <span style="color:{{ '#9ef0aa' if ep.pl.return_pct >= 0 else '#f0a0a0' }};font-weight:600;">{{ '+' if ep.pl.return_pct >= 0 else '' }}{{ "%.1f"|format(ep.pl.return_pct) }}%</span>
+        {% elif not ep.closed and ep.open_pl and ep.open_pl.held_qty > 0 %}
+        <span style="color:#888;font-size:0.82em;">残 {{ ep.open_pl.held_qty }}株</span>
         {% elif ep.closed %}
         <span style="color:#666;" title="取得記録がCSVに無い(期首持越し等)または空売りのため損益算出対象外">—</span>
         {% else %}
-        <span style="color:#666;">保有中</span>
+        <span style="color:#666;">—</span>
         {% endif %}
       </td>
+      {# 実現損益列 #}
       <td style="text-align:right;white-space:nowrap;">
         {% if ep.pl and ep.pl.profit_amount is not none %}
         <span style="color:{{ '#9ef0aa' if ep.pl.profit_amount >= 0 else '#f0a0a0' }};">{{ "{:+,}".format(ep.pl.profit_amount) }}円</span>
+        {% elif not ep.closed and ep.open_pl and ep.open_pl.realized %}
+        <span style="color:{{ '#9ef0aa' if ep.open_pl.realized >= 0 else '#f0a0a0' }};">{{ "{:+,}".format(ep.open_pl.realized) }}円</span>
+        {% else %}<span style="color:#666;">—</span>{% endif %}
+      </td>
+      {# 含み損益列 (保有中のみ) #}
+      <td style="text-align:right;white-space:nowrap;">
+        {% if not ep.closed and ep.open_pl and ep.open_pl.unrealized is not none %}
+        <span style="color:{{ '#9ef0aa' if ep.open_pl.unrealized >= 0 else '#f0a0a0' }};">{{ "{:+,}".format(ep.open_pl.unrealized) }}円</span>
+        {% elif not ep.closed %}
+        <span style="color:#666;" title="現在値が取得できないため含み損益は非表示">—</span>
         {% else %}<span style="color:#666;">—</span>{% endif %}
       </td>
     </tr>
     <tr class="th-ep-detail" id="ep-{{ loop.index }}" style="display:none;">
       <td></td>
-      <td colspan="6" style="padding:0.3em 0.5em 0.6em;">
+      <td colspan="7" style="padding:0.3em 0.5em 0.6em;">
         <table style="width:auto;font-size:0.82em;color:#999;border-collapse:collapse;">
           {% for f in ep.fills %}
           <tr>

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -37,8 +37,11 @@
     {% if broker_ranges %}
     <div style="color:#888;font-size:0.76em;white-space:nowrap;">
       取込済み最新:
-      {% for broker in ["楽天", "SBI"] %}
-        {% if broker_ranges.get(broker) %}<span style="color:#aaa;" title="取込済み: {{ broker_ranges[broker].first }} 〜 {{ broker_ranges[broker].last }}">{{ broker }} {{ broker_ranges[broker].last[5:] }}</span>{% if not loop.last %} / {% endif %}{% endif %}
+      {# 取込済みの証券会社だけを先に絞ってから回す。固定リストで loop.last を見ると
+         楽天のみ取込のとき末尾に区切りの / が残る (レビュー対応) #}
+      {% set shown = ["楽天", "SBI"] | select("in", broker_ranges) | list %}
+      {% for broker in shown %}
+        <span style="color:#aaa;" title="取込済み: {{ broker_ranges[broker].first }} 〜 {{ broker_ranges[broker].last }}">{{ broker }} {{ broker_ranges[broker].last[5:] }}</span>{% if not loop.last %} / {% endif %}
       {% endfor %}
     </div>
     {% endif %}
@@ -119,6 +122,9 @@
       <td style="white-space:nowrap;">
         {% if ep.kind == "信用" %}
         <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.74em;background:#4a3a2e;color:#e0b070;">信用</span>
+        {% if ep.is_short %}
+        <span title="信用売建 (空売り)。新規売で建て、返済買で決済" style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#4a2e3a;color:#e090b0;margin-left:0.2em;">売建</span>
+        {% endif %}
         {% else %}
         <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.74em;background:#2e4a3a;color:#80c0a0;">現物</span>
         {% endif %}

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -30,7 +30,7 @@
 
 {# 説明 + CSV取込 (issue #387 4a): 普段は「＋CSV取込」リンクのみ、クリックで展開 (details) #}
 <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1em;margin-bottom:0.6em;">
-  <p style="color:#888;font-size:0.85em;margin:0;">楽天・SBI証券CSVの実約定。約定日降順。同じ日・同じ売買方向・同じ取引区分の分割約定は加重平均単価でまとめています（「N件集約」）。</p>
+  <p style="color:#888;font-size:0.85em;margin:0;">楽天・SBI証券CSVの実約定を建玉ラウンド単位のエピソードにまとめています。行をクリックで内訳の個別約定を展開。損益は現物=平均取得単価法、信用=建単価/決済損益。</p>
   <details style="flex-shrink:0;">
     <summary style="color:#9ed8f0;font-size:0.82em;cursor:pointer;white-space:nowrap;list-style:none;">＋ CSV取込</summary>
     <form method="post" action="/trade-history/import" enctype="multipart/form-data"
@@ -43,72 +43,106 @@
     </form>
   </details>
 </div>
-{% if trade_fills %}
+
+{# 成績サマリー (issue #387 Phase4b): fill 基準。クローズ済みで損益算出できたエピソードから #}
+{% if fill_summary %}
+<div style="display:flex;gap:1.4em;align-items:baseline;flex-wrap:wrap;padding:0.6em 0.8em;margin-bottom:0.8em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:6px;">
+  <div><span style="color:#888;font-size:0.8em;">勝率</span>
+    <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{{ "%.0f"|format(fill_summary.win_rate) }}%</span>
+    <span style="color:#888;font-size:0.8em;">({{ fill_summary.n_win }}勝{{ fill_summary.n_lose }}敗)</span></div>
+  <div><span style="color:#888;font-size:0.8em;">ペイオフレシオ</span>
+    <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{% if fill_summary.payoff_ratio is not none %}{{ "%.2f"|format(fill_summary.payoff_ratio) }}{% else %}—{% endif %}</span></div>
+  <div><span style="color:#888;font-size:0.8em;">実現損益</span>
+    <span style="font-size:1.1em;font-weight:600;color:{{ '#9ef0aa' if fill_total_pl >= 0 else '#f0a0a0' }};margin-left:0.3em;">{{ "{:+,}".format(fill_total_pl) }}円</span></div>
+  <div><span style="color:#888;font-size:0.8em;">平均保有(勝)</span>
+    <span style="color:#9ef0aa;margin-left:0.3em;">{% if fill_summary.avg_hold_win is not none %}{{ "%.0f"|format(fill_summary.avg_hold_win) }}日{% else %}—{% endif %}</span></div>
+  <div><span style="color:#888;font-size:0.8em;">平均保有(負)</span>
+    <span style="color:#f0a0a0;margin-left:0.3em;">{% if fill_summary.avg_hold_lose is not none %}{{ "%.0f"|format(fill_summary.avg_hold_lose) }}日{% else %}—{% endif %}</span></div>
+  <div title="信用は建単価/決済損益、現物は平均取得単価法。期首持越し・空売りは損益算出対象外" style="color:#777;font-size:0.78em;margin-left:auto;cursor:help;">
+    算出 {{ fill_priced_count }} 件 / クローズ済 {{ fill_closed_count }} 件</div>
+</div>
+{% endif %}
+
+{% if fill_episodes %}
 <table class="trade-history-table">
   <colgroup>
-    <col style="width:6em;"><col style="width:9em;"><col style="width:4em;">
-    <col style="width:5em;"><col style="width:6em;"><col style="width:7em;"><col>
+    <col style="width:1.5em;"><col style="width:11em;"><col style="width:4em;">
+    <col style="width:9em;"><col style="width:4.5em;"><col style="width:6em;"><col>
   </colgroup>
   <thead>
     <tr>
-      <th style="white-space:nowrap;">約定日</th>
+      <th></th>
       <th>銘柄</th>
-      <th>売買</th>
-      <th style="white-space:nowrap;">株数</th>
-      <th style="white-space:nowrap;">株価</th>
-      <th>取引区分</th>
-      <th>証券</th>
+      <th>区分</th>
+      <th style="white-space:nowrap;">期間</th>
+      <th style="text-align:right;white-space:nowrap;">株数</th>
+      <th style="text-align:right;white-space:nowrap;">リターン</th>
+      <th style="text-align:right;white-space:nowrap;">実現損益</th>
     </tr>
   </thead>
   <tbody>
-  {% for f in trade_fills %}
-    <tr>
-      <td style="white-space:nowrap;color:#888;font-size:0.85em;">{{ f.trade_date[2:4] }}/{{ f.trade_date[5:7] }}/{{ f.trade_date[8:10] }}</td>
-      <td style="white-space:nowrap;"><a href="/stock/{{ f.code_s }}">{{ f.code_s }} {{ f.stock_name }}</a></td>
+  {% for ep in fill_episodes %}
+    <tr class="th-ep-row" data-ep="ep-{{ loop.index }}" style="cursor:pointer;">
+      <td style="color:#666;text-align:center;font-size:0.8em;"><span class="th-ep-caret">▸</span></td>
+      <td style="white-space:nowrap;"><a href="/stock/{{ ep.code_s }}" onclick="event.stopPropagation();">{{ ep.code_s }} {{ ep.stock_name }}</a></td>
       <td style="white-space:nowrap;">
-        {% if f.side == "buy" %}
-        <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#2e5a6e;color:#9ed8f0;">{{ f.side_label }}</span>
+        {% if ep.kind == "信用" %}
+        <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.74em;background:#4a3a2e;color:#e0b070;">信用</span>
         {% else %}
-        <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.78em;background:#5a2e2e;color:#f0a0a0;">{{ f.side_label }}</span>
+        <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:0.74em;background:#2e4a3a;color:#80c0a0;">現物</span>
         {% endif %}
-        {% if f.aggregated %}
-        <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#3a3a2e;color:#c8c070;margin-left:0.2em;">{{ f.count }}件集約</span>
+        {% if not ep.closed %}
+        <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#3a3a4a;color:#a0a0d0;margin-left:0.2em;">保有中</span>
         {% endif %}
       </td>
-      <td style="text-align:right;color:#888;font-size:0.85em;">{{ f.qty }}</td>
-      <td style="text-align:right;color:#888;font-size:0.85em;white-space:nowrap;">{{ "{:,}".format(f.price|round|int) }}</td>
-      <td style="color:#777;font-size:0.85em;">{{ f.trade_kind }}</td>
-      <td style="color:#777;font-size:0.85em;">{{ f.broker }}</td>
+      <td style="white-space:nowrap;color:#888;font-size:0.82em;">{{ ep.open_date[2:] }}{% if ep.close_date and ep.close_date != ep.open_date %} 〜 {{ ep.close_date[2:] }}{% endif %}</td>
+      <td style="text-align:right;color:#888;font-size:0.85em;">{{ ep.qty_peak }}</td>
+      <td style="text-align:right;white-space:nowrap;">
+        {% if ep.pl %}
+        <span style="color:{{ '#9ef0aa' if ep.pl.return_pct >= 0 else '#f0a0a0' }};font-weight:600;">{{ '+' if ep.pl.return_pct >= 0 else '' }}{{ "%.1f"|format(ep.pl.return_pct) }}%</span>
+        {% elif ep.closed %}
+        <span style="color:#666;" title="取得記録がCSVに無い(期首持越し等)または空売りのため損益算出対象外">—</span>
+        {% else %}
+        <span style="color:#666;">保有中</span>
+        {% endif %}
+      </td>
+      <td style="text-align:right;white-space:nowrap;">
+        {% if ep.pl and ep.pl.profit_amount is not none %}
+        <span style="color:{{ '#9ef0aa' if ep.pl.profit_amount >= 0 else '#f0a0a0' }};">{{ "{:+,}".format(ep.pl.profit_amount) }}円</span>
+        {% else %}<span style="color:#666;">—</span>{% endif %}
+      </td>
+    </tr>
+    <tr class="th-ep-detail" id="ep-{{ loop.index }}" style="display:none;">
+      <td></td>
+      <td colspan="6" style="padding:0.3em 0.5em 0.6em;">
+        <table style="width:auto;font-size:0.82em;color:#999;border-collapse:collapse;">
+          {% for f in ep.fills %}
+          <tr>
+            <td style="padding:1px 0.8em 1px 0;white-space:nowrap;color:#888;">{{ f.trade_date[2:4] }}/{{ f.trade_date[5:7] }}/{{ f.trade_date[8:10] }}</td>
+            <td style="padding:1px 0.8em;white-space:nowrap;">
+              {% if f.side == "buy" %}<span style="color:#9ed8f0;">{{ f.side_label }}</span>{% else %}<span style="color:#f0a0a0;">{{ f.side_label }}</span>{% endif %}
+            </td>
+            <td style="padding:1px 0.8em;color:#777;white-space:nowrap;">{{ f.trade_kind }}</td>
+            <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">{{ f.qty }}株</td>
+            <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">{{ "{:,}".format(f.price|round|int) }}円</td>
+            {% if f.tate_price %}<td style="padding:1px 0.8em;text-align:right;white-space:nowrap;color:#888;">建 {{ "{:,}".format(f.tate_price|round|int) }}</td>{% else %}<td></td>{% endif %}
+            <td style="padding:1px 0.8em;color:#666;white-space:nowrap;">{{ f.broker }}</td>
+          </tr>
+          {% endfor %}
+        </table>
+      </td>
     </tr>
   {% endfor %}
   </tbody>
 </table>
 {% else %}
-<p style="color:#888;">取り込まれた約定がありません。<code>import_rakuten_fills.py</code> / <code>import_sbi_fills.py</code> でCSVを取り込んでください。</p>
+<p style="color:#888;">取り込まれた約定がありません。CSV取込、または <code>import_rakuten_fills.py</code> / <code>import_sbi_fills.py</code> でCSVを取り込んでください。</p>
 {% endif %}
 </div>
 
 {# ============ タブ2: アクションログ (手動記録のエピソード) ============ #}
 <div id="tab-actions" class="th-tab-panel" style="display:none;">
-<p style="color:#888;font-size:0.85em;">保有エピソード単位で表示。保有日降順。株価は保有開始日の終値プロキシ（概算）。</p>
-
-{# 成績サマリー (issue #361): 売却済みエピソードのうち終値プロキシで概算できた分 #}
-{% if summary %}
-<div style="display:flex;gap:1.5em;flex-wrap:wrap;align-items:baseline;margin:0.5em 0 1em;padding:0.7em 1em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:5px;">
-  <div><span style="color:#888;font-size:0.8em;">勝率</span>
-    <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{{ "%.0f"|format(summary.win_rate) }}%</span>
-    <span style="color:#888;font-size:0.8em;">({{ summary.n_win }}勝{{ summary.n_lose }}敗)</span></div>
-  <div><span style="color:#888;font-size:0.8em;">ペイオフレシオ</span>
-    <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{% if summary.payoff_ratio is not none %}{{ "%.2f"|format(summary.payoff_ratio) }}{% else %}—{% endif %}</span></div>
-  <div><span style="color:#888;font-size:0.8em;">平均保有(勝)</span>
-    <span style="color:#9ef0aa;margin-left:0.3em;">{% if summary.avg_hold_win is not none %}{{ "%.0f"|format(summary.avg_hold_win) }}日{% else %}—{% endif %}</span></div>
-  <div><span style="color:#888;font-size:0.8em;">平均保有(負)</span>
-    <span style="color:#f0a0a0;margin-left:0.3em;">{% if summary.avg_hold_lose is not none %}{{ "%.0f"|format(summary.avg_hold_lose) }}日{% else %}—{% endif %}</span></div>
-  <div title="終値プロキシによる概算（手数料・配当は無視）" style="color:#777;font-size:0.78em;margin-left:auto;cursor:help;">
-    算出 {{ summary.n_total }} 件 / 売却済み {{ closed_count }} 件
-  </div>
-</div>
-{% endif %}
+<p style="color:#888;font-size:0.85em;">判断の記録 (保有理由・売却理由・振り返りメモ)。保有日降順。成績・実現損益は「売買履歴」タブ (実約定=真実源) に一本化しました。</p>
 
 {% macro episode_table(episodes) %}
 {% if episodes %}
@@ -141,23 +175,8 @@
       {% if loop.first %}
       <td rowspan="{{ ep.rowspan }}" style="vertical-align:top;white-space:nowrap;">
         <a href="/stock/{{ ep.code_s }}">{{ ep.code_s }} {{ ep.stock_name }}</a>
-        {# 概算損益 (issue #361): 算出できたエピソードのみ。None は非表示 #}
-        {% if ep.pl %}
-        <div style="font-size:0.82em;margin-top:2px;">
-          <span style="color:{{ '#9ef0aa' if ep.pl.return_pct >= 0 else '#f0a0a0' }};font-weight:600;">
-            {{ '+' if ep.pl.return_pct >= 0 else '' }}{{ "%.1f"|format(ep.pl.return_pct) }}%</span>
-          {% if ep.pl.profit_amount is not none %}
-          <span style="color:{{ '#9ef0aa' if ep.pl.profit_amount >= 0 else '#f0a0a0' }};margin-left:0.4em;">
-            {{ "{:+,}".format(ep.pl.profit_amount|round|int) }}円</span>
-          {% elif ep.pl.profit_per_share is not none %}
-          <span style="color:{{ '#9ef0aa' if ep.pl.profit_per_share >= 0 else '#f0a0a0' }};margin-left:0.4em;" title="株数不明のため1株あたり損益">
-            {{ "{:+,}".format(ep.pl.profit_per_share|round|int) }}円/株</span>
-          {% endif %}
-          <span style="color:#888;margin-left:0.4em;">{{ ep.pl.hold_days }}日</span>
-        </div>
-        {% elif ep.sell_date %}
-        <div style="font-size:0.82em;margin-top:2px;color:#666;">損益 —</div>
-        {% endif %}
+        {# 実現損益は売買履歴タブ (fill=真実源) に一本化 (issue #387 Phase4b)。
+           ここは売却後騰落率 (issue #366、振り返りの参考) のみ残す #}
         {% if ep.post_sell %}
         <div style="font-size:0.78em;margin-top:3px;color:#888;">
           {% for item in ep.post_sell.values() %}
@@ -262,6 +281,18 @@
     first.style.borderBottomColor = '#9ed8f0';
     first.style.color = '#ddd';
   }
+
+  // 売買履歴エピソード行のクリック展開 (issue #387 Phase4b)
+  document.querySelectorAll('.th-ep-row').forEach(function (row) {
+    row.addEventListener('click', function () {
+      var detail = document.getElementById(row.dataset.ep);
+      if (!detail) return;
+      var open = detail.style.display !== 'none';
+      detail.style.display = open ? 'none' : '';
+      var caret = row.querySelector('.th-ep-caret');
+      if (caret) caret.textContent = open ? '▸' : '▾';
+    });
+  });
 
   // 振り返りメモ編集
   document.querySelectorAll('.review-memo-cell').forEach(function (cell) {

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -31,7 +31,17 @@
 {# 説明 + CSV取込 (issue #387 4a): 普段は「＋CSV取込」リンクのみ、クリックで展開 (details) #}
 <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1em;margin-bottom:0.6em;">
   <p style="color:#888;font-size:0.85em;margin:0;">楽天・SBI証券CSVの実約定を建玉ラウンド単位のエピソードにまとめています。行をクリックで内訳の個別約定を展開。損益は現物=平均取得単価法、信用=建単価/決済損益。</p>
-  <details style="flex-shrink:0;">
+  <div style="flex-shrink:0;display:flex;flex-direction:column;align-items:flex-end;gap:0.3em;">
+    {# 取込済み最新約定日 (次回インポートの参考、取込のたびに更新) issue #387 #}
+    {% if broker_latest %}
+    <div title="取込済み約定の最新日。この翌営業日以降の約定をCSVで取り込む" style="color:#888;font-size:0.76em;white-space:nowrap;">
+      取込済み最新:
+      {% for broker in ["楽天", "SBI"] %}
+        {% if broker_latest.get(broker) %}<span style="color:#aaa;">{{ broker }} {{ broker_latest[broker][5:] }}</span>{% if not loop.last %} / {% endif %}{% endif %}
+      {% endfor %}
+    </div>
+    {% endif %}
+  <details>
     <summary style="color:#9ed8f0;font-size:0.82em;cursor:pointer;white-space:nowrap;list-style:none;">＋ CSV取込</summary>
     <form method="post" action="/trade-history/import" enctype="multipart/form-data"
           title="楽天・SBI の取引履歴CSVを自動判別して取り込みます"
@@ -42,6 +52,7 @@
               style="padding:0.25em 0.7em;font-size:0.82em;white-space:nowrap;background:#2e5a6e;color:#9ed8f0;border:1px solid #3a6a80;border-radius:4px;cursor:pointer;">取込</button>
     </form>
   </details>
+  </div>
 </div>
 
 {# 成績サマリー (issue #387 Phase4b): fill 基準。クローズ済みで損益算出できたエピソードから #}

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -4,7 +4,20 @@
 
 <h2>売買履歴</h2>
 
-{# issue #387: 2タブ構成。売買履歴=楽天CSVの実約定 / アクションログ=手動記録のエピソード #}
+{# CSV取込の結果メッセージ (issue #387 4a) #}
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    {% for category, msg in messages %}
+    <div style="margin:0.5em 0;padding:0.6em 0.9em;border-radius:5px;font-size:0.88em;
+      {% if category == 'error' %}background:rgba(200,80,80,0.12);border:1px solid #6a3030;color:#f0a0a0;
+      {% else %}background:rgba(80,180,100,0.10);border:1px solid #2e6e3e;color:#9ef0aa;{% endif %}">
+      {{ msg }}
+    </div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}
+
+{# issue #387: 2タブ構成。売買履歴=楽天/SBI CSVの実約定 / アクションログ=手動記録のエピソード #}
 <div class="th-tabs" style="display:flex;gap:0.5em;border-bottom:1px solid #333;margin-bottom:1.2em;">
   <button class="th-tab-btn active" data-tab="tab-fills"
           style="background:none;border:none;border-bottom:2px solid transparent;color:#aaa;font-size:0.95em;cursor:pointer;padding:0.5em 0.9em;">売買履歴</button>
@@ -12,8 +25,20 @@
           style="background:none;border:none;border-bottom:2px solid transparent;color:#aaa;font-size:0.95em;cursor:pointer;padding:0.5em 0.9em;">アクションログ</button>
 </div>
 
-{# ============ タブ1: 売買履歴 (楽天CSVの実約定) ============ #}
+{# ============ タブ1: 売買履歴 (楽天/SBI CSVの実約定) ============ #}
 <div id="tab-fills" class="th-tab-panel">
+
+{# CSV取込フォーム (issue #387 4a): 楽天/SBI をヘッダ自動判定 #}
+<form method="post" action="/trade-history/import" enctype="multipart/form-data"
+      style="display:flex;align-items:center;gap:0.6em;margin-bottom:0.9em;padding:0.6em 0.8em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:5px;">
+  <span style="color:#aaa;font-size:0.85em;">CSV取込</span>
+  <input type="file" name="csv_file" accept=".csv" required
+         style="font-size:0.82em;color:#aaa;">
+  <button type="submit"
+          style="padding:0.3em 0.9em;font-size:0.85em;background:#2e5a6e;color:#9ed8f0;border:1px solid #3a6a80;border-radius:4px;cursor:pointer;">取り込む</button>
+  <span style="color:#666;font-size:0.78em;">楽天・SBI を自動判別</span>
+</form>
+
 <p style="color:#888;font-size:0.85em;">楽天・SBI証券CSVの実約定。約定日降順。同じ日・同じ売買方向・同じ取引区分の分割約定は加重平均単価でまとめています（「N件集約」）。</p>
 {% if trade_fills %}
 <table class="trade-history-table">

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -64,6 +64,8 @@
     <span style="color:#888;font-size:0.8em;">({{ fill_summary.n_win }}勝{{ fill_summary.n_lose }}敗)</span></div>
   <div title="勝ちトレードの平均リターン ÷ 負けトレードの平均リターン (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">ペイオフレシオ</span>
     <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{% if fill_summary.payoff_ratio is not none %}{{ "%.2f"|format(fill_summary.payoff_ratio) }}{% else %}—{% endif %}</span></div>
+  <div title="1トレードあたりの平均リターン% (勝率とペイオフを統合した総合的な優位性。プラスならトータルで優位)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">期待値</span>
+    <span style="font-size:1.1em;font-weight:600;color:{{ '#9ef0aa' if fill_summary.expectancy is not none and fill_summary.expectancy >= 0 else '#f0a0a0' }};margin-left:0.3em;">{% if fill_summary.expectancy is not none %}{{ '+' if fill_summary.expectancy >= 0 else '' }}{{ "%.1f"|format(fill_summary.expectancy) }}%{% else %}—{% endif %}</span></div>
   <div title="勝ちトレードの平均リターン% (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">平均リターン(勝)</span>
     <span style="color:#9ef0aa;font-weight:600;margin-left:0.3em;">{% if fill_summary.avg_return_win is not none %}+{{ "%.1f"|format(fill_summary.avg_return_win) }}%{% else %}—{% endif %}</span></div>
   <div title="負けトレードの平均リターン% (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">平均リターン(負)</span>

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -14,12 +14,12 @@
 
 {# ============ タブ1: 売買履歴 (楽天CSVの実約定) ============ #}
 <div id="tab-fills" class="th-tab-panel">
-<p style="color:#888;font-size:0.85em;">楽天CSVの実約定。約定日降順。同じ日・同じ売買方向の分割約定は加重平均単価でまとめています（「N件集約」）。</p>
+<p style="color:#888;font-size:0.85em;">楽天・SBI証券CSVの実約定。約定日降順。同じ日・同じ売買方向・同じ取引区分の分割約定は加重平均単価でまとめています（「N件集約」）。</p>
 {% if trade_fills %}
 <table class="trade-history-table">
   <colgroup>
     <col style="width:6em;"><col style="width:9em;"><col style="width:4em;">
-    <col style="width:5em;"><col style="width:6em;"><col>
+    <col style="width:5em;"><col style="width:6em;"><col style="width:7em;"><col>
   </colgroup>
   <thead>
     <tr>
@@ -29,6 +29,7 @@
       <th style="white-space:nowrap;">株数</th>
       <th style="white-space:nowrap;">株価</th>
       <th>取引区分</th>
+      <th>証券</th>
     </tr>
   </thead>
   <tbody>
@@ -49,12 +50,13 @@
       <td style="text-align:right;color:#888;font-size:0.85em;">{{ f.qty }}</td>
       <td style="text-align:right;color:#888;font-size:0.85em;white-space:nowrap;">{{ "{:,}".format(f.price|round|int) }}</td>
       <td style="color:#777;font-size:0.85em;">{{ f.trade_kind }}</td>
+      <td style="color:#777;font-size:0.85em;">{{ f.broker }}</td>
     </tr>
   {% endfor %}
   </tbody>
 </table>
 {% else %}
-<p style="color:#888;">取り込まれた約定がありません。<code>import_rakuten_fills.py</code> で楽天CSVを取り込んでください。</p>
+<p style="color:#888;">取り込まれた約定がありません。<code>import_rakuten_fills.py</code> / <code>import_sbi_fills.py</code> でCSVを取り込んでください。</p>
 {% endif %}
 </div>
 

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -62,8 +62,12 @@
   <div><span style="color:#888;font-size:0.8em;">勝率</span>
     <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{{ "%.0f"|format(fill_summary.win_rate) }}%</span>
     <span style="color:#888;font-size:0.8em;">({{ fill_summary.n_win }}勝{{ fill_summary.n_lose }}敗)</span></div>
-  <div><span style="color:#888;font-size:0.8em;">ペイオフレシオ</span>
+  <div title="勝ちトレードの平均リターン ÷ 負けトレードの平均リターン (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">ペイオフレシオ</span>
     <span style="font-size:1.1em;font-weight:600;color:#ddd;margin-left:0.3em;">{% if fill_summary.payoff_ratio is not none %}{{ "%.2f"|format(fill_summary.payoff_ratio) }}{% else %}—{% endif %}</span></div>
+  <div title="勝ちトレードの平均リターン% (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">平均リターン(勝)</span>
+    <span style="color:#9ef0aa;font-weight:600;margin-left:0.3em;">{% if fill_summary.avg_return_win is not none %}+{{ "%.1f"|format(fill_summary.avg_return_win) }}%{% else %}—{% endif %}</span></div>
+  <div title="負けトレードの平均リターン% (金額加重)" style="cursor:help;"><span style="color:#888;font-size:0.8em;">平均リターン(負)</span>
+    <span style="color:#f0a0a0;font-weight:600;margin-left:0.3em;">{% if fill_summary.avg_return_lose is not none %}{{ "%.1f"|format(fill_summary.avg_return_lose) }}%{% else %}—{% endif %}</span></div>
   <div><span style="color:#888;font-size:0.8em;">実現損益</span>
     <span style="font-size:1.1em;font-weight:600;color:{{ '#9ef0aa' if fill_total_pl >= 0 else '#f0a0a0' }};margin-left:0.3em;">{{ "{:+,}".format(fill_total_pl) }}円</span></div>
   <div><span style="color:#888;font-size:0.8em;">平均保有(勝)</span>

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -234,6 +234,57 @@ class TestCarryOver:
         assert eps[0]["pl"] is None
 
 
+class TestShortRound:
+    """信用売建 (空売り): 新規売で建て、返済買で閉じる。損益の符号は買建と逆。"""
+
+    @pytest.mark.parametrize("settle_pl,tate_price,expected", [
+        (None, 1500.0, 20000),    # 楽天形式: (建1500 - 買戻1300) * 100 = +20000
+        (-176534, None, -176534),  # SBI形式: settle_pl をそのまま採用
+    ])
+    def test_short_round_pl(self, db_path, settle_pl, tate_price, expected):
+        _add(db_path, "5001", "2026-01-05", "sell", 100, 1500.0,
+             trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "5001", "2026-01-09", "buy", 100, 1300.0,
+             trade_kind="信用返済", tate_price=tate_price, settle_pl=settle_pl,
+             seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        assert len(eps) == 1
+        ep = eps[0]
+        assert ep["is_short"] is True
+        assert ep["closed"] is True
+        assert ep["qty_peak"] == 100
+        assert ep["pl"]["profit_amount"] == expected
+
+    def test_short_and_long_are_separate_rounds(self, db_path):
+        # 両建て: 売建が買建の建玉を打ち消してラウンドを誤って閉じないこと
+        _add(db_path, "5002", "2026-01-05", "sell", 100, 1500.0,
+             trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "5002", "2026-01-06", "buy", 100, 1000.0,
+             trade_kind="信用新規", seq_salt="b")
+        _add(db_path, "5002", "2026-01-09", "buy", 100, 1300.0,
+             trade_kind="信用返済", tate_price=1500.0, seq_salt="c")
+        _add(db_path, "5002", "2026-01-10", "sell", 100, 1200.0,
+             trade_kind="信用返済", tate_price=1000.0, seq_salt="d")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        assert len(eps) == 2
+        short = [e for e in eps if e["is_short"]][0]
+        long_ = [e for e in eps if not e["is_short"]][0]
+        # 売建: (1500-1300)*100 / 買建: (1200-1000)*100
+        assert short["pl"]["profit_amount"] == 20000
+        assert long_["pl"]["profit_amount"] == 20000
+        assert short["closed"] is True and long_["closed"] is True
+
+    def test_open_short_unrealized_is_inverted(self, db_path):
+        # 保有中の売建: 現在値が建単価より下なら含み益
+        _add(db_path, "5003", "2026-01-05", "sell", 100, 1500.0,
+             trade_kind="信用新規", seq_salt="a")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = eps[0]
+        assert ep["closed"] is False
+        assert helpers._episode_open_pl(ep, 1300.0)["unrealized"] == 20000
+        assert helpers._episode_open_pl(ep, 1700.0)["unrealized"] == -20000
+
+
 class TestGenbutsuAndShinyoSeparate:
     def test_genbutsu_and_shinyo_are_separate_rounds(self, db_path):
         # 同一銘柄で現物と信用が並行 → 別ラウンド

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -165,6 +165,50 @@ class TestGenbutsuAndShinyoSeparate:
         assert kinds == ["信用", "現物"]
 
 
+class TestOpenPositionPL:
+    """保有中エピソードの実現損益 (部分売り) と含み損益 (残玉評価)。"""
+
+    def test_genbutsu_partial_sell_realized_and_unrealized(self, db_path, monkeypatch):
+        # 現物 0→200 で100株@1500売却 (実現)、残100株、現在値1400 (含み)
+        _add(db_path, "7001", "2026-01-10", "buy", 200, 1000.0, seq_salt="a")
+        _add(db_path, "7001", "2026-01-20", "sell", 100, 1500.0, seq_salt="b")
+        # 現在値 = price_log 最新終値をモック
+        import datetime as _dt
+        monkeypatch.setattr(
+            helpers, "_bulk_price_logs",
+            lambda codes: {"7001": [(_dt.date(2026, 1, 31), 1400)]},
+        )
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = eps[0]
+        assert ep["closed"] is False
+        op = ep["open_pl"]
+        assert op["realized"] == 50000     # (1500-1000)*100
+        assert op["held_qty"] == 100
+        assert op["unrealized"] == 40000   # (1400-1000)*100
+
+    def test_open_without_price_has_none_unrealized(self, db_path, monkeypatch):
+        _add(db_path, "7002", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")
+        monkeypatch.setattr(helpers, "_bulk_price_logs", lambda codes: {"7002": []})
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        op = eps[0]["open_pl"]
+        assert op["realized"] == 0
+        assert op["unrealized"] is None    # 現在値なし
+        assert op["held_qty"] == 100
+
+    def test_shinyo_reverse_settle_disables_unrealized(self, db_path, monkeypatch):
+        # 信用返済 buy (建玉方向と逆) が混ざると含みは None (安全側)
+        _add(db_path, "7003", "2026-01-10", "buy", 100, 6000.0, trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "7003", "2026-01-12", "buy", 100, 6100.0, trade_kind="信用返済", seq_salt="b")
+        import datetime as _dt
+        monkeypatch.setattr(
+            helpers, "_bulk_price_logs",
+            lambda codes: {"7003": [(_dt.date(2026, 1, 31), 6500)]},
+        )
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        op = eps[0]["open_pl"]
+        assert op["unrealized"] is None
+
+
 class TestOrdering:
     def test_sorted_by_last_trade_date(self, db_path):
         # A: 建2026-01-01 売2026-01-05 (最終01-05)

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -308,15 +308,48 @@ class TestBrokerBackfill:
 class TestFillMemo:
     """fill エピソード単位の振り返りメモ (issue #387 Phase2)。"""
 
-    def test_episode_key_is_stable(self, db_path):
-        # 同一ラウンドは 銘柄+口座種別+建日+返済日 でキーが決まる
-        k1 = ps.fill_episode_key("1001", "現物", "2026-01-10", "2026-01-20")
-        k2 = ps.fill_episode_key("1001", "現物", "2026-01-10", "2026-01-20")
-        assert k1 == k2 == "1001|現物|2026-01-10|2026-01-20"
+    def test_episode_key_uses_first_seq(self, db_path):
+        # キーは 銘柄+口座種別+ラウンド先頭 fill の seq
+        k = ps.fill_episode_key("1001", "現物", 7)
+        assert k == "1001|現物|7"
 
-    def test_open_episode_key_uses_open_marker(self, db_path):
-        k = ps.fill_episode_key("1001", "現物", "2026-01-10", None)
-        assert k.endswith("|open")
+    def test_key_stable_from_open_to_closed(self, db_path, monkeypatch):
+        # P1-2: 保有中に付けたメモが売却後 (close_date 確定) も同じキーで追える
+        _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")
+        monkeypatch.setattr(helpers, "_bulk_price_logs", lambda codes: {"1001": []})
+        eps_open = helpers.build_fill_episodes(db_path=db_path)
+        key_open = eps_open[0]["episode_key"]
+        assert eps_open[0]["closed"] is False
+        ps.set_fill_memo(key_open, "保有中に書いたメモ", db_path=db_path)
+        # 売却してラウンドをクローズ
+        _add(db_path, "1001", "2026-01-20", "sell", 100, 1200.0, seq_salt="b")
+        eps_closed = helpers.build_fill_episodes(db_path=db_path)
+        assert eps_closed[0]["closed"] is True
+        # キーが変わらずメモが引き継がれる
+        assert eps_closed[0]["episode_key"] == key_open
+        assert eps_closed[0]["review_memo"] == "保有中に書いたメモ"
+
+    def test_multiple_rounds_have_distinct_keys(self, db_path):
+        # P1-2: 同一銘柄・同一区分で複数ラウンドあってもキーが衝突せず別メモを持てる。
+        # date ベースの旧キーでは open/close が近いと衝突しうるが seq ベースなら一意。
+        _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "1001", "2026-01-11", "sell", 100, 1100.0, trade_kind="信用返済",
+             tate_price=1000.0, seq_salt="b")
+        _add(db_path, "1001", "2026-01-12", "buy", 100, 1050.0, trade_kind="信用新規", seq_salt="c")
+        _add(db_path, "1001", "2026-01-13", "sell", 100, 1200.0, trade_kind="信用返済",
+             tate_price=1050.0, seq_salt="d")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        code_eps = [e for e in eps if e["code_s"] == "1001"]
+        assert len(code_eps) == 2
+        keys = {e["episode_key"] for e in code_eps}
+        assert len(keys) == 2  # 衝突しない
+        # 別々のメモを持てる
+        k1, k2 = sorted(keys)
+        ps.set_fill_memo(k1, "1回目", db_path=db_path)
+        ps.set_fill_memo(k2, "2回目", db_path=db_path)
+        memos = ps.list_fill_memos(db_path=db_path)
+        assert memos[k1] == "1回目"
+        assert memos[k2] == "2回目"
 
     def test_memo_attached_to_episode(self, db_path):
         _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -1,0 +1,170 @@
+"""fill 基準の建玉ラウンド・エピソード再構成テスト (issue #387 Phase4b)。
+
+build_fill_episodes / _episode_pl_from_round のロジックを合成 fill で検証する。
+現物ラウンド (平均取得単価法)・信用ラウンド (建単価/決済損益)・現引ブリッジ・
+部分売り・保有中・分割約定・期首持ち越しの境界を確認する。
+"""
+
+import pytest
+
+import portfolio_shelve as ps
+from webapp import helpers
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "portfolio")
+
+
+@pytest.fixture(autouse=True)
+def _stub_stock_names(monkeypatch):
+    # 銘柄名解決は stocks DB を開かずにコード=名前で返す (N+1 テストの分離)
+    monkeypatch.setattr(
+        helpers, "_bulk_resolve_stock_names",
+        lambda codes: {c: f"銘柄{c}" for c in codes},
+    )
+
+
+def _add(db_path, code_s, trade_date, side, qty, price, *,
+         trade_kind="現物", broker="楽天", tate_price=None, settle_pl=None,
+         seq_salt=""):
+    """テスト用に fill を1件追加する。dedup_key は一意化する。"""
+    dedup_key = f"{code_s}|{trade_date}|{side}|{qty}|{price}|{trade_kind}|{seq_salt}"
+    fill = ps.create_fill(
+        code_s, trade_date=trade_date, side=side, qty=qty, price=price,
+        amount=int(qty * price), trade_kind=trade_kind, dedup_key=dedup_key,
+        broker=broker, tate_price=tate_price, settle_pl=settle_pl,
+    )
+    ps.append_fill(fill, db_path=db_path)
+
+
+class TestGenbaiBridge:
+    """現引ブリッジ: 現引 (buy) → 現物売 で 1 現物ラウンドが閉じる。"""
+
+    def test_genbiki_to_uridashi_round(self, db_path):
+        # 4369 相当: 現引3 (取得原価3129.12/2678.5/2634.59) → 現物売3 (3150/2618/2642)
+        _add(db_path, "4369", "2026-02-05", "buy", 100, 3129.12, trade_kind="現引", seq_salt="a")
+        _add(db_path, "4369", "2026-02-05", "buy", 100, 2678.5, trade_kind="現引", seq_salt="b")
+        _add(db_path, "4369", "2026-02-05", "buy", 100, 2634.59, trade_kind="現引", seq_salt="c")
+        _add(db_path, "4369", "2026-03-09", "sell", 100, 3150.0, seq_salt="d")
+        _add(db_path, "4369", "2026-03-13", "sell", 100, 2618.0, seq_salt="e")
+        _add(db_path, "4369", "2026-03-19", "sell", 100, 2642.0, seq_salt="f")
+
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        genbutsu = [e for e in eps if e["code_s"] == "4369" and e["kind"] == "現物"]
+        assert len(genbutsu) == 1
+        ep = genbutsu[0]
+        assert ep["closed"] is True
+        assert ep["qty_peak"] == 300
+        assert ep["open_date"] == "2026-02-05"
+        assert ep["close_date"] == "2026-03-19"
+        # 取得 844,221 / 売却 841,000 → -3,221
+        assert ep["pl"]["profit_amount"] == -3221
+
+
+class TestGenbutsuRound:
+    def test_simple_win(self, db_path):
+        _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")
+        _add(db_path, "1001", "2026-01-20", "sell", 100, 1200.0, seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        assert len(eps) == 1
+        ep = eps[0]
+        assert ep["closed"]
+        assert ep["pl"]["profit_amount"] == 20000
+        assert round(ep["pl"]["return_pct"], 2) == 20.0
+        assert ep["pl"]["hold_days"] == 10
+
+    def test_average_cost_partial_sells(self, db_path):
+        # 0→200→300→0: 100@1000, 100@1200, 売100@1300, 売200@1400
+        _add(db_path, "1002", "2026-01-01", "buy", 100, 1000.0, seq_salt="a")
+        _add(db_path, "1002", "2026-01-02", "buy", 100, 1200.0, seq_salt="b")
+        _add(db_path, "1002", "2026-01-03", "buy", 100, 1100.0, seq_salt="c")
+        _add(db_path, "1002", "2026-01-10", "sell", 100, 1300.0, seq_salt="d")
+        _add(db_path, "1002", "2026-01-15", "sell", 200, 1400.0, seq_salt="e")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        assert len(eps) == 1
+        ep = eps[0]
+        assert ep["qty_peak"] == 300
+        # avg_cost = (1000+1200+1100)/3 = 1100
+        # 実現 = (1300-1100)*100 + (1400-1100)*200 = 20000 + 60000 = 80000
+        assert ep["pl"]["profit_amount"] == 80000
+
+    def test_two_rounds_separate(self, db_path):
+        # 0→100→0→100→0 で2エピソード
+        _add(db_path, "1003", "2026-01-01", "buy", 100, 1000.0, seq_salt="a")
+        _add(db_path, "1003", "2026-01-05", "sell", 100, 1100.0, seq_salt="b")
+        _add(db_path, "1003", "2026-02-01", "buy", 100, 1200.0, seq_salt="c")
+        _add(db_path, "1003", "2026-02-05", "sell", 100, 1150.0, seq_salt="d")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        assert len([e for e in eps if e["code_s"] == "1003"]) == 2
+        pls = sorted(e["pl"]["profit_amount"] for e in eps)
+        assert pls == [-5000, 10000]
+
+    def test_holding_open_round(self, db_path):
+        # 買いのみ = 保有中、損益 None
+        _add(db_path, "1004", "2026-01-01", "buy", 100, 1000.0, seq_salt="a")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        assert len(eps) == 1
+        assert eps[0]["closed"] is False
+        assert eps[0]["pl"] is None
+        assert eps[0]["close_date"] is None
+
+
+class TestShinyoRound:
+    def test_rakuten_credit_uses_tate_price(self, db_path):
+        # 信用新規買建 100@1000 → 信用返済売埋 100@1300 (tate_price=1000)
+        _add(db_path, "2001", "2026-01-01", "buy", 100, 1000.0, trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "2001", "2026-01-10", "sell", 100, 1300.0, trade_kind="信用返済",
+             tate_price=1000.0, seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        credit = [e for e in eps if e["kind"] == "信用"]
+        assert len(credit) == 1
+        # (1300-1000)*100 = 30000
+        assert credit[0]["pl"]["profit_amount"] == 30000
+
+    def test_sbi_credit_uses_settle_pl(self, db_path):
+        _add(db_path, "2002", "2026-01-01", "buy", 100, 1000.0, trade_kind="信用新規",
+             broker="SBI", seq_salt="a")
+        _add(db_path, "2002", "2026-01-10", "sell", 100, 1250.0, trade_kind="信用返済",
+             broker="SBI", settle_pl=24000, tate_price=None, seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        credit = [e for e in eps if e["kind"] == "信用"]
+        assert len(credit) == 1
+        assert credit[0]["pl"]["profit_amount"] == 24000
+
+    def test_credit_without_pl_source_is_none(self, db_path):
+        # 建単価も決済損益も無い信用返済 → 損益不能
+        _add(db_path, "2003", "2026-01-01", "buy", 100, 1000.0, trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "2003", "2026-01-10", "sell", 100, 1300.0, trade_kind="信用返済", seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        credit = [e for e in eps if e["kind"] == "信用"]
+        assert len(credit) == 1
+        assert credit[0]["pl"] is None
+
+
+class TestCarryOver:
+    def test_sell_only_round_is_pl_none(self, db_path):
+        # 期首持ち越し: 買い記録が無く売りだけ → クローズ済だが損益不能
+        _add(db_path, "3001", "2026-02-20", "sell", 300, 1500.0, seq_salt="a")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        assert len(eps) == 1
+        assert eps[0]["closed"] is True
+        assert eps[0]["pl"] is None
+
+
+class TestGenbutsuAndShinyoSeparate:
+    def test_genbutsu_and_shinyo_are_separate_rounds(self, db_path):
+        # 同一銘柄で現物と信用が並行 → 別ラウンド
+        _add(db_path, "4001", "2026-01-01", "buy", 100, 1000.0, trade_kind="現物", seq_salt="a")
+        _add(db_path, "4001", "2026-01-05", "sell", 100, 1100.0, trade_kind="現物", seq_salt="b")
+        _add(db_path, "4001", "2026-01-02", "buy", 100, 1000.0, trade_kind="信用新規", seq_salt="c")
+        _add(db_path, "4001", "2026-01-06", "sell", 100, 1200.0, trade_kind="信用返済",
+             tate_price=1000.0, seq_salt="d")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        kinds = sorted(e["kind"] for e in eps if e["code_s"] == "4001")
+        assert kinds == ["信用", "現物"]
+
+
+class TestEmpty:
+    def test_no_fills(self, db_path):
+        assert helpers.build_fill_episodes(db_path=db_path) == []

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -306,26 +306,29 @@ class TestOrdering:
         assert eps[0]["closed"] is False
 
 
-class TestLatestFillDatesByBroker:
-    """証券会社別の取込済み最新約定日 (取込タイミング参考) issue #387。"""
+class TestFillDateRangeByBroker:
+    """証券会社別の取込済み約定日レンジ (最古〜最新、取込タイミング参考) issue #387。"""
 
-    def test_latest_per_broker(self, db_path):
+    def test_range_per_broker(self, db_path):
         _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, broker="楽天", seq_salt="a")
         _add(db_path, "1001", "2026-07-31", "sell", 100, 1200.0, broker="楽天", seq_salt="b")
         _add(db_path, "2002", "2026-03-04", "buy", 100, 500.0,
              trade_kind="信用新規", broker="SBI", seq_salt="c")
         _add(db_path, "2002", "2026-07-21", "sell", 100, 600.0,
              trade_kind="信用返済", broker="SBI", settle_pl=10000, seq_salt="d")
-        latest = helpers.latest_fill_dates_by_broker(db_path=db_path)
-        assert latest == {"楽天": "2026-07-31", "SBI": "2026-07-21"}
+        ranges = helpers.fill_date_range_by_broker(db_path=db_path)
+        assert ranges == {
+            "楽天": {"first": "2026-01-10", "last": "2026-07-31"},
+            "SBI": {"first": "2026-03-04", "last": "2026-07-21"},
+        }
 
     def test_none_broker_counts_as_rakuten(self, db_path):
         _add(db_path, "1001", "2026-05-01", "buy", 100, 1000.0, broker=None, seq_salt="a")
-        latest = helpers.latest_fill_dates_by_broker(db_path=db_path)
-        assert latest == {"楽天": "2026-05-01"}
+        ranges = helpers.fill_date_range_by_broker(db_path=db_path)
+        assert ranges == {"楽天": {"first": "2026-05-01", "last": "2026-05-01"}}
 
     def test_empty(self, db_path):
-        assert helpers.latest_fill_dates_by_broker(db_path=db_path) == {}
+        assert helpers.fill_date_range_by_broker(db_path=db_path) == {}
 
 
 class TestEmpty:

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -27,13 +27,14 @@ def _stub_stock_names(monkeypatch):
 
 def _add(db_path, code_s, trade_date, side, qty, price, *,
          trade_kind="現物", broker="楽天", tate_price=None, settle_pl=None,
-         seq_salt=""):
+         tate_date=None, seq_salt=""):
     """テスト用に fill を1件追加する。dedup_key は一意化する。"""
     dedup_key = f"{code_s}|{trade_date}|{side}|{qty}|{price}|{trade_kind}|{seq_salt}"
     fill = ps.create_fill(
         code_s, trade_date=trade_date, side=side, qty=qty, price=price,
         amount=int(qty * price), trade_kind=trade_kind, dedup_key=dedup_key,
         broker=broker, tate_price=tate_price, settle_pl=settle_pl,
+        tate_date=tate_date,
     )
     ps.append_fill(fill, db_path=db_path)
 
@@ -195,6 +196,32 @@ class TestShinyoRound:
         credit = [e for e in eps if e["kind"] == "信用"]
         assert len(credit) == 1
         assert credit[0]["pl"] is None
+
+    def test_pre_import_repayment_does_not_close_current_round(self, db_path):
+        """取込前建玉の返済は、当期に新規で建てた信用玉と相殺しない。"""
+        _add(db_path, "7089", "2026-02-20", "buy", 200, 1339.0,
+             trade_kind="信用新規", seq_salt="new")
+        _add(db_path, "7089", "2026-02-20", "sell", 100, 1339.0,
+             trade_kind="信用返済", tate_date="2025-08-21", tate_price=955.0,
+             seq_salt="old-a")
+        _add(db_path, "7089", "2026-03-03", "sell", 100, 1304.0,
+             trade_kind="信用返済", tate_date="2025-12-29", tate_price=975.0,
+             seq_salt="old-b")
+        _add(db_path, "7089", "2026-05-12", "sell", 200, 1550.0,
+             trade_kind="信用返済", tate_date="2026-02-20", tate_price=1339.0,
+             seq_salt="settle")
+
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        current = [e for e in eps if e["kind"] == "信用" and not e["carry_over"]]
+        carry_over = [e for e in eps if e["kind"] == "信用" and e["carry_over"]]
+
+        assert len(current) == 1
+        assert current[0]["open_date"] == "2026-02-20"
+        assert current[0]["close_date"] == "2026-05-12"
+        assert current[0]["qty_peak"] == 200
+        assert current[0]["pl"]["profit_amount"] == 42200
+        assert len(carry_over) == 2
+        assert {e["open_date"] for e in carry_over} == {"2025-08-21", "2025-12-29"}
 
 
 class TestCarryOver:

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -165,6 +165,21 @@ class TestGenbutsuAndShinyoSeparate:
         assert kinds == ["信用", "現物"]
 
 
+class TestOrdering:
+    def test_sorted_by_last_trade_date(self, db_path):
+        # A: 建2026-01-01 売2026-01-05 (最終01-05)
+        _add(db_path, "5001", "2026-01-01", "buy", 100, 1000.0, seq_salt="a")
+        _add(db_path, "5001", "2026-01-05", "sell", 100, 1100.0, seq_salt="b")
+        # B: 建2026-01-02 のまま保有中で 2026-03-01 に買い増し (最終03-01)
+        _add(db_path, "5002", "2026-01-02", "buy", 100, 2000.0, seq_salt="c")
+        _add(db_path, "5002", "2026-03-01", "buy", 100, 2100.0, seq_salt="d")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        # 最終約定日降順 → 保有中(最終03-01)が先、クローズ済(最終01-05)が後
+        assert [e["code_s"] for e in eps] == ["5002", "5001"]
+        assert eps[0]["last_trade_date"] == "2026-03-01"
+        assert eps[0]["closed"] is False
+
+
 class TestEmpty:
     def test_no_fills(self, db_path):
         assert helpers.build_fill_episodes(db_path=db_path) == []

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -303,3 +303,50 @@ class TestBrokerBackfill:
         eps = helpers.build_fill_episodes(db_path=db_path)
         brokers = {f["broker"] for f in eps[0]["fills"]}
         assert brokers == {"SBI"}
+
+
+class TestFillMemo:
+    """fill エピソード単位の振り返りメモ (issue #387 Phase2)。"""
+
+    def test_episode_key_is_stable(self, db_path):
+        # 同一ラウンドは 銘柄+口座種別+建日+返済日 でキーが決まる
+        k1 = ps.fill_episode_key("1001", "現物", "2026-01-10", "2026-01-20")
+        k2 = ps.fill_episode_key("1001", "現物", "2026-01-10", "2026-01-20")
+        assert k1 == k2 == "1001|現物|2026-01-10|2026-01-20"
+
+    def test_open_episode_key_uses_open_marker(self, db_path):
+        k = ps.fill_episode_key("1001", "現物", "2026-01-10", None)
+        assert k.endswith("|open")
+
+    def test_memo_attached_to_episode(self, db_path):
+        _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")
+        _add(db_path, "1001", "2026-01-20", "sell", 100, 1200.0, seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        key = eps[0]["episode_key"]
+        assert eps[0]["review_memo"] == ""  # 初期は空
+        ps.set_fill_memo(key, "利確成功、再現性の検証を", db_path=db_path)
+        eps2 = helpers.build_fill_episodes(db_path=db_path)
+        assert eps2[0]["review_memo"] == "利確成功、再現性の検証を"
+
+    def test_empty_memo_deletes(self, db_path):
+        _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")
+        _add(db_path, "1001", "2026-01-20", "sell", 100, 1200.0, seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        key = eps[0]["episode_key"]
+        ps.set_fill_memo(key, "メモ", db_path=db_path)
+        assert ps.get_fill_memo(key, db_path=db_path) == "メモ"
+        ps.set_fill_memo(key, "  ", db_path=db_path)  # 空白は削除扱い
+        assert ps.get_fill_memo(key, db_path=db_path) == ""
+        assert key not in ps.list_fill_memos(db_path=db_path)
+
+    def test_memo_survives_fill_reimport(self, db_path):
+        # メモは fill と独立レイヤー。fill を作り直しても同一キーなら残る
+        _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")
+        _add(db_path, "1001", "2026-01-20", "sell", 100, 1200.0, seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        key = eps[0]["episode_key"]
+        ps.set_fill_memo(key, "残るはず", db_path=db_path)
+        # 同一 dedup の fill を再追加 (重複スキップされる) してもメモは維持
+        _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")
+        eps2 = helpers.build_fill_episodes(db_path=db_path)
+        assert eps2[0]["review_memo"] == "残るはず"

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -306,6 +306,28 @@ class TestOrdering:
         assert eps[0]["closed"] is False
 
 
+class TestLatestFillDatesByBroker:
+    """証券会社別の取込済み最新約定日 (取込タイミング参考) issue #387。"""
+
+    def test_latest_per_broker(self, db_path):
+        _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, broker="楽天", seq_salt="a")
+        _add(db_path, "1001", "2026-07-31", "sell", 100, 1200.0, broker="楽天", seq_salt="b")
+        _add(db_path, "2002", "2026-03-04", "buy", 100, 500.0,
+             trade_kind="信用新規", broker="SBI", seq_salt="c")
+        _add(db_path, "2002", "2026-07-21", "sell", 100, 600.0,
+             trade_kind="信用返済", broker="SBI", settle_pl=10000, seq_salt="d")
+        latest = helpers.latest_fill_dates_by_broker(db_path=db_path)
+        assert latest == {"楽天": "2026-07-31", "SBI": "2026-07-21"}
+
+    def test_none_broker_counts_as_rakuten(self, db_path):
+        _add(db_path, "1001", "2026-05-01", "buy", 100, 1000.0, broker=None, seq_salt="a")
+        latest = helpers.latest_fill_dates_by_broker(db_path=db_path)
+        assert latest == {"楽天": "2026-05-01"}
+
+    def test_empty(self, db_path):
+        assert helpers.latest_fill_dates_by_broker(db_path=db_path) == {}
+
+
 class TestEmpty:
     def test_no_fills(self, db_path):
         assert helpers.build_fill_episodes(db_path=db_path) == []

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -61,6 +61,58 @@ class TestGenbaiBridge:
         # 取得 844,221 / 売却 841,000 → -3,221
         assert ep["pl"]["profit_amount"] == -3221
 
+    def test_shinyo_to_genbiki_to_genbutsu_full_flow(self, db_path):
+        """信用新規買 → 現引 → 現物売 で、信用建玉が現引で現物へ振り替わる (1436相当)。
+
+        現引で信用建玉が尽きると信用ラウンドは損益なしでクローズ (保有中に残らない)。
+        現物ラウンドが現引取得原価 × 現物売で損益確定する。
+        """
+        _add(db_path, "1436", "2026-05-08", "buy", 300, 1440.0, trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "1436", "2026-05-13", "buy", 100, 1810.0, trade_kind="信用新規", seq_salt="b")
+        _add(db_path, "1436", "2026-06-08", "buy", 100, 1813.74, trade_kind="現引", seq_salt="c")
+        _add(db_path, "1436", "2026-06-08", "buy", 300, 1443.31, trade_kind="現引", seq_salt="d")
+        _add(db_path, "1436", "2026-06-09", "sell", 100, 1855.0, trade_kind="現物", seq_salt="e")
+        _add(db_path, "1436", "2026-06-16", "sell", 300, 1260.0, trade_kind="現物", seq_salt="f")
+
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        # 保有中は残らない (信用建玉は現引で全部振替、現物は全部売却)
+        assert all(e["closed"] for e in eps), [e for e in eps if not e["closed"]]
+        shinyo = [e for e in eps if e["kind"] == "信用"]
+        genbutsu = [e for e in eps if e["kind"] == "現物"]
+        assert len(shinyo) == 1
+        assert len(genbutsu) == 1
+        # 信用ラウンドは現引で閉じたため損益なし (信用として売っていない)
+        assert shinyo[0]["pl"] is None
+        # 現物: 取得 (1813.74*100 + 1443.31*300) / 売却 (1855*100 + 1260*300)
+        # = 181374 + 432993 = 614367 取得, 185500 + 378000 = 563500 売却 → -50,867
+        assert genbutsu[0]["pl"]["profit_amount"] == -50867
+
+    def test_genbiki_does_not_leave_open_shinyo(self, db_path):
+        """現引で信用建玉が尽きたら信用が保有中に残らない (誤保有バグの回帰)。"""
+        _add(db_path, "2001", "2026-01-10", "buy", 100, 1000.0, trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "2001", "2026-01-20", "buy", 100, 1050.0, trade_kind="現引", seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        # 信用は現引で振替済み → 信用の保有中は無い。現物は現引100株を保有中
+        open_shinyo = [e for e in eps if not e["closed"] and e["kind"] == "信用"]
+        open_genbutsu = [e for e in eps if not e["closed"] and e["kind"] == "現物"]
+        assert open_shinyo == []
+        assert len(open_genbutsu) == 1
+        assert open_genbutsu[0]["open_pl"]["held_qty"] == 100
+
+    def test_genbiki_then_same_day_sell_not_open(self, db_path):
+        """同日に 現引(買) → 現物売 があるとき、現引を先に処理し保有中に残さない (6366相当)。
+
+        CSVの seq 上は現物売が先に来ても、同日は建玉を作る側 (現引) を先に処理する。
+        """
+        _add(db_path, "6366", "2026-03-16", "buy", 300, 1051.0, trade_kind="信用新規", seq_salt="a")
+        # 同日 05-11: 現物売300 (seq が現引より先) と 現引300
+        _add(db_path, "6366", "2026-05-11", "sell", 300, 753.1, trade_kind="現物", seq_salt="b")
+        _add(db_path, "6366", "2026-05-11", "buy", 300, 1061.62, trade_kind="現引", seq_salt="c")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        # 現引で現物化した300株を同日売却 → 現物は保有中に残らない
+        open_genbutsu = [e for e in eps if not e["closed"] and e["kind"] == "現物"]
+        assert open_genbutsu == [], open_genbutsu
+
 
 class TestGenbutsuRound:
     def test_simple_win(self, db_path):

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -83,6 +83,9 @@ class TestGenbaiBridge:
         assert len(genbutsu) == 1
         # 信用ラウンドは現引で閉じたため損益なし (信用として売っていない)
         assert shinyo[0]["pl"] is None
+        # 信用ラウンドの終了日は最後の信用新規日 (05-13) ではなく現引日 (06-08) (P2)
+        assert shinyo[0]["close_date"] == "2026-06-08"
+        assert shinyo[0]["last_trade_date"] == "2026-06-08"
         # 現物: 取得 (1813.74*100 + 1443.31*300) / 売却 (1855*100 + 1260*300)
         # = 181374 + 432993 = 614367 取得, 185500 + 378000 = 563500 売却 → -50,867
         assert genbutsu[0]["pl"]["profit_amount"] == -50867
@@ -279,3 +282,24 @@ class TestOrdering:
 class TestEmpty:
     def test_no_fills(self, db_path):
         assert helpers.build_fill_episodes(db_path=db_path) == []
+
+
+class TestBrokerBackfill:
+    """既存の楽天取込 fill は broker 未設定 (None)。表示時に「楽天」で補完する (P2)。"""
+
+    def test_none_broker_shown_as_rakuten(self, db_path):
+        _add(db_path, "9001", "2026-01-10", "buy", 100, 1000.0, broker=None, seq_salt="a")
+        _add(db_path, "9001", "2026-01-20", "sell", 100, 1100.0, broker=None, seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        assert len(eps) == 1
+        brokers = {f["broker"] for f in eps[0]["fills"]}
+        assert brokers == {"楽天"}
+
+    def test_sbi_broker_preserved(self, db_path):
+        _add(db_path, "9002", "2026-01-10", "buy", 100, 1000.0,
+             trade_kind="信用新規", broker="SBI", seq_salt="a")
+        _add(db_path, "9002", "2026-01-20", "sell", 100, 1250.0,
+             trade_kind="信用返済", broker="SBI", settle_pl=24000, seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        brokers = {f["broker"] for f in eps[0]["fills"]}
+        assert brokers == {"SBI"}

--- a/tests/test_import_rakuten_fills.py
+++ b/tests/test_import_rakuten_fills.py
@@ -21,7 +21,8 @@ _HEADER = [
 ]
 
 
-def _row(code_s, trade_kind, baibai, qty, price, trade_date="2026/6/22", amount="0"):
+def _row(code_s, trade_kind, baibai, qty, price, trade_date="2026/6/22", amount="0",
+         tate_date="", tate_price=""):
     """28列の取引行を組み立てる (未使用列は '0' / '-' で埋める)。"""
     row = ["0"] * 28
     row[ir.COL_TRADE_DATE] = trade_date
@@ -31,6 +32,8 @@ def _row(code_s, trade_kind, baibai, qty, price, trade_date="2026/6/22", amount=
     row[ir.COL_QTY] = qty
     row[ir.COL_PRICE] = price
     row[ir.COL_AMOUNT] = amount
+    row[ir.COL_TATE_DATE] = tate_date
+    row[ir.COL_TATE_PRICE] = tate_price
     return row
 
 
@@ -63,6 +66,69 @@ def test_parse_row(trade_kind, baibai, qty, price, exp_side, exp_qty, exp_price)
     assert parsed["side"] == exp_side
     assert parsed["qty"] == exp_qty
     assert parsed["price"] == exp_price
+
+
+def test_parse_genbiki_row(tmp_path, db_path):
+    """現引 (売買区分が空) は buy 扱いで取込み、単価を取得原価とする (Phase4b)。"""
+    parsed = ir.parse_fill_row(
+        _row("4369", "現引", "", "100", "3,129.12", trade_date="2026/2/5")
+    )
+    assert parsed["side"] == "buy"
+    assert parsed["trade_kind"] == "現引"
+    assert parsed["qty"] == 100
+    assert parsed["price"] == 3129.12
+
+
+def test_parse_tate_price_on_credit_settle():
+    """信用返済行の建約定日・建単価をパースする (Phase4b)。"""
+    parsed = ir.parse_fill_row(
+        _row("9509", "信用返済", "売埋", "100", "1,065.0",
+             tate_date="2025/7/7", tate_price="795.0")
+    )
+    assert parsed["tate_date"] == "2025-07-07"
+    assert parsed["tate_price"] == 795.0
+
+
+def test_parse_no_tate_price_on_genbutsu():
+    """現物行は建約定日・建単価を持たない (None)。"""
+    parsed = ir.parse_fill_row(_row("6315", "現物", "買付", "100", "1,925.0"))
+    assert parsed["tate_date"] is None
+    assert parsed["tate_price"] is None
+
+
+def test_genbiki_imported_to_fill(tmp_path, db_path):
+    """現引行が fill として取込まれる (buy, trade_kind=現引)。"""
+    path = _write_csv(
+        tmp_path / "genbiki.csv",
+        [_row("4369", "現引", "", "100", "3,129.12", trade_date="2026/2/5")],
+    )
+    stats = ir.import_csv_to_fills(path, db_path=db_path)
+    assert stats["imported"] == 1
+    assert stats["skipped_invalid"] == 0
+    fills = ps.list_fills("4369", db_path=db_path)
+    assert len(fills) == 1
+    assert fills[0]["side"] == "buy"
+    assert fills[0]["trade_kind"] == "現引"
+
+
+def test_backfill_tate_price_on_reimport(tmp_path, db_path):
+    """建単価無しで取込済みの信用返済 fill に、再取込で建単価が後付けされる (Phase4b 移行)。"""
+    # 1回目: 建単価無し (旧取込を模す)
+    path1 = _write_csv(
+        tmp_path / "old.csv",
+        [_row("9509", "信用返済", "売埋", "100", "1,065.0")],
+    )
+    ir.import_csv_to_fills(path1, db_path=db_path)
+    assert ps.list_fills("9509", db_path=db_path)[0]["tate_price"] is None
+    # 2回目: 同一約定に建単価付き → dedup スキップだが tate_price が後付け
+    path2 = _write_csv(
+        tmp_path / "new.csv",
+        [_row("9509", "信用返済", "売埋", "100", "1,065.0",
+              tate_date="2025/7/7", tate_price="795.0")],
+    )
+    stats = ir.import_csv_to_fills(path2, db_path=db_path)
+    assert stats["skipped_dup"] == 1
+    assert ps.list_fills("9509", db_path=db_path)[0]["tate_price"] == 795.0
 
 
 def test_dedup_idempotent(tmp_path, db_path):

--- a/tests/test_import_rakuten_fills.py
+++ b/tests/test_import_rakuten_fills.py
@@ -1,6 +1,6 @@
 """import_rakuten_fills.py のテスト (issue #360 Phase2)。
 
-楽天 取引履歴CSV の fill 取込・冪等 dedup・エピソード自動マッチを検証する。
+楽天 取引履歴CSV の fill 取込・冪等 dedup を検証する (issue #387 で自動マッチは廃止)。
 """
 
 import csv
@@ -84,95 +84,3 @@ def test_dedup_idempotent(tmp_path, db_path):
     assert s2["imported"] == 0 and s2["skipped_dup"] == 3
     assert len(ps.list_fills(db_path=db_path)) == 3  # 総数不変 (冪等)
 
-
-def test_match_single_and_ambiguous(tmp_path, db_path):
-    """buy fill が ±5日内の1保ログに付く / 同日同side2行は曖昧で未マッチ。"""
-    # 6315: 単一 buy → 1保ログにマッチ確定
-    ps.add_to_watch("6315", db_path=db_path)
-    ps.transition_status("6315", "1保", action_date="2026-06-24", qty=100, db_path=db_path)
-    # 3496: 同日同side2行 → 曖昧で未マッチ
-    ps.add_to_watch("3496", db_path=db_path)
-    ps.transition_status("3496", "1保", action_date="2026-06-23", qty=100, db_path=db_path)
-
-    rows = [
-        _row("6315", "信用新規", "買建", "100", "3,390.0", trade_date="2026/6/23"),
-        _row("3496", "信用新規", "買建", "100", "4,140.0", trade_date="2026/6/23"),
-        _row("3496", "信用新規", "買建", "100", "4,200.0", trade_date="2026/6/23"),
-    ]
-    csv_path = _write_csv(tmp_path / "t.csv", rows)
-    ir.import_csv_to_fills(csv_path, db_path=db_path)
-
-    stats = ir.match_fills_to_episodes(db_path=db_path)
-    assert stats["matched"] == 1      # 6315 のみ
-    assert stats["ambiguous"] == 2    # 3496 の 2 行
-
-    matched = [f for f in ps.list_fills("6315", db_path=db_path) if f["matched_seq"] is not None]
-    assert len(matched) == 1
-    # 3496 は全て未マッチ
-    assert all(f["matched_seq"] is None for f in ps.list_fills("3496", db_path=db_path))
-
-
-def test_match_no_double_consume(tmp_path, db_path):
-    """1つの1保スロットに対し近接2 fill があっても消費は1件、増分取込でも再マッチしない。"""
-    ps.add_to_watch("6315", db_path=db_path)
-    ps.transition_status("6315", "1保", action_date="2026-06-24", qty=100, db_path=db_path)
-    # 別々の約定日 (曖昧集約は回避) だが両方が同じ1保スロットの±3日窓に入る buy 2 件
-    rows = [
-        _row("6315", "信用新規", "買建", "100", "3,390.0", trade_date="2026/6/23"),
-        _row("6315", "信用新規", "買建", "100", "3,400.0", trade_date="2026/6/25"),
-    ]
-    csv_path = _write_csv(tmp_path / "t.csv", rows)
-    ir.import_csv_to_fills(csv_path, db_path=db_path)
-
-    stats = ir.match_fills_to_episodes(db_path=db_path)
-    # 1保スロットは1つしかないので、マッチ確定は高々1件 (二重消費されない)
-    assert stats["matched"] == 1
-    matched = [f for f in ps.list_fills("6315", db_path=db_path) if f["matched_seq"] is not None]
-    assert len(matched) == 1
-
-    # 増分取込: 後日の別CSVで同スロット近傍の buy を追加し再マッチしても、既マッチ
-    # スロットは消費済みとして除外され二重マッチしない (P1)
-    rows2 = [_row("6315", "信用新規", "買建", "100", "3,410.0", trade_date="2026/6/26")]
-    csv2 = _write_csv(tmp_path / "t2.csv", rows2)
-    ir.import_csv_to_fills(csv2, db_path=db_path)
-    ir.match_fills_to_episodes(db_path=db_path)
-    matched2 = [f for f in ps.list_fills("6315", db_path=db_path) if f["matched_seq"] is not None]
-    assert len(matched2) == 1  # 増分後もマッチは1件のまま
-
-
-def test_match_two_episodes_no_cross(tmp_path, db_path):
-    """同一コードで近接2エピソード時、buy/sell が各エピソードの最近接スロットにのみ付き跨がない。
-
-    6227 縮図: 保有(6/20)→売却(6/25) と 保有(7/01)→売却(7/06) の2サイクル。
-    各サイクルの実約定 buy/sell が、隣サイクルに吸着せず自分の区間に収まる。
-    """
-    ps.add_to_watch("6227", db_path=db_path)
-    # サイクル1
-    ps.transition_status("6227", "1保", action_date="2026-06-20", qty=100, db_path=db_path)
-    ps.transition_status("6227", "2準", action_date="2026-06-25", db_path=db_path)
-    # サイクル2
-    ps.transition_status("6227", "1保", action_date="2026-07-01", qty=100, db_path=db_path)
-    ps.transition_status("6227", "2準", action_date="2026-07-06", db_path=db_path)
-
-    rows = [
-        _row("6227", "信用新規", "買建", "100", "7,000.0", trade_date="2026/6/21"),  # cyc1 buy
-        _row("6227", "信用返済", "売埋", "100", "7,300.0", trade_date="2026/6/24"),  # cyc1 sell
-        _row("6227", "信用新規", "買建", "100", "6,800.0", trade_date="2026/7/02"),  # cyc2 buy
-        _row("6227", "信用返済", "売埋", "100", "7,100.0", trade_date="2026/7/05"),  # cyc2 sell
-    ]
-    csv_path = _write_csv(tmp_path / "t.csv", rows)
-    ir.import_csv_to_fills(csv_path, db_path=db_path)
-    stats = ir.match_fills_to_episodes(db_path=db_path)
-
-    assert stats["matched"] == 4  # 4件すべてが自分のサイクルにマッチ
-
-    logs = ps.list_action_logs("6227", db_path=db_path)
-    hold_seqs = sorted(l["seq"] for l in logs if l.get("status_to") == "1保")
-    sell_seqs = sorted(l["seq"] for l in logs if l.get("action_type") == "売却")
-    fills = {(f["side"], f["trade_date"]): f["matched_seq"]
-             for f in ps.list_fills("6227", db_path=db_path)}
-    # cyc1 buy(6/21) は早い方の1保、cyc2 buy(7/02) は遅い方の1保 (跨がない)
-    assert fills[("buy", "2026-06-21")] == hold_seqs[0]
-    assert fills[("buy", "2026-07-02")] == hold_seqs[1]
-    assert fills[("sell", "2026-06-24")] == sell_seqs[0]
-    assert fills[("sell", "2026-07-05")] == sell_seqs[1]

--- a/tests/test_import_rakuten_fills.py
+++ b/tests/test_import_rakuten_fills.py
@@ -131,6 +131,22 @@ def test_backfill_tate_price_on_reimport(tmp_path, db_path):
     assert ps.list_fills("9509", db_path=db_path)[0]["tate_price"] == 795.0
 
 
+def test_etf_rows_are_excluded(tmp_path, db_path, monkeypatch):
+    """ETF (ETF_code.txt 掲載) の行は取込対象外 (issue #387)。個別株は通す。"""
+    monkeypatch.setattr(ps, "_etf_codes_cache", frozenset({"1357"}))
+    rows = [
+        _row("1357", "現物", "買付", "100", "4,862.0"),   # ETF → 除外
+        _row("6315", "現物", "買付", "100", "3,390.0"),   # 個別株 → 取込
+    ]
+    csv_path = _write_csv(tmp_path / "etf.csv", rows)
+
+    stats = ir.import_csv_to_fills(csv_path, db_path=db_path)
+    assert stats["imported"] == 1
+    assert stats["skipped_invalid"] == 1
+    assert len(ps.list_fills("1357", db_path=db_path)) == 0
+    assert len(ps.list_fills("6315", db_path=db_path)) == 1
+
+
 def test_dedup_idempotent(tmp_path, db_path):
     """同一CSVを2回取込→1回目 imported、2回目 skipped_dup。occurrence違いは別件。"""
     # 同日同単価の別注文 (occurrence 違い) を 2 行 + 別内容 1 行

--- a/tests/test_import_sbi_fills.py
+++ b/tests/test_import_sbi_fills.py
@@ -1,0 +1,108 @@
+"""import_sbi_fills.py のテスト (issue #387 Phase3)。
+
+SBI証券 約定履歴CSV の fill 取込・side/取引区分の正規化・決済損益保存・
+ETF除外・冪等 dedup を検証する。
+"""
+
+import csv
+
+import pytest
+
+import import_sbi_fills as isf
+import portfolio_shelve as ps
+import research_shelve as rs
+
+# SBI CSV の冒頭メタ行 + 本ヘッダ (実ファイル構造の縮図)
+_META = [
+    [],
+    ["約定履歴照会 "],
+    [],
+    ["商品指定", "約定開始年月日", "約定終了年月日", "明細数", "明細指定開始", "明細指定終了"],
+    ["すべての商品", "2026年07月03日", "2026年08月02日", "8", "1", "8"],
+    [],
+    ["（注）明細数はご指定された期間の合計です。"],
+    [],
+]
+_HEADER = ["約定日", "銘柄", "銘柄コード", "市場", "取引", "期限", "預り", "課税",
+           "約定数量", "約定単価", "手数料/諸経費等", "税額", "受渡日", "受渡金額/決済損益"]
+
+
+def _row(code_s, action, qty, price, amount, trade_date="2026/07/16", name="銘柄"):
+    return [trade_date, name, code_s, "東証", action, "6ヶ月", " 特定 ", "申告",
+            qty, price, "--", "--", "2026/07/21", amount]
+
+
+def _write_csv(path, data_rows):
+    with open(path, "w", encoding="shift_jis", newline="") as f:
+        w = csv.writer(f)
+        for r in _META:
+            w.writerow(r)
+        w.writerow(_HEADER)
+        for r in data_rows:
+            w.writerow(r)
+    return str(path)
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    """ウォッチリスト (stocks_shelve) に個別株 2 件を登録し、ETF は登録しない。"""
+    stocks_db = str(tmp_path / "stocks")
+    monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db)
+    monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db)
+    rs_db = str(tmp_path / "research")
+    monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", rs_db)
+    monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", rs_db)
+    for code, nm in [("6674", "ジーエス・ユアサ"), ("9984", "ソフトバンクG")]:
+        rec = rs.create_research_record(code, nm, overall_rating="B")
+        rs.upsert_research_record(rec, db_path=rs_db)
+    return str(tmp_path / "sbi_fills")
+
+
+@pytest.mark.parametrize(
+    "action,qty,price,exp_side,exp_kind",
+    [
+        ("株式現物買", "100", "1000", "buy", "現物"),
+        ("株式現物売", "100", "1000", "sell", "現物"),
+        ("信用新規買", "100", "5424", "buy", "信用新規"),
+        ("信用返済売", "100", "5846", "sell", "信用返済"),
+    ],
+)
+def test_parse_side_and_kind(action, qty, price, exp_side, exp_kind, db_path):
+    """SBI 取引区分から side と楽天互換 trade_kind を正規化する。"""
+    parsed = isf.parse_fill_row(_row("6674", action, qty, price, "0"))
+    assert parsed["side"] == exp_side
+    assert parsed["trade_kind"] == exp_kind
+
+
+def test_settle_pl_only_on_credit_repay(db_path):
+    """決済損益は信用返済行のみ保存し、それ以外は None。"""
+    repay = isf.parse_fill_row(_row("6674", "信用返済売", "100", "5846", "-33482"))
+    assert repay["settle_pl"] == -33482
+    new = isf.parse_fill_row(_row("9984", "信用新規買", "100", "5424", "0"))
+    assert new["settle_pl"] is None
+
+
+def test_etf_excluded(tmp_path, db_path):
+    """ウォッチリスト外 (ETF/投信) はスキップされ、個別株のみ取り込まれる。"""
+    rows = [
+        _row("9984", "信用新規買", "100", "5424", "0"),
+        _row("1306", "株式現物売", "1900", "410.2", "779380", name="TOPIX連動ETF"),
+    ]
+    csv_path = _write_csv(tmp_path / "sbi.csv", rows)
+    stats = isf.import_csv_to_fills(csv_path, db_path=db_path)
+    assert stats["imported"] == 1        # 9984 のみ
+    assert stats["skipped_invalid"] == 1  # 1306 ETF
+    assert len(ps.list_fills("1306", db_path=db_path)) == 0
+
+
+def test_dedup_idempotent_and_broker(tmp_path, db_path):
+    """同一CSV 2回取込は冪等。fill には broker=SBI と settle_pl が保存される。"""
+    rows = [_row("6674", "信用返済売", "100", "5846", "-33482")]
+    csv_path = _write_csv(tmp_path / "sbi.csv", rows)
+    s1 = isf.import_csv_to_fills(csv_path, db_path=db_path)
+    assert s1["imported"] == 1
+    s2 = isf.import_csv_to_fills(csv_path, db_path=db_path)
+    assert s2["imported"] == 0 and s2["skipped_dup"] == 1
+    f = ps.list_fills("6674", db_path=db_path)[0]
+    assert f["broker"] == "SBI"
+    assert f["settle_pl"] == -33482

--- a/tests/test_migrate_review_memo_to_fill_episode.py
+++ b/tests/test_migrate_review_memo_to_fill_episode.py
@@ -36,6 +36,12 @@ def _closed_shinyo_round(db_path, code_s, open_date, close_date, tate=1000.0, se
               tate_price=tate, salt="s")
 
 
+def _episode_key(db_path, code_s, kind="信用"):
+    """build_fill_episodes から対象銘柄・区分のエピソードキーを取る。"""
+    eps = helpers.build_fill_episodes(db_path=db_path)
+    return next(e["episode_key"] for e in eps if e["code_s"] == code_s and e["kind"] == kind)
+
+
 class TestMigrate:
     def test_migrates_memo_to_matching_episode(self, db_path):
         _closed_shinyo_round(db_path, "6324", "2026-06-29", "2026-06-30")
@@ -46,9 +52,9 @@ class TestMigrate:
                              review_memo="強さを買うはあってる", reason="利確",
                              timestamp="2026-06-30T15:00:00+09:00", db_path=db_path)
 
+        key = _episode_key(db_path, "6324")
         summary = mig.migrate(db_path=db_path, dry_run=False)
         assert len(summary["migrated"]) == 1
-        key = ps.fill_episode_key("6324", "信用", "2026-06-29", "2026-06-30")
         assert ps.get_fill_memo(key, db_path=db_path) == "強さを買うはあってる"
 
     def test_dry_run_does_not_write(self, db_path):
@@ -56,9 +62,9 @@ class TestMigrate:
         ps.append_action_log("6324", "売却", status_from="1保", status_to="2準",
                              review_memo="メモ",
                              timestamp="2026-06-30T15:00:00+09:00", db_path=db_path)
+        key = _episode_key(db_path, "6324")
         summary = mig.migrate(db_path=db_path, dry_run=True)
         assert len(summary["migrated"]) == 1
-        key = ps.fill_episode_key("6324", "信用", "2026-06-29", "2026-06-30")
         assert ps.get_fill_memo(key, db_path=db_path) == ""  # 書いていない
 
     def test_existing_memo_not_overwritten(self, db_path):
@@ -66,7 +72,7 @@ class TestMigrate:
         ps.append_action_log("6324", "売却", status_from="1保", status_to="2準",
                              review_memo="ログ側メモ",
                              timestamp="2026-06-30T15:00:00+09:00", db_path=db_path)
-        key = ps.fill_episode_key("6324", "信用", "2026-06-29", "2026-06-30")
+        key = _episode_key(db_path, "6324")
         ps.set_fill_memo(key, "既にある", db_path=db_path)
         summary = mig.migrate(db_path=db_path, dry_run=False)
         assert len(summary["already"]) == 1

--- a/tests/test_migrate_review_memo_to_fill_episode.py
+++ b/tests/test_migrate_review_memo_to_fill_episode.py
@@ -1,0 +1,101 @@
+"""migrate_review_memo_to_fill_episode の移行ロジックテスト (issue #387 Phase2)。"""
+
+import pytest
+
+import portfolio_shelve as ps
+from webapp import helpers
+import migrate_review_memo_to_fill_episode as mig
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "portfolio")
+
+
+@pytest.fixture(autouse=True)
+def _stub_stock_names(monkeypatch):
+    monkeypatch.setattr(
+        helpers, "_bulk_resolve_stock_names",
+        lambda codes: {c: f"銘柄{c}" for c in codes},
+    )
+
+
+def _add_fill(db_path, code_s, trade_date, side, qty, price, *,
+              trade_kind="信用新規", tate_price=None, settle_pl=None, salt=""):
+    f = ps.create_fill(code_s, trade_date=trade_date, side=side, qty=qty, price=price,
+                       amount=int(qty * price), trade_kind=trade_kind,
+                       dedup_key=f"{code_s}|{trade_date}|{side}|{salt}",
+                       tate_price=tate_price, settle_pl=settle_pl)
+    ps.append_fill(f, db_path=db_path)
+
+
+def _closed_shinyo_round(db_path, code_s, open_date, close_date, tate=1000.0, sell=1200.0):
+    """信用新規買→返済売 で1ラウンドを閉じる合成 fill を仕込む。"""
+    _add_fill(db_path, code_s, open_date, "buy", 100, tate, trade_kind="信用新規", salt="b")
+    _add_fill(db_path, code_s, close_date, "sell", 100, sell, trade_kind="信用返済",
+              tate_price=tate, salt="s")
+
+
+class TestMigrate:
+    def test_migrates_memo_to_matching_episode(self, db_path):
+        _closed_shinyo_round(db_path, "6324", "2026-06-29", "2026-06-30")
+        # 売却日と close_date が一致する action_log (review_memo 付き)
+        ps.append_action_log("6324", "ステータス変更", status_from="3監", status_to="1保",
+                             timestamp="2026-06-29T09:00:00+09:00", db_path=db_path)
+        ps.append_action_log("6324", "売却", status_from="1保", status_to="2準",
+                             review_memo="強さを買うはあってる", reason="利確",
+                             timestamp="2026-06-30T15:00:00+09:00", db_path=db_path)
+
+        summary = mig.migrate(db_path=db_path, dry_run=False)
+        assert len(summary["migrated"]) == 1
+        key = ps.fill_episode_key("6324", "信用", "2026-06-29", "2026-06-30")
+        assert ps.get_fill_memo(key, db_path=db_path) == "強さを買うはあってる"
+
+    def test_dry_run_does_not_write(self, db_path):
+        _closed_shinyo_round(db_path, "6324", "2026-06-29", "2026-06-30")
+        ps.append_action_log("6324", "売却", status_from="1保", status_to="2準",
+                             review_memo="メモ",
+                             timestamp="2026-06-30T15:00:00+09:00", db_path=db_path)
+        summary = mig.migrate(db_path=db_path, dry_run=True)
+        assert len(summary["migrated"]) == 1
+        key = ps.fill_episode_key("6324", "信用", "2026-06-29", "2026-06-30")
+        assert ps.get_fill_memo(key, db_path=db_path) == ""  # 書いていない
+
+    def test_existing_memo_not_overwritten(self, db_path):
+        _closed_shinyo_round(db_path, "6324", "2026-06-29", "2026-06-30")
+        ps.append_action_log("6324", "売却", status_from="1保", status_to="2準",
+                             review_memo="ログ側メモ",
+                             timestamp="2026-06-30T15:00:00+09:00", db_path=db_path)
+        key = ps.fill_episode_key("6324", "信用", "2026-06-29", "2026-06-30")
+        ps.set_fill_memo(key, "既にある", db_path=db_path)
+        summary = mig.migrate(db_path=db_path, dry_run=False)
+        assert len(summary["already"]) == 1
+        assert ps.get_fill_memo(key, db_path=db_path) == "既にある"  # 上書きしない
+
+    def test_within_tolerance_days_matches(self, db_path):
+        # 返済ラグ: 売却日 07-02 に対し close_date 06-30 (差2日) は許容
+        _closed_shinyo_round(db_path, "6324", "2026-06-29", "2026-06-30")
+        ps.append_action_log("6324", "売却", status_from="1保", status_to="2準",
+                             review_memo="ラグあり",
+                             timestamp="2026-07-02T15:00:00+09:00", db_path=db_path)
+        summary = mig.migrate(db_path=db_path, dry_run=False)
+        assert len(summary["migrated"]) == 1
+
+    def test_beyond_tolerance_days_skipped(self, db_path):
+        # 許容差を超える (差5日) と対応付けせずスキップ
+        _closed_shinyo_round(db_path, "6324", "2026-06-20", "2026-06-25")
+        ps.append_action_log("6324", "売却", status_from="1保", status_to="2準",
+                             review_memo="遠すぎ",
+                             timestamp="2026-06-30T15:00:00+09:00", db_path=db_path)
+        summary = mig.migrate(db_path=db_path, dry_run=False)
+        assert len(summary["skipped"]) == 1
+        assert len(summary["migrated"]) == 0
+
+    def test_no_matching_episode_skipped(self, db_path):
+        # fill が無い銘柄のメモはスキップ
+        ps.append_action_log("9999", "売却", status_from="1保", status_to="2準",
+                             review_memo="対応先なし",
+                             timestamp="2026-06-30T15:00:00+09:00", db_path=db_path)
+        summary = mig.migrate(db_path=db_path, dry_run=False)
+        assert len(summary["skipped"]) == 1
+        assert len(summary["migrated"]) == 0

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1293,3 +1293,55 @@ def test_backfill_price_proxies(db_path, stocks_with_price_log, monkeypatch, sce
         ps.backfill_price_proxies(overwrite=True, db_path=db_path)
         after = [l for l in ps.list_action_logs("6324", db_path=db_path) if l["seq"] == seq][0]
         assert after["price_proxy"] == 5555
+
+
+class TestFillMemo:
+    """fill 建玉ラウンド (エピソード) 単位の振り返りメモ (issue #387 Phase2)。"""
+
+    def test_set_get_roundtrip(self, db_path):
+        key = ps.fill_episode_key("6324", "信用", "2026-06-10", "2026-06-20")
+        assert ps.get_fill_memo(key, db_path=db_path) == ""
+        ps.set_fill_memo(key, "利確できたが再現性は微妙", db_path=db_path)
+        assert ps.get_fill_memo(key, db_path=db_path) == "利確できたが再現性は微妙"
+
+    def test_empty_deletes(self, db_path):
+        key = ps.fill_episode_key("6324", "信用", "2026-06-10", "2026-06-20")
+        ps.set_fill_memo(key, "メモ", db_path=db_path)
+        ps.set_fill_memo(key, "", db_path=db_path)
+        assert ps.get_fill_memo(key, db_path=db_path) == ""
+        assert key not in ps.list_fill_memos(db_path=db_path)
+
+    def test_list_returns_only_nonempty(self, db_path):
+        k1 = ps.fill_episode_key("1001", "現物", "2026-01-01", "2026-01-10")
+        k2 = ps.fill_episode_key("1002", "信用", "2026-02-01", "2026-02-10")
+        ps.set_fill_memo(k1, "あり", db_path=db_path)
+        ps.set_fill_memo(k2, "", db_path=db_path)
+        memos = ps.list_fill_memos(db_path=db_path)
+        assert memos == {k1: "あり"}
+
+    def test_key_normalizes_code(self, db_path):
+        # 全角/小文字コードは正規化される
+        k1 = ps.fill_episode_key("215a", "現物", "2026-01-01", "2026-01-10")
+        k2 = ps.fill_episode_key("215A", "現物", "2026-01-01", "2026-01-10")
+        assert k1 == k2
+
+    def test_open_episode_marker(self, db_path):
+        k = ps.fill_episode_key("1001", "現物", "2026-01-01", None)
+        assert k.endswith("|open")
+
+    def test_set_rejects_non_str(self, db_path):
+        key = ps.fill_episode_key("1001", "現物", "2026-01-01", "2026-01-10")
+        with pytest.raises(TypeError):
+            ps.set_fill_memo(key, 123, db_path=db_path)
+
+    def test_fill_memo_does_not_leak_into_list_fills(self, db_path):
+        # fill_memo: プレフィックスは fill: と衝突しない
+        key = ps.fill_episode_key("1001", "現物", "2026-01-01", "2026-01-10")
+        ps.set_fill_memo(key, "メモ", db_path=db_path)
+        f = ps.create_fill("1001", trade_date="2026-01-01", side="buy", qty=100,
+                           price=1000.0, amount=100000, trade_kind="現物",
+                           dedup_key="x")
+        ps.append_fill(f, db_path=db_path)
+        fills = ps.list_fills(db_path=db_path)
+        assert len(fills) == 1
+        assert all("review_memo" not in fl for fl in fills)

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1299,21 +1299,21 @@ class TestFillMemo:
     """fill 建玉ラウンド (エピソード) 単位の振り返りメモ (issue #387 Phase2)。"""
 
     def test_set_get_roundtrip(self, db_path):
-        key = ps.fill_episode_key("6324", "信用", "2026-06-10", "2026-06-20")
+        key = ps.fill_episode_key("6324", "信用", 3)
         assert ps.get_fill_memo(key, db_path=db_path) == ""
         ps.set_fill_memo(key, "利確できたが再現性は微妙", db_path=db_path)
         assert ps.get_fill_memo(key, db_path=db_path) == "利確できたが再現性は微妙"
 
     def test_empty_deletes(self, db_path):
-        key = ps.fill_episode_key("6324", "信用", "2026-06-10", "2026-06-20")
+        key = ps.fill_episode_key("6324", "信用", 3)
         ps.set_fill_memo(key, "メモ", db_path=db_path)
         ps.set_fill_memo(key, "", db_path=db_path)
         assert ps.get_fill_memo(key, db_path=db_path) == ""
         assert key not in ps.list_fill_memos(db_path=db_path)
 
     def test_list_returns_only_nonempty(self, db_path):
-        k1 = ps.fill_episode_key("1001", "現物", "2026-01-01", "2026-01-10")
-        k2 = ps.fill_episode_key("1002", "信用", "2026-02-01", "2026-02-10")
+        k1 = ps.fill_episode_key("1001", "現物", 1)
+        k2 = ps.fill_episode_key("1002", "信用", 1)
         ps.set_fill_memo(k1, "あり", db_path=db_path)
         ps.set_fill_memo(k2, "", db_path=db_path)
         memos = ps.list_fill_memos(db_path=db_path)
@@ -1321,22 +1321,25 @@ class TestFillMemo:
 
     def test_key_normalizes_code(self, db_path):
         # 全角/小文字コードは正規化される
-        k1 = ps.fill_episode_key("215a", "現物", "2026-01-01", "2026-01-10")
-        k2 = ps.fill_episode_key("215A", "現物", "2026-01-01", "2026-01-10")
+        k1 = ps.fill_episode_key("215a", "現物", 1)
+        k2 = ps.fill_episode_key("215A", "現物", 1)
         assert k1 == k2
 
-    def test_open_episode_marker(self, db_path):
-        k = ps.fill_episode_key("1001", "現物", "2026-01-01", None)
-        assert k.endswith("|open")
+    def test_key_is_seq_based(self, db_path):
+        # 同一銘柄・区分でも先頭 seq が異なればキーは別 (同日ラウンドトリップ対応)
+        k1 = ps.fill_episode_key("1001", "信用", 5)
+        k2 = ps.fill_episode_key("1001", "信用", 9)
+        assert k1 != k2
+        assert k1 == "1001|信用|5"
 
     def test_set_rejects_non_str(self, db_path):
-        key = ps.fill_episode_key("1001", "現物", "2026-01-01", "2026-01-10")
+        key = ps.fill_episode_key("1001", "現物", 1)
         with pytest.raises(TypeError):
             ps.set_fill_memo(key, 123, db_path=db_path)
 
     def test_fill_memo_does_not_leak_into_list_fills(self, db_path):
         # fill_memo: プレフィックスは fill: と衝突しない
-        key = ps.fill_episode_key("1001", "現物", "2026-01-01", "2026-01-10")
+        key = ps.fill_episode_key("1001", "現物", 1)
         ps.set_fill_memo(key, "メモ", db_path=db_path)
         f = ps.create_fill("1001", trade_date="2026-01-01", side="buy", qty=100,
                            price=1000.0, amount=100000, trade_kind="現物",

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -3537,24 +3537,25 @@ def test_calc_episode_pl(ep, expect):
 
 @pytest.mark.parametrize("pls, checks", [
     # 勝ち負け混在: +20%(amt100) 勝ち, -10%(amt100) 負け → win_rate50, payoff 20/10=2.0
-    # 勝ち平均リターン+20%, 負け平均リターン-10% (金額加重)
+    # 勝ち平均+20%, 負け平均-10%, 期待値 (20*100-10*100)/200 = +5%
     ([{"return_pct": 20, "hold_days": 5, "amount": 100},
       {"return_pct": -10, "hold_days": 15, "amount": 100}],
      {"win_rate": 50.0, "payoff_ratio": 2.0, "n_win": 1, "n_lose": 1,
-      "avg_return_win": 20.0, "avg_return_lose": -10.0}),
-    # 0% は負け扱い
+      "avg_return_win": 20.0, "avg_return_lose": -10.0, "expectancy": 5.0}),
+    # 0% は負け扱い、期待値は 0%
     ([{"return_pct": 0, "hold_days": 3, "amount": 100}],
      {"win_rate": 0.0, "n_win": 0, "n_lose": 1,
-      "avg_return_win": None, "avg_return_lose": 0.0}),
-    # 負け0件 → payoff None、負け平均は None
+      "avg_return_win": None, "avg_return_lose": 0.0, "expectancy": 0.0}),
+    # 負け0件 → payoff None、負け平均は None、期待値は勝ち平均と一致
     ([{"return_pct": 20, "hold_days": 5, "amount": 100}],
      {"win_rate": 100.0, "payoff_ratio": None, "n_win": 1, "n_lose": 0,
-      "avg_return_win": 20.0, "avg_return_lose": None}),
+      "avg_return_win": 20.0, "avg_return_lose": None, "expectancy": 20.0}),
     # 金額加重: 勝ち +10%(amt300) と +30%(amt100) → (10*300+30*100)/400 = 15%
+    # 期待値 (10*300+30*100-20*100)/500 = (3000+3000-2000)/500 = 8%
     ([{"return_pct": 10, "hold_days": 5, "amount": 300},
       {"return_pct": 30, "hold_days": 5, "amount": 100},
       {"return_pct": -20, "hold_days": 5, "amount": 100}],
-     {"avg_return_win": 15.0, "avg_return_lose": -20.0}),
+     {"avg_return_win": 15.0, "avg_return_lose": -20.0, "expectancy": 8.0}),
 ])
 def test_calc_trade_summary(pls, checks):
     s = helpers.calc_trade_summary(pls)

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -3537,15 +3537,24 @@ def test_calc_episode_pl(ep, expect):
 
 @pytest.mark.parametrize("pls, checks", [
     # 勝ち負け混在: +20%(amt100) 勝ち, -10%(amt100) 負け → win_rate50, payoff 20/10=2.0
+    # 勝ち平均リターン+20%, 負け平均リターン-10% (金額加重)
     ([{"return_pct": 20, "hold_days": 5, "amount": 100},
       {"return_pct": -10, "hold_days": 15, "amount": 100}],
-     {"win_rate": 50.0, "payoff_ratio": 2.0, "n_win": 1, "n_lose": 1}),
+     {"win_rate": 50.0, "payoff_ratio": 2.0, "n_win": 1, "n_lose": 1,
+      "avg_return_win": 20.0, "avg_return_lose": -10.0}),
     # 0% は負け扱い
     ([{"return_pct": 0, "hold_days": 3, "amount": 100}],
-     {"win_rate": 0.0, "n_win": 0, "n_lose": 1}),
-    # 負け0件 → payoff None
+     {"win_rate": 0.0, "n_win": 0, "n_lose": 1,
+      "avg_return_win": None, "avg_return_lose": 0.0}),
+    # 負け0件 → payoff None、負け平均は None
     ([{"return_pct": 20, "hold_days": 5, "amount": 100}],
-     {"win_rate": 100.0, "payoff_ratio": None, "n_win": 1, "n_lose": 0}),
+     {"win_rate": 100.0, "payoff_ratio": None, "n_win": 1, "n_lose": 0,
+      "avg_return_win": 20.0, "avg_return_lose": None}),
+    # 金額加重: 勝ち +10%(amt300) と +30%(amt100) → (10*300+30*100)/400 = 15%
+    ([{"return_pct": 10, "hold_days": 5, "amount": 300},
+      {"return_pct": 30, "hold_days": 5, "amount": 100},
+      {"return_pct": -20, "hold_days": 5, "amount": 100}],
+     {"avg_return_win": 15.0, "avg_return_lose": -20.0}),
 ])
 def test_calc_trade_summary(pls, checks):
     s = helpers.calc_trade_summary(pls)

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -128,11 +128,11 @@ class TestTradeHistoryPage:
         # アクションログタブでは proxy が維持される
         assert "5,678" in actions
 
-    def test_trade_fills_listed_in_fills_tab(self, app, client):
-        """全 fill が売買履歴タブに一覧され、同日同side分割は加重平均で集約される (issue #387)。
+    def test_fill_episode_listed_in_fills_tab(self, app, client):
+        """fill が建玉ラウンドのエピソードとして売買履歴タブに表示され、実現損益が出る (Phase4b)。
 
-        matched_seq の有無を問わず全 fill を表示する (突合廃止)。同日同side2件は加重平均単価・
-        合計株数で1行に畳み「2件集約」バッジが出る。
+        現物買100@1234 → 売50@1500 + 売50@1510 で 1 現物ラウンドが閉じる。
+        平均取得単価1234, 実現 = (1500-1234)*50 + (1510-1234)*50 = 13300 + 13800 = 27100。
         """
         with app.app_context():
             ps.append_fill(ps.create_fill("3496", trade_date="2026-06-15", side="buy", qty=100,
@@ -147,34 +147,58 @@ class TestTradeHistoryPage:
 
         html = client.get("/trade-history").data.decode()
         fills_tab = html.split('id="tab-fills"')[1].split('id="tab-actions"')[0]
-        assert "1,234" in fills_tab       # 単発 buy の単価
-        assert "2件集約" in fills_tab      # 分割約定を集約したバッジ
-        assert "1,505" in fills_tab       # 集約後の加重平均単価 (50@1500 + 50@1510)
+        assert "+27,100円" in fills_tab   # 現物ラウンドの実現損益
+        assert "1,234" in fills_tab       # 内訳展開の取得単価
 
-    def test_different_trade_kind_not_aggregated(self, app, client):
-        """同一銘柄・同日・同 side でも取引区分が違えば集約せず別行にする (PR #388 レビュー)。
-
-        現物買 (@1000) と信用新規買 (@2000) を同日に足す。誤って集約されると加重平均で
-        混ざるが、区分別に別行なら両単価がそのまま出る。
-        """
+    def test_genbutsu_and_shinyo_are_separate_episodes(self, app, client):
+        """現物と信用は同一銘柄でも別エピソードになる (口座種別で分離、Phase4b)。"""
         with app.app_context():
             ps.append_fill(ps.create_fill("3496", trade_date="2026-06-15", side="buy", qty=100,
                                           price=1000.0, amount=-100000, trade_kind="現物",
-                                          dedup_key="tk-genbutsu"))
-            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-15", side="buy", qty=100,
+                                          dedup_key="tk-genbutsu-b"))
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-20", side="sell", qty=100,
+                                          price=1100.0, amount=110000, trade_kind="現物",
+                                          dedup_key="tk-genbutsu-s"))
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-16", side="buy", qty=100,
                                           price=2000.0, amount=-200000, trade_kind="信用新規",
-                                          dedup_key="tk-shinyo"))
+                                          dedup_key="tk-shinyo-b"))
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-21", side="sell", qty=100,
+                                          price=2200.0, amount=220000, trade_kind="信用返済",
+                                          tate_price=2000.0, dedup_key="tk-shinyo-s"))
 
         html = client.get("/trade-history").data.decode()
         fills_tab = html.split('id="tab-fills"')[1].split('id="tab-actions"')[0]
-        assert "1,000" in fills_tab       # 現物の単価
-        assert "2,000" in fills_tab       # 信用新規の単価 (加重平均 1,500 に潰れない)
-        assert "1,500" not in fills_tab   # 混ぜた加重平均は出ない
-        # 別区分なので集約バッジ (>N件集約<) は付かない (説明文の「N件集約」は除く)
-        assert "件集約</span>" not in fills_tab
+        # 現物ラウンド: (1100-1000)*100 = 10000、信用ラウンド: (2200-2000)*100 = 20000
+        assert "+10,000円" in fills_tab
+        assert "+20,000円" in fills_tab
+        # 現物・信用の区分バッジが両方出る
+        assert "現物" in fills_tab
+        assert "信用" in fills_tab
+
+    def test_fill_summary_on_fills_tab(self, app, client):
+        """成績サマリー (勝率/ペイオフ) が売買履歴タブに表示される (Phase4b で fill 側へ一本化)。"""
+        with app.app_context():
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-15", side="buy", qty=100,
+                                          price=1000.0, amount=-100000, trade_kind="現物",
+                                          dedup_key="sm-b"))
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-20", side="sell", qty=100,
+                                          price=1200.0, amount=120000, trade_kind="現物",
+                                          dedup_key="sm-s"))
+        html = client.get("/trade-history").data.decode()
+        fills_tab = html.split('id="tab-fills"')[1].split('id="tab-actions"')[0]
+        assert "勝率" in fills_tab
+        assert "ペイオフレシオ" in fills_tab
+
+    def test_action_log_summary_removed(self, client):
+        """旧 price_proxy 成績サマリーはアクションログタブから撤去された (Phase4b)。"""
+        html = client.get("/trade-history").data.decode()
+        actions = html.split('id="tab-actions"')[1]
+        # 成績サマリー・実現損益は売買履歴タブへ一本化。アクションログ側は判断の記録のみ
+        assert "終値プロキシによる概算" not in actions
+        assert "一本化" in actions  # 導線の説明文
 
     def test_fills_tab_shown_without_episodes(self, tmp_path, monkeypatch):
-        """action_log が空でも売買履歴タブに fill が表示される (issue #387)。"""
+        """action_log が空でも売買履歴タブに fill エピソードが表示される (issue #387)。"""
         portfolio_db = str(tmp_path / "pf_um")
         stocks_db = str(tmp_path / "st_um")
         research_db = str(tmp_path / "rs_um")
@@ -192,7 +216,7 @@ class TestTradeHistoryPage:
         app2.config["TESTING"] = True
         html = app2.test_client().get("/trade-history").data.decode()
         assert "アクションログがありません" in html
-        assert "5,000" in html
+        assert "5,000" in html  # 保有中エピソードの内訳に建単価が出る
 
     def test_all_episodes_have_review_memo_textarea(self, client):
         """売却済み・未売却どちらのエピソードにも textarea が表示される。"""

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -151,6 +151,28 @@ class TestTradeHistoryPage:
         assert "2件集約" in fills_tab      # 分割約定を集約したバッジ
         assert "1,505" in fills_tab       # 集約後の加重平均単価 (50@1500 + 50@1510)
 
+    def test_different_trade_kind_not_aggregated(self, app, client):
+        """同一銘柄・同日・同 side でも取引区分が違えば集約せず別行にする (PR #388 レビュー)。
+
+        現物買 (@1000) と信用新規買 (@2000) を同日に足す。誤って集約されると加重平均で
+        混ざるが、区分別に別行なら両単価がそのまま出る。
+        """
+        with app.app_context():
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-15", side="buy", qty=100,
+                                          price=1000.0, amount=-100000, trade_kind="現物",
+                                          dedup_key="tk-genbutsu"))
+            ps.append_fill(ps.create_fill("3496", trade_date="2026-06-15", side="buy", qty=100,
+                                          price=2000.0, amount=-200000, trade_kind="信用新規",
+                                          dedup_key="tk-shinyo"))
+
+        html = client.get("/trade-history").data.decode()
+        fills_tab = html.split('id="tab-fills"')[1].split('id="tab-actions"')[0]
+        assert "1,000" in fills_tab       # 現物の単価
+        assert "2,000" in fills_tab       # 信用新規の単価 (加重平均 1,500 に潰れない)
+        assert "1,500" not in fills_tab   # 混ぜた加重平均は出ない
+        # 別区分なので集約バッジ (>N件集約<) は付かない (説明文の「N件集約」は除く)
+        assert "件集約</span>" not in fills_tab
+
     def test_fills_tab_shown_without_episodes(self, tmp_path, monkeypatch):
         """action_log が空でも売買履歴タブに fill が表示される (issue #387)。"""
         portfolio_db = str(tmp_path / "pf_um")

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -224,11 +224,14 @@ class TestTradeHistoryPage:
         assert "5,000" in html  # 保有中エピソードの内訳に建単価が出る
 
     def test_latest_import_date_shown_per_broker(self, app, client):
-        """取込済み最新約定日が証券会社別に表示される (issue #387)。"""
+        """取込済み最新約定日が証券会社別に表示され、title に最古〜最新が出る (issue #387)。"""
         with app.app_context():
-            ps.append_fill(ps.create_fill("6324", trade_date="2026-07-31", side="buy", qty=100,
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-01-05", side="buy", qty=100,
                                           price=6990.0, amount=-699000, trade_kind="信用新規",
-                                          broker="楽天", dedup_key="li-r"))
+                                          broker="楽天", dedup_key="li-r0"))
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-07-31", side="sell", qty=100,
+                                          price=7100.0, amount=710000, trade_kind="信用返済",
+                                          tate_price=6990.0, broker="楽天", dedup_key="li-r1"))
             ps.append_fill(ps.create_fill("6324", trade_date="2026-07-21", side="buy", qty=100,
                                           price=500.0, amount=-50000, trade_kind="信用新規",
                                           broker="SBI", dedup_key="li-s"))
@@ -237,6 +240,8 @@ class TestTradeHistoryPage:
         assert "取込済み最新" in fills
         assert "楽天 07-31" in fills
         assert "SBI 07-21" in fills
+        # ツールチップに最古〜最新のフルレンジ
+        assert "取込済み: 2026-01-05 〜 2026-07-31" in fills
 
     def test_latest_import_date_updates_after_import(self, app, client):
         """CSV取込後の再表示で最新約定日が更新される (取込のたびに再計算)。"""

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -54,14 +54,19 @@ class TestTradeHistoryPage:
         assert client.get("/trade-history").status_code == 200
 
     def test_column_headers_shown(self, client):
-        """種類・日付・株数・株価・理由・振り返りメモのヘッダが表示される。"""
+        """アクションログタブの種類・日付・株数・株価・理由ヘッダが表示される。
+
+        振り返りメモ列はアクションログ側から撤去し売買履歴タブへ一本化した
+        (issue #387 Phase2)。
+        """
         html = client.get("/trade-history").data.decode()
-        assert "種類" in html
-        assert "日付" in html
-        assert "株数" in html
-        assert "株価" in html
-        assert "理由" in html
-        assert "振り返りメモ" in html
+        actions = html.split('id="tab-actions"')[1]
+        assert "種類" in actions
+        assert "日付" in actions
+        assert "株数" in actions
+        assert "株価" in actions
+        assert "理由" in actions
+        assert "<th>振り返りメモ</th>" not in actions  # アクションログの列は撤去
 
     def test_price_proxy_column_shown(self, client):
         """保有・売却イベント日の終値プロキシが株価列に表示される。"""
@@ -218,21 +223,35 @@ class TestTradeHistoryPage:
         assert "アクションログがありません" in html
         assert "5,000" in html  # 保有中エピソードの内訳に建単価が出る
 
-    def test_all_episodes_have_review_memo_textarea(self, client):
-        """売却済み・未売却どちらのエピソードにも textarea が表示される。"""
+    def test_fill_episode_has_review_memo_cell(self, app, client):
+        """売買履歴タブの fill エピソード展開に振り返りメモ入力欄が出る (Phase2)。"""
+        with app.app_context():
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=300,
+                                          price=6990.0, amount=-2097000, trade_kind="信用新規",
+                                          dedup_key="rm-buy"))
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-06-20", side="sell", qty=300,
+                                          price=7810.0, amount=2343000, trade_kind="信用返済",
+                                          tate_price=6990.0, dedup_key="rm-sell"))
         html = client.get("/trade-history").data.decode()
-        # 3496（未売却）と 6324（売却済み）の両方で data-url が出る（class は JS内にも1つ）
-        assert html.count("data-url=") == 2
+        fills = html.split('id="tab-fills"')[1].split('id="tab-actions"')[0]
+        assert "data-episode-key=" in fills
+        assert 'save_fill_memo' not in fills  # url_for は解決済みのURLになる
+        assert "/trade-history/fill-memo" in fills
 
-    def test_save_review_memo_sold(self, client):
-        """売却済みエピソード（6324）の振り返りメモを POST で保存できる。"""
-        logs = ps.list_action_logs("6324")
-        sell_log = next(l for l in logs if l["action_type"] == "売却")
-        seq = sell_log["seq"]
+    def test_save_fill_memo(self, app, client):
+        """fill エピソードの振り返りメモをエピソードキーで保存・表示できる (Phase2)。"""
+        with app.app_context():
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=300,
+                                          price=6990.0, amount=-2097000, trade_kind="信用新規",
+                                          dedup_key="fm-buy"))
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-06-20", side="sell", qty=300,
+                                          price=7810.0, amount=2343000, trade_kind="信用返済",
+                                          tate_price=6990.0, dedup_key="fm-sell"))
+            key = ps.fill_episode_key("6324", "信用", "2026-06-10", "2026-06-20")
 
         resp = client.post(
-            f"/trade-history/6324/{seq}/review-memo",
-            data={"review_memo": "上値で薄く売り過ぎた"},
+            "/trade-history/fill-memo",
+            data={"episode_key": key, "review_memo": "上値で薄く売り過ぎた"},
         )
         assert resp.status_code == 200
         assert resp.get_json()["ok"] is True
@@ -240,21 +259,25 @@ class TestTradeHistoryPage:
         html = client.get("/trade-history").data.decode()
         assert "上値で薄く売り過ぎた" in html
 
-    def test_save_review_memo_unsold(self, client):
-        """未売却エピソード（3496）の振り返りメモを POST で保存できる。"""
-        logs = ps.list_action_logs("3496")
-        hold_log = next(l for l in logs if l.get("status_to") == "1保")
-        seq = hold_log["seq"]
+    def test_save_fill_memo_empty_deletes(self, app, client):
+        """空文字を送るとメモが削除される (Phase2)。"""
+        with app.app_context():
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=300,
+                                          price=6990.0, amount=-2097000, trade_kind="信用新規",
+                                          dedup_key="fd-buy"))
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-06-20", side="sell", qty=300,
+                                          price=7810.0, amount=2343000, trade_kind="信用返済",
+                                          tate_price=6990.0, dedup_key="fd-sell"))
+            key = ps.fill_episode_key("6324", "信用", "2026-06-10", "2026-06-20")
+            ps.set_fill_memo(key, "消す前")
+        client.post("/trade-history/fill-memo", data={"episode_key": key, "review_memo": ""})
+        with app.app_context():
+            assert ps.get_fill_memo(key) == ""
 
-        resp = client.post(
-            f"/trade-history/3496/{seq}/review-memo",
-            data={"review_memo": "保有中メモ"},
-        )
-        assert resp.status_code == 200
-        assert resp.get_json()["ok"] is True
-
-        html = client.get("/trade-history").data.decode()
-        assert "保有中メモ" in html
+    def test_save_fill_memo_requires_key(self, client):
+        """episode_key が空なら 400 (Phase2)。"""
+        resp = client.post("/trade-history/fill-memo", data={"review_memo": "x"})
+        assert resp.status_code == 400
 
     def test_qty_changes_subrow(self, client):
         """株数増加は「買増」サブ行として表示される。"""

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -321,3 +321,90 @@ class TestLastActionDate:
     def test_last_action_date(self, ep, expected):
         from webapp.routes.trade_history import _last_action_date
         assert _last_action_date(ep) == expected
+
+
+class TestImportTradeCsv:
+    """CSVアップロード取込 (issue #387 4a): 楽天/SBI 自動判定・原本コピー・不正弾き。"""
+
+    @pytest.fixture
+    def env(self, tmp_path, monkeypatch):
+        portfolio_db = str(tmp_path / "portfolio")
+        stocks_db = str(tmp_path / "stocks")
+        research_db = str(tmp_path / "research")
+        save_dir = tmp_path / "trade_history"
+        monkeypatch.setattr("db_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("portfolio_shelve.PORTFOLIO_SHELVE", portfolio_db)
+        monkeypatch.setattr("db_shelve.STOCKS_SHELVE", stocks_db)
+        monkeypatch.setattr("webapp.helpers.STOCKS_SHELVE", stocks_db)
+        monkeypatch.setattr("db_shelve.RESEARCH_SHELVE", research_db)
+        monkeypatch.setattr("research_shelve.RESEARCH_SHELVE", research_db)
+        monkeypatch.setattr("portfolio_shelve.DATA_DIR", str(tmp_path))
+        # 原本コピー先を tmp に差し替え (本番 trade_history を汚さない)
+        monkeypatch.setattr("webapp.routes.trade_history.TRADE_HISTORY_DIR", str(save_dir))
+        # 個別株を1件ウォッチリスト登録 (SBI ETF除外の対比用)
+        rec = rs.create_research_record("6324", "ダイフク", overall_rating="B")
+        rs.upsert_research_record(rec, db_path=research_db)
+        app = create_app()
+        app.config["TESTING"] = True
+        return app, save_dir
+
+    def _rakuten_csv(self):
+        header = ",".join(["約定日"] + ["c%d" % i for i in range(1, 28)])
+        # COL: 0約定日 2コード 6区分 7売買 10数量 11単価 16金額
+        row = ["0"] * 28
+        row[0], row[2], row[6], row[7], row[10], row[11], row[16] = \
+            "2026/6/22", "6324", "現物", "買付", "100", "5678", "-567800"
+        return (header + "\n" + ",".join(row) + "\n").encode("shift_jis")
+
+    def _sbi_csv(self):
+        lines = [
+            "", "約定履歴照会 ", "",
+            "約定日,銘柄,銘柄コード,市場,取引,期限,預り,課税,約定数量,約定単価,手数料/諸経費等,税額,受渡日,受渡金額/決済損益",
+            '"2026/07/16","ダイフク","6324","東証",株式現物買,"--"," 特定 ","--",100,5678,"--","--","2026/07/21",-567800',
+        ]
+        return ("\n".join(lines) + "\n").encode("shift_jis")
+
+    def test_rakuten_upload(self, env):
+        import io
+        app, save_dir = env
+        client = app.test_client()
+        data = {"csv_file": (io.BytesIO(self._rakuten_csv()), "tradehistory(JP)_20260622.csv")}
+        resp = client.post("/trade-history/import", data=data,
+                           content_type="multipart/form-data", follow_redirects=True)
+        html = resp.data.decode()
+        assert "楽天 CSV 取込完了" in html
+        assert "新規 1 件" in html
+        assert len(ps.list_fills("6324")) == 1
+        # 原本が保存先へコピーされている
+        assert (save_dir / "tradehistory(JP)_20260622.csv").exists()
+
+    def test_sbi_upload(self, env):
+        import io
+        app, save_dir = env
+        client = app.test_client()
+        data = {"csv_file": (io.BytesIO(self._sbi_csv()), "SaveFile_0001.csv")}
+        resp = client.post("/trade-history/import", data=data,
+                           content_type="multipart/form-data", follow_redirects=True)
+        html = resp.data.decode()
+        assert "SBI CSV 取込完了" in html
+        f = ps.list_fills("6324")
+        assert len(f) == 1 and f[0]["broker"] == "SBI"
+        assert (save_dir / "SaveFile_0001.csv").exists()
+
+    def test_unknown_csv_rejected(self, env):
+        import io
+        app, save_dir = env
+        client = app.test_client()
+        data = {"csv_file": (io.BytesIO("foo,bar\n1,2\n".encode("shift_jis")), "unknown.csv")}
+        resp = client.post("/trade-history/import", data=data,
+                           content_type="multipart/form-data", follow_redirects=True)
+        assert "認識できませんでした" in resp.data.decode()
+        # 不正ファイルは保存先へコピーしない
+        assert not (save_dir / "unknown.csv").exists()
+
+    def test_no_file_selected(self, env):
+        app, _ = env
+        resp = app.test_client().post("/trade-history/import", data={},
+                                      content_type="multipart/form-data",
+                                      follow_redirects=True)
+        assert "選択されていません" in resp.data.decode()

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -223,6 +223,37 @@ class TestTradeHistoryPage:
         assert "アクションログがありません" in html
         assert "5,000" in html  # 保有中エピソードの内訳に建単価が出る
 
+    def test_latest_import_date_shown_per_broker(self, app, client):
+        """取込済み最新約定日が証券会社別に表示される (issue #387)。"""
+        with app.app_context():
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-07-31", side="buy", qty=100,
+                                          price=6990.0, amount=-699000, trade_kind="信用新規",
+                                          broker="楽天", dedup_key="li-r"))
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-07-21", side="buy", qty=100,
+                                          price=500.0, amount=-50000, trade_kind="信用新規",
+                                          broker="SBI", dedup_key="li-s"))
+        html = client.get("/trade-history").data.decode()
+        fills = html.split('id="tab-fills"')[1].split('id="tab-actions"')[0]
+        assert "取込済み最新" in fills
+        assert "楽天 07-31" in fills
+        assert "SBI 07-21" in fills
+
+    def test_latest_import_date_updates_after_import(self, app, client):
+        """CSV取込後の再表示で最新約定日が更新される (取込のたびに再計算)。"""
+        with app.app_context():
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-07-10", side="buy", qty=100,
+                                          price=6990.0, amount=-699000, trade_kind="信用新規",
+                                          broker="楽天", dedup_key="u1"))
+        html1 = client.get("/trade-history").data.decode()
+        assert "楽天 07-10" in html1
+        # 新しい約定を追加 (取込相当) → 再表示で最新日が更新
+        with app.app_context():
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-07-25", side="sell", qty=100,
+                                          price=7100.0, amount=710000, trade_kind="信用返済",
+                                          tate_price=6990.0, broker="楽天", dedup_key="u2"))
+        html2 = client.get("/trade-history").data.decode()
+        assert "楽天 07-25" in html2
+
     def test_fill_episode_has_review_memo_cell(self, app, client):
         """売買履歴タブの fill エピソード展開に振り返りメモ入力欄が出る (Phase2)。"""
         with app.app_context():

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -101,73 +101,58 @@ class TestTradeHistoryPage:
         saved = next(l for l in ps.list_action_logs("6324") if l["action_type"] == "売却")
         assert saved["post_sell_returns"].keys() == {"5d", "20d"}
 
-    def test_matched_fill_overrides_price_qty_date(self, app, client):
-        """マッチ済み fill があると 6324 の売却済みエピソードの株価・株数・日付が実約定で上書き。
+    def test_two_tabs_present(self, client):
+        """売買履歴タブとアクションログタブの両方が1ページに存在する (issue #387)。"""
+        html = client.get("/trade-history").data.decode()
+        assert 'data-tab="tab-fills"' in html
+        assert 'data-tab="tab-actions"' in html
+        assert 'id="tab-fills"' in html
+        assert 'id="tab-actions"' in html
 
-        1保ログ・売却ログには手入力の株数プロキシが無い代わりに、fill を株数の真実源として
-        置換する (P2a)。日付も約定日で上書きされる。
+    def test_fill_does_not_override_action_log_price(self, app, client):
+        """fill があってもアクションログ側は price_proxy のまま (突合撤去、issue #387)。
+
+        6324 に実約定 fill (6,990/7,810) を足しても、アクションログタブのエピソードは
+        proxy (5,678) を表示し続ける。fill による上書きは行われない。
         """
         with app.app_context():
-            logs = ps.list_action_logs("6324")
-            hold_seq = next(l["seq"] for l in logs if l.get("status_to") == "1保")
-            sell_seq = next(l["seq"] for l in logs if l["action_type"] == "売却")
-            # buy fill (hold) と sell fill を作成し、対応ログへマッチ済みにする
-            buy = ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=300,
-                                 price=6990.0, amount=-2097000, trade_kind="信用新規",
-                                 dedup_key="th-buy")
-            _, _ = ps.append_fill(buy)
-            sell = ps.create_fill("6324", trade_date="2026-06-20", side="sell", qty=300,
-                                  price=7810.0, amount=2343000, trade_kind="信用返済",
-                                  dedup_key="th-sell")
-            _, _ = ps.append_fill(sell)
-            for f in ps.list_fills("6324"):
-                seq = hold_seq if f["side"] == "buy" else sell_seq
-                ps.set_fill_matched_seq("6324", f["seq"], seq)
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=300,
+                                          price=6990.0, amount=-2097000, trade_kind="信用新規",
+                                          dedup_key="th-buy"))
+            ps.append_fill(ps.create_fill("6324", trade_date="2026-06-20", side="sell", qty=300,
+                                          price=7810.0, amount=2343000, trade_kind="信用返済",
+                                          dedup_key="th-sell"))
 
         html = client.get("/trade-history").data.decode()
-        # 実約定価格・株数・約定日が反映される (proxy 5,678 ではなく 6,990/7,810)
-        assert "6,990" in html
-        assert "7,810" in html
-        assert "300" in html          # 実約定株数
-        assert "26/06/10" in html     # 約定日 (buy)
-        assert "26/06/20" in html     # 約定日 (sell)
+        actions = html.split('id="tab-actions"')[1]
+        # アクションログタブでは proxy が維持される
+        assert "5,678" in actions
 
-    def test_unmatched_fills_listed(self, app, client):
-        """未マッチ fill が未反映セクションに一覧・同日集約され、マッチ済みは出ない (issue #360 (c))。
+    def test_trade_fills_listed_in_fills_tab(self, app, client):
+        """全 fill が売買履歴タブに一覧され、同日同side分割は加重平均で集約される (issue #387)。
 
-        3496 に未マッチ buy を1件 + 同日同side2件 (分割約定) を足し、6324 にはマッチ済み fill を
-        足す。同日同side2件は加重平均単価・合計株数で1行に集約され「2件集約」バッジが出る。
-        6324 のマッチ済み単価はセクションに出ないことを確認する。
+        matched_seq の有無を問わず全 fill を表示する (突合廃止)。同日同side2件は加重平均単価・
+        合計株数で1行に畳み「2件集約」バッジが出る。
         """
         with app.app_context():
-            logs = ps.list_action_logs("6324")
-            hold_seq = next(l["seq"] for l in logs if l.get("status_to") == "1保")
-            matched = ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=100,
-                                     price=6990.0, amount=-699000, trade_kind="信用新規",
-                                     dedup_key="um-matched")
-            ps.append_fill(matched)
-            ps.set_fill_matched_seq("6324", ps.list_fills("6324")[0]["seq"], hold_seq)
-            # 3496: 未マッチ buy 1件 + 同日同side2件 (分割約定 → 加重平均集約)
             ps.append_fill(ps.create_fill("3496", trade_date="2026-06-15", side="buy", qty=100,
                                           price=1234.0, amount=-123400, trade_kind="現物",
-                                          dedup_key="um-a"))
+                                          dedup_key="tf-a"))
             ps.append_fill(ps.create_fill("3496", trade_date="2026-06-18", side="sell", qty=50,
                                           price=1500.0, amount=75000, trade_kind="現物",
-                                          dedup_key="um-b1"))
+                                          dedup_key="tf-b1"))
             ps.append_fill(ps.create_fill("3496", trade_date="2026-06-18", side="sell", qty=50,
                                           price=1510.0, amount=75500, trade_kind="現物",
-                                          dedup_key="um-b2"))
+                                          dedup_key="tf-b2"))
 
         html = client.get("/trade-history").data.decode()
-        section = html.split("取込済みで未反映")[1]
-        assert "取込済みで未反映の約定" in html
-        assert "1,234" in section        # 未マッチ単発 buy の単価
-        assert "2件集約" in section       # 分割約定を集約したバッジ
-        assert "1,505" in section        # 集約後の加重平均単価 (50@1500 + 50@1510)
-        assert "6,990" not in section     # マッチ済みはセクション外
+        fills_tab = html.split('id="tab-fills"')[1].split('id="tab-actions"')[0]
+        assert "1,234" in fills_tab       # 単発 buy の単価
+        assert "2件集約" in fills_tab      # 分割約定を集約したバッジ
+        assert "1,505" in fills_tab       # 集約後の加重平均単価 (50@1500 + 50@1510)
 
-    def test_unmatched_fills_shown_without_episodes(self, tmp_path, monkeypatch):
-        """action_log が空でも未マッチ fill セクションは表示される (codexレビュー指摘)。"""
+    def test_fills_tab_shown_without_episodes(self, tmp_path, monkeypatch):
+        """action_log が空でも売買履歴タブに fill が表示される (issue #387)。"""
         portfolio_db = str(tmp_path / "pf_um")
         stocks_db = str(tmp_path / "st_um")
         research_db = str(tmp_path / "rs_um")
@@ -180,12 +165,11 @@ class TestTradeHistoryPage:
         monkeypatch.setattr("portfolio_shelve.DATA_DIR", str(tmp_path))
         ps.append_fill(ps.create_fill("6324", trade_date="2026-06-10", side="buy", qty=100,
                                       price=5000.0, amount=-500000, trade_kind="信用新規",
-                                      dedup_key="um-noep"), db_path=portfolio_db)
+                                      dedup_key="tf-noep"), db_path=portfolio_db)
         app2 = create_app()
         app2.config["TESTING"] = True
         html = app2.test_client().get("/trade-history").data.decode()
-        assert "売買履歴がありません" in html
-        assert "取込済みで未反映の約定" in html
+        assert "アクションログがありません" in html
         assert "5,000" in html
 
     def test_all_episodes_have_review_memo_textarea(self, client):
@@ -274,7 +258,7 @@ class TestTradeHistoryPage:
         assert sell_log["review_memo"] == "保有中メモ"
 
     def test_empty_portfolio_shows_no_entries(self, tmp_path, monkeypatch):
-        """portfolio が空の場合はエントリなしメッセージが表示される。"""
+        """action_log が空の場合はアクションログなしメッセージが表示される (issue #387)。"""
         portfolio_db = str(tmp_path / "portfolio2")
         stocks_db = str(tmp_path / "stocks2")
         research_db = str(tmp_path / "research2")
@@ -287,7 +271,7 @@ class TestTradeHistoryPage:
         monkeypatch.setattr("portfolio_shelve.DATA_DIR", str(tmp_path))
         app2 = create_app()
         app2.config["TESTING"] = True
-        assert "売買履歴がありません" in app2.test_client().get("/trade-history").data.decode()
+        assert "アクションログがありません" in app2.test_client().get("/trade-history").data.decode()
 
 
 class TestLastActionDate:

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -247,7 +247,8 @@ class TestTradeHistoryPage:
             ps.append_fill(ps.create_fill("6324", trade_date="2026-06-20", side="sell", qty=300,
                                           price=7810.0, amount=2343000, trade_kind="信用返済",
                                           tate_price=6990.0, dedup_key="fm-sell"))
-            key = ps.fill_episode_key("6324", "信用", "2026-06-10", "2026-06-20")
+            from webapp.helpers import build_fill_episodes
+            key = next(e["episode_key"] for e in build_fill_episodes() if e["code_s"] == "6324")
 
         resp = client.post(
             "/trade-history/fill-memo",
@@ -268,7 +269,8 @@ class TestTradeHistoryPage:
             ps.append_fill(ps.create_fill("6324", trade_date="2026-06-20", side="sell", qty=300,
                                           price=7810.0, amount=2343000, trade_kind="信用返済",
                                           tate_price=6990.0, dedup_key="fd-sell"))
-            key = ps.fill_episode_key("6324", "信用", "2026-06-10", "2026-06-20")
+            from webapp.helpers import build_fill_episodes
+            key = next(e["episode_key"] for e in build_fill_episodes() if e["code_s"] == "6324")
             ps.set_fill_memo(key, "消す前")
         client.post("/trade-history/fill-memo", data={"episode_key": key, "review_memo": ""})
         with app.app_context():


### PR DESCRIPTION
## 概要

issue #387。楽天/SBI CSVの約定 (fill) と手動 action_log を突合する二層モデル (issue #360 / PR #382) は、実運用でマッチ成功率 10/73 件 (14%) と破綻した。本PRで **両者を原則独立**させ、突合を撤去。**売買履歴 (実約定=真実源) を建玉ラウンド単位のエピソードにまとめ、勝率・ペイオフレシオ・実現損益を fill 側で計算**する。アクションログは判断の記録に専念する。

Refs #387 (親 issue のため Closes は使わない)

## Phase 別の変更

### Phase 1: タブ分割 + 突合撤去
- `/trade-history` を「売買履歴」「アクションログ」の2タブに分割 (JSトグル)
- fill×action_log 突合 (`_apply_fill_prices`/`--match`/`match_fills_to_episodes`/`set_fill_matched_seq`/未マッチリスト) を全撤去

### Phase 3: SBI取込 + 全期間バックフィル
- `import_sbi_fills.py` 新規 (冒頭メタ行+14列、取引区分→side/楽天互換trade_kind、ETF/投信は除外)
- fill に `broker` ("楽天"/"SBI")・`settle_pl` (SBI信用返済の決済損益) を追加
- 全期間バックフィル (本番DB 2026-01〜07)

### Phase 4a: CSVアップロード取込UI
- `POST /trade-history/import`。ヘッダ自動判定 (`is_rakuten_csv`/`is_sbi_csv`)、成功時のみ原本を `$KS_DATA_DIR/trade_history/` へコピー。折りたたみ (details) UI

### Phase 4b: fill 基準のエピソード化 + 実現損益
- **パーサー**: 楽天の現引行 (建玉の現物化) を buy 取込 (現引ブリッジ)、信用返済行の建約定日 (col17)・建単価 (col18) を取込。fill に `tate_date`/`tate_price`。`append_fill` に再取込時の後付け移行 (None→非None のみ)
- **`helpers.build_fill_episodes`**: 銘柄×口座種別 (現物/信用) で保有0→建→0を1エピソード。現物=平均取得単価法、信用=建単価/settle_pl。成績は既存 `calc_trade_summary` を再利用
- **売買履歴タブ**: 建玉ラウンドのエピソード表示 (区分/保有中バッジ・期間・最大株数・リターン%・実現損益)。行クリックで内訳の個別約定を展開。SBI併用銘柄も1ラウンドに統合。上部に fill 基準の成績サマリー。**表示順=最終約定日 (買い増し・部分売り含む最新の取引日) 降順**
- **アクションログタブ**: 旧 price_proxy 成績サマリー・行ごと概算損益を撤去、判断の記録に専念 (売却後騰落率#366は残置)

## 検証

- 関連 534 テスト green。`test_fill_episodes.py` 新規 (エピソード再構成/P/L/並び順)、ルートテストをエピソード表示前提に刷新、楽天テストに現引/建単価/後付け移行を追加
- 本番DB再取込済 (fill 583→602、現引19追加・建単価210後付け)。202エピソード (クローズ166/保有中36)、勝率47.3%・ペイオフ2.34・総実現損益 +4,092,393円
- クロスチェック: 4369 現引→現物売 -3,221円 手計算一致、6501 は SBI買→楽天買→楽天売×2 が1現物ラウンドに統合
- 損益不能=母数除外は仕様: 期首持ち越し (取得記録なし) と空売り (9984の1件)。空売りは未対応 (実質使わない戦略)
- Playwright 目視: 両タブ・エピソード展開・サマリー・並び順を確認。描画 2.6〜4s

## スコープ外 (次候補)

- Phase 2: 売買履歴側の執行メモ (エピソード単位)。エピソード対応が済んだので着手可能
- マージ後: 未参照になった `list_trade_fills`/`calc_episode_pl` の撤去

🤖 Generated with [Claude Code](https://claude.com/claude-code)