### PR TITLE
マネックス証券 取引履歴CSV の fill 取込を追加 (issue #390)

### DIFF
--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -125,9 +125,9 @@ cd scripts && python backfill_price_proxy.py             # None のみ埋める 
 cd scripts && python backfill_price_proxy.py --overwrite # actual 以外を再取得
 ```
 
-### 証券会社CSV → fill レイヤー取込 (issue #360, #387)
+### 証券会社CSV → fill レイヤー取込 (issue #360, #387, #390)
 
-楽天・SBI証券の約定CSVの実約定価格・株数を fill として取り込む。同一 dedup キーは冪等スキップ。取り込んだ fill は `/trade-history` の「売買履歴」タブに建玉ラウンド単位のエピソードとして表示され、勝率・ペイオフレシオも fill 側で計算される (issue #387 Phase4b)。SBI は個別株のみ取込 (ETF/投信=ウォッチリスト外は自動除外)。楽天は信用返済行の建約定日・建単価と現引行 (建玉の現物化) も取込む (信用/現物のエピソード損益計算に使用)。SBI 信用返済行の決済損益は fill に保存する。既存 fill への建単価・決済損益は再取込時に後付けされる (None→非None のみ)。
+楽天・SBI・マネックス証券の約定CSVの実約定価格・株数を fill として取り込む。同一 dedup キーは冪等スキップ。取り込んだ fill は `/trade-history` の「売買履歴」タブに建玉ラウンド単位のエピソードとして表示され、勝率・ペイオフレシオも fill 側で計算される (issue #387 Phase4b)。SBI は個別株のみ取込 (ETF/投信=ウォッチリスト外は自動除外)。楽天は信用返済行の建約定日・建単価と現引行 (建玉の現物化) も取込む (信用/現物のエピソード損益計算に使用)。SBI 信用返済行の決済損益は fill に保存する。既存 fill への建単価・決済損益は再取込時に後付けされる (None→非None のみ)。
 
 ```bash
 # 楽天 (tradehistory(JP)_YYYYMMDD.csv, Shift-JIS, 28列)
@@ -137,7 +137,15 @@ cd scripts && python import_rakuten_fills.py "<csv_path>"             # 本番�
 # SBI (SaveFile_*.csv, Shift-JIS, 冒頭メタ行あり)
 cd scripts && python import_sbi_fills.py "<csv_path>" --dry-run       # 読込・パース検証 (DB 非書込)
 cd scripts && python import_sbi_fills.py "<csv_path>"                 # 本番取込
+
+# マネックス (YYYYMMDD-YYYYMMDD.csv, Shift-JIS, 冒頭メタ行あり25列)
+cd scripts && python import_monex_fills.py "<csv_path>" --dry-run     # 読込・パース検証 (DB 非書込)
+cd scripts && python import_monex_fills.py "<csv_path>"               # 本番取込
 ```
+
+マネックスは過去データのバックフィル用途 (現在は未使用)。銘柄コードが5桁 (`54710`) なので末尾の付加桁を落として4文字 `code_s` に正規化する。信用返済行は建約定日・建単価 (楽天と同じ) と受渡金額=諸経費控除後の決済損益 (SBI と同じ) の両方を持つ。税金・入出金・入出庫・配当金の行はスキップする。過去に売買したが現在ウォッチリストに無い銘柄を欠落させないため、除外は ETF のみ (SBI のようなウォッチリスト外除外はしない)。
+
+いずれも `/trade-history` の取込UIからアップロードすれば、ヘッダの列数で証券会社を自動判別する (楽天=28列 / SBI=14列 / マネックス=25列)。
 
 取込後の建玉ラウンド (エピソード) 損益・保有中の含み損益・振り返りメモの紐付けをターミナルで確認する (DB 非更新)。
 

--- a/doc/plan/issue390_monex_fills.md
+++ b/doc/plan/issue390_monex_fills.md
@@ -1,0 +1,203 @@
+# issue #390 実装プラン: マネックス証券 取引履歴CSV の fill 取込
+
+## ゴール
+
+マネックス証券の取引履歴CSV (過去データ、一度きりのバックフィル) を既存 fill レイヤーへ
+取り込み、売買履歴タブのエピソード損益にマネックス分を合流させる。
+
+検証可能なゴール:
+1. `python scripts/import_monex_fills.py <csv> --dry-run` が有効約定のみを fill 化する
+2. `/trade-history/import` でマネックスCSVをアップロードすると自動判別されて取り込まれる
+3. `show_fill_episodes.py` でマネックス建玉のラウンド損益が表示される
+
+## 実CSVから確定した仕様
+
+サンプル: `~/Downloads/20260101-20260807.csv` (Shift-JIS/CP932, 119行, 25列)
+
+- 1行目は `データ作成日：2026/08/09 15:15:44` のメタ行。**ヘッダは2行目**。
+- 列 (0-indexed):
+
+| idx | ヘッダ | 用途 |
+|---|---|---|
+| 0 | 約定日 | `YYYY/MM/DD` |
+| 3 | 商品 | `信用新規`/`信用返済`/`現引`/`株式`/空 |
+| 4 | 取引 | `半年新規買い`/`半年返済売り`/`お買付`/`ご売却`/`半年現引` 等 |
+| 5 | 銘柄コード | **5桁+パディング空白** (`54710    `, `471A0    `) |
+| 7 | 数量（株/口）/返済数量 | |
+| 8 | 単価/返済約定単価 | |
+| 12 | 受渡金額(円) | 信用返済行では**決済損益**(諸経費控除後) |
+| 13 | 建約定日 | 信用返済/現引行のみ |
+| 14 | 建単価 | 信用返済/現引行のみ |
+
+### 確定した3つの判断材料
+
+1. **建約定日・建単価が両方入っている** → issue 本文の懸念「無ければ信用は損益算出対象外」は
+   不要。楽天と同じ `tate_date`/`tate_price` を渡せばエピソード損益が組める。
+
+2. **受渡金額(12列) は信用返済行では決済損益** (SBI の `settle_pl` と同じ意味)。実測検証:
+   - 大同特鋼: (2165-1888)*200 = 55,400 に対し受渡 54,831 (差 -569 = 手数料360+税36+順日歩173)
+   - スクリン: (16075-16150)*100 = -7,500 に対し受渡 -8,889 (差 -1,389)
+
+   → 諸経費控除後の実質損益。`settle_pl` として持たせるのが真実源として正しい。
+
+3. **銘柄コードが5桁**。`ps.CODE_S_PATTERN` は `^(?:\d{4}|\d{3}[A-Z])$` なので、
+   末尾1桁を落とす正規化が必須 (`54710`→`5471`, `471A0`→`471A`)。これを怠ると全行スキップ。
+
+### 取引区分の全出現 (サンプル119行)
+
+| 商品 | 取引 | 件数 | 扱い |
+|---|---|---|---|
+| 信用新規 | 半年新規買い | 23 | buy / 信用新規 |
+| 信用返済 | 半年返済売り | 28 | sell / 信用返済 |
+| 信用新規 | 半年新規売り | 2 | sell / 信用新規 |
+| 信用返済 | 半年返済買い | 2 | buy / 信用返済 |
+| 現引 | 半年現引 | 1 | buy / 現引 |
+| 株式 | お買付 | 1 | buy / 現物 |
+| 株式 | ご売却 | 8 | sell / 現物 |
+| 株式 | 入庫/出庫 | 12 | **スキップ** (振替であって約定でない) |
+| 株式 | 配当金 | 1 | **スキップ** |
+| (空) | 源泉徴収税/還付金/銀行出金/ご入金/振替入金 | 31 | **スキップ** |
+
+## 実装
+
+### 1. `scripts/import_monex_fills.py` (新規)
+
+`import_sbi_fills.py` をベースに 4層構成 (読込/パース/統合/実行) を踏襲。
+共通処理 (`RowSkip` / `_normalize_trade_date` / `_parse_num`) は `import_rakuten_fills`
+から再利用 (SBI と同じ依存の張り方)。
+
+```python
+CSV_ENCODING = "shift_jis"
+EXPECTED_COL_COUNT = 25
+HEADER_FIRST_COL = "約定日"
+HEADER_MARKER = "建単価"   # 楽天/SBI に無い列名でヘッダ行を同定
+BROKER = "マネックス"
+
+# (商品, 取引) → (side, trade_kind)。trade_kind は楽天語彙に合わせる
+_ACTION_MAP = {
+    ("信用新規", "半年新規買い"): ("buy",  "信用新規"),
+    ("信用新規", "半年新規売り"): ("sell", "信用新規"),
+    ("信用返済", "半年返済売り"): ("sell", "信用返済"),
+    ("信用返済", "半年返済買い"): ("buy",  "信用返済"),
+    ("現引",     "半年現引"):     ("buy",  "現引"),
+    ("株式",     "お買付"):       ("buy",  "現物"),
+    ("株式",     "ご売却"):       ("sell", "現物"),
+}
+_SETTLE_ACTIONS = frozenset({("信用返済", "半年返済売り"), ("信用返済", "半年返済買い")})
+```
+
+`_ACTION_MAP` に無い (商品, 取引) はすべて `RowSkip` → 税金・入出金・入出庫・配当金は
+明示的な除外リストを持たずに自然に落ちる。
+
+#### 銘柄コード正規化
+
+```python
+def _normalize_monex_code(raw: str) -> str:
+    """マネックスの5桁銘柄コード (`54710    `) を4桁 code_s (`5471`) に変換する。
+
+    末尾1桁はチェック用の付加桁 (英字コードは `471A0` → `471A`)。
+    5桁でなければそのまま返し、後段の validate_code_s に判定を委ねる。
+    """
+    s = (raw or "").strip().upper()
+    return s[:-1] if len(s) == 5 and s.endswith("0") else s
+```
+
+末尾が `0` の5桁のときだけ落とす (誤変換の予防)。サンプル28コード全てが末尾 `0`。
+
+#### パース層
+
+`parse_fill_row` は SBI 版と同構造。差分は:
+- `code_s` に `_normalize_monex_code` を適用してから `validate_code_s`
+- `_ACTION_MAP` のキーが (商品, 取引) タプル
+- `settle_pl` (信用返済のみ) **と** `tate_date`/`tate_price` の両方を返す
+- 除外は **ETF除外 (`ps.is_etf_code`) のみ**。SBI 版の `resolve_stock_name` による
+  ウォッチリスト外除外は**採用しない** (下記「除外方針」参照)
+
+#### 除外方針: ウォッチリスト外除外を使わない理由
+
+SBI 版 (`import_sbi_fills.py:143`) は `resolve_stock_name(code_s)` が空なら投信等として
+スキップする。マネックスは**過去データの一度きりバックフィル**であり、当時売買したが
+現在のウォッチリスト (stocks_shelve/research_shelve) に載っていない銘柄が原理的にありうる。
+それを落とすと実約定が欠落し、ゴール1「有効約定のみを fill 化」・ゴール3「ラウンド損益」が
+成立しない (売りだけ残って建玉が消える等、片肺のエピソードになる)。
+
+サンプルCSVでの実測: 全28コード中、`resolve_stock_name` が空なのは `1540` 純金信託 と
+`1681` 上場ＭＳエマ の2件のみで、**どちらも `is_etf_code` が True**。つまり本サンプルでは
+ETF除外だけで投信も落ちる。ウォッチリスト外除外は効果ゼロで欠落リスクだけを負う。
+
+→ ETF除外のみを採用。ETF_code.txt に無い投信が将来混ざったら dry-run のスキップ一覧で
+気付ける (バックフィルは目視確認前提の一度きり作業)。
+
+#### 統合層
+
+`import_csv_to_fills` は SBI 版とほぼ同一。`ps.create_fill` に
+`broker="マネックス"`, `settle_pl`, `tate_date`, `tate_price` を渡す。
+dedup 空間分離のため `make_dedup_key` の `baibai_kubun` には `f"{商品}/{取引}"` を渡す。
+
+**`settle_pl` と `tate_price` が両方ある場合の損益計算**: `helpers.py:4292-4301` は
+`settle_pl is not None` を優先し、`total_cost` に `tate_price` を使う。つまり
+両方渡すのが最良の組み合わせ (損益=諸経費控除後の実額、コスト=建玉簿価) で、
+既存ロジックの変更は不要。
+
+### 2. `scripts/webapp/routes/trade_history.py` (1分岐追加)
+
+```python
+if rakuten.is_rakuten_csv(tmp_path):
+    module = rakuten
+elif sbi.is_sbi_csv(tmp_path):
+    module = sbi
+elif monex.is_monex_csv(tmp_path):
+    module = monex
+else:
+    flash(f"楽天/SBI/マネックス の取引履歴CSVとして認識できませんでした: {filename}", "error")
+```
+
+判定衝突の確認:
+- 楽天 = 先頭行がヘッダ・28列 → マネックスは先頭行がメタ行なので不一致
+- SBI = ヘッダ行 index>0 かつ **14列** → マネックスは25列なので不一致
+- マネックス = ヘッダ行 index>0 かつ 25列 かつ `建単価` 列あり
+
+3者は排他。エラーメッセージ文言も更新。
+
+### 3. `tests/test_import_monex_fills.py` (新規、4本)
+
+`tests/test_import_sbi_fills.py` の構成を踏襲。**5本以下**の方針に従う。
+
+1. `test_parse_side_and_kind` — parametrize で (商品,取引) 7種 → side/trade_kind
+2. `test_code_normalization_and_etf` — parametrize で `54710`→`5471`, `471A0`→`471A`,
+   `15400`(ETF)→スキップ。あわせて**ウォッチリスト外の非ETFコードが取り込まれる**こと
+   (除外方針の回帰防止) を確認
+3. `test_settle_pl_and_tate_price` — 信用返済行で settle_pl と tate_price が両方入る /
+   信用新規行では settle_pl=None
+4. `test_skip_non_trade_rows_and_dedup` — 税金・入出庫行がスキップされ、
+   再取込が冪等 + broker="マネックス"
+
+### 4. `doc/COMMANDS.md` に `import_monex_fills.py` を追記
+
+楽天/SBI の記載箇所に並べる。
+
+## 実行手順 (バックフィル)
+
+```bash
+source .venv/bin/activate
+cd scripts
+python import_monex_fills.py ~/Downloads/20260101-20260807.csv --dry-run   # 確認
+python import_monex_fills.py ~/Downloads/20260101-20260807.csv            # 本取込
+python show_fill_episodes.py                                              # 検算
+```
+
+サンプルCSV (117データ行) での想定内訳 (実測):
+
+| 区分 | 件数 |
+|---|---|
+| 取込 (fill 化) | **62** |
+| ETF除外 (純金信託・上場ＭＳエマ) | 3 |
+| 非約定スキップ (税金・入出金・入出庫・配当金) | 52 |
+
+`--dry-run` の `imported=62` / `skipped_invalid=55` が期待値。
+
+## スコープ外
+
+- マネックスの継続運用 (現在は未使用、一度きりのバックフィル)
+- 米国株口座 (`振替入金（米国株口座から）` 行はスキップ)
+- 配当金・税金の損益への反映 (既存 fill レイヤーが扱わない)

--- a/scripts/import_monex_fills.py
+++ b/scripts/import_monex_fills.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""マネックス証券 取引履歴CSV → portfolio_shelve fill レイヤー 取込 (issue #390)。
+
+楽天・SBI と同じ fill レイヤーへ取り込むが、マネックスの CSV は列構成・語彙が異なる。
+マネックスは現在利用しておらず、**過去データの一度きりバックフィル**用途。
+
+マネックス CSV の特徴 (Shift-JIS, 25列):
+- 1行目が `データ作成日：YYYY/MM/DD HH:MM:SS` のメタ行。ヘッダは2行目
+- `商品` (信用新規/信用返済/現引/株式) と `取引` (半年新規買い/ご売却 等) の
+  2列の組で売買区分が決まる
+- 銘柄コードは **5桁+パディング空白** (`54710    `)。末尾1桁は付加桁なので落とす
+- 信用返済行は 建約定日・建単価 (楽天と同じ) と 受渡金額=決済損益 (SBI と同じ) の両方を持つ
+- 税金・入出金・入出庫・配当金の行が混在するので、約定行のみ取り込む
+- ETF (成長株ウォッチリスト外) は取込対象外 (issue #387)
+
+楽天との共通処理 (_parse_num / _normalize_trade_date / RowSkip) は
+import_rakuten_fills から再利用する (SBI 版と同じ依存の張り方)。
+"""
+
+import argparse
+import csv
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import portfolio_shelve as ps  # noqa: E402
+from import_rakuten_fills import RowSkip, _normalize_trade_date, _parse_num  # noqa: E402
+
+try:
+    from ks_util import log_print, log_warning
+except ImportError:
+    def log_print(*args, **kwargs):
+        print(*args, **kwargs)
+
+    def log_warning(*args, **kwargs):
+        print("WARNING:", *args, **kwargs)
+
+
+# ===========================================
+# 定数 (マネックス 取引履歴CSV フォーマット)
+# ===========================================
+
+CSV_ENCODING = "shift_jis"
+EXPECTED_COL_COUNT = 25
+
+# 列インデックス (0-indexed、実CSVで確認済み)
+COL_TRADE_DATE = 0     # 約定日 (YYYY/MM/DD)
+COL_PRODUCT = 3        # 商品 (信用新規 / 信用返済 / 現引 / 株式)
+COL_ACTION = 4         # 取引 (半年新規買い / 半年返済売り / お買付 / ご売却 ...)
+COL_CODE_S = 5         # 銘柄コード (5桁+空白)
+COL_QTY = 7            # 数量（株/口）/返済数量
+COL_PRICE = 8          # 単価/返済約定単価
+COL_AMOUNT = 12        # 受渡金額(円) — 信用返済行では決済損益
+COL_TATE_DATE = 13     # 建約定日 (信用返済/現引行のみ)
+COL_TATE_PRICE = 14    # 建単価 (信用返済/現引行のみ)
+
+HEADER_FIRST_COL = "約定日"
+HEADER_MARKER = "建単価"  # 楽天/SBI に無い列名。ヘッダ行の同定に使う
+
+# (商品, 取引) → (side, 楽天互換の trade_kind)。
+# trade_kind を楽天語彙に合わせることで売買履歴タブの集約・表示を一貫させる。
+# ここに無い組合せ (税金・入出金・入出庫・配当金) は約定でないので RowSkip される。
+_ACTION_MAP = {
+    ("信用新規", "半年新規買い"): ("buy", "信用新規"),
+    ("信用新規", "半年新規売り"): ("sell", "信用新規"),
+    ("信用返済", "半年返済売り"): ("sell", "信用返済"),
+    ("信用返済", "半年返済買い"): ("buy", "信用返済"),
+    ("現引", "半年現引"): ("buy", "現引"),
+    ("株式", "お買付"): ("buy", "現物"),
+    ("株式", "ご売却"): ("sell", "現物"),
+}
+
+# 受渡金額列が決済損益になる取引 (信用返済のみ)。
+# 現引は建玉の現物化で損益確定しないため含めない。
+_SETTLE_ACTIONS = frozenset({
+    ("信用返済", "半年返済売り"),
+    ("信用返済", "半年返済買い"),
+})
+
+# 現引 (建玉の現物化)。損益は確定しないが建約定日・建単価は持つ
+PRODUCT_GENBIKI = "現引"
+
+BROKER = "マネックス"
+
+
+# ===========================================
+# 1. CSV 読込層
+# ===========================================
+
+def _find_header_row(rows: List[List[str]]) -> int:
+    """ヘッダ行 (`約定日,...,建単価,...`) の index を返す。無ければ -1。"""
+    for i, row in enumerate(rows):
+        if row and row[0].strip() == HEADER_FIRST_COL and HEADER_MARKER in [c.strip() for c in row]:
+            return i
+    return -1
+
+
+def is_monex_csv(csv_path: str) -> bool:
+    """CSV がマネックス 取引履歴CSV 形式か判定する。
+
+    楽天 (先頭行ヘッダ・28列) / SBI (メタ行+14列) とは列数と `建単価` 列の有無で区別する。
+    """
+    try:
+        with open(csv_path, "r", encoding=CSV_ENCODING, newline="") as f:
+            rows = list(csv.reader(f))
+    except (OSError, UnicodeDecodeError):
+        return False
+    hi = _find_header_row(rows)
+    return hi >= 0 and len(rows[hi]) == EXPECTED_COL_COUNT
+
+
+def read_csv_rows(csv_path: str) -> List[List[str]]:
+    """マネックス 取引履歴CSV を Shift-JIS で読み、ヘッダ行以降のデータ行を返す。
+
+    冒頭の `データ作成日：...` メタ行を読み飛ばし、ヘッダ行を探す。
+    ヘッダが見つからなければ ValueError。
+    """
+    with open(csv_path, "r", encoding=CSV_ENCODING, newline="") as f:
+        rows = list(csv.reader(f))
+    hi = _find_header_row(rows)
+    if hi < 0:
+        raise ValueError(f"ヘッダ行 (約定日...建単価) が見つかりません: {csv_path}")
+    return rows[hi + 1:]
+
+
+# ===========================================
+# 2. 行パース層
+# ===========================================
+
+def _normalize_monex_code(raw: str) -> str:
+    """マネックスの5桁銘柄コード (`54710    `) を4桁 code_s (`5471`) に変換する。
+
+    末尾1桁は付加桁 (`471A0` → `471A`)。5桁かつ末尾が 0 のときだけ落とし、
+    それ以外はそのまま返して後段の validate_code_s に判定を委ねる。
+    """
+    s = (raw or "").strip().upper()
+    return s[:-1] if len(s) == 5 and s.endswith("0") else s
+
+
+def parse_fill_row(row: List[str]) -> Dict[str, Any]:
+    """マネックス CSV 1 行を fill 構築用の中間 dict に変換する。
+
+    約定でない行 (税金・入出金・入出庫・配当金) と ETF は RowSkip。空行・列数不足も RowSkip。
+    """
+    if not any(c.strip() for c in row):
+        raise RowSkip("空行")
+    if len(row) < EXPECTED_COL_COUNT:
+        raise RowSkip(f"列数不足 ({len(row)})")
+
+    # 先に取引区分を見る (税金・入出金行は銘柄コードも空なので、より的確な理由を出せる)
+    product = (row[COL_PRODUCT] or "").strip()
+    action = (row[COL_ACTION] or "").strip()
+    mapped = _ACTION_MAP.get((product, action))
+    if mapped is None:
+        raise RowSkip(f"約定行でない/未知の取引区分: {product!r}/{action!r}")
+    side, trade_kind = mapped
+
+    code_s = _normalize_monex_code(row[COL_CODE_S])
+    try:
+        ps.validate_code_s(code_s)
+    except (ValueError, TypeError):
+        raise RowSkip(f"無効な銘柄コード: {row[COL_CODE_S]!r}")
+
+    # ETF は株式分析の対象外なので取込まない (issue #387)。
+    # なお SBI 版の resolve_stock_name によるウォッチリスト外除外は、過去バックフィルで
+    # 当時売買した銘柄を落としてしまうため本スクリプトでは採用しない (issue #390)。
+    if ps.is_etf_code(code_s):
+        raise RowSkip(f"ETF のため対象外: {code_s}")
+
+    trade_date = _normalize_trade_date(row[COL_TRADE_DATE])
+    if trade_date is None:
+        raise RowSkip(f"約定日パース不可: {row[COL_TRADE_DATE]!r}")
+
+    qty_f = _parse_num(row[COL_QTY])
+    price_f = _parse_num(row[COL_PRICE])
+    if qty_f is None or qty_f <= 0:
+        raise RowSkip(f"数量欠落/不正: {row[COL_QTY]!r}")
+    if price_f is None or price_f <= 0:
+        raise RowSkip(f"単価欠落/不正: {row[COL_PRICE]!r}")
+
+    amount_f = _parse_num(row[COL_AMOUNT])
+    amount = int(amount_f) if amount_f is not None else 0
+    # 信用返済行の受渡金額列は諸経費控除後の「決済損益」。P/L の真実源として持たせる
+    settle_pl = amount if (product, action) in _SETTLE_ACTIONS else None
+
+    # 建約定日・建単価 (信用返済/現引行のみ)。信用ラウンドの建玉コスト算出に使う。
+    # 信用新規行にも同じ列が埋まっているが、そこは自身の約定日・単価のエコーで情報量が無く、
+    # 「建玉を持っていた」という誤った意味を持たせないため決済側の行に限って取り込む。
+    if (product, action) in _SETTLE_ACTIONS or product == PRODUCT_GENBIKI:
+        tate_date = _normalize_trade_date(row[COL_TATE_DATE])
+        tate_price_f = _parse_num(row[COL_TATE_PRICE])
+        tate_price = tate_price_f if (tate_price_f is not None and tate_price_f > 0) else None
+    else:
+        tate_date = None
+        tate_price = None
+
+    return {
+        "code_s": code_s,
+        "trade_date": trade_date,
+        "side": side,
+        "qty": int(qty_f),
+        "price": price_f,
+        "amount": amount,
+        "trade_kind": trade_kind,
+        "action": f"{product}/{action}",  # dedup 素材 (元の区分)
+        "settle_pl": settle_pl,
+        "tate_date": tate_date,
+        "tate_price": tate_price,
+    }
+
+
+# ===========================================
+# 3. 統合層
+# ===========================================
+
+def import_csv_to_fills(
+    csv_path: str,
+    *,
+    dry_run: bool = False,
+    db_path: Optional[str] = None,
+) -> Dict[str, int]:
+    """マネックス CSV を読み、各行を fill として冪等取込する。
+
+    Returns: {"rows", "imported", "skipped_dup", "skipped_invalid"}
+    """
+    rows = read_csv_rows(csv_path)
+    stats = {"rows": len(rows), "imported": 0, "skipped_dup": 0, "skipped_invalid": 0}
+    occurrence_counter: Dict[str, int] = {}
+    samples: List[Dict[str, Any]] = []
+
+    for row in rows:
+        try:
+            parsed = parse_fill_row(row)
+        except RowSkip as e:
+            stats["skipped_invalid"] += 1
+            log_print("import_monex_fills: スキップ", e.reason)
+            continue
+
+        # occurrence: 同一CSV内で dedup 素材が同一な行の出現順 (分割約定を別 fill に)
+        occ_key = "|".join(
+            [
+                parsed["trade_date"],
+                parsed["code_s"],
+                parsed["trade_kind"],
+                parsed["action"],
+                str(parsed["qty"]),
+                f"{parsed['price']:.4f}",
+                str(parsed["amount"]),
+            ]
+        )
+        occurrence = occurrence_counter.get(occ_key, 0)
+        occurrence_counter[occ_key] = occurrence + 1
+
+        # baibai_kubun にはマネックスの元区分 (商品/取引) を渡し、楽天・SBI と dedup 空間を分ける
+        dedup_key = ps.make_dedup_key(
+            trade_date=parsed["trade_date"],
+            code_s=parsed["code_s"],
+            trade_kind=parsed["trade_kind"],
+            baibai_kubun=parsed["action"],
+            qty=parsed["qty"],
+            price=parsed["price"],
+            amount=parsed["amount"],
+            occurrence=occurrence,
+        )
+        fill = ps.create_fill(
+            parsed["code_s"],
+            trade_date=parsed["trade_date"],
+            side=parsed["side"],
+            qty=parsed["qty"],
+            price=parsed["price"],
+            amount=parsed["amount"],
+            trade_kind=parsed["trade_kind"],
+            dedup_key=dedup_key,
+            broker=BROKER,
+            settle_pl=parsed["settle_pl"],
+            tate_date=parsed["tate_date"],
+            tate_price=parsed["tate_price"],
+        )
+
+        if dry_run:
+            if len(samples) < 3:
+                samples.append(fill)
+            stats["imported"] += 1
+            continue
+
+        _, is_new = ps.append_fill(fill, db_path=db_path)
+        if is_new:
+            stats["imported"] += 1
+        else:
+            stats["skipped_dup"] += 1
+
+    if dry_run and samples:
+        log_print("import_monex_fills: dry-run サンプル (先頭 3 件):")
+        for s in samples:
+            log_print(
+                f"  {s['code_s']} {s['trade_date']} {s['side']} "
+                f"qty={s['qty']} price={s['price']} kind={s['trade_kind']} "
+                f"settle_pl={s['settle_pl']} tate_price={s['tate_price']}"
+            )
+    return stats
+
+
+# ===========================================
+# 4. 実行層
+# ===========================================
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="マネックス証券 取引履歴CSV を fill レイヤーへ取込 (issue #390)",
+    )
+    parser.add_argument("csv_path", help="マネックス 取引履歴CSV のパス (Shift-JIS)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="読込・パースまで行うが DB へは書かない",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="portfolio_shelve のパス上書き (検証用)",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    if not os.path.exists(args.csv_path):
+        log_warning(f"CSV が見つかりません: {args.csv_path}")
+        return 1
+
+    stats = import_csv_to_fills(
+        args.csv_path,
+        dry_run=args.dry_run,
+        db_path=args.db_path,
+    )
+    log_print(
+        "import_monex_fills: 取込完了",
+        f"rows={stats['rows']}",
+        f"imported={stats['imported']}",
+        f"skipped_dup={stats['skipped_dup']}",
+        f"skipped_invalid={stats['skipped_invalid']}",
+        "(dry-run)" if args.dry_run else "",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import_monex_fills.py
+++ b/scripts/import_monex_fills.py
@@ -21,7 +21,7 @@ import argparse
 import csv
 import os
 import sys
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _THIS_DIR not in sys.path:
@@ -74,14 +74,9 @@ _ACTION_MAP = {
     ("株式", "ご売却"): ("sell", "現物"),
 }
 
-# 受渡金額列が決済損益になる取引 (信用返済のみ)。
-# 現引は建玉の現物化で損益確定しないため含めない。
-_SETTLE_ACTIONS = frozenset({
-    ("信用返済", "半年返済売り"),
-    ("信用返済", "半年返済買い"),
-})
-
-# 現引 (建玉の現物化)。損益は確定しないが建約定日・建単価は持つ
+# 商品列の値。_ACTION_MAP を通った後は商品だけで取引の性質が決まる。
+# 信用返済 = 受渡金額列が決済損益。現引 = 建玉の現物化 (損益は確定しないが建単価は持つ)。
+PRODUCT_SETTLE = "信用返済"
 PRODUCT_GENBIKI = "現引"
 
 BROKER = "マネックス"
@@ -134,11 +129,11 @@ def read_csv_rows(csv_path: str) -> List[List[str]]:
 def _normalize_monex_code(raw: str) -> str:
     """マネックスの5桁銘柄コード (`54710    `) を4桁 code_s (`5471`) に変換する。
 
-    末尾1桁は付加桁 (`471A0` → `471A`)。5桁かつ末尾が 0 のときだけ落とし、
-    それ以外はそのまま返して後段の validate_code_s に判定を委ねる。
+    末尾1桁は付加桁 (`471A0` → `471A`)。5桁以外はそのまま返し、
+    正否の判定は後段の validate_code_s に委ねる。
     """
     s = (raw or "").strip().upper()
-    return s[:-1] if len(s) == 5 and s.endswith("0") else s
+    return s[:-1] if len(s) == 5 else s
 
 
 def parse_fill_row(row: List[str]) -> Dict[str, Any]:
@@ -184,19 +179,19 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
 
     amount_f = _parse_num(row[COL_AMOUNT])
     amount = int(amount_f) if amount_f is not None else 0
-    # 信用返済行の受渡金額列は諸経費控除後の「決済損益」。P/L の真実源として持たせる
-    settle_pl = amount if (product, action) in _SETTLE_ACTIONS else None
+    # 信用返済行の受渡金額列は諸経費控除後の「決済損益」。P/L の真実源として持たせる。
+    # パース不能時は 0 (損益ゼロ) と区別できないので None (不明) のままにする。
+    settle_pl = int(amount_f) if (product == PRODUCT_SETTLE and amount_f is not None) else None
 
     # 建約定日・建単価 (信用返済/現引行のみ)。信用ラウンドの建玉コスト算出に使う。
     # 信用新規行にも同じ列が埋まっているが、そこは自身の約定日・単価のエコーで情報量が無く、
     # 「建玉を持っていた」という誤った意味を持たせないため決済側の行に限って取り込む。
-    if (product, action) in _SETTLE_ACTIONS or product == PRODUCT_GENBIKI:
+    tate_date = tate_price = None
+    if product in (PRODUCT_SETTLE, PRODUCT_GENBIKI):
         tate_date = _normalize_trade_date(row[COL_TATE_DATE])
         tate_price_f = _parse_num(row[COL_TATE_PRICE])
-        tate_price = tate_price_f if (tate_price_f is not None and tate_price_f > 0) else None
-    else:
-        tate_date = None
-        tate_price = None
+        if tate_price_f is not None and tate_price_f > 0:
+            tate_price = tate_price_f
 
     return {
         "code_s": code_s,
@@ -206,7 +201,9 @@ def parse_fill_row(row: List[str]) -> Dict[str, Any]:
         "price": price_f,
         "amount": amount,
         "trade_kind": trade_kind,
-        "action": f"{product}/{action}",  # dedup 素材 (元の区分)
+        # dedup 素材。side が dedup キーに入らないため、同日同数量同単価の
+        # 新規買 / 新規売 を区別できるよう商品と取引を連結した元区分を持たせる
+        "kubun": f"{product}/{action}",
         "settle_pl": settle_pl,
         "tate_date": tate_date,
         "tate_price": tate_price,
@@ -246,7 +243,7 @@ def import_csv_to_fills(
                 parsed["trade_date"],
                 parsed["code_s"],
                 parsed["trade_kind"],
-                parsed["action"],
+                parsed["kubun"],
                 str(parsed["qty"]),
                 f"{parsed['price']:.4f}",
                 str(parsed["amount"]),
@@ -260,7 +257,7 @@ def import_csv_to_fills(
             trade_date=parsed["trade_date"],
             code_s=parsed["code_s"],
             trade_kind=parsed["trade_kind"],
-            baibai_kubun=parsed["action"],
+            baibai_kubun=parsed["kubun"],
             qty=parsed["qty"],
             price=parsed["price"],
             amount=parsed["amount"],

--- a/scripts/import_monex_fills.py
+++ b/scripts/import_monex_fills.py
@@ -129,11 +129,13 @@ def read_csv_rows(csv_path: str) -> List[List[str]]:
 def _normalize_monex_code(raw: str) -> str:
     """マネックスの5桁銘柄コード (`54710    `) を4桁 code_s (`5471`) に変換する。
 
-    末尾1桁は付加桁 (`471A0` → `471A`)。5桁以外はそのまま返し、
-    正否の判定は後段の validate_code_s に委ねる。
+    末尾1桁は付加桁で、確認済みのマネックス形式では常に `0` (`471A0` → `471A`)。
+    末尾が `0` の5桁のときだけ落とす。`54711` のような想定外の値まで切り詰めると
+    `5471` として validate_code_s を通り、別銘柄の fill として保存されてしまうため、
+    そのまま返して無効コードとしてスキップさせる。
     """
     s = (raw or "").strip().upper()
-    return s[:-1] if len(s) == 5 else s
+    return s[:-1] if len(s) == 5 and s.endswith("0") else s
 
 
 def parse_fill_row(row: List[str]) -> Dict[str, Any]:

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -21,6 +21,7 @@ from flask import (
     url_for,
 )
 
+import import_monex_fills as monex
 import import_rakuten_fills as rakuten
 import import_sbi_fills as sbi
 import portfolio_shelve as ps
@@ -285,13 +286,19 @@ def import_trade_csv():
     try:
         file.save(tmp_path)
 
-        # ヘッダ自動判定 (楽天=先頭行が約定日ヘッダ / SBI=冒頭メタ行+銘柄コード列)
+        # ヘッダ自動判定 (楽天=先頭行が約定日ヘッダ28列 / SBI=メタ行+14列 /
+        # マネックス=メタ行+25列+建単価列)。列数が異なるので3者は排他。
         if rakuten.is_rakuten_csv(tmp_path):
             module = rakuten
         elif sbi.is_sbi_csv(tmp_path):
             module = sbi
+        elif monex.is_monex_csv(tmp_path):
+            module = monex
         else:
-            flash(f"楽天/SBI の取引履歴CSVとして認識できませんでした: {filename}", "error")
+            flash(
+                f"楽天/SBI/マネックス の取引履歴CSVとして認識できませんでした: {filename}",
+                "error",
+            )
             return redirect(url_for("trade_history.trade_history"))
 
         try:

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -30,7 +30,7 @@
 
 {# 説明 + CSV取込 (issue #387 4a): 普段は「＋CSV取込」リンクのみ、クリックで展開 (details) #}
 <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1em;margin-bottom:0.6em;">
-  <p style="color:#888;font-size:0.85em;margin:0;cursor:help;" title="損益は現物=平均取得単価法、信用=建単価/決済損益。">楽天・SBI証券CSVの実約定を建玉ラウンド単位のエピソードにまとめています。行をクリックで内訳の個別約定を展開。</p>
+  <p style="color:#888;font-size:0.85em;margin:0;cursor:help;" title="損益は現物=平均取得単価法、信用=建単価/決済損益。">楽天・SBI・マネックス証券CSVの実約定を建玉ラウンド単位のエピソードにまとめています。行をクリックで内訳の個別約定を展開。</p>
   <div style="flex-shrink:0;display:flex;flex-direction:column;align-items:flex-end;gap:0.3em;">
     {# 取込済み最新約定日 (次回インポートの参考、取込のたびに更新) issue #387。
        title に最古〜最新のフルレンジをツールチップ表示 #}
@@ -39,7 +39,7 @@
       取込済み最新:
       {# 取込済みの証券会社だけを先に絞ってから回す。固定リストで loop.last を見ると
          楽天のみ取込のとき末尾に区切りの / が残る (レビュー対応) #}
-      {% set shown = ["楽天", "SBI"] | select("in", broker_ranges) | list %}
+      {% set shown = ["楽天", "SBI", "マネックス"] | select("in", broker_ranges) | list %}
       {% for broker in shown %}
         <span style="color:#aaa;" title="取込済み: {{ broker_ranges[broker].first }} 〜 {{ broker_ranges[broker].last }}">{{ broker }} {{ broker_ranges[broker].last[5:] }}</span>{% if not loop.last %} / {% endif %}
       {% endfor %}
@@ -48,7 +48,7 @@
   <details>
     <summary style="color:#9ed8f0;font-size:0.82em;cursor:pointer;white-space:nowrap;list-style:none;">＋ CSV取込</summary>
     <form method="post" action="/trade-history/import" enctype="multipart/form-data"
-          title="楽天・SBI の取引履歴CSVを自動判別して取り込みます"
+          title="楽天・SBI・マネックス の取引履歴CSVを自動判別して取り込みます"
           style="display:flex;align-items:center;gap:0.5em;margin-top:0.5em;padding:0.4em 0.6em;background:rgba(255,255,255,0.03);border:1px solid #333;border-radius:5px;">
       <input type="file" name="csv_file" accept=".csv" required
              style="font-size:0.78em;color:#aaa;width:18em;">

--- a/tests/test_import_monex_fills.py
+++ b/tests/test_import_monex_fills.py
@@ -45,44 +45,42 @@ def db_path(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "product,action,exp_side,exp_kind",
+    "product,action,exp_side,exp_kind,exp_tate",
     [
-        ("信用新規", "半年新規買い", "buy", "信用新規"),
-        ("信用新規", "半年新規売り", "sell", "信用新規"),
-        ("信用返済", "半年返済売り", "sell", "信用返済"),
-        ("信用返済", "半年返済買い", "buy", "信用返済"),
-        ("現引", "半年現引", "buy", "現引"),
-        ("株式", "お買付", "buy", "現物"),
-        ("株式", "ご売却", "sell", "現物"),
+        # 建約定日・建単価は決済側 (信用返済/現引) の行だけ取り込む。信用新規行では
+        # 同じ列に自身の約定日・単価がエコーされているだけなので捨てる。
+        ("信用新規", "半年新規買い", "buy", "信用新規", False),
+        ("信用新規", "半年新規売り", "sell", "信用新規", False),
+        ("信用返済", "半年返済売り", "sell", "信用返済", True),
+        ("信用返済", "半年返済買い", "buy", "信用返済", True),
+        ("現引", "半年現引", "buy", "現引", True),
+        ("株式", "お買付", "buy", "現物", False),
+        ("株式", "ご売却", "sell", "現物", False),
     ],
 )
-def test_parse_side_and_kind(product, action, exp_side, exp_kind):
-    """(商品,取引) の組から side と楽天互換 trade_kind を正規化する。
-
-    信用新規行は建約定日・建単価の列が自身の約定日・単価のエコーになっているため、
-    決済側の行以外では取り込まないことも確認する。
-    """
+def test_parse_side_kind_and_tate(product, action, exp_side, exp_kind, exp_tate):
+    """(商品,取引) の組から side / trade_kind / 建単価の取込可否を正規化する。"""
     parsed = imf.parse_fill_row(
         _row("54710", product, action, "200", "1,888", "0",
              tate_date="2026/01/09", tate_price="1,888")
     )
     assert parsed["side"] == exp_side
     assert parsed["trade_kind"] == exp_kind
-    if exp_kind == "信用新規":
-        assert parsed["tate_price"] is None and parsed["tate_date"] is None
+    assert (parsed["tate_price"] is not None) is exp_tate
+    assert (parsed["tate_date"] is not None) is exp_tate
 
 
 @pytest.mark.parametrize(
     "raw_code,exp_code_s",
     [
-        ("54710", "5471"),   # 数字4桁+付加桁
-        ("471A0", "471A"),   # 英字混じり4文字+付加桁
+        ("54710    ", "5471"),  # 数字4桁+付加桁 (実CSVは空白パディング付き)
+        ("471A0", "471A"),      # 英字混じり4文字+付加桁
+        ("5471", "5471"),       # 5桁でなければそのまま
     ],
 )
 def test_code_normalization(raw_code, exp_code_s):
     """5桁銘柄コードの末尾付加桁を落として4文字 code_s にする。"""
-    parsed = imf.parse_fill_row(_row(raw_code, "信用新規", "半年新規買い", "100", "1,000", "0"))
-    assert parsed["code_s"] == exp_code_s
+    assert imf._normalize_monex_code(raw_code) == exp_code_s
 
 
 def test_etf_excluded_but_non_watchlist_stock_imported(tmp_path, db_path):

--- a/tests/test_import_monex_fills.py
+++ b/tests/test_import_monex_fills.py
@@ -10,6 +10,7 @@ import pytest
 
 import import_monex_fills as imf
 import portfolio_shelve as ps
+from import_rakuten_fills import RowSkip
 
 # マネックス CSV の冒頭メタ行 + 本ヘッダ (実ファイル構造の縮図)
 _META = [["データ作成日：2026/08/09 15:15:44"]]
@@ -37,6 +38,16 @@ def _write_csv(path, data_rows):
         for r in data_rows:
             w.writerow(r)
     return str(path)
+
+
+@pytest.fixture(autouse=True)
+def etf_codes(monkeypatch):
+    """ETF 判定を固定する。
+
+    `data/ETF_code.txt` は git 管理外で CI には存在しないため、実ファイルに依存すると
+    ETF 除外が効かずテストが落ちる。1540 (純金信託) を ETF として固定する。
+    """
+    monkeypatch.setattr(ps, "_etf_codes_cache", frozenset({"1540"}))
 
 
 @pytest.fixture
@@ -76,11 +87,20 @@ def test_parse_side_kind_and_tate(product, action, exp_side, exp_kind, exp_tate)
         ("54710    ", "5471"),  # 数字4桁+付加桁 (実CSVは空白パディング付き)
         ("471A0", "471A"),      # 英字混じり4文字+付加桁
         ("5471", "5471"),       # 5桁でなければそのまま
+        # 末尾が 0 以外の5桁は切り詰めない。切り詰めると 5471 として
+        # validate_code_s を通り、別銘柄の fill になってしまう
+        ("54711", "54711"),
     ],
 )
 def test_code_normalization(raw_code, exp_code_s):
     """5桁銘柄コードの末尾付加桁を落として4文字 code_s にする。"""
     assert imf._normalize_monex_code(raw_code) == exp_code_s
+
+
+def test_unexpected_5digit_code_is_skipped():
+    """末尾が 0 以外の5桁コードは無効として弾く (別銘柄への誤取込を防ぐ)。"""
+    with pytest.raises(RowSkip):
+        imf.parse_fill_row(_row("54711", "信用新規", "半年新規買い", "100", "1,000", "0"))
 
 
 def test_etf_excluded_but_non_watchlist_stock_imported(tmp_path, db_path):

--- a/tests/test_import_monex_fills.py
+++ b/tests/test_import_monex_fills.py
@@ -1,0 +1,127 @@
+"""import_monex_fills.py のテスト (issue #390)。
+
+マネックス証券 取引履歴CSV の fill 取込・(商品,取引) の正規化・5桁銘柄コード変換・
+決済損益/建単価の保存・非約定行スキップ・冪等 dedup を検証する。
+"""
+
+import csv
+
+import pytest
+
+import import_monex_fills as imf
+import portfolio_shelve as ps
+
+# マネックス CSV の冒頭メタ行 + 本ヘッダ (実ファイル構造の縮図)
+_META = [["データ作成日：2026/08/09 15:15:44"]]
+_HEADER = ["約定日", "受渡日", "口座", "商品", "取引", "銘柄コード", "銘柄名",
+           "数量（株/口）/返済数量", "単価/返済約定単価", "手数料",
+           "税金(手数料消費税及び譲渡益税)", "利金・分配金・償還金", "受渡金額(円)",
+           "建約定日", "建単価", "建約定金額", "建手数料", "建手数料消費税",
+           "事務管理費", "名義書換料", "順日歩", "逆日歩", "貸株料", "諸経費", "備考"]
+
+
+def _row(code_s, product, action, qty, price, amount,
+         trade_date="2026/01/09", tate_date="", tate_price="", name="銘柄"):
+    """マネックス CSV の1行を組み立てる (銘柄コードは実CSV同様に空白パディング)。"""
+    return [trade_date, "2026/01/14", "特定", product, action, f"{code_s}    ", name,
+            qty, price, "0", "0", "0", amount,
+            tate_date, tate_price, "", "0", "0", "", "", "", "", "0", "", ""]
+
+
+def _write_csv(path, data_rows):
+    with open(path, "w", encoding="shift_jis", newline="") as f:
+        w = csv.writer(f)
+        for r in _META:
+            w.writerow(r)
+        w.writerow(_HEADER)
+        for r in data_rows:
+            w.writerow(r)
+    return str(path)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "monex_fills")
+
+
+@pytest.mark.parametrize(
+    "product,action,exp_side,exp_kind",
+    [
+        ("信用新規", "半年新規買い", "buy", "信用新規"),
+        ("信用新規", "半年新規売り", "sell", "信用新規"),
+        ("信用返済", "半年返済売り", "sell", "信用返済"),
+        ("信用返済", "半年返済買い", "buy", "信用返済"),
+        ("現引", "半年現引", "buy", "現引"),
+        ("株式", "お買付", "buy", "現物"),
+        ("株式", "ご売却", "sell", "現物"),
+    ],
+)
+def test_parse_side_and_kind(product, action, exp_side, exp_kind):
+    """(商品,取引) の組から side と楽天互換 trade_kind を正規化する。
+
+    信用新規行は建約定日・建単価の列が自身の約定日・単価のエコーになっているため、
+    決済側の行以外では取り込まないことも確認する。
+    """
+    parsed = imf.parse_fill_row(
+        _row("54710", product, action, "200", "1,888", "0",
+             tate_date="2026/01/09", tate_price="1,888")
+    )
+    assert parsed["side"] == exp_side
+    assert parsed["trade_kind"] == exp_kind
+    if exp_kind == "信用新規":
+        assert parsed["tate_price"] is None and parsed["tate_date"] is None
+
+
+@pytest.mark.parametrize(
+    "raw_code,exp_code_s",
+    [
+        ("54710", "5471"),   # 数字4桁+付加桁
+        ("471A0", "471A"),   # 英字混じり4文字+付加桁
+    ],
+)
+def test_code_normalization(raw_code, exp_code_s):
+    """5桁銘柄コードの末尾付加桁を落として4文字 code_s にする。"""
+    parsed = imf.parse_fill_row(_row(raw_code, "信用新規", "半年新規買い", "100", "1,000", "0"))
+    assert parsed["code_s"] == exp_code_s
+
+
+def test_etf_excluded_but_non_watchlist_stock_imported(tmp_path, db_path):
+    """ETF は除外するが、ウォッチリスト外の個別株は取り込む (issue #390 バックフィル方針)。
+
+    SBI 版のような resolve_stock_name による除外を入れると、過去に売買しただけで
+    現在ウォッチリストに無い銘柄の約定が欠落するため、ETF 除外のみとしている。
+    """
+    rows = [
+        # 1540 純金信託 = ETF_code.txt 掲載 → 除外
+        _row("15400", "株式", "ご売却", "10", "23,440", "234,125", name="純金信託"),
+        # ウォッチリストに登録していない個別株 → 取り込まれること
+        _row("98800", "株式", "ご売却", "100", "1,500", "149,725", name="イノテック"),
+    ]
+    csv_path = _write_csv(tmp_path / "monex.csv", rows)
+    stats = imf.import_csv_to_fills(csv_path, db_path=db_path)
+    assert stats["imported"] == 1
+    assert stats["skipped_invalid"] == 1
+    assert len(ps.list_fills("1540", db_path=db_path)) == 0
+    assert len(ps.list_fills("9880", db_path=db_path)) == 1
+
+
+def test_skip_non_trade_rows_and_dedup(tmp_path, db_path):
+    """税金・入出庫行はスキップし、信用返済は settle_pl と建単価を保持。再取込は冪等。"""
+    rows = [
+        _row("", "", "源泉徴収税（所得税）", "0", "0", "7,036"),
+        _row("15400", "株式", "入庫", "10", "24,480", "0", name="純金信託"),
+        _row("54710", "信用返済", "半年返済売り", "200", "2,165", "54,831",
+             trade_date="2026/01/15", tate_date="2026/01/09", tate_price="1,888"),
+    ]
+    csv_path = _write_csv(tmp_path / "monex.csv", rows)
+    s1 = imf.import_csv_to_fills(csv_path, db_path=db_path)
+    assert s1["imported"] == 1 and s1["skipped_invalid"] == 2
+
+    s2 = imf.import_csv_to_fills(csv_path, db_path=db_path)
+    assert s2["imported"] == 0 and s2["skipped_dup"] == 1
+
+    f = ps.list_fills("5471", db_path=db_path)[0]
+    assert f["broker"] == "マネックス"
+    assert f["settle_pl"] == 54831       # 受渡金額 = 諸経費控除後の決済損益
+    assert f["tate_price"] == 1888
+    assert f["tate_date"] == "2026-01-09"


### PR DESCRIPTION
Closes #390

## Summary

- マネックス証券の取引履歴CSVパーサー `import_monex_fills.py` を追加し、楽天・SBI と同じ fill レイヤーへ取り込めるようにした
- `/trade-history/import` の証券会社自動判別に `is_monex_csv` を追加 (楽天=28列 / SBI=14列 / マネックス=25列 で排他)
- 実CSV (2026-01〜08, 117行) のバックフィルを実施済み

## 実CSVから判明した仕様

issue 本文では「信用取引の建約定日・建単価・決済損益がCSVに含まれるか要確認」としていたが、**両方とも含まれていた**ため、信用も損益算出対象にできた。

| 項目 | 内容 |
|---|---|
| 建約定日・建単価 | 信用返済行にあり (楽天と同じ) |
| 受渡金額 | 信用返済行では諸経費控除後の決済損益 (SBI の `settle_pl` と同じ) |
| 銘柄コード | **5桁+空白パディング** (`54710`) → 末尾の付加桁を落として4文字 `code_s` に正規化 |

`settle_pl` と `tate_price` を両方渡すことで、既存の損益ロジック (`helpers.py`) は**無改修**のまま損益=実額・コスト=建玉簿価で計算される。

## 設計判断

- **除外は ETF のみ**。SBI 版の `resolve_stock_name` によるウォッチリスト外除外は採用しなかった。過去バックフィルでは「当時売買したが現在ウォッチリストに無い銘柄」が落ちて片肺エピソードになるため (codex レビュー指摘)。実データでは非ETFの26銘柄すべてが解決可能で、除外効果はゼロだった
- **建約定日・建単価は決済側の行のみ取込む**。信用新規行にも同じ列が埋まっているが、自身の約定日・単価のエコーで情報量が無く、「建玉を持っていた」という誤った意味を与えるため

## Test plan

- [x] `pytest tests/test_import_monex_fills.py` — 12 passed
- [x] 関連スイート (rakuten/sbi/fill_episodes/webapp_routes) — 177 passed
- [x] 全体 `pytest tests/ -m "not local_db and not live_html"` — 2110 passed
- [x] 実CSV取込: `imported=62 / skipped_invalid=55` (税金・入出金・入出庫・配当金・ETFを除外)
- [x] **損益突合**: 信用返済30件の決済損益合計が DB `-32,405`円 = CSV集計 `-32,405`円 で一致
- [x] エピソード検算 (`show_fill_episodes.py 5471`): 建1,888→返済2,165 で実現 +54,831円、同一銘柄の楽天ラウンドと干渉せず別エピソードとして表示
- [x] 再取込が冪等 (`imported=0 / skipped_dup=62`)
- [x] Web UI 取込: マネックスと自動判別され flash 正常
- [x] ブラウザ実機確認: 取込レンジに3社表示、エピソード内訳に `マネックス` タグ付きで個別約定が展開される
- [x] 証券会社をまたぐ建玉ラウンドの合流を確認 (4417: マネックスで建て→楽天で返済が1エピソードに繋がる)
- [x] 判別衝突なし: 実際の楽天/SBI/マネックス CSV 3種で相互に誤検知しないことを確認

> [!NOTE]
> `tests/test_webapp_helpers.py::TestSignalDisplay::test_resolve_markers_x_interp_and_drop` が1件失敗するが、**本PRの変更を stash した状態でも main で同様に失敗する既存の失敗**で、本PRとは無関係。

## 追加修正 (3コミット目)

ブラウザ実機確認の結果、`trade_history.html` の取込レンジが `["楽天", "SBI"]` 固定で、マネックス取込後も UI に出ていなかった。バックエンド (`fill_date_range_by_broker`) は3社返していたためテンプレートのみ修正。

- 取込レンジの対象に `"マネックス"` を追加
- 説明文・CSV取込フォームの tooltip を3社表記に

## 備考

- DB書込前に `portfolio_shelve.{dat,dir,bak}.bak_issue390_20260809_154545` をバックアップ済み
- simplify レビュー (4観点) を実施し、局所的な簡素化を2コミット目に反映。「3パーサーの統合層が重複している」「`append_fill` が全DB走査」の2件は、一度きりのバックフィル用途に対して影響範囲が大きいため見送り (別途リファクタ候補)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
