### PR TITLE
月足タグをメモタブの月足列へ分離 + 株探業績テーブルのパーサー修正

### DIFF
--- a/scripts/shihyou.py
+++ b/scripts/shihyou.py
@@ -368,47 +368,59 @@ def get_from_kabutan_base(html, shiyo_data):
 
     # ---- PSR
     psr = 0.0
+    # 通期業績テーブル。株探の2ページでレイアウトが異なるため両対応する。
+    #   finance ページ: <div class="fin_year_t0_d fin_year_result_d">
+    #       列= 決算期/売上高/営業益/経常益/最終益/...、単位=百万円 (2026-08 に旧形式から変更)
+    #   base ページ:    <div class="gyouseki_block">
+    #       列= 決算期/売上高/経常益/最終益/...、単位=億円
+    # kubun1 (単/連/予 等) を持つ行だけが決算期行で、前期比 行は kubun1 が無いので除外される。
+    # 時価総額が億円なので、百万円のページだけ 100 で割って単位を揃える。
     gyoseki_m = re.search(
-        r'<div class="gyouseki_block">\r\n<div class="title">(.*?)</table>\r\n</div>',
+        r'<div class="fin_year_t0_d fin_year_result_d">\s*<table>(.*?)</table>',
         html,
         re.DOTALL,
     )
+    if gyoseki_m:
+        keijo_idx, profit_idx, unit_divisor = 2, 3, 100.0  # 営業益列あり・百万円
+    else:
+        gyoseki_m = re.search(
+            r'<div class="gyouseki_block">\s*<div class="title">(.*?)</table>',
+            html,
+            re.DOTALL,
+        )
+        keijo_idx, profit_idx, unit_divisor = 1, 2, 1.0  # 営業益列なし・億円
     uriage_lst = []
     profit = 0
     if gyoseki_m:
-        # print gyoseki_m.group(0)
         latest_term = ""
         for row_m in re.finditer(
-            r'<tr>\r\n    <th scope=\'row\'><span class="kubun1">(.*?)</span>(.*?)</th>(.*?)</tr>',
+            # scope='row' (base) と scope="row" (finance) の両方を許容
+            r'<th scope=[\'"]row[\'"][^>]*><span class="kubun1">(.*?)</span>(.*?)</th>(.*?)</tr>',
             gyoseki_m.group(1),
             re.DOTALL,
         ):
-            # print row_m.group(1), row_m.group(2)
-            # 一列目が売上高なので最初に見つかった<td></td>
-            # print row_m.group(1), row_m.group(2)
-            uriage_m = re.search(
-                r"<td>(.*?)</td>\r\n    <td>(.*?)</td>\r\n    <td>(.*?)</td>",
-                row_m.group(3),
-            )
+            # 値セルは class 付き (<td class="high">) もあるため属性を許容して順に拾う。
+            # 売上高は常に index 0、経常益/最終益の位置はページごとに異なる。
+            tds = re.findall(r"<td[^>]*>(.*?)</td>", row_m.group(3), re.DOTALL)
+            if len(tds) <= profit_idx:
+                continue
             cur_term = row_m.group(2).replace("&nbsp;", "")
             try:
-                uriage = float(uriage_m.group(1).replace(",", ""))
+                uriage = float(tds[0].replace(",", "")) / unit_divisor
                 latest_term = cur_term
                 uriage_lst.append(uriage)
             except ValueError:
-                log_debug("  売上高取得できず:", uriage_m.group(1), cur_term)
+                log_debug("  売上高取得できず:", tds[0], cur_term)
 
             try:
-                profit = float(uriage_m.group(3))  # 最終益
-                # latest_term = cur_term
+                profit = float(tds[profit_idx].replace(",", "")) / unit_divisor  # 最終益
             except ValueError:
-                log_debug("  最終益取得できず:", uriage_m.group(3), cur_term)
+                log_debug("  最終益取得できず:", tds[profit_idx], cur_term)
             try:
-                keijo = float(uriage_m.group(2))  # 経常益
+                keijo = float(tds[keijo_idx].replace(",", "")) / unit_divisor  # 経常益
             except ValueError:
                 keijo = 0
-                log_debug("   経常益取得できず", uriage_m.group(2), cur_term)
-            # print uriage
+                log_debug("   経常益取得できず", tds[keijo_idx], cur_term)
         if uriage_lst:
             uriage = uriage_lst[-1]  # 直近
             if uriage > 0:

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -2007,12 +2007,23 @@ def list_portfolio_with_indicators(
     return rows
 
 
+# 月足位置タグ (issue #53)。portfolio 一覧ではタグ列から外し、メモページの月足列に出す。
+# タグ種別は make_stock_db.judge_monthly_position が返す 月破/月高/月低 と対応。
+MONTHLY_TAG_DESCRIPTIONS = {
+    "月破": "月破: 月足で低位滞留から直近3ヶ月内に3年高値をブレイク (Stage 1→2)",
+    "月高": "月高: 月足で10年レンジの上位30%の高値圏 (戻り売り圧力が小さい)",
+    "月低": "月低: 月足で10年レンジの下位35%以下の低位圏",
+}
+MONTHLY_TAGS = tuple(MONTHLY_TAG_DESCRIPTIONS)
+
+
 def _format_tags(stock: Dict[str, Any], tags=None) -> str:
-    """code_rank.csv「タグ」列と同じ表記を返す。
+    """code_rank.csv「タグ」列と同じ表記から月足タグを除いて返す。
 
     make_stock_db.make_signal() の tags リストを "/" join する。
     market_db を渡さないので 強乖/弱乖 タグは出ない (Phase 4 送り)。
     tags を渡すと make_signal の再呼び出しを省略する (一覧の二重計算回避)。
+    月足タグ (月破/月高/月低) は専用の月足列に出すためここでは除外する。
     """
     if not stock:
         return "—"
@@ -2022,7 +2033,16 @@ def _format_tags(stock: Dict[str, Any], tags=None) -> str:
             _signal, tags = make_signal(stock)
         except Exception:
             return "—"
+    tags = [t for t in (tags or []) if t not in MONTHLY_TAGS]
     return "/".join(tags) if tags else "—"
+
+
+def _format_monthly_tag(tags=None) -> str:
+    """portfolio メモページの月足列に出すタグ (月破/月高/月低) を返す。"""
+    for tag in (tags or []):
+        if tag in MONTHLY_TAGS:
+            return tag
+    return "—"
 
 
 def _format_tags_tooltip(tags: str) -> str:
@@ -2036,12 +2056,6 @@ def _format_tags_tooltip(tags: str) -> str:
         lines.append("警: RS高いのに売り圧力比率<45 または wma10割れ（1条件のみ）")
     if "早売" in tags:
         lines.append("早売: 10ma維持実績あり→10ma割れ後に、最初に10ma割れした日の安値をさらに下回って確定")
-    if "月破" in tags:
-        lines.append("月破: 月足で低位滞留から直近3ヶ月内に3年高値をブレイク (Stage 1→2)")
-    elif "月高" in tags:
-        lines.append("月高: 月足で10年レンジの上位30%の高値圏 (戻り売り圧力が小さい)")
-    elif "月低" in tags:
-        lines.append("月低: 月足で10年レンジの下位35%以下の低位圏")
     return "\n".join(lines)
 
 
@@ -3640,6 +3654,9 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
     except Exception:  # noqa: BLE001
         _tags = None
     signal_mark, signal_full = _format_signal(stock)
+    # tags / monthly_tag は表示値と tooltip の両方で使うため1回だけ組み立てる
+    tags_expr = _format_tags(stock, _tags)
+    monthly_tag = _format_monthly_tag(_tags)
 
     return {
         "rank": rank if isinstance(rank, int) else None,
@@ -3667,8 +3684,11 @@ def _extract_indicators_for_portfolio(stock: Dict[str, Any]) -> Dict[str, Any]:
         "trend_template_misses": trend_misses if isinstance(trend_misses, list) else None,
         "trend_template_tooltip": trend_info["tooltip"],
         "kairi_gauge_svg": trend_info["kairi_gauge_svg"],
-        "tags": _format_tags(stock, _tags),
-        "tags_tooltip": _format_tags_tooltip(_format_tags(stock, _tags)),
+        "tags": tags_expr,
+        "tags_tooltip": _format_tags_tooltip(tags_expr),
+        # 月足位置タグ (issue #53) はタグ列から分離し、メモページの月足列に出す
+        "monthly_tag": monthly_tag,
+        "monthly_tag_tooltip": MONTHLY_TAG_DESCRIPTIONS.get(monthly_tag, ""),
         "signal_mark": signal_mark,
         "signal_full": signal_full,
         "signal_display": _build_signal_display(stock),  # issue #253: tooltip+背景色
@@ -3872,6 +3892,10 @@ def compute_cell_styles(row: Dict[str, Any], today: Optional[date] = None) -> Di
     if signal_mark and signal_mark != "—":
         sig_style = (row.get("signal_display") or {}).get("style")
         styles["signal"] = sig_style or bg_with_white("赤")
+
+    # --- 月足: 月破 (低位滞留からのブレイク) だけ薄赤でやや目立たせる
+    if row.get("monthly_tag") == "月破":
+        styles["monthly_tag"] = bg("薄赤")
 
     # --- 時価総額 (ルール 29, 30): カテゴリ "中" / "大" → 薄黄 (極小/小/特大は色なし)
     cat = row.get("market_cap_category")

--- a/scripts/webapp/routes/portfolio.py
+++ b/scripts/webapp/routes/portfolio.py
@@ -26,6 +26,7 @@ import portfolio
 import portfolio_shelve as ps
 import research_shelve
 from webapp.helpers import (
+    MONTHLY_TAG_DESCRIPTIONS,
     THEME_SUMMARY_SORT_FIELDS,
     build_portfolio_theme_summary,
     compute_cell_styles,
@@ -993,6 +994,7 @@ def dashboard():
         stage_t_options=ps.STAGE_T_OPTIONS,
         chart_style_options=ps.CHART_STYLE_OPTIONS,
         chart_state_options=ps.CHART_STATE_OPTIONS,
+        monthly_tag_descriptions=MONTHLY_TAG_DESCRIPTIONS,
         hold_summary=hold_summary,
     )
 
@@ -1059,6 +1061,7 @@ def charts():
         stage_t_options=ps.STAGE_T_OPTIONS,
         chart_style_options=ps.CHART_STYLE_OPTIONS,
         chart_state_options=ps.CHART_STATE_OPTIONS,
+        monthly_tag_descriptions=MONTHLY_TAG_DESCRIPTIONS,
     )
 
 

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -474,5 +474,8 @@ nav .quick-search {
 .trend-bg-missing  { background: #ea4335; }
 
 /* 需給バランスセル (issue #247): SPR/rv の横バー 2 本縦積み */
-.spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; width: 80px; }
-.spr-gauge-cell svg { display: block; width: 80px; height: auto; }
+.spr-gauge-cell { padding: 4px; vertical-align: middle; white-space: nowrap; width: 104px; }
+.spr-gauge-cell svg { display: block; width: 104px; height: 31px; }
+/* トレンド列: 乖離ゲージ SVG は 40x28 固定生成。viewBox があるので CSS で横だけ広げる。
+   height を auto にすると縦も比例拡大して行高が増え、指標タブだけ背が高くなるため固定する。 */
+.kairi-gauge-cell svg { width: 56px; height: 28px; margin: 0 auto; }

--- a/scripts/webapp/templates/portfolio_list.html
+++ b/scripts/webapp/templates/portfolio_list.html
@@ -18,6 +18,9 @@
     padding: 0.25em 0.35em;
     white-space: normal;  /* ヘッダの折り返しを許可してセル幅を縮める */
   }
+  /* ゲージ SVG のセルは縦 padding を持たせない。SVG 自体が背が高いため、
+     指標タブ (ページ1) だけ行高が伸びてメモタブと表示件数がズレるのを防ぐ。 */
+  table.portfolio-list td.spr-gauge-cell { padding-top: 0; padding-bottom: 0; }
   /* 長いヘッダラベル ("RSライン(20,5)" 等) が列幅を引っ張らないよう、
      ヘッダ側に max-width を設けて強制改行させる。データセル幅優先。 */
   table.portfolio-list thead th {
@@ -442,6 +445,8 @@
       <th data-page="2">更新日</th>
       <th data-page="2">ステージ</th>
       <th data-page="2">チャートパターン</th>
+      {# tooltip 文言は helpers.MONTHLY_TAG_DESCRIPTIONS を単一の出典にする (セル側と共通) #}
+      <th data-page="2" title="月足位置の自動判定。&#10;{{ monthly_tag_descriptions.values()|join('\n') }}">月足</th>
       <th data-page="2" title="定型リストから単一選択。未分類は警告色">売買戦略</th>
       <th data-page="2">イナゴ元</th>
       <th data-page="2">IN理由</th>
@@ -528,13 +533,14 @@
       <td data-page="1" title="{{ row.price_rs_chart.tooltip }}" style="padding:0 2px;line-height:0;">
         {% if row.price_rs_chart.svg %}{{ row.price_rs_chart.svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
       </td>
-      <td data-page="1" title="{{ row.trend_template_tooltip }}" style="width:40px;padding:0;line-height:0;text-align:center;{{ row.styles.trend_template or '' }}">
+      <td data-page="1" class="kairi-gauge-cell" title="{{ row.trend_template_tooltip }}" style="width:56px;padding:0;line-height:0;text-align:center;{{ row.styles.trend_template or '' }}">
         {% if row.kairi_gauge_svg %}{{ row.kairi_gauge_svg|safe }}{% else %}<span style="color:#bbb;line-height:1.2;">—</span>{% endif %}
       </td>
       <td data-page="1" title="{{ row.tags_tooltip or '' }}"
-          style="max-width:6em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
+          style="max-width:4em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.tags or '' }}">{{ row.tags }}</td>
+      {# シグナルは「ポ/ブ/週ブ」まで出るため見切れない幅を確保 #}
       <td data-page="1" title="{{ row.signal_full or '' }}"
-          style="max-width:3em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.signal or '' }}">{{ row.signal_mark }}</td>
+          style="max-width:5.4em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{{ row.styles.signal or '' }}">{{ row.signal_mark }}</td>
       <td data-page="1" class="spr-gauge-cell" title="{{ row.spr_gauge.tooltip }}">{{ row.spr_gauge.svg|safe }}</td>
       <td data-page="1" style="{{ row.styles.market_cap or '' }}">{{ row.market_cap }}</td>
       {# issue #327: ページ2 (手動入力)。更新日/ステージ/チャートパターンをページ1から移設 #}
@@ -592,6 +598,9 @@
           </select>
         </div>
       </td>
+      {# 月足位置タグ (issue #53)。自動判定のためチャートパターンと違い編集不可 #}
+      <td data-page="2" title="{{ row.monthly_tag_tooltip or '' }}"
+          style="white-space:nowrap;text-align:center;{{ row.styles.monthly_tag or '' }}">{{ row.monthly_tag }}</td>
       {# issue #327: 売買戦略 (定型リスト単一選択 + 色分けバッジ)。
          リスト外の旧自由記述値は ⚠️ 付き option を差し込んで保持し、再分類を促す #}
       {% set current_idea = row.memo.trade_idea or '' %}

--- a/tests/test_live_html.py
+++ b/tests/test_live_html.py
@@ -22,7 +22,7 @@ import shintakane
 import make_market_db
 import market_breadth
 import rironkabuka
-from ks_util import http_get_html
+from ks_util import http_get_html, UPD_CACHE, UPD_FORCE
 
 # テスト用銘柄（大型株・安定して存在する）
 TEST_CODE = "7203"  # トヨタ自動車
@@ -90,6 +90,30 @@ class TestLiveHtmlShihyou:
         # トヨタは大型製造業なので EVR は正値で 1.0 前後の想定。
         # ネットキャッシュ企業の場合は負値もあり得るため範囲は緩めに見る。
         assert isinstance(result["EV_Sales"], float)
+        _sleep()
+
+    def test_通期業績テーブルからPER_PSRが算出できる(self):
+        """業績テーブル (売上高/経常益/最終益) から PER/MPER/PSR が算出できること。
+
+        2026-08 の株探フォーマット変更 (base ページは gyouseki_block 維持・
+        finance ページは fin_year_result_d へ) で MPER/PSR が全欠損したが、既存テストは
+        別関数のキーだけを見ていたため素通りした。
+        本番と同じ analyze_from_kabutan 経由 (= base ページ) で検証する。
+        値の存在に加えて桁 (単位換算ミス) も検証する。
+
+        取得は2段階にする。UPD_FORCE で最新HTMLをDLしてキャッシュを更新した上で、
+        判定は UPD_CACHE (=キャッシュ読み) で行う。ファイルキャッシュ経由では改行が
+        LF に正規化されるため、通信直後のHTML (CRLF) だけを見ると本番と条件が変わり、
+        CRLF 前提の正規表現バグを取りこぼす。
+        """
+        shihyou.analyze_from_kabutan(TEST_CODE, upd=UPD_FORCE)  # 最新HTMLをキャッシュへ
+        result = shihyou.analyze_from_kabutan(TEST_CODE, upd=UPD_CACHE)  # 本番と同じ読み方
+        for key in ("MPER", "PER", "PSR"):
+            assert key in result, f"{key} が欠損 (業績テーブルのフォーマット変更疑い)"
+        # 単位換算ミス (100倍/1/100) を検知する。トヨタは PER 10 前後・PSR 1 前後。
+        assert 1 < result["PER"] < 200, f"PER の桁が異常: {result['PER']}"
+        assert 1 < result["MPER"] < 200, f"MPER の桁が異常: {result['MPER']}"
+        assert 0.1 < result["PSR"] < 20, f"PSR の桁が異常: {result['PSR']}"
         _sleep()
 
 

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1802,6 +1802,21 @@ class TestFormatTagsTooltip:
         assert "売" in tooltip
         assert "RS高いのに売り圧力比率" in tooltip
 
+    @pytest.mark.parametrize(
+        "tags, expected_tags, expected_monthly",
+        [
+            # 月足タグはタグ列から除かれ、月足列に回る
+            (["押", "月破"], "押", "月破"),
+            (["月高"], "—", "月高"),
+            # 月足タグが無ければ月足列は "—"、タグ列はそのまま
+            (["押", "早売"], "押/早売", "—"),
+            ([], "—", "—"),
+        ],
+    )
+    def test_monthly_tags_split_out_of_tags_column(self, tags, expected_tags, expected_monthly):
+        assert helpers._format_tags({"code_s": "1234"}, tags) == expected_tags
+        assert helpers._format_monthly_tag(tags) == expected_monthly
+
     # ----- 進捗率乖離: <C3>=赤(注目) 単独 / eiri≧20 = 濃黄 単独 / 両該当=左右分割 -----
     def test_progress_diff_c3_only(self):
         """<C3> タグのみで eiri 不該当: 赤 (注目) 単色 + 白文字"""


### PR DESCRIPTION
## Summary
- portfolio のタグ列から月足タグ (月破/月高/月低) を外し、メモタブの**チャートパターン隣に月足列**を新設 (月破は薄赤背景)
- 【指標】の **PER/PSR が空欄になる不具合を修正**。株探の改行が CRLF→LF に変わり業績テーブルの正規表現がマッチしなくなっていた
- 同種のフォーマット変更を**検知できるテストを追加** (既存テストは PER/MPER/PSR を検証しておらず素通りしていた)

## 月足列の分離
`make_signal()` は `code_rank.csv` (make_stock_db.py:1499) と shintakane.py:624 でも使われるため**本体は変更せず**、portfolio の表示層 (`_format_tags`) でフィルタして新列に出す。CSV・ランキング出力への影響なし。

## パーサー修正 (根本原因)
株探の2ページでレイアウトが異なっていた:

| | finance ページ | base ページ |
|---|---|---|
| ブロック | `fin_year_t0_d fin_year_result_d` (新) | `gyouseki_block` (旧のまま) |
| 列構成 | 売上高/**営業益**/経常益/最終益 | 売上高/経常益/最終益 |
| 単位 | 百万円 | 億円 |

両方とも改行が `\r\n`→`\n` に変わり、`\r\n` をリテラルで要求していた正規表現が全滅。**shihyo 保持 2409 銘柄中 505 銘柄 (21%) で MPER 欠損**、うち 399 銘柄は PER を保持しており本来表示できた。

経常益・最終益で `replace(",", "")` が漏れていた既存バグ (`5,122` が ValueError で `keijo=0`) も修正。

## 検知テスト
既存の `TestLiveHtmlShihyou` が素通りした理由は2点:
1. PER/MPER/PSR を検証するテストが**1本も無かった** (既存5本は別関数のキーのみ)
2. `upd=-1` は**キャッシュを使う**分岐に落ち、live HTML を見ていなかった

新テストは本番と同じ `analyze_from_kabutan` 経由で、最新HTML取得後に**キャッシュ読みで判定**する。ファイルキャッシュでは改行が LF に正規化されるため、通信直後のHTML (CRLF あり) だけを見ると本番と条件が変わり CRLF 前提のバグを取りこぼす。値の存在に加え**桁**も検証し単位換算ミスを検知。

## Test plan
- [x] `pytest tests/ -m "not local_db and not live_html"` → **2036 passed**
- [x] `pytest tests/test_live_html.py -k Shihyou` → 6 passed (新テスト含む)
- [x] **リグレッション注入で検知を実証**: base ページの正規表現を旧 CRLF 前提に戻すと新テストが `AssertionError: MPER が欠損` で落ち、復元で green に戻ることを確認
- [x] finance/base 両ページの算出値が**完全一致**することを4銘柄で確認 (7203: MPER 14.3 / PER 10.6 / PSR 0.8)。旧フォーマット時代のDB保存値とも一致
- [x] Playwright で実機確認: 月足列がチャートパターン隣に描画、月破3件に `#f4c7c3`、タグ列への漏れ0、指標/メモ両タブの行高差 245px→8px

### 既知の事項
- `tests/test_trend_template.py::test_empty_trend_template_passes_signals` が失敗しますが、**未変更の main でも同様に失敗する既存の不具合**で本PRとは無関係です
- `test_live_html.py` の他5クラス (Gyoseki/Shintakane/Pts/Kessan/Theme) も同様に main 時点から失敗中 (テスト側の cache_dir 未指定による ValueError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)