### PR TITLE
fix(rs): RS(0~99)履歴を全銘柄ループで記録し詳細チャートの線切れを解消

### DIFF
--- a/scripts/make_stock_db.py
+++ b/scripts/make_stock_db.py
@@ -151,16 +151,39 @@ def update_stock_rank(stock, rank):
     stock.update(rank_dict)  # 更新
 
 
+def append_rs_rank_log(stock):
+    """stock の momentum_pt を rs_rank_log に追記して返す。
+
+    rs_rank_log への書き込み規則をここに一本化する (get_price_data 経路と
+    list_all_db の全銘柄ループ経路の両方から使う)。
+    """
+    rs_rank_log = stock.get("rs_rank_log", [])
+    rs_rank = stock.get("momentum_pt")
+    # 未算出(None)/算出失敗(0以下)は描画側でも除外される値なので記録しない
+    if not rs_rank or rs_rank <= 0:
+        return rs_rank_log
+    return update_stock_log(rs_rank_log, rs_rank)
+
+
 def update_rs_rank(stocks, code_s):
     """RSとRSログを更新"""
     if code_s not in stocks:
         return []
-    stock = stocks[code_s]
-    rs_rank_log = stock.get("rs_rank_log", [])
-    # print "rs_rank_log:", rs_rank_log
-    rs_rank = stock.get("momentum_pt")
+    return append_rs_rank_log(stocks[code_s])
 
-    return update_stock_log(rs_rank_log, rs_rank)
+
+def update_rs_rank_if_fresh(stock):
+    """価格が当日更新済みの銘柄のみ rs_rank_log に momentum_pt を追記する。
+
+    momentum_pt は price.get_price_data 内でしか再計算されないため、価格未更新の銘柄は
+    古い値のまま。記録すると横ばいの実線として描かれ、欠損より誤認を招く。
+    """
+    access_date = stock.get("access_date_price")
+    if not access_date:
+        return
+    if get_price_day(access_date) != get_price_day(datetime.today()):
+        return
+    stock["rs_rank_log"] = append_rs_rank_log(stock)
 
 
 # ==================================================
@@ -1869,6 +1892,8 @@ def list_all_db(upload_csv=True, update_portforio=True):
         stock = stocks[elem[0]]
         rank = i + 1
         update_stock_rank(stock, rank)
+        # RS(0~99)履歴も全銘柄ループで記録する (価格更新済み銘柄のみ)
+        update_rs_rank_if_fresh(stock)
     save_stock_db(stocks)  # 更新した順位のDB保存
 
     # ---- テーマ別株価騰落率を計算してmarket_dbに保存

--- a/tests/test_make_stock_db.py
+++ b/tests/test_make_stock_db.py
@@ -1579,3 +1579,43 @@ class TestMonthlyPositionTags:
         """monthly_position 未保存 (未更新の既存銘柄) では月足タグを出さない"""
         _signal, tags = make_stock_db.make_signal({"price": 1000})
         assert not any(t in ("月低", "月破", "月高") for t in tags)
+
+
+class TestUpdateRsRankIfFresh:
+    """rs_rank_log の全銘柄ループ記録 (鮮度ガード付き)。
+
+    momentum_pt は価格更新時にしか再計算されないため、価格未更新の銘柄で記録すると
+    古い値が水平な実線として描かれてしまう。当日更新済みの銘柄のみ記録すること。
+    """
+
+    @staticmethod
+    def _today():
+        return make_stock_db.get_price_day(datetime.today())
+
+    @pytest.mark.parametrize(
+        "case, access_delta_days, momentum_pt, expect_recorded",
+        [
+            ("当日更新かつ有効値は記録", 0, 77, True),
+            ("価格未更新(古いmomentum_pt)は記録しない", 20, 55, False),
+            ("momentum_pt未算出(None)は記録しない", 0, None, False),
+            ("momentum_pt算出失敗(0)は記録しない", 0, 0, False),
+            ("access_date_price欠損では落ちず記録しない", None, 60, False),
+        ],
+    )
+    def test_freshness_guard(self, case, access_delta_days, momentum_pt, expect_recorded):
+        stock = {"momentum_pt": momentum_pt, "rs_rank_log": []}
+        if access_delta_days is not None:
+            stock["access_date_price"] = datetime.today() - timedelta(days=access_delta_days)
+        make_stock_db.update_rs_rank_if_fresh(stock)
+        assert (stock["rs_rank_log"] == [(self._today(), momentum_pt)]) is expect_recorded
+
+    def test_same_day_rerun_does_not_duplicate(self):
+        """同日に2回実行しても点が重複しない (cron再実行・手動再実行時)"""
+        stock = {
+            "access_date_price": datetime.today(),
+            "momentum_pt": 80,
+            "rs_rank_log": [],
+        }
+        make_stock_db.update_rs_rank_if_fresh(stock)
+        make_stock_db.update_rs_rank_if_fresh(stock)
+        assert stock["rs_rank_log"] == [(self._today(), 80)]


### PR DESCRIPTION
## Summary

- stock ページの RS(0~99) 紫ラインが直近数日で途切れる問題を修正
- 原因: `rs_rank_log` は `get_price_data` (テーマ/100位以内/ポートフォリオのみ更新) でしか追記されず、更新対象から外れた日は点が空いていた。全銘柄が毎日更新される `stock_rank_log` と非対称だった
- 対処: `stock_rank_log` と同じ全銘柄ループで記録する。ただし `momentum_pt` は価格更新時にしか再計算されないため、`access_date_price` が当日の銘柄に限定 (古い値を横ばいの実線として描くと欠損より誤認を招くため)
- あわせて `rs_rank_log` への書き込み規則を `append_rs_rank_log` に一本化し、旧経路が `momentum_pt` 未算出時に `None` を書き込んでいた問題も解消

### 調査データ

| 銘柄 | 修正前の rs_rank_log | stock_rank_log |
|---|---|---|
| 6525 | 3 | 4 |
| 7089 | 3 | 4 |
| 6965 | 58 | 60 |

DB全体では 2539銘柄中 859銘柄 (34%) が描画点3以下。`access_date_price` が15日以上前の銘柄が628件あり、これらの `momentum_pt` は古いため鮮度ガードで除外している。

### 効果と限界

- 実運用では日々1000〜1500銘柄に点が入る見込み (直近の実行日 08-07 の価格更新実績は1357銘柄)
- 既存履歴は遡って埋まらないため、6525/7089 が実用的な線量になるには数週間かかる
- 更新対象外の銘柄は依然として疎のまま (根本解決には `rs_raw` の全銘柄再計算が必要だが、`code_rank` の churn を伴うため今回は見送り)

## Test plan

- [x] `pytest tests/test_make_stock_db.py tests/test_append_research_snapshots.py` → 187 passed
- [x] `pytest tests/ -m "not local_db and not live_html"` → 2105 passed (既存の失敗 `test_resolve_markers_x_interp_and_drop` は本PRと無関係。変更を stash して再現確認済み)
- [x] 実DBで `list_all_db` のランクループ相当を再現 (2712銘柄) — 完走、`RANK_LOG_DAYS=60` 上限超過なし、0以下の値の新規混入なし
- [x] 価格更新直後を模擬した実データ1500銘柄で、先頭が `(当日, momentum_pt)` になることを確認
- [x] 旧経路 `update_rs_rank` が `momentum_pt` 欠損時に `None` を書かなくなったことを確認
- [x] 週末実行時に金曜データを当日扱いしないことを確認 (`is_latest_price` の `recent_weekday` 基準を採用しなかった理由)
- [x] 追加コスト実測: 全銘柄ループで約 0.025 秒 (通信の追加なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)