### PR TITLE
約定ごとの損益を表示

### DIFF
--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4276,6 +4276,10 @@ def _episode_pl_from_round(rnd: dict) -> Optional[dict]:
                 cost_basis_total += price * qty
             else:  # sell
                 sell_qty = min(qty, held_qty) if held_qty > 0 else qty
+                if held_qty > 0 and avg_cost > 0:
+                    fill_pl = (price - avg_cost) * sell_qty
+                    f["fill_pl"] = round(fill_pl)
+                    f["fill_return_pct"] = fill_pl / (avg_cost * sell_qty) * 100
                 realized += (price - avg_cost) * sell_qty
                 held_qty -= qty
         total_cost = cost_basis_total
@@ -4293,15 +4297,26 @@ def _episode_pl_from_round(rnd: dict) -> Optional[dict]:
             tate_price = f.get("tate_price")
             if settle_pl is not None:
                 realized += settle_pl
+                f["fill_pl"] = settle_pl
                 total_cost += (tate_price or price) * qty
             elif tate_price is not None:
                 # 売建は (建単価 - 買戻単価)、買建は (返済単価 - 建単価)
-                realized += ((tate_price - price) if is_short
-                             else (price - tate_price)) * qty
+                fill_pl = ((tate_price - price) if is_short
+                           else (price - tate_price)) * qty
+                realized += fill_pl
+                f["fill_pl"] = round(fill_pl)
                 total_cost += tate_price * qty
             else:
                 # 建単価も決済損益も無い → 損益不能
                 return None
+            if tate_price is not None:
+                f["fill_return_pct"] = f["fill_pl"] / (tate_price * qty) * 100
+            tate_date = f.get("tate_date")
+            if tate_date:
+                try:
+                    f["hold_days"] = (date.fromisoformat(f["trade_date"]) - date.fromisoformat(tate_date)).days
+                except (ValueError, TypeError):
+                    pass
 
     if total_cost <= 0:
         return None
@@ -4352,6 +4367,10 @@ def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict
                 held_qty = new_qty
             else:  # sell (部分売り)
                 sell_qty = min(qty, held_qty) if held_qty > 0 else qty
+                if held_qty > 0 and avg_cost > 0:
+                    fill_pl = (price - avg_cost) * sell_qty
+                    f["fill_pl"] = round(fill_pl)
+                    f["fill_return_pct"] = fill_pl / (avg_cost * sell_qty) * 100
                 realized += (price - avg_cost) * sell_qty
                 held_qty -= qty
         cost_basis = avg_cost
@@ -4382,14 +4401,27 @@ def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict
                 tate_price = f.get("tate_price")
                 if settle_pl is not None:
                     realized += settle_pl
+                    f["fill_pl"] = settle_pl
                 elif tate_price is not None:
                     # 売建は (建単価 - 買戻単価)、買建は (返済単価 - 建単価)
-                    realized += ((tate_price - price) if is_short
-                                 else (price - tate_price)) * qty
+                    fill_pl = ((tate_price - price) if is_short
+                               else (price - tate_price)) * qty
+                    realized += fill_pl
+                    f["fill_pl"] = round(fill_pl)
                 else:
                     # 建単価不明時は平均建単価で近似
-                    realized += ((avg_cost - price) if is_short
-                                 else (price - avg_cost)) * qty
+                    fill_pl = ((avg_cost - price) if is_short
+                               else (price - avg_cost)) * qty
+                    realized += fill_pl
+                    f["fill_pl"] = round(fill_pl)
+                if tate_price is not None:
+                    f["fill_return_pct"] = f["fill_pl"] / (tate_price * qty) * 100
+                tate_date = f.get("tate_date")
+                if tate_date:
+                    try:
+                        f["hold_days"] = (date.fromisoformat(f["trade_date"]) - date.fromisoformat(tate_date)).days
+                    except (ValueError, TypeError):
+                        pass
                 held_qty -= qty
         cost_basis = avg_cost
         if has_reverse_settle:
@@ -4733,6 +4765,7 @@ def _finalize_round(code_s: str, kind: str, stock_name: str,
                 # 補完する (SBI取込は必ず broker="SBI" を持つ、P2 レビュー対応)。
                 "broker": f.get("broker") or "楽天",
                 "tate_price": f.get("tate_price"),
+                "tate_date": f.get("tate_date"),
                 "settle_pl": f.get("settle_pl"),
             }
             for f in round_fills

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -172,6 +172,20 @@
       <td></td>
       <td colspan="7" style="padding:0.3em 0.5em 0.6em;">
         <table style="width:auto;font-size:0.82em;color:#999;border-collapse:collapse;">
+          <thead style="color:#666;font-size:0.9em;">
+            <tr>
+              <th style="padding:1px 0.8em 1px 0;text-align:left;">日付</th>
+              <th style="padding:1px 0.8em;text-align:left;">売買</th>
+              <th style="padding:1px 0.8em;text-align:left;">区分</th>
+              <th style="padding:1px 0.8em;text-align:right;">株数</th>
+              <th style="padding:1px 0.8em;text-align:right;">単価</th>
+              <th style="padding:1px 0.8em;text-align:right;">建単価</th>
+              <th style="padding:1px 0.8em;">建日・保有</th>
+              <th style="padding:1px 0.8em;text-align:right;">損益率</th>
+              <th style="padding:1px 0.8em;text-align:right;">損益額</th>
+              <th style="padding:1px 0.8em;">証券会社</th>
+            </tr>
+          </thead>
           {% for f in ep.fills %}
           <tr>
             <td style="padding:1px 0.8em 1px 0;white-space:nowrap;color:#888;">{{ f.trade_date[2:4] }}/{{ f.trade_date[5:7] }}/{{ f.trade_date[8:10] }}</td>
@@ -182,6 +196,15 @@
             <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">{{ f.qty }}株</td>
             <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">{{ "{:,}".format(f.price|round|int) }}円</td>
             {% if f.tate_price %}<td style="padding:1px 0.8em;text-align:right;white-space:nowrap;color:#888;">建 {{ "{:,}".format(f.tate_price|round|int) }}</td>{% else %}<td></td>{% endif %}
+            {% if f.hold_days is defined %}<td style="padding:1px 0.8em;color:#777;white-space:nowrap;">{{ f.tate_date[2:] }} 建 → {{ f.hold_days }}日</td>{% else %}<td></td>{% endif %}
+            <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">
+              {% if f.fill_return_pct is defined %}<span style="color:{{ '#9ef0aa' if f.fill_return_pct >= 0 else '#f0a0a0' }};">{{ '+' if f.fill_return_pct >= 0 else '' }}{{ "%.2f"|format(f.fill_return_pct) }}%</span>
+              {% elif f.fill_pl is defined %}<span style="color:#666;" title="建単価または平均取得単価がないため損益率は算出できません">—</span>{% endif %}
+            </td>
+            <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">
+              {% if f.fill_pl is defined %}<span style="color:{{ '#9ef0aa' if f.fill_pl >= 0 else '#f0a0a0' }};">{{ "{:+,}".format(f.fill_pl) }}円</span>
+              {% elif f.side == 'sell' and f.trade_kind == '現物' %}<span style="color:#666;" title="取得記録がCSVに無いため損益は算出できません">—</span>{% endif %}
+            </td>
             <td style="padding:1px 0.8em;color:#666;white-space:nowrap;">{{ f.broker }}</td>
           </tr>
           {% endfor %}

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -129,6 +129,9 @@ class TestGenbutsuRound:
         assert ep["pl"]["profit_amount"] == 20000
         assert round(ep["pl"]["return_pct"], 2) == 20.0
         assert ep["pl"]["hold_days"] == 10
+        sell = next(f for f in ep["fills"] if f["side"] == "sell")
+        assert sell["fill_pl"] == 20000
+        assert sell["fill_return_pct"] == 20.0
 
     def test_average_cost_partial_sells(self, db_path):
         # 0→200→300→0: 100@1000, 100@1200, 売100@1300, 売200@1400
@@ -144,6 +147,11 @@ class TestGenbutsuRound:
         # avg_cost = (1000+1200+1100)/3 = 1100
         # 実現 = (1300-1100)*100 + (1400-1100)*200 = 20000 + 60000 = 80000
         assert ep["pl"]["profit_amount"] == 80000
+        sells = [f for f in ep["fills"] if f["side"] == "sell"]
+        assert [f["fill_pl"] for f in sells] == [20000, 60000]
+        assert [f["fill_return_pct"] for f in sells] == pytest.approx(
+            [1300 / 1100 * 100 - 100, 1400 / 1100 * 100 - 100]
+        )
 
     def test_two_rounds_separate(self, db_path):
         # 0→100→0→100→0 で2エピソード
@@ -171,12 +179,16 @@ class TestShinyoRound:
         # 信用新規買建 100@1000 → 信用返済売埋 100@1300 (tate_price=1000)
         _add(db_path, "2001", "2026-01-01", "buy", 100, 1000.0, trade_kind="信用新規", seq_salt="a")
         _add(db_path, "2001", "2026-01-10", "sell", 100, 1300.0, trade_kind="信用返済",
-             tate_price=1000.0, seq_salt="b")
+             tate_date="2026-01-01", tate_price=1000.0, seq_salt="b")
         eps = helpers.build_fill_episodes(db_path=db_path)
         credit = [e for e in eps if e["kind"] == "信用"]
         assert len(credit) == 1
         # (1300-1000)*100 = 30000
         assert credit[0]["pl"]["profit_amount"] == 30000
+        settle = next(f for f in credit[0]["fills"] if f["trade_kind"] == "信用返済")
+        assert settle["fill_pl"] == 30000
+        assert settle["fill_return_pct"] == 30.0
+        assert settle["hold_days"] == 9
 
     def test_sbi_credit_uses_settle_pl(self, db_path):
         _add(db_path, "2002", "2026-01-01", "buy", 100, 1000.0, trade_kind="信用新規",
@@ -187,6 +199,10 @@ class TestShinyoRound:
         credit = [e for e in eps if e["kind"] == "信用"]
         assert len(credit) == 1
         assert credit[0]["pl"]["profit_amount"] == 24000
+        settle = next(f for f in credit[0]["fills"] if f["trade_kind"] == "信用返済")
+        assert settle["fill_pl"] == 24000
+        assert "fill_return_pct" not in settle
+        assert "hold_days" not in settle
 
     def test_credit_without_pl_source_is_none(self, db_path):
         # 建単価も決済損益も無い信用返済 → 損益不能
@@ -254,6 +270,12 @@ class TestShortRound:
         assert ep["closed"] is True
         assert ep["qty_peak"] == 100
         assert ep["pl"]["profit_amount"] == expected
+        settle = next(f for f in ep["fills"] if f["trade_kind"] == "信用返済")
+        assert settle["fill_pl"] == expected
+        if tate_price is not None:
+            assert settle["fill_return_pct"] == expected / (tate_price * 100) * 100
+        else:
+            assert "fill_return_pct" not in settle
 
     def test_short_and_long_are_separate_rounds(self, db_path):
         # 両建て: 売建が買建の建玉を打ち消してラウンドを誤って閉じないこと

--- a/tests/test_webapp_trade_history_routes.py
+++ b/tests/test_webapp_trade_history_routes.py
@@ -154,6 +154,9 @@ class TestTradeHistoryPage:
         fills_tab = html.split('id="tab-fills"')[1].split('id="tab-actions"')[0]
         assert "+27,100円" in fills_tab   # 現物ラウンドの実現損益
         assert "1,234" in fills_tab       # 内訳展開の取得単価
+        assert "損益率" in fills_tab
+        assert "+13,300円" in fills_tab
+        assert "+13,800円" in fills_tab
 
     def test_genbutsu_and_shinyo_are_separate_episodes(self, app, client):
         """現物と信用は同一銘柄でも別エピソードになる (口座種別で分離、Phase4b)。"""


### PR DESCRIPTION
## 概要

売買履歴の展開明細に、約定ごとの損益率・損益額と、取得できる場合の建日・保有日数を表示します。

## 変更内容

- 現物売: 移動平均取得単価法で約定単位の実現損益・損益率を付与
- 信用返済: 建単価または決済損益から損益額を付与
  - 建単価がある場合は損益率と建日・保有日数も表示
  - SBIのように建単価がない場合は損益額のみ表示
- 信用売建の損益符号反転を維持
- 期首持越しの現物売は算出不能として `—` を表示
- fill DBおよびエピソード集計値には変更を加えない

## 確認

- `.venv/bin/python -m pytest tests/test_fill_episodes.py tests/test_webapp_trade_history_routes.py -q`
  - 70 passed

Closes #396