### PR TITLE
決算日と重要開示を可視化

### DIFF
--- a/scripts/disclosure.py
+++ b/scripts/disclosure.py
@@ -19,8 +19,8 @@ UPD_FORCE = 2  # html取得から強制
 HEAD_TYPE_DIC = {
     # 新HTML形式（2026年3月〜）: <div class="newslist_ctg newsctgXX_b">
     "newsctg5_b": "special",     # 特集
-    "newsctg3_kk_b": "modify",   # 決算・修正下方
-    "newsctg3_ks_b": "modify",   # 修正上方
+    "newsctg3_kk_b": "modify",   # 決算・修正
+    "newsctg3_ks_b": "modify",   # 決算・修正
     "newsctg12_b": "5per",       # 5%
     "newsctg9_b": "kessan",      # 注目/決算
     "newsctg1_b": "zairyo",      # 市況 → 材料扱い
@@ -33,6 +33,64 @@ HEAD_TYPE_DIC = {
     "ctg12": "5per",
     "ctg9": "kessan",
 }
+
+DISCLOSURE_IMPACT_RULES = [
+    {
+        "kind": "downward",
+        "label": "下方",
+        "tone": "negative",
+        "strength": "strong",
+        "keywords": ("下方修正",),
+    },
+    {
+        "kind": "upward",
+        "label": "上方",
+        "tone": "positive",
+        "strength": "strong",
+        "keywords": ("上方修正",),
+    },
+    {
+        "kind": "profit_high",
+        "label": "最高益",
+        "tone": "positive",
+        "strength": "weak",
+        "keywords": ("最高益",),
+    },
+    {
+        "kind": "dividend_positive",
+        "label": "増配",
+        "tone": "positive",
+        "strength": "weak",
+        "keywords": ("増額修正", "増配", "復配"),
+    },
+    {
+        "kind": "dividend_negative",
+        "label": "減配",
+        "tone": "negative",
+        "strength": "weak",
+        "keywords": ("減配", "減額修正", "無配"),
+    },
+]
+
+
+def classify_disclosure_impact(heading):
+    """開示見出しから株価インパクトの大きいキーワードを分類する。
+
+    株探のカテゴリタグではなく見出し本文だけを見る。増益/減益の着地見出しは
+    上方/下方修正ではないため、明示キーワードが無い限り分類しない。
+    """
+    heading = heading or ""
+    for rule in DISCLOSURE_IMPACT_RULES:
+        if any(keyword in heading for keyword in rule["keywords"]):
+            result = {
+                "kind": rule["kind"],
+                "label": rule["label"],
+                "tone": rule["tone"],
+                "strength": rule["strength"],
+                "surprise": "一転" in heading,
+            }
+            return result
+    return None
 
 HEAD_TYPE_EXPR = {
     "kaiji": "開示",

--- a/scripts/make_market_db.py
+++ b/scripts/make_market_db.py
@@ -17,6 +17,7 @@ import sys
 import price
 import make_stock_db
 import fng
+import disclosure
 
 from ks_util import *
 
@@ -1048,6 +1049,17 @@ details summary:hover { background: #d5dbdb; }
 .disc-table a { color: #2980b9; text-decoration: none; }
 .disc-table a:hover { text-decoration: underline; }
 .disc-row-gyoseki { background: #e8f5e9; }
+.disc-impact-strong-positive { background: #ffe7e0; border-left: 3px solid #c0392b; }
+.disc-impact-strong-negative { background: #eaf3ff; border-left: 3px solid #2980b9; }
+.disc-impact-weak-positive { background: #fff3e8; border-left: 3px solid #e67e22; }
+.disc-impact-weak-negative { background: #f1f6ff; border-left: 3px solid #5d8cc1; }
+.disc-impact-label, .disc-impact-surprise {
+  display: inline-block; margin-right: 4px; padding: 1px 5px;
+  border-radius: 3px; font-size: 0.82em; font-weight: bold;
+}
+.disc-impact-label.positive { background: #c0392b; color: #fff; }
+.disc-impact-label.negative { background: #2980b9; color: #fff; }
+.disc-impact-surprise { background: #6c3483; color: #fff; }
 
 /* ランキング履歴 */
 .rank-history { font-size: 0.83em; overflow-x: auto; }
@@ -2477,23 +2489,37 @@ def _html_disclosure(disc_csv):
                 body_text = body_match.group(2)
                 body_html = '<a href="%s">%s</a>' % (body_url, html_mod.escape(body_text))
             else:
+                body_text = str(row[4])
                 body_html = html_mod.escape(str(row[4]))
 
             # 決算・修正行は背景色を変える
             row_class = ""
+            impact_html = ""
             if type_label in ("決算", "修正"):
-                row_class = ' class="disc-row-gyoseki"'
+                classes = ["disc-row-gyoseki"]
+                impact = disclosure.classify_disclosure_impact(body_text)
+                if impact:
+                    classes.append("disc-impact-%s-%s" % (impact["strength"], impact["tone"]))
+                    impact_html = (
+                        '<span class="disc-impact-label %s">%s</span>' % (
+                            html_mod.escape(impact["tone"]),
+                            html_mod.escape(impact["label"]),
+                        )
+                    )
+                    if impact.get("surprise"):
+                        impact_html += '<span class="disc-impact-surprise">一転</span>'
+                row_class = ' class="%s"' % " ".join(classes)
 
             lines.append(
                 '<tr%s><td>%s</td><td>%s %s</td><td>%s</td><td>%s</td></tr>' % (
                     row_class, date_display, code_html, stock_name,
-                    type_label, body_html,
+                    type_label, impact_html + body_html,
                 )
             )
         lines.append('</table>')
         return '\n'.join(lines)
 
-    parts = ['<h2>適宜開示</h2>']
+    parts = ['<h2 id="disclosure-section">適宜開示</h2>']
 
     if recent_rows:
         parts.append('<details open>')
@@ -2597,11 +2623,11 @@ def create_disclosure_html(disc_csv):
         '<html lang="ja">\n'
         '<head>\n'
         '<meta charset="UTF-8">\n'
-        '<title>適宜開示 - %s</title>\n'
+        '<title>決算日・適宜開示 - %s</title>\n'
         '<style>\n%s</style>\n'
         '</head>\n'
         '<body>\n\n'
-        '<h1>適宜開示 <span class="date">%s</span></h1>\n\n'
+        '<h1>決算日・適宜開示 <span class="date">%s</span></h1>\n\n'
         '%s\n\n'
         '<footer style="margin-top: 40px; padding-top: 12px; border-top: 1px solid #ddd; '
         'font-size: 0.8em; color: #999;">\n'

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -7,6 +7,7 @@ research_shelve のデータ取得・更新をWebアプリ用にラップする�
 """
 
 import html
+import csv
 import os
 import re
 from datetime import date, datetime, timedelta
@@ -1424,6 +1425,107 @@ def _select_market_kessan_winner(
     return cur
 
 
+_DISCLOSURE_LINK_RE = re.compile(r'^=HYPERLINK\("([^"]+)","([^"]+)"\)$')
+
+
+def _parse_disclosure_csv_link(value: Any) -> Tuple[str, str]:
+    """disclosure_db.csv の HYPERLINK セルを (url, text) に分解する。"""
+    m = _DISCLOSURE_LINK_RE.match(str(value))
+    if not m:
+        return "", str(value)
+    return m.group(1), m.group(2)
+
+
+def _attach_market_kessan_disclosure_impacts(entries: List[Dict[str, Any]]) -> None:
+    """決算カレンダーの各エントリに、近傍の重要開示バッジ情報を付与する。"""
+    if not entries:
+        return
+    targets: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for entry in entries:
+        entry["disclosure_impacts"] = []
+        entry["disclosure_impact_extra_count"] = 0
+        entry["disclosure_impact_tooltip"] = ""
+        code_s = entry.get("code_s", "")
+        kessanbi = entry.get("kessanbi", "")
+        if code_s and _parse_kessanbi(kessanbi) is not None:
+            targets[(code_s, kessanbi)] = entry
+    if not targets:
+        return
+
+    try:
+        import disclosure
+    except Exception as e:
+        log_warning(f"[market] disclosure import 失敗: {e}")
+        return
+    if not os.path.exists(disclosure.DISCLOSURE_CSV):
+        return
+
+    by_entry: Dict[Tuple[str, str], List[Dict[str, Any]]] = {key: [] for key in targets}
+    try:
+        with open(disclosure.DISCLOSURE_CSV, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if len(row) < 5 or row[0] in ("", "日付"):
+                    continue
+                if str(row[3]) not in ("決算", "修正"):
+                    continue
+                try:
+                    disclosure_day = datetime.strptime(str(row[0]), "%Y%m%d").date()
+                except (ValueError, TypeError):
+                    continue
+                _, code_s = _parse_disclosure_csv_link(row[1])
+                if not code_s:
+                    continue
+                url, heading = _parse_disclosure_csv_link(row[4])
+                impact = disclosure.classify_disclosure_impact(heading)
+                if impact is None:
+                    continue
+                for (target_code, kessanbi), entry in targets.items():
+                    if target_code != code_s:
+                        continue
+                    kessan_day = _parse_kessanbi(kessanbi)
+                    if kessan_day is None:
+                        continue
+                    if kessan_day - timedelta(days=14) <= disclosure_day <= kessan_day + timedelta(days=1):
+                        rec = dict(impact)
+                        rec.update({
+                            "heading": heading,
+                            "url": url,
+                            "date": disclosure_day.strftime("%Y/%m/%d"),
+                        })
+                        by_entry[(target_code, kessanbi)].append(rec)
+    except OSError as e:
+        log_warning(f"[market] disclosure_db.csv 読み込み失敗: {e}")
+        return
+
+    for key, impacts in by_entry.items():
+        entry = targets[key]
+        unique_impacts: List[Dict[str, Any]] = []
+        seen_kinds = set()
+        headlines = []
+        for impact in impacts:
+            headlines.append("%s %s" % (impact.get("date", ""), impact.get("heading", "")))
+            kind = impact.get("kind")
+            if kind in seen_kinds:
+                continue
+            seen_kinds.add(kind)
+            unique_impacts.append(impact)
+        if not unique_impacts:
+            continue
+
+        selected: List[Dict[str, Any]] = []
+        positives = [i for i in unique_impacts if i.get("tone") == "positive"]
+        negatives = [i for i in unique_impacts if i.get("tone") == "negative"]
+        if positives and negatives:
+            selected = [positives[0], negatives[0]]
+        else:
+            selected = unique_impacts[:2]
+
+        entry["disclosure_impacts"] = selected
+        entry["disclosure_impact_extra_count"] = max(0, len(unique_impacts) - len(selected))
+        entry["disclosure_impact_tooltip"] = "\n".join(headlines)
+
+
 def get_market_kessan_data() -> Dict[str, Any]:
     """決算カレンダー表示用データを構築する。
 
@@ -1449,7 +1551,7 @@ def get_market_kessan_data() -> Dict[str, Any]:
         各 stock dict:
           code_s, stock_name, kessanbi, quarter,
           pre_expectation, pre_outlook, post_price_changes, post_comment,
-          has_comment (bool)
+          has_comment (bool), disclosure_impacts
         post_price_changes は {"1d": str, "5d": str} の dict。取得不可期間は ""
     """
     import kessan  # 遅延 import (sys.path 解決後)
@@ -1565,6 +1667,8 @@ def get_market_kessan_data() -> Dict[str, Any]:
                         winner.setdefault("post_price_changes", {})["pts"] = src_pts
                         break
             merged[merged_key] = winner
+
+    _attach_market_kessan_disclosure_impacts(list(merged.values()))
 
     # 過去エントリで post_price_changes のいずれかの期間が空のものだけ
     # 一括で price_log を取得し補完計算する

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -1436,6 +1436,24 @@ def _parse_disclosure_csv_link(value: Any) -> Tuple[str, str]:
     return m.group(1), m.group(2)
 
 
+def _sort_disclosure_impacts_for_badge(impacts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """決算カードのバッジ表示順: 強い開示を優先し、同強度なら新しい日付を優先する。"""
+    strength_rank = {"strong": 0, "weak": 1}
+
+    def sort_key(impact: Dict[str, Any]) -> Tuple[int, int]:
+        date_key = str(impact.get("date", "")).replace("/", "")
+        try:
+            date_rank = -int(date_key)
+        except ValueError:
+            date_rank = 0
+        return (
+            strength_rank.get(impact.get("strength", ""), 9),
+            date_rank,
+        )
+
+    return sorted(impacts, key=sort_key)
+
+
 def _attach_market_kessan_disclosure_impacts(entries: List[Dict[str, Any]]) -> None:
     """決算カレンダーの各エントリに、近傍の重要開示バッジ情報を付与する。"""
     if not entries:
@@ -1514,12 +1532,16 @@ def _attach_market_kessan_disclosure_impacts(entries: List[Dict[str, Any]]) -> N
             continue
 
         selected: List[Dict[str, Any]] = []
-        positives = [i for i in unique_impacts if i.get("tone") == "positive"]
-        negatives = [i for i in unique_impacts if i.get("tone") == "negative"]
+        positives = _sort_disclosure_impacts_for_badge([
+            i for i in unique_impacts if i.get("tone") == "positive"
+        ])
+        negatives = _sort_disclosure_impacts_for_badge([
+            i for i in unique_impacts if i.get("tone") == "negative"
+        ])
         if positives and negatives:
             selected = [positives[0], negatives[0]]
         else:
-            selected = unique_impacts[:2]
+            selected = _sort_disclosure_impacts_for_badge(unique_impacts)[:2]
 
         entry["disclosure_impacts"] = selected
         entry["disclosure_impact_extra_count"] = max(0, len(unique_impacts) - len(selected))

--- a/scripts/webapp/static/style.css
+++ b/scripts/webapp/static/style.css
@@ -317,6 +317,55 @@ nav .quick-search {
 .kessan-expectation-badge.exp-△ { background: #bdc3c7; color: #333; border-color: #95a5a6; }
 .kessan-expectation-badge.exp-× { background: #3498db; color: #fff; border-color: #2874a6; }
 
+.disclosure-toc {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin: -6px 0 6px;
+  color: #666;
+  font-size: 0.95em;
+  line-height: 1.2;
+}
+.disclosure-toc a {
+  color: #2980b9;
+  text-decoration: none;
+  font-weight: bold;
+}
+.disclosure-toc a:hover {
+  text-decoration: underline;
+}
+.kessan-disclosure-impacts {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+.kessan-impact-badge,
+.kessan-impact-surprise,
+.kessan-impact-extra {
+  display: inline-block;
+  padding: 0 5px;
+  border-radius: 3px;
+  font-size: 0.78em;
+  font-weight: bold;
+  line-height: 1.5;
+}
+.kessan-impact-badge {
+  color: #fff;
+  text-decoration: none;
+}
+.kessan-impact-badge:hover {
+  text-decoration: none;
+  filter: brightness(0.95);
+}
+.kessan-impact-badge.impact-strong-positive { background: #c0392b; }
+.kessan-impact-badge.impact-strong-negative { background: #2980b9; }
+.kessan-impact-badge.impact-weak-positive { background: #e67e22; }
+.kessan-impact-badge.impact-weak-negative { background: #5d8cc1; }
+.kessan-impact-surprise { background: #6c3483; color: #fff; }
+.kessan-impact-extra { background: #ecf0f1; color: #555; }
+
 .kessan-editor {
   margin: 4px 0 6px 14px;
   padding: 6px 8px;

--- a/scripts/webapp/templates/disclosure.html
+++ b/scripts/webapp/templates/disclosure.html
@@ -9,16 +9,22 @@
 {{ disclosure_parts.css | safe }}
 </style>
 {{ disclosure_parts.header | safe }}
+<nav class="disclosure-toc" aria-label="ページ内目次">
+  <a href="#kessan-section">決算日</a><a href="#disclosure-section">適宜開示</a>
+</nav>
 {% else %}
 <div style="padding:12px;margin:12px 0;background:#fef3e6;border:1px solid #f5c37c;border-radius:6px;">
   決算・開示データ (<code>disclosure_data.html</code>) が未生成です。<br>
   <small>scripts/make_market_db.py を実行すると生成されます。決算カレンダーは以下の通り利用できます。</small>
 </div>
+<nav class="disclosure-toc" aria-label="ページ内目次">
+  <a href="#kessan-section">決算日</a><span>適宜開示</span>
+</nav>
 {% endif %}
 
 {# 動的決算セクション (市場ページから移設) #}
-<h2 title="株価変動率の表記: 翌営業日 | 5営業日後 20営業日後 / 例: +16.2% | +51% +30%">決算日 <span style="font-size:0.55em; color:#888; cursor:help;">[?]</span></h2>
-<div id="kessan-section">
+<h2 id="kessan-section" title="株価変動率の表記: 翌営業日 | 5営業日後 20営業日後 / 例: +16.2% | +51% +30%">決算日 <span style="font-size:0.55em; color:#888; cursor:help;">[?]</span></h2>
+<div>
   {% macro render_kessan_editor(s, is_past) -%}
     <div class="kessan-editor" style="display:none;" data-loaded="0">
       <div class="kessan-editor-row">
@@ -76,6 +82,20 @@
       <a href="/stock/{{ s.code_s }}">{% if s.stock_name %}{{ macros.stock_name_with_prev(s) }}{% else %}-{% endif %}</a>
       {% if s.quarter %}<span class="kessan-q-label">[{{ s.quarter }}Q]</span>{% endif %}
       {% if s.pre_expectation %}<span class="kessan-expectation-badge exp-{{ s.pre_expectation }}">{{ s.pre_expectation }}</span>{% endif %}
+      {% if s.disclosure_impacts %}
+        <span class="kessan-disclosure-impacts" title="{{ s.disclosure_impact_tooltip }}">
+          {% for impact in s.disclosure_impacts %}
+            <a class="kessan-impact-badge impact-{{ impact.strength }}-{{ impact.tone }}"
+               href="{{ impact.url }}"
+               target="_blank"
+               onclick="event.stopPropagation();">{{ impact.label }}</a>
+            {% if impact.surprise %}<span class="kessan-impact-surprise">一転</span>{% endif %}
+          {% endfor %}
+          {% if s.disclosure_impact_extra_count %}
+            <span class="kessan-impact-extra">+{{ s.disclosure_impact_extra_count }}</span>
+          {% endif %}
+        </span>
+      {% endif %}
       {% if is_past and (s.post_price_changes['pts'] or s.post_price_changes['1d'] or s.post_price_changes['5d'] or s.post_price_changes['20d']) %}
         {% set pcp = s.post_price_changes['pts'] %}
         {% set pc1 = s.post_price_changes['1d'] %}

--- a/tests/test_disclosure.py
+++ b/tests/test_disclosure.py
@@ -9,6 +9,30 @@ import pytest
 import disclosure
 
 
+class TestClassifyDisclosureImpact:
+    """開示見出しの株価インパクト分類テスト"""
+
+    @pytest.mark.parametrize("heading, expected", [
+        ("今期経常を一転赤字に下方修正", ("downward", "negative", "strong", True)),
+        ("今期最終を一転増益に上方修正", ("upward", "positive", "strong", True)),
+        ("今期経常は3期ぶり最高益へ", ("profit_high", "positive", "weak", False)),
+        ("配当予想を増額修正、増配へ", ("dividend_positive", "positive", "weak", False)),
+        ("配当予想を減額修正、減配へ", ("dividend_negative", "negative", "weak", False)),
+        ("今期経常は10％増益で着地", None),
+        ("前期経常は25％減益で着地", None),
+    ])
+    def test_見出しキーワードで分類する(self, heading, expected):
+        result = disclosure.classify_disclosure_impact(heading)
+        if expected is None:
+            assert result is None
+        else:
+            kind, tone, strength, surprise = expected
+            assert result["kind"] == kind
+            assert result["tone"] == tone
+            assert result["strength"] == strength
+            assert result["surprise"] is surprise
+
+
 class TestFilterRecentNews:
     """filter_recent_news のテスト"""
 

--- a/tests/test_make_market_db.py
+++ b/tests/test_make_market_db.py
@@ -1050,14 +1050,20 @@ class TestHtmlDisclosure:
         assert result == ""
 
     def test_gyoseki_row_class(self):
-        """決算・修正行にdisc-row-gyosekiクラスが付く"""
+        """決算・修正行に従来クラスと影響度クラスが付く"""
         today_str = make_market_db.get_price_day(datetime.today()).strftime("%Y%m%d")
         disc_csv = [
             ["日付", "銘柄コード", "銘柄名", "種類", "本文"],
             [today_str, "1234", "テスト", "決算", "決算発表"],
+            [today_str, "1234", "テスト", "修正",
+             '=HYPERLINK("https://example.com/up","今期最終を一転増益に上方修正")'],
         ]
         result = make_market_db._html_disclosure(disc_csv)
+        assert '<h2 id="disclosure-section">適宜開示</h2>' in result
         assert 'disc-row-gyoseki' in result
+        assert 'disc-impact-strong-positive' in result
+        assert '<span class="disc-impact-label positive">上方</span>' in result
+        assert '<span class="disc-impact-surprise">一転</span>' in result
 
 
 class TestUpdateIndexMarketStateFTD:
@@ -1239,6 +1245,7 @@ class TestCreateDisclosureHtml:
             with open(html_path, encoding="utf-8") as f:
                 content = f.read()
             assert '<!DOCTYPE html>' in content
+            assert '<h1>決算日・適宜開示 <span class="date">2026-04-25 (土)</span></h1>' in content
             assert '適宜開示' in content
             assert '6324' in content
 

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -275,18 +275,18 @@ class TestGetMarketKessanData:
         csv_path = tmp_path / "disclosure_db.csv"
         rows = [
             ["日付", "銘柄コード", "銘柄名", "種類", "本文"],
-            ["20260412", '=HYPERLINK("u","6501")', "日立", "修正",
-             '=HYPERLINK("https://example.com/excluded-before","除外前の下方修正")'],
-            ["20260413", '=HYPERLINK("u","6501")', "日立", "修正",
-             '=HYPERLINK("https://example.com/down","今期経常を一転赤字に下方修正")'],
-            ["20260426", '=HYPERLINK("u","6501")', "日立", "修正",
-             '=HYPERLINK("https://example.com/up","今期最終を一転増益に上方修正")'],
-            ["20260427", '=HYPERLINK("u","6501")', "日立", "決算",
-             '=HYPERLINK("https://example.com/high","今期経常は3期ぶり最高益へ")'],
-            ["20260428", '=HYPERLINK("u","6501")', "日立", "修正",
-             '=HYPERLINK("https://example.com/divdown","配当予想を減額修正、減配へ")'],
             ["20260429", '=HYPERLINK("u","6501")', "日立", "修正",
              '=HYPERLINK("https://example.com/excluded-after","除外後の増配")'],
+            ["20260428", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/divdown","配当予想を減額修正、減配へ")'],
+            ["20260427", '=HYPERLINK("u","6501")', "日立", "決算",
+             '=HYPERLINK("https://example.com/high","今期経常は3期ぶり最高益へ")'],
+            ["20260426", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/up","今期最終を一転増益に上方修正")'],
+            ["20260413", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/down","今期経常を一転赤字に下方修正")'],
+            ["20260412", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/excluded-before","除外前の下方修正")'],
         ]
         with open(csv_path, "w", newline="", encoding="utf-8") as f:
             csv.writer(f).writerows(rows)
@@ -307,6 +307,7 @@ class TestGetMarketKessanData:
 
         selected_kinds = {impact["kind"] for impact in stock["disclosure_impacts"]}
         assert {"upward", "downward"} == selected_kinds
+        assert [impact["strength"] for impact in stock["disclosure_impacts"]] == ["strong", "strong"]
         assert stock["disclosure_impact_extra_count"] == 2
         assert "除外前の下方修正" not in stock["disclosure_impact_tooltip"]
         assert "除外後の増配" not in stock["disclosure_impact_tooltip"]

--- a/tests/test_webapp_helpers.py
+++ b/tests/test_webapp_helpers.py
@@ -1,5 +1,6 @@
 """webapp/helpers.py のテスト (tmp_path で一時DBを作成)"""
 
+import csv
 import html
 import os
 
@@ -265,6 +266,51 @@ class TestGetMarketKessanData:
         assert "2026/04/27" in today_keys
         assert "2026/04/27" not in past_keys
         assert "2026/04/27" not in future_keys
+
+    def test_disclosure_impacts_linked_by_kessan_window(self, kessan_env, tmp_path, monkeypatch):
+        """決算日前14日〜翌日の重要開示を、ポジ/ネガ両方見える形で紐付ける"""
+        from datetime import datetime as _dt
+        import disclosure as _disclosure
+
+        csv_path = tmp_path / "disclosure_db.csv"
+        rows = [
+            ["日付", "銘柄コード", "銘柄名", "種類", "本文"],
+            ["20260412", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/excluded-before","除外前の下方修正")'],
+            ["20260413", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/down","今期経常を一転赤字に下方修正")'],
+            ["20260426", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/up","今期最終を一転増益に上方修正")'],
+            ["20260427", '=HYPERLINK("u","6501")', "日立", "決算",
+             '=HYPERLINK("https://example.com/high","今期経常は3期ぶり最高益へ")'],
+            ["20260428", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/divdown","配当予想を減額修正、減配へ")'],
+            ["20260429", '=HYPERLINK("u","6501")', "日立", "修正",
+             '=HYPERLINK("https://example.com/excluded-after","除外後の増配")'],
+        ]
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerows(rows)
+        monkeypatch.setattr(_disclosure, "DISCLOSURE_CSV", str(csv_path))
+
+        today_dt = _dt(2026, 4, 27, 19, 0)
+        pf_dict = {
+            "6501": {
+                "code_s": "6501",
+                "stock_name": "日立製作所",
+                "kessanbi": "2026/04/27",
+                "kessan_quarter": 4,
+            },
+        }
+        kessan_env(pf_dict, today_dt)
+        result = helpers.get_market_kessan_data()
+        stock = result["today_entries"][0][1][0]
+
+        selected_kinds = {impact["kind"] for impact in stock["disclosure_impacts"]}
+        assert {"upward", "downward"} == selected_kinds
+        assert stock["disclosure_impact_extra_count"] == 2
+        assert "除外前の下方修正" not in stock["disclosure_impact_tooltip"]
+        assert "除外後の増配" not in stock["disclosure_impact_tooltip"]
+        assert "最高益" in stock["disclosure_impact_tooltip"]
 
     def test_yesterday_kessan_in_recent_past(self, kessan_env):
         """base_day より前の決算は recent_past_entries"""


### PR DESCRIPTION
## 変更内容

- /disclosure の見出しを「決算日・適宜開示」に変更し、決算日/適宜開示への目次リンクを追加
- 開示見出しから上方修正・下方修正・最高益・増配/減配・一転を分類し、決算カレンダーと適宜開示テーブルで可視化
- 決算日前14日〜翌日の重要開示を決算カレンダーへバッジ表示
- 株探カテゴリタグの誤コメントを修正

## 検証

- /Users/k_sohara/Library/CloudStorage/Dropbox/document/shintakane/.venv/bin/python -m pytest tests/test_disclosure.py tests/test_webapp_helpers.py tests/test_make_market_db.py tests/test_webapp_routes.py -k 'disclosure or GetMarketKessanData or HtmlDisclosure or CreateDisclosureHtml' -v
- cd scripts && /Users/k_sohara/Library/CloudStorage/Dropbox/document/shintakane/.venv/bin/python make_market_db.py html
- http://127.0.0.1:5001/disclosure で見出し反映を確認

Fixes #401