### PR TITLE
株式分割・併合をまたぐ売買履歴の残高・損益を換算 (issue #398)

### DIFF
--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -156,6 +156,13 @@ cd scripts && python show_fill_episodes.py --open     # 保有中のみ (残株�
 cd scripts && python show_fill_episodes.py --memo     # 振り返りメモ付きのみ
 ```
 
+株式分割・併合をまたぐ現物銘柄の診断・換算比率の登録 (issue #398)。証券会社CSVは分割・併合を調整してくれない (信用は建単価/決済損益で調整済みのため対象外、現物のみ)。`--check-splits` は fill 本体・換算比率 (split_adj) は更新しないが、未登録の発見を拒否リスト (split_pending_review) に記録する (webapp は yfinance を呼ばないため、単価変化が小さく保有中総当たりチェックでのみ見つかるケースを検知できるようにするため)。`--register-split` で登録すれば拒否リストは自動解除される。
+
+```bash
+cd scripts && python show_fill_episodes.py --check-splits                       # 分割・併合の疑いを診断・拒否リスト記録
+cd scripts && python show_fill_episodes.py --register-split 1491 2025-09-29 0.05  # 換算比率を登録 (新株数/旧株数、0.05=20株->1株併合)
+```
+
 ## 自動実行
 
 `shintakane_cron.sh` が `shintakane.py` → `make_stock_db.py` を逐次実行。macOS launchd（`com.k_sohara.shintakane.cron.plist`）で平日19:00に定期実行。

--- a/doc/plan/issue398_split_adjustment.md
+++ b/doc/plan/issue398_split_adjustment.md
@@ -1,0 +1,154 @@
+# issue #398: 売買履歴の株式分割・併合対応
+
+## 背景 (issue #398 より)
+
+fill 基準のエピソード再構成は、約定CSVに記録された当時の数量・単価をそのまま集計している。株式分割・併合をまたいで保有した銘柄は、保有数量・平均取得単価・損益・騰落率が不正確になる。
+
+### 実例: 1491 中外鉱業
+
+- 2025-09-29 権利落ち、20株→1株の株式併合 (yfinance `Ticker('1491.T').splits` で確認: `2025-09-29: 0.05`)
+- 併合前の買売差分は +4,000株 (併合後基準では +200株)
+- 併合後の買売差分は -200株
+- 実際の残高は0株だが、現行は併合前の4,000株を未換算のまま合算し「保有中3,800株・含み益+1,858,094円」と誤表示する
+- **実現損益も誤っている**: 現行 +996,206円 → 換算後 +27,100円 (キャッシュフロー検算: 総売却1,662,600円 - 総買付1,635,500円 = +27,100円 で一致)
+
+### 発生頻度
+
+現物エピソード133件中、単価が隣接約定間で3倍以上/1/3以下に飛ぶもの (=分割・併合の痕跡) は **1件のみ** (1491)。信用ラウンド (277件) は影響なし (下記スコープ参照)。保有中の現物13銘柄が今後踏みうる。
+
+## スコープ判断: 信用は対象外
+
+信用返済 fill は証券会社が計算した決済損益・建単価を直接使っている:
+
+- SBI: `settle_pl` (決済損益、`受渡金額/決済損益` 列由来)
+- 楽天/マネックス: `tate_price` (建単価、建約定日と同一ペア行)
+
+建玉と返済が1トランザクションでペアになるため、分割・併合があっても証券会社側で調整済みの数字が来る。**換算すると証券会社の確定損益と二重にズレるため、信用ラウンドは換算しない。**
+
+現物のみ対象。理由: 買い fill と売り fill が独立した約定事実で、損益は当方の平均取得単価法で計算しており、企業アクションを挟むと単位が揺れる。
+
+## 方針
+
+手動メンテナンスする企業アクションマスターは持たない。yfinance の `Ticker(code).splits` を使い、検知は自動、比率適用はユーザー確認を挟む。
+
+### 全体フロー
+
+```
+fill (永続, 不変)
+  → [対象銘柄の企業アクション取得: yfinance, キャッシュ]
+  → [現物 fill のみ、権利落ち日より前を換算した「作業用コピー」を生成]
+  → _build_code_episodes (既存ロジック、そのまま)
+  → エピソード (残高・損益とも正しい基準)
+```
+
+元の fill (CSV由来の約定事実) は一切変更しない。エピソード再構成の入力直前でコピーを換算する。
+
+### 1. 検知 (2系統。単価ジャンプ検知だけでは「片側にfillが無い」保有継続ケースを取り逃すため)
+
+**(a) 単価ジャンプ検知** — 銘柄ごとに現物 fill を約定日順に見て、隣接する fill 間で単価が3倍以上/1÷3以下に飛ぶ箇所を検出する。133件の実データで検証済み、誤検出0件・1491のみ検出。分割前後の両方に売買があるケースをノーコストで拾える。
+
+```python
+def _detect_price_jumps(fills: List[Dict]) -> List[Dict]:
+    """現物 fill を約定日順に見て、隣接単価が3倍以上/1/3以下に飛ぶ箇所を検出する。
+    Returns: [{"code_s", "before_date", "before_price", "after_date", "after_price"}]
+    """
+```
+
+**(b) 保有中現物銘柄の総当たりチェック** — 単価ジャンプが無くても、「分割前に買って以降売買していない」保有継続銘柄は fill 間の比較ができず (a) では検知できない。これが今回の主目的 (保有中13銘柄の将来リスク) の本体なので、`show_fill_episodes.py --check-splits` は **保有中の現物銘柄すべて**に対して yfinance `Ticker(f"{code_s}.T").splits` を呼び、`open_date` 以降の split イベントが無いか確認する。件数は保有中の現物銘柄数 (現状13件) 程度で、CLI診断コマンドのみが叩くため webapp のリクエストパスへの影響はない。
+
+```python
+def _check_holding_splits(open_genbutsu_episodes: List[Dict]) -> List[Dict]:
+    """保有中の現物エピソードについて、open_date 以降の split イベントの有無を yfinance で確認する。
+    単価ジャンプが無くても検知できる (保有継続中で売買が発生していないケース)。
+    """
+```
+
+### 2. 比率取得・保存 (yfinance、キャッシュ付き、銘柄ごとに複数イベント)
+
+(a)(b) いずれかで検知された銘柄について、yfinance の corporate actions を取得し、**銘柄ごとに複数の企業アクションイベントをリストで**キャッシュする (`Ticker.splits` は時系列を返すため、同一銘柄で将来複数回の分割・併合が起きても破綻しない構造にする)。
+
+```python
+# portfolio_shelve.py に追加
+KEY_SPLIT_ADJ_PREFIX = "split_adj:"  # split_adj:{code_s} -> {"events": [{"ex_date": "YYYY-MM-DD", "ratio": 0.05}, ...], "fetched_at": iso, "source": "yfinance"}
+
+def get_split_adjustments(code_s, *, db_path=None) -> List[dict]:
+    """登録済みイベントのリストを ex_date 昇順で返す (無ければ空リスト)。"""
+
+def add_split_adjustment(code_s, ex_date, ratio, *, db_path=None) -> dict:
+    """イベントを1件追加する (同一 ex_date は上書き、dedup)。"""
+```
+
+- `ratio`: 新株数/旧株数 (0.05 = 20:1併合、2.0 = 1:2分割)
+- 取得は `show_fill_episodes.py --check-splits` 実行時のみ。webapp では yfinance 呼び出しを避け、事前にキャッシュされた値のみ参照する
+
+### 3. 換算 (エピソード再構成の直前、現物のみ)
+
+`build_fill_episodes` 内、`_build_code_episodes` に渡す fill リストを作る際、該当銘柄に `split_adj` イベントがあれば、**現物 fill のみ**を対象に、各イベントの権利落ち日より前の fill を比率で換算したコピーに差し替える。イベントが複数ある場合は ex_date 昇順に、古いイベントから順に適用する (各 fill は自分より後の全イベントの累積比率を受ける)。
+
+```python
+def _apply_split_adjustments(fills: List[Dict], events: List[dict]) -> List[Dict]:
+    """現物 fill のうち trade_date < ex_date のものを比率で換算したコピーを返す。
+    events は ex_date 昇順。各 fill には、自身より後の ex_date を持つ全イベントの
+    比率を掛け合わせた累積比率を適用する。数量 = qty * cum_ratio、単価 = price / cum_ratio、
+    amount は不変。信用 fill は素通し。
+    """
+```
+
+- 数量は分割後に小数になり得る (併合で端数が出るケースは実際の約定にも起こりうるため、四捨五入せず float のまま `_episode_pl_from_round` の既存の加重平均ロジックに渡す。既存ロジックは int 前提の箇所がないか確認し、必要なら qty の型ヒントを float 許容に広げる)
+- **ゼロ判定のフロート誤差対策 (codexレビュー指摘)**: `_build_code_episodes` 内の建玉クローズ判定は `qty <= 0` の単純比較だが、float 換算後は浮動小数演算の誤差で `qty` が厳密に0にならず `5.55e-17` のような残差が残ってクローズ判定を取り逃す恐れがある。`genbutsu_qty <= 0` 相当の判定箇所 (`helpers.py:4612` 付近) に、換算 fill を含む処理経路でのみ `abs(qty) < 1e-6` 程度の許容誤差判定を追加する (通常の整数 fill のみのケースは既存の厳密な `<= 0` を変えない)
+- 元の `ps.list_fills()` の返り値は変更しない (コピー後に差し替え)
+
+### 4. 診断コマンド (読み取り専用)
+
+`show_fill_episodes.py --check-splits` を追加。(a) 単価ジャンプ検知 + (b) 保有中現物銘柄の総当たりチェックの両方を実行し、`split_adj` に登録済みかどうか、登録済みなら換算後の残高・損益を並べて表示する。DB は変更しない (登録は別コマンド)。
+
+```
+$ python show_fill_episodes.py --check-splits
+ 1491 中外鉱業  単価ジャンプ検出: 2025-09-03 @62 -> 2025-09-30 @925 (x14.9)
+      split_adj 未登録。yfinance suggests: 2025-09-29 ratio=0.05 (20株->1株)
+      登録: python show_fill_episodes.py --register-split 1491 2025-09-29 0.05
+ 6501 日立製作所  保有中チェック: split イベント無し (yfinance)
+```
+
+登録用の `--register-split CODE EX_DATE RATIO` も同コマンドに追加し、`add_split_adjustment` を呼ぶ (複数回実行すれば同一銘柄に複数イベントを積める)。yfinance 呼び出しはこの診断コマンド実行時のみで、webapp のリクエストパスには含めない (パフォーマンス・失敗時の表示崩れを避ける)。
+
+### 5. 未登録時の表示
+
+検知されたが `split_adj` が未登録のエピソードは、**残高・含み損益だけでなく実現損益・損益率も含めて**数値を一切出さず「⚠ 分割・併合の疑い、要確認」を表示する (既存の誤った数値を出し続けない)。
+
+1491 の実例で確認した通り、分割・併合をまたぐ現物エピソードは残高だけでなく `pl.profit_amount` / `pl.return_pct` (クローズ済みの場合) も誤っている。`trade_history.html` は `ep.pl.return_pct` / `ep.pl.profit_amount` をクローズ済みエピソードの列にそのまま表示するため (`trade_history.html:144,156`)、`split_suspect=True` の場合は closed/open 問わずエピソード全体の損益列を隠す。`_episode_pl_from_round` / `_episode_open_pl` の計算自体は行うが (内部値として保持)、テンプレート側の表示分岐で `split_suspect` を見て隠す。
+
+**成績サマリー集計からの除外 (codexレビュー指摘)**: 行表示を隠すだけでは不十分で、`scripts/webapp/routes/trade_history.py` の `fill_pls = [ep["pl"] for ep in fill_episodes if ep["closed"] and ep["pl"]]` (line 245 付近) はテンプレートを経由せず `fill_episodes` から直接集計しており、ここで `split_suspect` を除外しないと `fill_summary`（勝率・ペイオフレシオ）・`fill_total_pl`・`fill_priced_count` に誤った実現損益が混入する。`fill_pls` のリスト内包表記に `and not ep.get("split_suspect")` を追加し、`fill_closed_count` / `fill_priced_count` も同じ基準で suspect エピソードを一貫して除外する (`fill_priced_count = len(fill_pls)` なので `fill_pls` から除外すれば自動的に揃う)。
+
+## 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `scripts/portfolio_shelve.py` | `split_adj:` キー追加。`get_split_adjustment` / `set_split_adjustment` |
+| `scripts/webapp/helpers.py` | `_detect_price_jumps`, `_apply_split_adjustment` 追加。`build_fill_episodes` で現物 fill に適用してから `_build_code_episodes` へ渡す。未登録検知エピソードに `split_suspect: bool` フラグを付与 |
+| `scripts/webapp/templates/trade_history.html` | `split_suspect` エピソードの警告表示 (残高・含み損益・実現損益・損益率の全列を隠す、closed/open 問わず) |
+| `scripts/webapp/routes/trade_history.py` | `fill_pls` / `fill_closed_count` 等の集計から `split_suspect` エピソードを除外 |
+| `scripts/show_fill_episodes.py` | `--check-splits`, `--register-split` サブコマンド追加 |
+| `tests/test_fill_episodes.py` | 分割・併合まわりのテスト追加 (下記) |
+| `tests/test_portfolio_shelve.py` | `split_adj` get/set のテスト (存在すれば既存ファイルに追加) |
+| `doc/COMMANDS.md` | `--check-splits` / `--register-split` を追記 |
+
+## テスト計画 (5本以内)
+
+`tests/test_fill_episodes.py` に追加:
+
+1. `test_split_adjustment_closes_episode_at_zero` — 1491 相当の合成 fill (併合前5件+併合後11件) に `split_adj` イベントを1件登録した状態で `build_fill_episodes` を呼び、残高0株・クローズ済み・実現損益 +27,100円 になることを確認
+2. `test_multiple_split_events_apply_cumulative_ratio` — 同一銘柄に2回の分割・併合イベントを登録し、最古の fill に両方の累積比率が適用されること・中間の fill に1回分だけ適用されることを確認 (codex指摘の複数イベント対応の検証)
+3. `test_shinyo_round_not_affected_by_split_adjustment` — 同一銘柄に信用ラウンドが混在するケースで、信用側の損益 (settle_pl/tate_price 由来) が換算の影響を受けないことを確認
+4. `test_price_jump_detected_without_registration_marks_suspect` — `split_adj` 未登録の状態で単価ジャンプのある fill (1491相当) を渡すと、クローズ済み・保有中の両方で `split_suspect=True` が一貫して付与されることを確認 (codexレビュー指摘: closed/open 双方への伝播漏れがないかの検証)。同テストで `calc_trade_summary` 相当の集計対象からも除外されることを合わせて確認する
+5. `test_merger_ratio_closes_without_residual_qty` — 20:1 併合相当の比率で換算した際、浮動小数の残差 (`5.55e-17` 相当) がクローズ判定を妨げないことを確認 (codexレビュー指摘: floatゼロ判定の許容誤差の検証)
+
+`portfolio_shelve.py` 側の get/add は単純な shelve get/set なので、既存の `fill_memo` 系テストパターンに準拠する1本に留める。
+
+`_check_holding_splits` (yfinance 同期呼び出しを含む) はユニットテスト対象外とし、`--check-splits` 実行による手動確認で見る (既存の `test_live_html.py` 系と同様、外部依存のため自動テストに組み込まない)。
+
+## 除外・非対応
+
+- 手動の企業アクションマスターファイルは持たない
+- webapp のリクエストパス内での yfinance 同期呼び出しは行わない (診断CLIでのみ取得)
+- 出来高分割型でない特殊イベント (合併に伴う交換比率など) は対象外。単価ジャンプ検知にヒットしても `--check-splits` で「yfinance splits に該当データなし」と出た場合は要手動判断とし、その旨をログに残す

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -1274,8 +1274,17 @@ def add_split_adjustment(code_s: str, ex_date: str, ratio: float, *,
                 "source": "yfinance",
             }
             db[storage_key] = stored
-            if pending_key in db:
-                del db[pending_key]
+            # pending は銘柄単位ではなくイベント日単位で解除する。同一銘柄に複数の
+            # 未登録イベントがある状態で1件だけ登録した場合、残りのイベントの
+            # pending フラグは消さない (PRレビュー #405 P1 対応)。
+            pending_value = db.get(pending_key)
+            if isinstance(pending_value, dict):
+                remaining = [d for d in pending_value.get("ex_dates", []) if d != ex_date]
+                if remaining:
+                    pending_value["ex_dates"] = remaining
+                    db[pending_key] = pending_value
+                else:
+                    del db[pending_key]
     log_print("portfolio_shelve: split_adj 登録", code_s, ex_date, ratio)
     return stored
 
@@ -1284,21 +1293,36 @@ def _split_pending_review_storage_key(code_s: str) -> str:
     return f"{KEY_SPLIT_PENDING_REVIEW_PREFIX}{normalize_code_s(code_s)}"
 
 
-def mark_split_pending_review(code_s: str, *, reason: str,
+def mark_split_pending_review(code_s: str, *, reason: str, ex_date: Optional[str] = None,
                               db_path: Optional[str] = None) -> None:
     """--check-splits の (a)/(b) 検知結果を、webapp からも見える形で残す。
 
     build_fill_episodes は yfinance を呼ばないため、単価ジャンプが無く
     保有中の総当たりチェックでのみ見つかったケース (9252 相当) を検知できない。
     この拒否リストに載せておけば、次回 webapp 表示時にも split_suspect を
-    付与できる (yfinance 呼び出しなし)。add_split_adjustment で登録すれば解除される。
+    付与できる (yfinance 呼び出しなし)。
+
+    ex_date (yfinance が示す権利落ち日) が分かれば ex_dates リストに積む。
+    add_split_adjustment はイベント単位で ex_dates から解除するため、同一銘柄に
+    複数の未登録イベントがあっても、登録済みの日付だけが解除される
+    (PRレビュー #405 P1 対応: 銘柄単位で丸ごと解除すると、他の未登録イベントの
+    警告が消えてしまう)。ex_date 不明 (単価ジャンプ検知は yfinance 未参照でも
+    呼ばれる) の場合は "unknown" として積み、build_fill_episodes 側は
+    ex_dates の有無に関わらず銘柄が pending なら警告する (安全側)。
     """
     path = _resolve_db_path(db_path)
+    pending_key = _split_pending_review_storage_key(code_s)
     with _flock(db_path):
         with ShelveDB(path) as db:
-            db[_split_pending_review_storage_key(code_s)] = {
+            value = db.get(pending_key)
+            ex_dates = list(value.get("ex_dates", [])) if isinstance(value, dict) else []
+            marker = ex_date or "unknown"
+            if marker not in ex_dates:
+                ex_dates.append(marker)
+            db[pending_key] = {
                 "code_s": normalize_code_s(code_s),
                 "reason": reason,
+                "ex_dates": ex_dates,
                 "marked_at": now_iso(),
             }
 

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -30,6 +30,7 @@ shelve ベースのラッパー。
 import fcntl
 import glob
 import hashlib
+import math
 import os
 import re
 import threading
@@ -95,6 +96,8 @@ KEY_SPLIT_ADJ_PREFIX = "split_adj:"
 # build_fill_episodes は yfinance を呼ばないため、単価ジャンプが無く保有中の
 # 総当たりチェックでのみ見つかるケースを検知できない。ここに記録して埋める。
 KEY_SPLIT_PENDING_REVIEW_PREFIX = "split_pending_review:"
+# --reject-split で分割・併合ではないと判断したイベント (再検出抑止リスト)。
+KEY_SPLIT_REJECTED_REVIEW_PREFIX = "split_rejected_review:"
 
 # テーママスター (issue #282)
 THEME_FIELDS = frozenset({"name", "description", "created_at"})
@@ -1255,7 +1258,7 @@ def add_split_adjustment(code_s: str, ex_date: str, ratio: float, *,
     """
     if not _ACTION_DATE_RE.match(ex_date):
         raise ValueError(f"ex_date は YYYY-MM-DD 形式で指定してください: {ex_date!r}")
-    if not isinstance(ratio, (int, float)) or ratio <= 0:
+    if not isinstance(ratio, (int, float)) or not math.isfinite(ratio) or ratio <= 0:
         raise ValueError(f"ratio must be > 0, got {ratio!r}")
     path = _resolve_db_path(db_path)
     storage_key = _split_adj_storage_key(code_s)
@@ -1298,12 +1301,16 @@ def _split_pending_review_storage_key(code_s: str) -> str:
     return f"{KEY_SPLIT_PENDING_REVIEW_PREFIX}{normalize_code_s(code_s)}"
 
 
+def _split_rejected_review_storage_key(code_s: str) -> str:
+    return f"{KEY_SPLIT_REJECTED_REVIEW_PREFIX}{normalize_code_s(code_s)}"
+
+
 def mark_split_pending_review(code_s: str, *, reason: str, ex_date: Optional[str] = None,
                               db_path: Optional[str] = None) -> None:
     """--check-splits の (a)/(b) 検知結果を、webapp からも見える形で残す。
 
     build_fill_episodes は yfinance を呼ばないため、単価ジャンプが無く
-    保有中の総当たりチェックでのみ見つかったケース (9252 相当) を検知できない。
+    エピソード期間総当たりチェックでのみ見つかったケース (9252 相当) を検知できない。
     この拒否リストに載せておけば、次回 webapp 表示時にも split_suspect を
     付与できる (yfinance 呼び出しなし)。
 
@@ -1325,6 +1332,28 @@ def mark_split_pending_review(code_s: str, *, reason: str, ex_date: Optional[str
             if marker not in ex_dates:
                 ex_dates.append(marker)
             db[pending_key] = {
+                "code_s": normalize_code_s(code_s),
+                "reason": reason,
+                "ex_dates": ex_dates,
+                "marked_at": now_iso(),
+            }
+
+
+def mark_split_rejected_review(code_s: str, *, reason: str, ex_date: Optional[str] = None,
+                               db_path: Optional[str] = None) -> None:
+    """分割・併合ではないと判断した検知結果を再検出抑止用に保存する。"""
+    if ex_date is not None and ex_date != "unknown" and not _ACTION_DATE_RE.match(ex_date):
+        raise ValueError(f"ex_date は YYYY-MM-DD 形式で指定してください: {ex_date!r}")
+    path = _resolve_db_path(db_path)
+    rejected_key = _split_rejected_review_storage_key(code_s)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            value = db.get(rejected_key)
+            ex_dates = list(value.get("ex_dates", [])) if isinstance(value, dict) else []
+            marker = ex_date or "unknown"
+            if marker not in ex_dates:
+                ex_dates.append(marker)
+            db[rejected_key] = {
                 "code_s": normalize_code_s(code_s),
                 "reason": reason,
                 "ex_dates": ex_dates,
@@ -1362,6 +1391,25 @@ def clear_split_pending_review(code_s: str, *, ex_date: Optional[str] = None,
             return True
 
 
+def reject_split_pending_review(code_s: str, *, ex_date: Optional[str] = None,
+                                reason: str = "分割ではないと判断",
+                                db_path: Optional[str] = None) -> bool:
+    """pending_review を却下し、同じイベントを再検出しないよう保存する。"""
+    if ex_date is not None:
+        mark_split_rejected_review(code_s, reason=reason, ex_date=ex_date, db_path=db_path)
+        clear_split_pending_review(code_s, ex_date=ex_date, db_path=db_path)
+        return True
+
+    pending_events = list_pending_review_events(db_path=db_path).get(normalize_code_s(code_s), [])
+    if pending_events:
+        for marker in pending_events:
+            mark_split_rejected_review(code_s, reason=reason, ex_date=marker, db_path=db_path)
+    else:
+        mark_split_rejected_review(code_s, reason=reason, db_path=db_path)
+        return True
+    return clear_split_pending_review(code_s, db_path=db_path)
+
+
 def list_pending_review_codes(*, db_path: Optional[str] = None) -> List[str]:
     """split_pending_review が付いている銘柄コードの一覧を返す。"""
     path = _resolve_db_path(db_path)
@@ -1388,6 +1436,21 @@ def list_pending_review_events(*, db_path: Optional[str] = None) -> Dict[str, Li
             if not isinstance(value, dict):
                 continue
             code_s = value.get("code_s", key[len(KEY_SPLIT_PENDING_REVIEW_PREFIX):])
+            results[code_s] = list(value.get("ex_dates", []))
+    return results
+
+
+def list_rejected_review_events(*, db_path: Optional[str] = None) -> Dict[str, List[str]]:
+    """却下済みの分割・併合検知イベント日を銘柄別に返す。"""
+    path = _resolve_db_path(db_path)
+    results: Dict[str, List[str]] = {}
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_SPLIT_REJECTED_REVIEW_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            code_s = value.get("code_s", key[len(KEY_SPLIT_REJECTED_REVIEW_PREFIX):])
             results[code_s] = list(value.get("ex_dates", []))
     return results
 

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -1332,6 +1332,36 @@ def mark_split_pending_review(code_s: str, *, reason: str, ex_date: Optional[str
             }
 
 
+def clear_split_pending_review(code_s: str, *, ex_date: Optional[str] = None,
+                               db_path: Optional[str] = None) -> bool:
+    """split_pending_review を手動解除する。
+
+    ex_date 指定時はその日付だけを解除し、未指定なら同銘柄の pending を全解除する。
+    分割・併合ではないと判断した誤検知を解除するための操作。
+    """
+    if ex_date is not None and ex_date != "unknown" and not _ACTION_DATE_RE.match(ex_date):
+        raise ValueError(f"ex_date は YYYY-MM-DD 形式で指定してください: {ex_date!r}")
+    path = _resolve_db_path(db_path)
+    pending_key = _split_pending_review_storage_key(code_s)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            value = db.get(pending_key)
+            if not isinstance(value, dict):
+                return False
+            if ex_date is None:
+                del db[pending_key]
+                return True
+            remaining = [d for d in value.get("ex_dates", []) if d != ex_date]
+            if len(remaining) == len(value.get("ex_dates", [])):
+                return False
+            if remaining:
+                value["ex_dates"] = remaining
+                db[pending_key] = value
+            else:
+                del db[pending_key]
+            return True
+
+
 def list_pending_review_codes(*, db_path: Optional[str] = None) -> List[str]:
     """split_pending_review が付いている銘柄コードの一覧を返す。"""
     path = _resolve_db_path(db_path)
@@ -1341,6 +1371,25 @@ def list_pending_review_codes(*, db_path: Optional[str] = None) -> List[str]:
             if key.startswith(KEY_SPLIT_PENDING_REVIEW_PREFIX) and isinstance(value, dict):
                 codes.append(value.get("code_s", key[len(KEY_SPLIT_PENDING_REVIEW_PREFIX):]))
     return codes
+
+
+def list_pending_review_events(*, db_path: Optional[str] = None) -> Dict[str, List[str]]:
+    """split_pending_review の未登録イベント日を銘柄別に返す。
+
+    ex_date 不明時の "unknown" もそのまま含める。呼び出し側は日付範囲で
+    絞れるものだけ絞り、不明分は従来どおり安全側で扱う。
+    """
+    path = _resolve_db_path(db_path)
+    results: Dict[str, List[str]] = {}
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_SPLIT_PENDING_REVIEW_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            code_s = value.get("code_s", key[len(KEY_SPLIT_PENDING_REVIEW_PREFIX):])
+            results[code_s] = list(value.get("ex_dates", []))
+    return results
 
 
 # ===========================================

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -1276,10 +1276,15 @@ def add_split_adjustment(code_s: str, ex_date: str, ratio: float, *,
             db[storage_key] = stored
             # pending は銘柄単位ではなくイベント日単位で解除する。同一銘柄に複数の
             # 未登録イベントがある状態で1件だけ登録した場合、残りのイベントの
-            # pending フラグは消さない (PRレビュー #405 P1 対応)。
+            # pending フラグは消さない (PRレビュー #405 P1 対応)。"unknown" は
+            # yfinance 取得失敗時に ex_date 不明のまま積まれたマーカーで、以後
+            # ex_date が判明して登録できた時点で「不明だった」状態は解消したとみなし
+            # 合わせて解除する (PRレビュー対応: unknown は ex_date と一致しないため
+            # 残り続け、以後も保有中エピソードの残高・損益が非表示のままになる)。
             pending_value = db.get(pending_key)
             if isinstance(pending_value, dict):
-                remaining = [d for d in pending_value.get("ex_dates", []) if d != ex_date]
+                remaining = [d for d in pending_value.get("ex_dates", [])
+                            if d != ex_date and d != "unknown"]
                 if remaining:
                     pending_value["ex_dates"] = remaining
                     db[pending_key] = pending_value

--- a/scripts/portfolio_shelve.py
+++ b/scripts/portfolio_shelve.py
@@ -88,6 +88,13 @@ KEY_FILL_SEQ_PREFIX = "_fill_seq:"
 # fill は再取込で作り直されるため、メモは別レイヤーに独立保存し
 # エピソードキー (code_s|kind|open_date|close_date) で紐付ける。
 KEY_FILL_MEMO_PREFIX = "fill_memo:"
+# issue #398: 株式分割・併合の換算比率 (yfinance corporate actions 由来のキャッシュ)。
+# fill 本体は不変のまま、エピソード再構成時にのみ適用する派生情報として分離保存する。
+KEY_SPLIT_ADJ_PREFIX = "split_adj:"
+# --check-splits で検知したが split_adj 未登録の銘柄コード (拒否リスト)。
+# build_fill_episodes は yfinance を呼ばないため、単価ジャンプが無く保有中の
+# 総当たりチェックでのみ見つかるケースを検知できない。ここに記録して埋める。
+KEY_SPLIT_PENDING_REVIEW_PREFIX = "split_pending_review:"
 
 # テーママスター (issue #282)
 THEME_FIELDS = frozenset({"name", "description", "created_at"})
@@ -1195,6 +1202,116 @@ def list_fill_memos(*, db_path: Optional[str] = None) -> Dict[str, str]:
             if memo:
                 results[value.get("episode_key", key[len(KEY_FILL_MEMO_PREFIX):])] = memo
     return results
+
+
+# ===========================================
+# 株式分割・併合の換算比率キャッシュ (issue #398)
+# ===========================================
+
+def _split_adj_storage_key(code_s: str) -> str:
+    return f"{KEY_SPLIT_ADJ_PREFIX}{normalize_code_s(code_s)}"
+
+
+def get_split_adjustments(code_s: str, *, db_path: Optional[str] = None) -> List[Dict[str, Any]]:
+    """銘柄の分割・併合イベントを ex_date 昇順で返す (未登録なら空リスト)。
+
+    各要素は {"ex_date": "YYYY-MM-DD", "ratio": float}。ratio は新株数/旧株数
+    (0.05 = 20株->1株併合、2.0 = 1株->2株分割)。
+    """
+    path = _resolve_db_path(db_path)
+    with ShelveDB(path) as db:
+        value = db.get(_split_adj_storage_key(code_s))
+    if not isinstance(value, dict):
+        return []
+    events = value.get("events") or []
+    return sorted(events, key=lambda e: e["ex_date"])
+
+
+def list_all_split_adjustments(*, db_path: Optional[str] = None) -> Dict[str, List[Dict[str, Any]]]:
+    """全銘柄の分割・併合イベントを {code_s: [events...]} で一括取得する。
+
+    build_fill_episodes の全銘柄ループで銘柄ごとに DB を開き直す N+1 を避けるため。
+    """
+    path = _resolve_db_path(db_path)
+    results: Dict[str, List[Dict[str, Any]]] = {}
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if not key.startswith(KEY_SPLIT_ADJ_PREFIX):
+                continue
+            if not isinstance(value, dict):
+                continue
+            events = value.get("events") or []
+            if events:
+                code_s = value.get("code_s", key[len(KEY_SPLIT_ADJ_PREFIX):])
+                results[code_s] = sorted(events, key=lambda e: e["ex_date"])
+    return results
+
+
+def add_split_adjustment(code_s: str, ex_date: str, ratio: float, *,
+                         db_path: Optional[str] = None) -> Dict[str, Any]:
+    """分割・併合イベントを1件追加する (同一 ex_date は上書き、dedup)。
+
+    登録すると同銘柄の split_pending_review (未登録の疑いマーク) も解除する。
+    """
+    if not _ACTION_DATE_RE.match(ex_date):
+        raise ValueError(f"ex_date は YYYY-MM-DD 形式で指定してください: {ex_date!r}")
+    if not isinstance(ratio, (int, float)) or ratio <= 0:
+        raise ValueError(f"ratio must be > 0, got {ratio!r}")
+    path = _resolve_db_path(db_path)
+    storage_key = _split_adj_storage_key(code_s)
+    pending_key = _split_pending_review_storage_key(code_s)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            value = db.get(storage_key)
+            events = list(value.get("events", [])) if isinstance(value, dict) else []
+            events = [e for e in events if e["ex_date"] != ex_date]
+            events.append({"ex_date": ex_date, "ratio": float(ratio)})
+            events.sort(key=lambda e: e["ex_date"])
+            stored = {
+                "code_s": normalize_code_s(code_s),
+                "events": events,
+                "updated_at": now_iso(),
+                "source": "yfinance",
+            }
+            db[storage_key] = stored
+            if pending_key in db:
+                del db[pending_key]
+    log_print("portfolio_shelve: split_adj 登録", code_s, ex_date, ratio)
+    return stored
+
+
+def _split_pending_review_storage_key(code_s: str) -> str:
+    return f"{KEY_SPLIT_PENDING_REVIEW_PREFIX}{normalize_code_s(code_s)}"
+
+
+def mark_split_pending_review(code_s: str, *, reason: str,
+                              db_path: Optional[str] = None) -> None:
+    """--check-splits の (a)/(b) 検知結果を、webapp からも見える形で残す。
+
+    build_fill_episodes は yfinance を呼ばないため、単価ジャンプが無く
+    保有中の総当たりチェックでのみ見つかったケース (9252 相当) を検知できない。
+    この拒否リストに載せておけば、次回 webapp 表示時にも split_suspect を
+    付与できる (yfinance 呼び出しなし)。add_split_adjustment で登録すれば解除される。
+    """
+    path = _resolve_db_path(db_path)
+    with _flock(db_path):
+        with ShelveDB(path) as db:
+            db[_split_pending_review_storage_key(code_s)] = {
+                "code_s": normalize_code_s(code_s),
+                "reason": reason,
+                "marked_at": now_iso(),
+            }
+
+
+def list_pending_review_codes(*, db_path: Optional[str] = None) -> List[str]:
+    """split_pending_review が付いている銘柄コードの一覧を返す。"""
+    path = _resolve_db_path(db_path)
+    codes = []
+    with ShelveDB(path) as db:
+        for key, value in db.items():
+            if key.startswith(KEY_SPLIT_PENDING_REVIEW_PREFIX) and isinstance(value, dict):
+                codes.append(value.get("code_s", key[len(KEY_SPLIT_PENDING_REVIEW_PREFIX):]))
+    return codes
 
 
 # ===========================================

--- a/scripts/show_fill_episodes.py
+++ b/scripts/show_fill_episodes.py
@@ -2,14 +2,20 @@
 """fill 建玉ラウンド (エピソード) を確認する開発補助CLI (issue #387)。
 
 build_fill_episodes (webapp.helpers) を呼んで、取込後の検算・保有中確認・
-現引や信用の損益・振り返りメモの紐付けをターミナルで確認する。DB は更新しない。
+現引や信用の損益・振り返りメモの紐付けをターミナルで確認する。
 
 使い方:
-    cd scripts && python show_fill_episodes.py            # 全エピソード (最新約定日降順)
-    cd scripts && python show_fill_episodes.py 6324       # 特定銘柄のみ
-    cd scripts && python show_fill_episodes.py --open     # 保有中のみ
-    cd scripts && python show_fill_episodes.py --memo     # 振り返りメモ付きのみ
-    cd scripts && python show_fill_episodes.py --fills 6324  # 内訳 fill も表示
+    cd scripts && python show_fill_episodes.py            # 全エピソード (最新約定日降順、DB非更新)
+    cd scripts && python show_fill_episodes.py 6324       # 特定銘柄のみ (DB非更新)
+    cd scripts && python show_fill_episodes.py --open     # 保有中のみ (DB非更新)
+    cd scripts && python show_fill_episodes.py --memo     # 振り返りメモ付きのみ (DB非更新)
+    cd scripts && python show_fill_episodes.py --fills 6324  # 内訳 fill も表示 (DB非更新)
+    cd scripts && python show_fill_episodes.py --check-splits          # 分割・併合の疑いを診断 (issue #398)
+    cd scripts && python show_fill_episodes.py --register-split 1491 2025-09-29 0.05  # 換算比率を登録
+
+--check-splits は fill 本体・split_adj を更新しないが、未登録の発見を
+split_pending_review (拒否リスト) に記録する。これにより webapp 表示 (yfinance を
+呼ばない) でも同じ疑いを検知できる。--register-split で登録すれば解除される。
 """
 
 import argparse
@@ -21,11 +27,19 @@ _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _THIS_DIR not in sys.path:
     sys.path.insert(0, _THIS_DIR)
 
+import portfolio_shelve as ps  # noqa: E402
+from ks_util import log_warning  # noqa: E402
 from webapp import helpers  # noqa: E402
 
 
 def _fmt_pl(ep: Dict[str, Any]) -> str:
-    """損益列の文字列を組み立てる (クローズ=実現、保有中=実現+含み)。"""
+    """損益列の文字列を組み立てる (クローズ=実現、保有中=実現+含み)。
+
+    split_suspect (issue #398、分割・併合の疑いだが未換算) は残高・損益が
+    誤っている可能性があるため、webapp (trade_history.html) と同様に隠す。
+    """
+    if ep.get("split_suspect"):
+        return "⚠ 分割・併合の疑い (要確認、--check-splits参照)"
     if ep["closed"]:
         pl = ep.get("pl")
         if not pl or pl.get("profit_amount") is None:
@@ -60,6 +74,109 @@ def _print_episode(ep: Dict[str, Any], show_fills: bool) -> None:
                   f" {f['qty']:>5}株 @{f['price']:,.0f}{tate} [{f['broker']}]")
 
 
+def _yfinance_splits(code_s: str, stock_db: Dict[str, Any]):
+    """yfinance の corporate actions (splits) を取得する。失敗時は None。issue #398。
+
+    ticker symbol は price._get_ticker_symbol で市場区分別のサフィックス
+    (.T/.S/.N/.F) を解決する (東証固定の .T だと札証・名証・福証銘柄で誤る)。
+    """
+    import price as price_module
+
+    try:
+        import yfinance as yf
+        ticker_symbol = price_module._get_ticker_symbol(code_s, stock_db.get(code_s, {}))
+        ticker = yf.Ticker(ticker_symbol)
+        return ticker.splits
+    except Exception as e:  # yfinance 側の例外種別は不定
+        log_warning(f"yfinance 取得失敗 ({code_s}): {e}")
+        return None
+
+
+def _report_split_candidate(code_s: str, splits, reason: str, db_path: Optional[str]) -> None:
+    """未登録の分割・併合イベントを pending_review に記録し、登録コマンドを案内する。
+
+    (a) 単価ジャンプ検知・(b) 保有中総当たりチェックの両方から呼ぶ共通処理。
+    """
+    ps.mark_split_pending_review(code_s, reason=reason, db_path=db_path)
+    if splits is None or splits.empty:
+        print("      split_adj 未登録。yfinance に該当データなし (要手動判断)")
+        return
+    for ex_date, ratio in splits.items():
+        print(f"      split_adj 未登録。yfinance suggests: {ex_date.date()} ratio={ratio}")
+    print(f"      登録: python show_fill_episodes.py --register-split {code_s} "
+          f"<ex_date> <ratio>")
+
+
+def _check_splits(db_path: Optional[str]) -> int:
+    """分割・併合の疑いを診断する。issue #398。
+
+    (a) 単価ジャンプ検知: 全銘柄の fill を約定日順に見て単価が急変する箇所を検出。
+    (b) 保有中現物の総当たり: 単価ジャンプが無くても、保有継続中で売買が発生していない
+        銘柄は yfinance で open_date 以降の split イベントの有無を直接確認する。
+
+    fill 本体・split_adj は更新しないが、未登録の発見は split_pending_review
+    (拒否リスト) に記録する。build_fill_episodes は yfinance を呼ばないため、
+    (b) でのみ見つかるケース (9252相当) を webapp 表示でも検知できるようにするため。
+    """
+    import make_stock_db
+
+    all_fills = ps.list_fills(db_path=db_path)
+    by_code: Dict[str, List[Dict[str, Any]]] = {}
+    for f in all_fills:
+        by_code.setdefault(f["code_s"], []).append(f)
+
+    names = helpers._bulk_resolve_stock_names(list(by_code.keys()))
+    registered = ps.list_all_split_adjustments(db_path=db_path)
+    stock_db = make_stock_db.load_stock_db()  # ticker symbol の市場区分解決用 (1回だけロード)
+    found = 0
+
+    for code_s, fills in sorted(by_code.items()):
+        jumps = helpers._detect_price_jumps(fills)
+        for jump in jumps:
+            found += 1
+            print(f" {code_s:>5} {names.get(code_s, ''):<12} 単価ジャンプ検出: "
+                  f"{jump['before_date']} @{jump['before_price']:,.0f} -> "
+                  f"{jump['after_date']} @{jump['after_price']:,.0f} "
+                  f"(x{jump['after_price'] / jump['before_price']:.1f})")
+            if code_s in registered:
+                print(f"      split_adj 登録済み: {registered[code_s]}")
+                continue
+            _report_split_candidate(
+                code_s, _yfinance_splits(code_s, stock_db), "単価ジャンプ検出", db_path)
+
+    open_genbutsu_dates = {
+        ep["code_s"]: ep["open_date"] for ep in helpers.build_fill_episodes(db_path=db_path)
+        if not ep["closed"] and ep["kind"] == "現物"
+    }
+    for code_s, open_date in sorted(open_genbutsu_dates.items()):
+        if code_s in registered:
+            continue
+        splits = _yfinance_splits(code_s, stock_db)
+        if splits is None or splits.empty:
+            continue
+        # open_date より後に権利落ちしたイベントのみが今の保有に影響する
+        relevant_dates = [ex_date for ex_date in splits.index
+                          if ex_date.strftime("%Y-%m-%d") >= open_date]
+        if not relevant_dates:
+            continue
+        found += 1
+        print(f" {code_s:>5} {names.get(code_s, ''):<12} 保有中チェック (open_date={open_date}): "
+              f"split イベントあり (未登録)")
+        _report_split_candidate(
+            code_s, splits.loc[relevant_dates], "保有中総当たりチェック", db_path)
+
+    if found == 0:
+        print("分割・併合の疑いは検出されませんでした。")
+    return 0
+
+
+def _register_split(code_s: str, ex_date: str, ratio: str, db_path: Optional[str]) -> int:
+    """split_adj イベントを1件登録する (issue #398)。"""
+    stored = ps.add_split_adjustment(code_s, ex_date, float(ratio), db_path=db_path)
+    print(f"登録しました: {code_s} {stored['events']}")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="fill 建玉ラウンド (エピソード) を確認する (DB非更新)"
@@ -70,7 +187,16 @@ def main() -> int:
     parser.add_argument("--memo", action="store_true", help="振り返りメモ付きのみ表示")
     parser.add_argument("--fills", action="store_true", help="内訳の個別 fill も表示")
     parser.add_argument("--db-path", default=None, help="portfolio DB パス")
+    parser.add_argument("--check-splits", action="store_true",
+                        help="分割・併合の疑いを診断する (issue #398、DB非更新)")
+    parser.add_argument("--register-split", nargs=3, metavar=("CODE", "EX_DATE", "RATIO"),
+                        help="分割・併合の換算比率を登録する (例: 1491 2025-09-29 0.05)")
     args = parser.parse_args()
+
+    if args.register_split:
+        return _register_split(*args.register_split, db_path=args.db_path)
+    if args.check_splits:
+        return _check_splits(args.db_path)
 
     episodes: List[Dict[str, Any]] = helpers.build_fill_episodes(db_path=args.db_path)
 

--- a/scripts/show_fill_episodes.py
+++ b/scripts/show_fill_episodes.py
@@ -132,14 +132,19 @@ def _check_splits(db_path: Optional[str]) -> int:
 
     for code_s, fills in sorted(by_code.items()):
         jumps = helpers._detect_price_jumps(fills)
+        events = registered.get(code_s, [])
         for jump in jumps:
             found += 1
             print(f" {code_s:>5} {names.get(code_s, ''):<12} 単価ジャンプ検出: "
                   f"{jump['before_date']} @{jump['before_price']:,.0f} -> "
                   f"{jump['after_date']} @{jump['after_price']:,.0f} "
                   f"(x{jump['after_price'] / jump['before_price']:.1f})")
-            if code_s in registered:
-                print(f"      split_adj 登録済み: {registered[code_s]}")
+            # このジャンプの日付範囲をカバーする登録済みイベントがあるかで判定する
+            # (銘柄単位の in registered だけだと、後日発生した別イベントを見逃す)
+            covering = [ev for ev in events
+                       if jump["before_date"] < ev["ex_date"] <= jump["after_date"]]
+            if covering:
+                print(f"      split_adj 登録済み: {covering}")
                 continue
             _report_split_candidate(
                 code_s, _yfinance_splits(code_s, stock_db), "単価ジャンプ検出", db_path)
@@ -149,14 +154,15 @@ def _check_splits(db_path: Optional[str]) -> int:
         if not ep["closed"] and ep["kind"] == "現物"
     }
     for code_s, open_date in sorted(open_genbutsu_dates.items()):
-        if code_s in registered:
-            continue
         splits = _yfinance_splits(code_s, stock_db)
         if splits is None or splits.empty:
             continue
-        # open_date より後に権利落ちしたイベントのみが今の保有に影響する
+        registered_dates = {ev["ex_date"] for ev in registered.get(code_s, [])}
+        # open_date より後に権利落ちし、かつ未登録のイベントのみが今の保有に影響する
+        # (銘柄単位の in registered だけだと、登録後に発生した別イベントを見逃す)
         relevant_dates = [ex_date for ex_date in splits.index
-                          if ex_date.strftime("%Y-%m-%d") >= open_date]
+                          if ex_date.strftime("%Y-%m-%d") >= open_date
+                          and ex_date.strftime("%Y-%m-%d") not in registered_dates]
         if not relevant_dates:
             continue
         found += 1

--- a/scripts/show_fill_episodes.py
+++ b/scripts/show_fill_episodes.py
@@ -30,7 +30,7 @@ if _THIS_DIR not in sys.path:
     sys.path.insert(0, _THIS_DIR)
 
 import portfolio_shelve as ps  # noqa: E402
-from ks_util import log_warning  # noqa: E402
+from ks_util import log_print, log_warning  # noqa: E402
 from webapp import helpers  # noqa: E402
 
 
@@ -103,16 +103,26 @@ def _report_split_candidate(code_s: str, splits, reason: str, db_path: Optional[
     """
     if splits is None or splits.empty:
         ps.mark_split_pending_review(code_s, reason=reason, db_path=db_path)
-        print("      split_adj 未登録。yfinance に該当データなし (要手動判断)")
-        print(f"      却下: python show_fill_episodes.py --reject-split {code_s}")
+        log_warning("      split_adj 未登録。yfinance に該当データなし (要手動判断)")
+        log_print(f"      却下: python show_fill_episodes.py --reject-split {code_s}")
         return
     for ex_date, ratio in splits.items():
         ps.mark_split_pending_review(
             code_s, reason=reason, ex_date=str(ex_date.date()), db_path=db_path)
-        print(f"      split_adj 未登録。yfinance suggests: {ex_date.date()} ratio={ratio}")
-    print(f"      登録: python show_fill_episodes.py --register-split {code_s} "
-          f"<ex_date> <ratio>")
-    print(f"      却下: python show_fill_episodes.py --reject-split {code_s} <ex_date>")
+        log_warning(f"      split_adj 未登録。yfinance suggests: {ex_date.date()} ratio={ratio}")
+    log_print(f"      登録: python show_fill_episodes.py --register-split {code_s} "
+              f"<ex_date> <ratio>")
+    log_print(f"      却下: python show_fill_episodes.py --reject-split {code_s} <ex_date>")
+
+
+def _filter_rejected_splits(code_s: str, splits, rejected_dates: set):
+    """却下済み ex_date を yfinance splits から除外する。"""
+    if splits is None or splits.empty:
+        return splits
+    if not rejected_dates:
+        return splits
+    mask = [ex_date.strftime("%Y-%m-%d") not in rejected_dates for ex_date in splits.index]
+    return splits[mask]
 
 
 def _check_splits(db_path: Optional[str]) -> int:
@@ -136,28 +146,27 @@ def _check_splits(db_path: Optional[str]) -> int:
 
     names = helpers._bulk_resolve_stock_names(list(by_code.keys()))
     registered = ps.list_all_split_adjustments(db_path=db_path)
+    rejected = ps.list_rejected_review_events(db_path=db_path)
     stock_db = make_stock_db.load_stock_db()  # ticker symbol の市場区分解決用 (1回だけロード)
     found = 0
 
     for code_s, fills in sorted(by_code.items()):
         events = registered.get(code_s, [])
+        rejected_dates = set(rejected.get(code_s, []))
         # ジャンプ検知は換算後の fills に対して行う (build_fill_episodes と同じ理由:
         # 未換算のまま検知すると、登録済みイベントで残高の基準が変わった後の
         # 残高追跡が崩れ、別の未登録イベントのジャンプを見逃す)。
         adjusted_fills = helpers._apply_split_adjustments(fills, events) if events else fills
         jumps = helpers._detect_price_jumps(adjusted_fills)
         for jump in jumps:
-            found += 1
-            print(f" {code_s:>5} {names.get(code_s, ''):<12} 単価ジャンプ検出: "
-                  f"{jump['before_date']} @{jump['before_price']:,.0f} -> "
-                  f"{jump['after_date']} @{jump['after_price']:,.0f} "
-                  f"(x{jump['after_price'] / jump['before_price']:.1f})")
             # このジャンプの日付範囲をカバーする登録済みイベントがあるかで判定する
             # (銘柄単位の in registered だけだと、後日発生した別イベントを見逃す)
             covering = [ev for ev in events
                        if jump["before_date"] < ev["ex_date"] <= jump["after_date"]]
             if covering:
-                print(f"      split_adj 登録済み: {covering}")
+                log_print(f"      split_adj 登録済み: {covering}")
+                continue
+            if "unknown" in rejected_dates:
                 continue
             splits = _yfinance_splits(code_s, stock_db)
             # yfinance の全履歴をそのまま渡すと、登録済みの古い日付まで再度
@@ -168,9 +177,17 @@ def _check_splits(db_path: Optional[str]) -> int:
                 mask = [
                     jump["before_date"] < ex_date.strftime("%Y-%m-%d") <= jump["after_date"]
                     and ex_date.strftime("%Y-%m-%d") not in registered_dates
+                    and ex_date.strftime("%Y-%m-%d") not in rejected_dates
                     for ex_date in splits.index
                 ]
                 splits = splits[mask]
+                if splits.empty:
+                    continue
+            found += 1
+            log_warning(f" {code_s:>5} {names.get(code_s, ''):<12} 単価ジャンプ検出: "
+                        f"{jump['before_date']} @{jump['before_price']:,.0f} -> "
+                        f"{jump['after_date']} @{jump['after_price']:,.0f} "
+                        f"(x{jump['after_price'] / jump['before_price']:.1f})")
             _report_split_candidate(code_s, splits, "単価ジャンプ検出", db_path)
 
     genbutsu_ranges: Dict[str, List[Dict[str, str]]] = {}
@@ -186,6 +203,10 @@ def _check_splits(db_path: Optional[str]) -> int:
         if splits is None or splits.empty:
             continue
         registered_dates = {ev["ex_date"] for ev in registered.get(code_s, [])}
+        rejected_dates = set(rejected.get(code_s, []))
+        splits = _filter_rejected_splits(code_s, splits, rejected_dates)
+        if splits.empty:
+            continue
         # エピソード期間中に権利落ちし、かつ未登録のイベントのみが当該ラウンドに影響する。
         # 保有中だけに限定すると、pending 検出後に売却でクローズした瞬間に警告が外れ、
         # 2:1 分割など単価ジャンプ閾値未満の誤損益が集計へ戻ってしまう。
@@ -194,42 +215,42 @@ def _check_splits(db_path: Optional[str]) -> int:
             ex_date_s = ex_date.strftime("%Y-%m-%d")
             if ex_date_s in registered_dates:
                 continue
-            if any(r["open_date"] <= ex_date_s <= r["close_date"] for r in ranges):
+            if any(r["open_date"] < ex_date_s <= r["close_date"] for r in ranges):
                 relevant_dates.append(ex_date)
         if not relevant_dates:
             continue
         found += 1
-        print(f" {code_s:>5} {names.get(code_s, ''):<12} エピソード期間チェック: "
-              f"split イベントあり (未登録)")
+        log_warning(f" {code_s:>5} {names.get(code_s, ''):<12} エピソード期間チェック: "
+                    f"split イベントあり (未登録)")
         _report_split_candidate(
             code_s, splits.loc[relevant_dates], "エピソード期間総当たりチェック", db_path)
 
     if found == 0:
-        print("分割・併合の疑いは検出されませんでした。")
+        log_print("分割・併合の疑いは検出されませんでした。")
     return 0
 
 
 def _register_split(code_s: str, ex_date: str, ratio: str, db_path: Optional[str]) -> int:
     """split_adj イベントを1件登録する (issue #398)。"""
     stored = ps.add_split_adjustment(code_s, ex_date, float(ratio), db_path=db_path)
-    print(f"登録しました: {code_s} {stored['events']}")
+    log_print(f"登録しました: {code_s} {stored['events']}")
     return 0
 
 
 def _reject_split(args: List[str], db_path: Optional[str]) -> int:
     """分割・併合ではないと判断した pending_review を解除する。"""
     if len(args) not in (1, 2):
-        print("--reject-split は CODE または CODE EX_DATE を指定してください。")
+        log_warning("--reject-split は CODE または CODE EX_DATE を指定してください。")
         return 2
     code_s = args[0]
     ex_date = args[1] if len(args) == 2 else None
-    changed = ps.clear_split_pending_review(code_s, ex_date=ex_date, db_path=db_path)
+    changed = ps.reject_split_pending_review(code_s, ex_date=ex_date, db_path=db_path)
     if changed:
         target = ex_date or "全pending"
-        print(f"却下しました: {code_s} {target}")
+        log_print(f"却下しました: {code_s} {target}")
     else:
         target = ex_date or "pending"
-        print(f"該当する pending はありません: {code_s} {target}")
+        log_print(f"該当する pending はありません: {code_s} {target}")
     return 0
 
 

--- a/scripts/show_fill_episodes.py
+++ b/scripts/show_fill_episodes.py
@@ -96,12 +96,16 @@ def _report_split_candidate(code_s: str, splits, reason: str, db_path: Optional[
     """未登録の分割・併合イベントを pending_review に記録し、登録コマンドを案内する。
 
     (a) 単価ジャンプ検知・(b) 保有中総当たりチェックの両方から呼ぶ共通処理。
+    ex_date が分かるイベントごとに pending へ積む (PRレビュー #405 P1 対応:
+    複数の未登録イベントがあっても登録済みの日付だけが解除されるようにするため)。
     """
-    ps.mark_split_pending_review(code_s, reason=reason, db_path=db_path)
     if splits is None or splits.empty:
+        ps.mark_split_pending_review(code_s, reason=reason, db_path=db_path)
         print("      split_adj 未登録。yfinance に該当データなし (要手動判断)")
         return
     for ex_date, ratio in splits.items():
+        ps.mark_split_pending_review(
+            code_s, reason=reason, ex_date=str(ex_date.date()), db_path=db_path)
         print(f"      split_adj 未登録。yfinance suggests: {ex_date.date()} ratio={ratio}")
     print(f"      登録: python show_fill_episodes.py --register-split {code_s} "
           f"<ex_date> <ratio>")

--- a/scripts/show_fill_episodes.py
+++ b/scripts/show_fill_episodes.py
@@ -135,8 +135,12 @@ def _check_splits(db_path: Optional[str]) -> int:
     found = 0
 
     for code_s, fills in sorted(by_code.items()):
-        jumps = helpers._detect_price_jumps(fills)
         events = registered.get(code_s, [])
+        # ジャンプ検知は換算後の fills に対して行う (build_fill_episodes と同じ理由:
+        # 未換算のまま検知すると、登録済みイベントで残高の基準が変わった後の
+        # 残高追跡が崩れ、別の未登録イベントのジャンプを見逃す)。
+        adjusted_fills = helpers._apply_split_adjustments(fills, events) if events else fills
+        jumps = helpers._detect_price_jumps(adjusted_fills)
         for jump in jumps:
             found += 1
             print(f" {code_s:>5} {names.get(code_s, ''):<12} 単価ジャンプ検出: "
@@ -150,8 +154,19 @@ def _check_splits(db_path: Optional[str]) -> int:
             if covering:
                 print(f"      split_adj 登録済み: {covering}")
                 continue
-            _report_split_candidate(
-                code_s, _yfinance_splits(code_s, stock_db), "単価ジャンプ検出", db_path)
+            splits = _yfinance_splits(code_s, stock_db)
+            # yfinance の全履歴をそのまま渡すと、登録済みの古い日付まで再度
+            # pending に積んでしまう (PRレビュー対応)。このジャンプの日付範囲を
+            # カバーする未登録イベントだけに絞り込む。
+            if splits is not None and not splits.empty:
+                registered_dates = {ev["ex_date"] for ev in events}
+                mask = [
+                    jump["before_date"] < ex_date.strftime("%Y-%m-%d") <= jump["after_date"]
+                    and ex_date.strftime("%Y-%m-%d") not in registered_dates
+                    for ex_date in splits.index
+                ]
+                splits = splits[mask]
+            _report_split_candidate(code_s, splits, "単価ジャンプ検出", db_path)
 
     open_genbutsu_dates = {
         ep["code_s"]: ep["open_date"] for ep in helpers.build_fill_episodes(db_path=db_path)

--- a/scripts/show_fill_episodes.py
+++ b/scripts/show_fill_episodes.py
@@ -12,10 +12,12 @@ build_fill_episodes (webapp.helpers) を呼んで、取込後の検算・保有�
     cd scripts && python show_fill_episodes.py --fills 6324  # 内訳 fill も表示 (DB非更新)
     cd scripts && python show_fill_episodes.py --check-splits          # 分割・併合の疑いを診断 (issue #398)
     cd scripts && python show_fill_episodes.py --register-split 1491 2025-09-29 0.05  # 換算比率を登録
+    cd scripts && python show_fill_episodes.py --reject-split 1491 2025-09-29  # 誤検知を解除
 
 --check-splits は fill 本体・split_adj を更新しないが、未登録の発見を
 split_pending_review (拒否リスト) に記録する。これにより webapp 表示 (yfinance を
-呼ばない) でも同じ疑いを検知できる。--register-split で登録すれば解除される。
+呼ばない) でも同じ疑いを検知できる。--register-split で登録、または
+--reject-split で誤検知として却下すれば解除される。
 """
 
 import argparse
@@ -95,13 +97,14 @@ def _yfinance_splits(code_s: str, stock_db: Dict[str, Any]):
 def _report_split_candidate(code_s: str, splits, reason: str, db_path: Optional[str]) -> None:
     """未登録の分割・併合イベントを pending_review に記録し、登録コマンドを案内する。
 
-    (a) 単価ジャンプ検知・(b) 保有中総当たりチェックの両方から呼ぶ共通処理。
+    (a) 単価ジャンプ検知・(b) エピソード期間総当たりチェックの両方から呼ぶ共通処理。
     ex_date が分かるイベントごとに pending へ積む (PRレビュー #405 P1 対応:
     複数の未登録イベントがあっても登録済みの日付だけが解除されるようにするため)。
     """
     if splits is None or splits.empty:
         ps.mark_split_pending_review(code_s, reason=reason, db_path=db_path)
         print("      split_adj 未登録。yfinance に該当データなし (要手動判断)")
+        print(f"      却下: python show_fill_episodes.py --reject-split {code_s}")
         return
     for ex_date, ratio in splits.items():
         ps.mark_split_pending_review(
@@ -109,18 +112,20 @@ def _report_split_candidate(code_s: str, splits, reason: str, db_path: Optional[
         print(f"      split_adj 未登録。yfinance suggests: {ex_date.date()} ratio={ratio}")
     print(f"      登録: python show_fill_episodes.py --register-split {code_s} "
           f"<ex_date> <ratio>")
+    print(f"      却下: python show_fill_episodes.py --reject-split {code_s} <ex_date>")
 
 
 def _check_splits(db_path: Optional[str]) -> int:
     """分割・併合の疑いを診断する。issue #398。
 
     (a) 単価ジャンプ検知: 全銘柄の fill を約定日順に見て単価が急変する箇所を検出。
-    (b) 保有中現物の総当たり: 単価ジャンプが無くても、保有継続中で売買が発生していない
-        銘柄は yfinance で open_date 以降の split イベントの有無を直接確認する。
+    (b) 現物エピソード期間の総当たり: 単価ジャンプが無くても、エピソード期間中の
+        split イベントの有無を yfinance で直接確認する。
 
     fill 本体・split_adj は更新しないが、未登録の発見は split_pending_review
     (拒否リスト) に記録する。build_fill_episodes は yfinance を呼ばないため、
-    (b) でのみ見つかるケース (9252相当) を webapp 表示でも検知できるようにするため。
+    (b) でのみ見つかるケース (9252相当、2:1分割など) を webapp 表示でも
+    検知できるようにするため。
     """
     import make_stock_db
 
@@ -168,27 +173,36 @@ def _check_splits(db_path: Optional[str]) -> int:
                 splits = splits[mask]
             _report_split_candidate(code_s, splits, "単価ジャンプ検出", db_path)
 
-    open_genbutsu_dates = {
-        ep["code_s"]: ep["open_date"] for ep in helpers.build_fill_episodes(db_path=db_path)
-        if not ep["closed"] and ep["kind"] == "現物"
-    }
-    for code_s, open_date in sorted(open_genbutsu_dates.items()):
+    genbutsu_ranges: Dict[str, List[Dict[str, str]]] = {}
+    for ep in helpers.build_fill_episodes(db_path=db_path):
+        if ep["kind"] != "現物":
+            continue
+        genbutsu_ranges.setdefault(ep["code_s"], []).append({
+            "open_date": ep["open_date"],
+            "close_date": ep.get("close_date") or "9999-12-31",
+        })
+    for code_s, ranges in sorted(genbutsu_ranges.items()):
         splits = _yfinance_splits(code_s, stock_db)
         if splits is None or splits.empty:
             continue
         registered_dates = {ev["ex_date"] for ev in registered.get(code_s, [])}
-        # open_date より後に権利落ちし、かつ未登録のイベントのみが今の保有に影響する
-        # (銘柄単位の in registered だけだと、登録後に発生した別イベントを見逃す)
-        relevant_dates = [ex_date for ex_date in splits.index
-                          if ex_date.strftime("%Y-%m-%d") >= open_date
-                          and ex_date.strftime("%Y-%m-%d") not in registered_dates]
+        # エピソード期間中に権利落ちし、かつ未登録のイベントのみが当該ラウンドに影響する。
+        # 保有中だけに限定すると、pending 検出後に売却でクローズした瞬間に警告が外れ、
+        # 2:1 分割など単価ジャンプ閾値未満の誤損益が集計へ戻ってしまう。
+        relevant_dates = []
+        for ex_date in splits.index:
+            ex_date_s = ex_date.strftime("%Y-%m-%d")
+            if ex_date_s in registered_dates:
+                continue
+            if any(r["open_date"] <= ex_date_s <= r["close_date"] for r in ranges):
+                relevant_dates.append(ex_date)
         if not relevant_dates:
             continue
         found += 1
-        print(f" {code_s:>5} {names.get(code_s, ''):<12} 保有中チェック (open_date={open_date}): "
+        print(f" {code_s:>5} {names.get(code_s, ''):<12} エピソード期間チェック: "
               f"split イベントあり (未登録)")
         _report_split_candidate(
-            code_s, splits.loc[relevant_dates], "保有中総当たりチェック", db_path)
+            code_s, splits.loc[relevant_dates], "エピソード期間総当たりチェック", db_path)
 
     if found == 0:
         print("分割・併合の疑いは検出されませんでした。")
@@ -199,6 +213,23 @@ def _register_split(code_s: str, ex_date: str, ratio: str, db_path: Optional[str
     """split_adj イベントを1件登録する (issue #398)。"""
     stored = ps.add_split_adjustment(code_s, ex_date, float(ratio), db_path=db_path)
     print(f"登録しました: {code_s} {stored['events']}")
+    return 0
+
+
+def _reject_split(args: List[str], db_path: Optional[str]) -> int:
+    """分割・併合ではないと判断した pending_review を解除する。"""
+    if len(args) not in (1, 2):
+        print("--reject-split は CODE または CODE EX_DATE を指定してください。")
+        return 2
+    code_s = args[0]
+    ex_date = args[1] if len(args) == 2 else None
+    changed = ps.clear_split_pending_review(code_s, ex_date=ex_date, db_path=db_path)
+    if changed:
+        target = ex_date or "全pending"
+        print(f"却下しました: {code_s} {target}")
+    else:
+        target = ex_date or "pending"
+        print(f"該当する pending はありません: {code_s} {target}")
     return 0
 
 
@@ -216,10 +247,14 @@ def main() -> int:
                         help="分割・併合の疑いを診断する (issue #398、DB非更新)")
     parser.add_argument("--register-split", nargs=3, metavar=("CODE", "EX_DATE", "RATIO"),
                         help="分割・併合の換算比率を登録する (例: 1491 2025-09-29 0.05)")
+    parser.add_argument("--reject-split", nargs="+", metavar=("CODE_OR_EX_DATE"),
+                        help="分割・併合ではない pending を解除する (例: 1491 [2025-09-29])")
     args = parser.parse_args()
 
     if args.register_split:
         return _register_split(*args.register_split, db_path=args.db_path)
+    if args.reject_split:
+        return _reject_split(args.reject_split, db_path=args.db_path)
     if args.check_splits:
         return _check_splits(args.db_path)
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4474,6 +4474,21 @@ def _is_qty_closed(qty: float) -> bool:
     return qty <= _SPLIT_QTY_ZERO_TOL
 
 
+def _is_fractional_residual(qty: float) -> bool:
+    """分割・併合後の端株精算で消える想定の1株未満残高か判定する。"""
+    return _SPLIT_QTY_ZERO_TOL < qty < 1.0
+
+
+def _is_genbutsu_qty_closed(qty: float) -> bool:
+    """現物残高が実質クローズ済みか判定する。
+
+    分割・併合比率によって 0.3333 株のような端株が残る場合、証券会社CSVには
+    整数株の売却だけが出て端株精算が fill として入らないことがある。残高上は
+    クローズ扱いにするが、損益は精算額を確認できないため別途 suspect にする。
+    """
+    return _is_qty_closed(qty) or _is_fractional_residual(qty)
+
+
 def _detect_price_jumps(fills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """現物 fill を約定日順に見て、建玉が継続したまま隣接単価が3倍以上/1/3以下に
     飛ぶ箇所を検出する。
@@ -4497,7 +4512,7 @@ def _detect_price_jumps(fills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for a, b in zip(genbutsu, genbutsu[1:]):
         held_qty += a["qty"] if a["side"] == "buy" else -a["qty"]
         pa, pb = a.get("price"), b.get("price")
-        if pa and pb and not _is_qty_closed(held_qty):
+        if pa and pb and not _is_genbutsu_qty_closed(held_qty):
             ratio = pb / pa
             if ratio >= _SPLIT_PRICE_JUMP_RATIO or ratio <= 1 / _SPLIT_PRICE_JUMP_RATIO:
                 jumps.append({
@@ -4533,6 +4548,12 @@ def _jump_affects_episode(jump: Dict[str, Any], ep: Dict[str, Any]) -> bool:
     """
     close_date = ep.get("close_date") or "9999-12-31"  # 保有中は無期限
     return jump["before_date"] < close_date and jump["after_date"] >= ep["open_date"]
+
+
+def _split_event_affects_episode(ex_date: str, ep: Dict[str, Any]) -> bool:
+    """pending の ex_date がエピソード期間に含まれるか判定する。"""
+    close_date = ep.get("close_date") or "9999-12-31"  # 保有中は無期限
+    return ep["open_date"] <= ex_date <= close_date
 
 
 def _apply_split_adjustments(fills: List[Dict[str, Any]],
@@ -4621,6 +4642,7 @@ def _build_code_episodes(code_s: str, stock_name: str,
     genbutsu_fills: List[Dict[str, Any]] = []  # 現ラウンドの現物 fill
     genbutsu_qty = 0
     genbutsu_peak = 0
+    genbutsu_fractional_residual = False
     # 取込済みの信用新規日。これに無い建約定日の返済は、取込前からの持越し玉である。
     shinyo_open_dates = {
         f.get("trade_date")
@@ -4658,12 +4680,16 @@ def _build_code_episodes(code_s: str, stock_name: str,
         short_peak = 0
 
     def close_genbutsu():
-        nonlocal genbutsu_fills, genbutsu_qty, genbutsu_peak
+        nonlocal genbutsu_fills, genbutsu_qty, genbutsu_peak, genbutsu_fractional_residual
         if genbutsu_fills:
-            episodes.append(_finalize_round(code_s, "現物", stock_name, genbutsu_fills, genbutsu_peak))
+            ep = _finalize_round(code_s, "現物", stock_name, genbutsu_fills, genbutsu_peak)
+            if genbutsu_fractional_residual:
+                ep["split_fractional_residual"] = True
+            episodes.append(ep)
         genbutsu_fills = []
         genbutsu_qty = 0
         genbutsu_peak = 0
+        genbutsu_fractional_residual = False
 
     for f in fills:
         tk = f.get("trade_kind") or ""
@@ -4734,7 +4760,8 @@ def _build_code_episodes(code_s: str, stock_name: str,
             else:
                 genbutsu_qty -= qty
             genbutsu_peak = max(genbutsu_peak, genbutsu_qty)
-            if _is_qty_closed(genbutsu_qty):
+            if _is_genbutsu_qty_closed(genbutsu_qty):
+                genbutsu_fractional_residual = _is_fractional_residual(genbutsu_qty)
                 close_genbutsu()
 
     # 保有中 (残った建玉)
@@ -4827,12 +4854,13 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
     # 「登録済みイベントが1件でもあれば安全」という銘柄単位の判定は粗く、同一銘柄で
     # 後日発生した別の分割・併合を見逃す。また銘柄単位で全エピソードに付けると、
     # 分割前に完結した無関係なラウンドの正しい損益まで隠してしまう)。
-    # pending_review は --check-splits の (a)単価ジャンプ/(b)保有中総当たりの両方の検知結果を
+    # pending_review は --check-splits の (a)単価ジャンプ/(b)エピソード期間総当たりの検知結果を
     # 拒否リストとして反映する (webapp は yfinance を呼ばないため (b) を自力では検知できない)。
-    # pending_review は銘柄単位のフラグなので、pending 該当銘柄は保有中エピソードのみに
-    # 限定して付与する (保有中総当たりチェックは常に保有中エピソードが対象のため)。
+    # pending_review の ex_dates がエピソード期間に含まれる場合は、クローズ済みでも
+    # split_suspect を維持する。2:1 分割など単価ジャンプ閾値未満のイベントは
+    # クローズ後に警告が外れると誤った実現損益が集計へ戻ってしまうため。
     all_split_adj = ps.list_all_split_adjustments(db_path=db_path)
-    pending_codes = set(ps.list_pending_review_codes(db_path=db_path))
+    pending_events = ps.list_pending_review_events(db_path=db_path)
     episodes: List[Dict[str, Any]] = []
     for code_s, fills in by_code.items():
         events = all_split_adj.get(code_s, [])
@@ -4844,13 +4872,18 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
         jumps = _detect_price_jumps(fills)
         code_episodes = _build_code_episodes(code_s, names.get(code_s, ""), fills)
         uncovered = _uncovered_jumps(jumps, events)
-        is_pending = code_s in pending_codes
+        pending_dates = pending_events.get(code_s, [])
         for ep in code_episodes:
             if ep["kind"] != "現物":
                 continue
-            if any(_jump_affects_episode(j, ep) for j in uncovered):
+            if ep.get("split_fractional_residual"):
                 ep["split_suspect"] = True
-            elif is_pending and not ep["closed"]:
+            elif any(_jump_affects_episode(j, ep) for j in uncovered):
+                ep["split_suspect"] = True
+            elif any(d != "unknown" and _split_event_affects_episode(d, ep)
+                     for d in pending_dates):
+                ep["split_suspect"] = True
+            elif "unknown" in pending_dates and not ep["closed"]:
                 ep["split_suspect"] = True
         episodes.extend(code_episodes)
 

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4475,10 +4475,16 @@ def _is_qty_closed(qty: float) -> bool:
 
 
 def _detect_price_jumps(fills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """現物 fill を約定日順に見て、隣接単価が3倍以上/1/3以下に飛ぶ箇所を検出する。
+    """現物 fill を約定日順に見て、建玉が継続したまま隣接単価が3倍以上/1/3以下に
+    飛ぶ箇所を検出する。
 
     分割・併合は取引として記録されないため、単価の断絶が唯一の痕跡になる。
     133件の実データで検証済み (誤検出0件、1491 中外鉱業のみ検出、issue #398)。
+
+    建玉を一度売り切ってから (残高0) 数年後に買い直した場合、その間の株価変動は
+    分割・併合と無関係な通常の値上がり・値下がりであり分割候補ではない
+    (PRレビュー対応)。残高を追跡し、直前の fill で残高が0になっていた場合は
+    ジャンプ判定をスキップする。
 
     Returns: [{"before_date", "before_price", "after_date", "after_price"}]
     """
@@ -4487,37 +4493,46 @@ def _detect_price_jumps(fills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         key=lambda f: (f.get("trade_date") or "", f.get("seq") or 0),
     )
     jumps = []
+    held_qty = 0.0
     for a, b in zip(genbutsu, genbutsu[1:]):
+        held_qty += a["qty"] if a["side"] == "buy" else -a["qty"]
         pa, pb = a.get("price"), b.get("price")
-        if not pa or not pb:
-            continue
-        ratio = pb / pa
-        if ratio >= _SPLIT_PRICE_JUMP_RATIO or ratio <= 1 / _SPLIT_PRICE_JUMP_RATIO:
-            jumps.append({
-                "before_date": a.get("trade_date"),
-                "before_price": pa,
-                "after_date": b.get("trade_date"),
-                "after_price": pb,
-            })
+        if pa and pb and not _is_qty_closed(held_qty):
+            ratio = pb / pa
+            if ratio >= _SPLIT_PRICE_JUMP_RATIO or ratio <= 1 / _SPLIT_PRICE_JUMP_RATIO:
+                jumps.append({
+                    "before_date": a.get("trade_date"),
+                    "before_price": pa,
+                    "after_date": b.get("trade_date"),
+                    "after_price": pb,
+                })
     return jumps
 
 
-def _has_uncovered_jump(jumps: List[Dict[str, Any]],
-                        events: List[Dict[str, Any]]) -> bool:
-    """検知した単価ジャンプのうち、登録済みイベントでカバーされていないものがあるか。
+def _uncovered_jumps(jumps: List[Dict[str, Any]],
+                     events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """検知した単価ジャンプのうち、登録済みイベントでカバーされていないものを返す。
 
     「登録済みイベントが1件でもあれば安全」という判定は粗く、同一銘柄で後日
     発生した別の分割・併合を見逃す (PRレビュー対応)。ジャンプの日付境界
     (before_date, after_date] に ex_date が入る登録イベントがあればカバー済み。
     """
-    for jump in jumps:
-        covered = any(
-            jump["before_date"] < ev["ex_date"] <= jump["after_date"]
-            for ev in events
-        )
-        if not covered:
-            return True
-    return False
+    return [
+        jump for jump in jumps
+        if not any(jump["before_date"] < ev["ex_date"] <= jump["after_date"]
+                   for ev in events)
+    ]
+
+
+def _jump_affects_episode(jump: Dict[str, Any], ep: Dict[str, Any]) -> bool:
+    """未カバーの単価ジャンプが、このエピソードの残高・損益に影響するか。
+
+    ジャンプの (before_date, after_date] がエピソードの期間 [open_date, close_date]
+    (保有中は close_date なし=無期限) と重なる場合のみ影響する。分割前に完結した
+    無関係なラウンドまで split_suspect で隠さないため (PRレビュー対応)。
+    """
+    close_date = ep.get("close_date") or "9999-12-31"  # 保有中は無期限
+    return jump["before_date"] < close_date and jump["after_date"] >= ep["open_date"]
 
 
 def _apply_split_adjustments(fills: List[Dict[str, Any]],
@@ -4807,11 +4822,15 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
 
     # issue #398: 分割・併合の疑いがある銘柄を検知し、登録済みイベントがあれば
     # 現物 fill を換算したコピーに差し替えてからエピソード再構成に渡す。
-    # 未カバーのジャンプがあれば換算せず既存動作を維持し、該当銘柄のエピソードに
-    # split_suspect を付与する (PRレビュー対応: 「登録済みイベントが1件でもあれば
-    # 安全」という判定は粗く、同一銘柄で後日発生した別の分割・併合を見逃す)。
+    # 未カバーのジャンプがあれば換算せず既存動作を維持し、その期間と重なる
+    # エピソードにのみ split_suspect を付与する (PRレビュー対応:
+    # 「登録済みイベントが1件でもあれば安全」という銘柄単位の判定は粗く、同一銘柄で
+    # 後日発生した別の分割・併合を見逃す。また銘柄単位で全エピソードに付けると、
+    # 分割前に完結した無関係なラウンドの正しい損益まで隠してしまう)。
     # pending_review は --check-splits の (a)単価ジャンプ/(b)保有中総当たりの両方の検知結果を
     # 拒否リストとして反映する (webapp は yfinance を呼ばないため (b) を自力では検知できない)。
+    # pending_review は銘柄単位のフラグなので、pending 該当銘柄は保有中エピソードのみに
+    # 限定して付与する (保有中総当たりチェックは常に保有中エピソードが対象のため)。
     all_split_adj = ps.list_all_split_adjustments(db_path=db_path)
     pending_codes = set(ps.list_pending_review_codes(db_path=db_path))
     episodes: List[Dict[str, Any]] = []
@@ -4821,11 +4840,15 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
         if events:
             fills = _apply_split_adjustments(fills, events)
         code_episodes = _build_code_episodes(code_s, names.get(code_s, ""), fills)
-        uncovered = _has_uncovered_jump(jumps, events)
-        if (uncovered or code_s in pending_codes):
-            for ep in code_episodes:
-                if ep["kind"] == "現物":
-                    ep["split_suspect"] = True
+        uncovered = _uncovered_jumps(jumps, events)
+        is_pending = code_s in pending_codes
+        for ep in code_episodes:
+            if ep["kind"] != "現物":
+                continue
+            if any(_jump_affects_episode(j, ep) for j in uncovered):
+                ep["split_suspect"] = True
+            elif is_pending and not ep["closed"]:
+                ep["split_suspect"] = True
         episodes.extend(code_episodes)
 
     # 保有中エピソードに実現損益 (部分売り分) と含み損益 (残玉評価) を付与 (issue #387 Phase4b)。

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4432,8 +4432,8 @@ def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict
                 "avg_cost": cost_basis,
             }
 
-    if held_qty <= 0:
-        # 保有中扱いだが実質建玉が残っていない (空売り等) → 含み対象なし
+    if _is_qty_closed(held_qty):
+        # 保有中扱いだが実質建玉が残っていない (空売り等・分割換算後の丸め誤差含む) → 含み対象なし
         return {
             "realized": round(realized),
             "unrealized": None,
@@ -4454,6 +4454,90 @@ def _episode_open_pl(rnd: dict, current_price: Optional[float]) -> Optional[dict
         "held_qty": held_qty,
         "avg_cost": cost_basis,
     }
+
+
+# ===========================================
+# issue #398: 株式分割・併合対応
+# ===========================================
+
+_SPLIT_PRICE_JUMP_RATIO = 3.0  # 隣接単価がこの倍数以上/以下に飛べば分割・併合の疑い
+_SPLIT_QTY_ZERO_TOL = 1e-6  # 換算後 float qty のクローズ判定許容誤差
+
+
+def _is_qty_closed(qty: float) -> bool:
+    """建玉が0に戻ったとみなせるか判定する (qty <= 0 の許容誤差付き版)。
+
+    分割・併合換算で qty が float になった場合、丸め誤差で厳密な0にならず
+    5.55e-17 のような残差が残ってクローズ判定を取り逃す (issue #398)。
+    整数 fill のみの既存経路では qty <= 0 と等価に振る舞う。
+    """
+    return qty <= _SPLIT_QTY_ZERO_TOL
+
+
+def _detect_price_jumps(fills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """現物 fill を約定日順に見て、隣接単価が3倍以上/1/3以下に飛ぶ箇所を検出する。
+
+    分割・併合は取引として記録されないため、単価の断絶が唯一の痕跡になる。
+    133件の実データで検証済み (誤検出0件、1491 中外鉱業のみ検出、issue #398)。
+
+    Returns: [{"before_date", "before_price", "after_date", "after_price"}]
+    """
+    genbutsu = sorted(
+        (f for f in fills if not (f.get("trade_kind") or "").startswith("信用")),
+        key=lambda f: (f.get("trade_date") or "", f.get("seq") or 0),
+    )
+    jumps = []
+    for a, b in zip(genbutsu, genbutsu[1:]):
+        pa, pb = a.get("price"), b.get("price")
+        if not pa or not pb:
+            continue
+        ratio = pb / pa
+        if ratio >= _SPLIT_PRICE_JUMP_RATIO or ratio <= 1 / _SPLIT_PRICE_JUMP_RATIO:
+            jumps.append({
+                "before_date": a.get("trade_date"),
+                "before_price": pa,
+                "after_date": b.get("trade_date"),
+                "after_price": pb,
+            })
+    return jumps
+
+
+def _apply_split_adjustments(fills: List[Dict[str, Any]],
+                             events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """現物 fill のうち各イベントの ex_date より前のものを比率換算したコピーを返す。
+
+    events は ex_date 昇順。各 fill には、自身の trade_date より後の ex_date を
+    持つ全イベントの比率を掛け合わせた累積比率を適用する (古いイベントから順に)。
+    数量 = qty * cum_ratio、単価 = price / cum_ratio、amount は不変。
+    信用 fill・現引は素通しする (元の fill dict は変更しない)。
+
+    現引は「信用建玉の現物化」で、qty は信用新規側の shinyo_qty 減算と現物側の
+    genbutsu_qty 加算の両方に同じ値で使われる (_build_code_episodes)。現引だけ
+    換算すると信用新規(未換算)と現引(換算後)で株数基準がずれ、shinyo_qty が
+    0に戻らずクローズを取り逃す。現引を除外し分割前基準のまま扱う (簡易な安全策、
+    現引を挟んで分割をまたぐ複雑なケースは単価ジャンプ検知の split_suspect に委ねる)。
+    """
+    if not events:
+        return fills
+    adjusted = []
+    for f in fills:
+        tk = f.get("trade_kind") or ""
+        if tk.startswith("信用") or tk == "現引":
+            adjusted.append(f)
+            continue
+        trade_date = f.get("trade_date") or ""
+        cum_ratio = 1.0
+        for ev in events:
+            if trade_date < ev["ex_date"]:
+                cum_ratio *= ev["ratio"]
+        if cum_ratio == 1.0:
+            adjusted.append(f)
+            continue
+        g = dict(f)
+        g["qty"] = f["qty"] * cum_ratio
+        g["price"] = f["price"] / cum_ratio
+        adjusted.append(g)
+    return adjusted
 
 
 def _build_code_episodes(code_s: str, stock_name: str,
@@ -4610,7 +4694,7 @@ def _build_code_episodes(code_s: str, stock_name: str,
             else:
                 genbutsu_qty -= qty
             genbutsu_peak = max(genbutsu_peak, genbutsu_qty)
-            if genbutsu_qty <= 0:
+            if _is_qty_closed(genbutsu_qty):
                 close_genbutsu()
 
     # 保有中 (残った建玉)
@@ -4676,7 +4760,9 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
       closed (bool), fills (内部の個別 fill 明細リスト),
       carry_over (bool: 取込対象期間より前の信用建玉の返済),
       pl (クローズ済みのみ: _episode_pl_from_round の結果, 未クローズは None),
-      open_pl (保有中のみ: realized/unrealized/held_qty/avg_cost)
+      open_pl (保有中のみ: realized/unrealized/held_qty/avg_cost),
+      split_suspect (bool, 現物のみ: 単価ジャンプ検知だが split_adj 未登録、issue #398。
+        残高・損益が分割・併合未換算で誤っている可能性があるため画面上は数値を隠す)
 
     Returns: 最終約定日 (買い増し・部分売り含むラウンド内の最新の取引日) 降順の
     エピソードリスト。保有中エピソードも最後に約定した日で並ぶ。
@@ -4694,9 +4780,25 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
 
     names = _bulk_resolve_stock_names(list(by_code.keys()))
 
+    # issue #398: 分割・併合の疑いがある銘柄を検知し、登録済みイベントがあれば
+    # 現物 fill を換算したコピーに差し替えてからエピソード再構成に渡す。
+    # 未登録なら換算せず既存動作を維持し、該当銘柄のエピソードに split_suspect を付与する。
+    # pending_review は --check-splits の (a)単価ジャンプ/(b)保有中総当たりの両方の検知結果を
+    # 拒否リストとして反映する (webapp は yfinance を呼ばないため (b) を自力では検知できない)。
+    all_split_adj = ps.list_all_split_adjustments(db_path=db_path)
+    pending_codes = set(ps.list_pending_review_codes(db_path=db_path))
     episodes: List[Dict[str, Any]] = []
     for code_s, fills in by_code.items():
-        episodes.extend(_build_code_episodes(code_s, names.get(code_s, ""), fills))
+        jumps = _detect_price_jumps(fills)
+        events = all_split_adj.get(code_s, [])
+        if events:
+            fills = _apply_split_adjustments(fills, events)
+        code_episodes = _build_code_episodes(code_s, names.get(code_s, ""), fills)
+        if (jumps or code_s in pending_codes) and not events:
+            for ep in code_episodes:
+                if ep["kind"] == "現物":
+                    ep["split_suspect"] = True
+        episodes.extend(code_episodes)
 
     # 保有中エピソードに実現損益 (部分売り分) と含み損益 (残玉評価) を付与 (issue #387 Phase4b)。
     # 含みは price_log の直近終値を現在値とする。銘柄をバルク取得して N+1 を避ける。

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4502,6 +4502,24 @@ def _detect_price_jumps(fills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return jumps
 
 
+def _has_uncovered_jump(jumps: List[Dict[str, Any]],
+                        events: List[Dict[str, Any]]) -> bool:
+    """検知した単価ジャンプのうち、登録済みイベントでカバーされていないものがあるか。
+
+    「登録済みイベントが1件でもあれば安全」という判定は粗く、同一銘柄で後日
+    発生した別の分割・併合を見逃す (PRレビュー対応)。ジャンプの日付境界
+    (before_date, after_date] に ex_date が入る登録イベントがあればカバー済み。
+    """
+    for jump in jumps:
+        covered = any(
+            jump["before_date"] < ev["ex_date"] <= jump["after_date"]
+            for ev in events
+        )
+        if not covered:
+            return True
+    return False
+
+
 def _apply_split_adjustments(fills: List[Dict[str, Any]],
                              events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """現物 fill のうち各イベントの ex_date より前のものを比率換算したコピーを返す。
@@ -4514,8 +4532,15 @@ def _apply_split_adjustments(fills: List[Dict[str, Any]],
     現引は「信用建玉の現物化」で、qty は信用新規側の shinyo_qty 減算と現物側の
     genbutsu_qty 加算の両方に同じ値で使われる (_build_code_episodes)。現引だけ
     換算すると信用新規(未換算)と現引(換算後)で株数基準がずれ、shinyo_qty が
-    0に戻らずクローズを取り逃す。現引を除外し分割前基準のまま扱う (簡易な安全策、
-    現引を挟んで分割をまたぐ複雑なケースは単価ジャンプ検知の split_suspect に委ねる)。
+    0に戻らずクローズを取り逃す。現引を除外し分割前基準のまま扱う (簡易な安全策)。
+
+    既知の限界 (PRレビュー #405 で指摘、対応複雑度とのバランスで見送り): 現引後に
+    現物のまま分割・併合をまたいで売却すると、現引 fill (未換算) と売却 fill (換算後)
+    の株数基準がずれ、端数が誤って保有中に残る可能性がある。現時点の実データでは
+    分割検知銘柄 (1491, 9252) に現引が絡むケースは無い。単価変化が3倍以上/1/3以下なら
+    _detect_price_jumps が検知するが、それ未満の比率では split_suspect も付かず
+    残高が誤ったまま表示されうる。再発したら現引 fill に現物側専用の換算済み
+    qty/price を別キーで持たせ、_build_code_episodes 側で使い分ける対応が必要。
     """
     if not events:
         return fills
@@ -4782,7 +4807,9 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
 
     # issue #398: 分割・併合の疑いがある銘柄を検知し、登録済みイベントがあれば
     # 現物 fill を換算したコピーに差し替えてからエピソード再構成に渡す。
-    # 未登録なら換算せず既存動作を維持し、該当銘柄のエピソードに split_suspect を付与する。
+    # 未カバーのジャンプがあれば換算せず既存動作を維持し、該当銘柄のエピソードに
+    # split_suspect を付与する (PRレビュー対応: 「登録済みイベントが1件でもあれば
+    # 安全」という判定は粗く、同一銘柄で後日発生した別の分割・併合を見逃す)。
     # pending_review は --check-splits の (a)単価ジャンプ/(b)保有中総当たりの両方の検知結果を
     # 拒否リストとして反映する (webapp は yfinance を呼ばないため (b) を自力では検知できない)。
     all_split_adj = ps.list_all_split_adjustments(db_path=db_path)
@@ -4794,7 +4821,8 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
         if events:
             fills = _apply_split_adjustments(fills, events)
         code_episodes = _build_code_episodes(code_s, names.get(code_s, ""), fills)
-        if (jumps or code_s in pending_codes) and not events:
+        uncovered = _has_uncovered_jump(jumps, events)
+        if (uncovered or code_s in pending_codes):
             for ep in code_episodes:
                 if ep["kind"] == "現物":
                     ep["split_suspect"] = True

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4553,7 +4553,7 @@ def _jump_affects_episode(jump: Dict[str, Any], ep: Dict[str, Any]) -> bool:
 def _split_event_affects_episode(ex_date: str, ep: Dict[str, Any]) -> bool:
     """pending の ex_date がエピソード期間に含まれるか判定する。"""
     close_date = ep.get("close_date") or "9999-12-31"  # 保有中は無期限
-    return ep["open_date"] <= ex_date <= close_date
+    return ep["open_date"] < ex_date <= close_date
 
 
 def _apply_split_adjustments(fills: List[Dict[str, Any]],

--- a/scripts/webapp/helpers.py
+++ b/scripts/webapp/helpers.py
@@ -4835,10 +4835,13 @@ def build_fill_episodes(db_path: Optional[str] = None) -> List[Dict[str, Any]]:
     pending_codes = set(ps.list_pending_review_codes(db_path=db_path))
     episodes: List[Dict[str, Any]] = []
     for code_s, fills in by_code.items():
-        jumps = _detect_price_jumps(fills)
         events = all_split_adj.get(code_s, [])
         if events:
             fills = _apply_split_adjustments(fills, events)
+        # ジャンプ検知は換算後の fills に対して行う (PRレビュー対応: 未換算のまま
+        # 検知すると、登録済みイベントで残高の基準が変わった後の残高追跡が崩れ、
+        # 別の未登録イベントのジャンプを見逃す)。
+        jumps = _detect_price_jumps(fills)
         code_episodes = _build_code_episodes(code_s, names.get(code_s, ""), fills)
         uncovered = _uncovered_jumps(jumps, events)
         is_pending = code_s in pending_codes

--- a/scripts/webapp/routes/trade_history.py
+++ b/scripts/webapp/routes/trade_history.py
@@ -241,10 +241,17 @@ def trade_history():
 
     # issue #387 Phase4b: 売買履歴タブ = fill 基準の建玉ラウンド・エピソード。
     # 成績サマリー (勝率/ペイオフ) はクローズ済みで損益算出できたエピソードから算出。
+    # issue #398: split_suspect (分割・併合の疑いだが未換算) は残高・損益が誤っている
+    # 可能性があるため、成績サマリーの集計から一貫して除外する。
     fill_episodes = build_fill_episodes()
-    fill_pls = [ep["pl"] for ep in fill_episodes if ep["closed"] and ep["pl"]]
+    fill_pls = [
+        ep["pl"] for ep in fill_episodes
+        if ep["closed"] and ep["pl"] and not ep.get("split_suspect")
+    ]
     fill_summary = calc_trade_summary(fill_pls)
-    fill_closed_count = sum(1 for ep in fill_episodes if ep["closed"])
+    fill_closed_count = sum(
+        1 for ep in fill_episodes if ep["closed"] and not ep.get("split_suspect")
+    )
     fill_priced_count = len(fill_pls)
     fill_total_pl = sum(
         p["profit_amount"] for p in fill_pls if p["profit_amount"] is not None

--- a/scripts/webapp/templates/trade_history.html
+++ b/scripts/webapp/templates/trade_history.html
@@ -134,14 +134,19 @@
         {% if ep.carry_over %}
         <span title="取込対象期間より前に建てた信用玉の返済" style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#4a4a3a;color:#c8c890;margin-left:0.2em;">期首持越し</span>
         {% endif %}
+        {% if ep.split_suspect %}
+        <span title="株式分割・併合をまたぐ可能性 (単価が急変)。換算未登録のため残高・損益は非表示。show_fill_episodes.py --check-splits で確認" style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:0.72em;background:#4a2e2e;color:#e08080;margin-left:0.2em;">⚠ 分割・併合の疑い</span>
+        {% endif %}
         {% if ep.review_memo %}
         <span title="振り返りメモあり" style="margin-left:0.2em;">📝</span>
         {% endif %}
       </td>
       <td style="white-space:nowrap;color:#888;font-size:0.82em;">{{ ep.open_date[2:] }}{% if ep.close_date and ep.close_date != ep.open_date %} 〜 {{ ep.close_date[2:] }}{% endif %}</td>
-      <td style="text-align:right;color:#888;font-size:0.85em;">{{ ep.qty_peak }}</td>
+      <td style="text-align:right;color:#888;font-size:0.85em;">{{ "%g"|format(ep.qty_peak) }}</td>
       <td style="text-align:right;white-space:nowrap;">
-        {% if ep.pl %}
+        {% if ep.split_suspect %}
+        <span style="color:#e08080;font-size:0.82em;" title="分割・併合をまたぐため残高・リターンは非表示">要確認</span>
+        {% elif ep.pl %}
         <span style="color:{{ '#9ef0aa' if ep.pl.return_pct >= 0 else '#f0a0a0' }};font-weight:600;">{{ '+' if ep.pl.return_pct >= 0 else '' }}{{ "%.1f"|format(ep.pl.return_pct) }}%</span>
         {% elif not ep.closed and ep.open_pl and ep.open_pl.held_qty > 0 %}
         <span style="color:#888;font-size:0.82em;">残 {{ ep.open_pl.held_qty }}株</span>
@@ -153,7 +158,9 @@
       </td>
       {# 実現損益列 #}
       <td style="text-align:right;white-space:nowrap;">
-        {% if ep.pl and ep.pl.profit_amount is not none %}
+        {% if ep.split_suspect %}
+        <span style="color:#666;">—</span>
+        {% elif ep.pl and ep.pl.profit_amount is not none %}
         <span style="color:{{ '#9ef0aa' if ep.pl.profit_amount >= 0 else '#f0a0a0' }};">{{ "{:+,}".format(ep.pl.profit_amount) }}円</span>
         {% elif not ep.closed and ep.open_pl and ep.open_pl.realized %}
         <span style="color:{{ '#9ef0aa' if ep.open_pl.realized >= 0 else '#f0a0a0' }};">{{ "{:+,}".format(ep.open_pl.realized) }}円</span>
@@ -161,7 +168,9 @@
       </td>
       {# 含み損益列 (保有中のみ) #}
       <td style="text-align:right;white-space:nowrap;">
-        {% if not ep.closed and ep.open_pl and ep.open_pl.unrealized is not none %}
+        {% if ep.split_suspect %}
+        <span style="color:#666;">—</span>
+        {% elif not ep.closed and ep.open_pl and ep.open_pl.unrealized is not none %}
         <span style="color:{{ '#9ef0aa' if ep.open_pl.unrealized >= 0 else '#f0a0a0' }};">{{ "{:+,}".format(ep.open_pl.unrealized) }}円</span>
         {% elif not ep.closed %}
         <span style="color:#666;" title="現在値が取得できないため含み損益は非表示">—</span>
@@ -193,7 +202,7 @@
               {% if f.side == "buy" %}<span style="color:#9ed8f0;">{{ f.side_label }}</span>{% else %}<span style="color:#f0a0a0;">{{ f.side_label }}</span>{% endif %}
             </td>
             <td style="padding:1px 0.8em;color:#777;white-space:nowrap;">{{ f.trade_kind }}</td>
-            <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">{{ f.qty }}株</td>
+            <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">{{ "%g"|format(f.qty) }}株</td>
             <td style="padding:1px 0.8em;text-align:right;white-space:nowrap;">{{ "{:,}".format(f.price|round|int) }}円</td>
             {% if f.tate_price %}<td style="padding:1px 0.8em;text-align:right;white-space:nowrap;color:#888;">建 {{ "{:,}".format(f.tate_price|round|int) }}</td>{% else %}<td></td>{% endif %}
             {% if f.hold_days is defined %}<td style="padding:1px 0.8em;color:#777;white-space:nowrap;">{{ f.tate_date[2:] }} 建 → {{ f.hold_days }}日</td>{% else %}<td></td>{% endif %}

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -532,3 +532,136 @@ class TestFillMemo:
         _add(db_path, "1001", "2026-01-10", "buy", 100, 1000.0, seq_salt="a")
         eps2 = helpers.build_fill_episodes(db_path=db_path)
         assert eps2[0]["review_memo"] == "残るはず"
+
+
+class TestSplitAdjustment:
+    """株式分割・併合をまたぐ現物エピソードの換算 (issue #398)。
+
+    1491 中外鉱業の実データ相当 (2025-09-29 権利落ち、20株->1株併合)。
+    """
+
+    def _add_1491_fills(self, db_path):
+        # 併合前 (20:1)
+        _add(db_path, "1491", "2025-02-17", "buy", 8000, 45, seq_salt="a")
+        _add(db_path, "1491", "2025-04-03", "buy", 3000, 60, seq_salt="b")
+        _add(db_path, "1491", "2025-07-11", "sell", 3000, 63, seq_salt="c")
+        _add(db_path, "1491", "2025-07-22", "sell", 2000, 65, seq_salt="d")
+        _add(db_path, "1491", "2025-09-03", "sell", 2000, 62, seq_salt="e")
+        # 併合後
+        _add(db_path, "1491", "2025-09-30", "buy", 300, 925, seq_salt="f")
+        _add(db_path, "1491", "2025-10-06", "buy", 300, 936, seq_salt="g")
+        _add(db_path, "1491", "2025-10-16", "buy", 300, 950, seq_salt="h")
+        _add(db_path, "1491", "2025-12-02", "sell", 400, 738, seq_salt="i")
+        _add(db_path, "1491", "2025-12-17", "sell", 400, 702, seq_salt="j")
+        _add(db_path, "1491", "2025-12-18", "buy", 100, 757, seq_salt="k")
+        _add(db_path, "1491", "2025-12-25", "buy", 100, 869, seq_salt="l")
+        _add(db_path, "1491", "2025-12-25", "buy", 100, 896, seq_salt="m")
+        _add(db_path, "1491", "2026-02-16", "sell", 100, 1118, seq_salt="n")
+        _add(db_path, "1491", "2026-02-16", "sell", 100, 1118, seq_salt="o")
+        _add(db_path, "1491", "2026-02-25", "sell", 400, 1050, seq_salt="p")
+
+    def test_split_adjustment_closes_episode_at_zero(self, db_path):
+        self._add_1491_fills(db_path)
+        ps.add_split_adjustment("1491", "2025-09-29", 0.05, db_path=db_path)
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        genbutsu = [e for e in eps if e["code_s"] == "1491" and e["kind"] == "現物"]
+        assert len(genbutsu) == 1
+        ep = genbutsu[0]
+        assert ep["closed"] is True  # 換算後は残高0株でクローズする
+        assert ep["pl"]["profit_amount"] == 27100  # キャッシュフロー検算と一致 (issue #398)
+
+    def test_multiple_split_events_apply_cumulative_ratio(self, db_path):
+        # 最古の fill (2025-01-01) は2回のイベント両方の累積比率、
+        # 中間の fill (2025-06-01) は2回目のイベントのみ適用される
+        _add(db_path, "2491", "2025-01-01", "buy", 100, 10000, seq_salt="a")
+        _add(db_path, "2491", "2025-06-01", "buy", 100, 500, seq_salt="b")
+        _add(db_path, "2491", "2025-12-01", "sell", 1200, 100, seq_salt="c")
+        ps.add_split_adjustment("2491", "2025-03-01", 0.1, db_path=db_path)   # 10:1併合
+        ps.add_split_adjustment("2491", "2025-09-01", 2.0, db_path=db_path)   # 1:2分割
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = [e for e in eps if e["code_s"] == "2491"][0]
+        fills = {f["trade_date"]: f for f in ep["fills"]}
+        # 2025-01-01: 100株@10000 -> ×0.1×2.0 = ×0.2 -> 20株@50000
+        assert fills["2025-01-01"]["qty"] == pytest.approx(20)
+        assert fills["2025-01-01"]["price"] == pytest.approx(50000)
+        # 2025-06-01: 100株@500 -> ×2.0 (03-01イベントより後なので対象外) -> 200株@250
+        assert fills["2025-06-01"]["qty"] == pytest.approx(200)
+        assert fills["2025-06-01"]["price"] == pytest.approx(250)
+        # 2025-12-01 の売りは両イベントより後なので換算なし
+        assert fills["2025-12-01"]["qty"] == 1200
+
+    def test_shinyo_round_not_affected_by_split_adjustment(self, db_path):
+        # 同一銘柄に信用ラウンドを混在させ、split_adj 登録後も settle_pl 側の損益が不変
+        _add(db_path, "3491", "2025-01-01", "buy", 100, 1000, trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "3491", "2025-02-01", "sell", 100, 1100, trade_kind="信用返済",
+             settle_pl=9500, seq_salt="b")
+        ps.add_split_adjustment("3491", "2025-06-01", 0.5, db_path=db_path)  # 1:2併合
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        shinyo = [e for e in eps if e["code_s"] == "3491" and e["kind"] == "信用"][0]
+        assert shinyo["pl"]["profit_amount"] == 9500  # settle_pl のまま、換算されない
+        assert shinyo["fills"][0]["qty"] == 100  # 信用 fill の qty も不変
+
+    def test_genbiki_not_adjusted_so_shinyo_round_closes(self, db_path):
+        # 現引の qty は信用新規側の減算にも使われるため、現引だけ換算すると
+        # shinyo_qty が0に戻らずクローズを取り逃す (simplifyレビューで発見した回帰)。
+        # 現引を換算対象から除外すれば、信用新規と現引が同じ株数基準のままクローズできる。
+        _add(db_path, "6491", "2025-01-01", "buy", 300, 1000, trade_kind="信用新規", seq_salt="a")
+        _add(db_path, "6491", "2025-06-01", "buy", 300, 1000, trade_kind="現引", seq_salt="b")
+        _add(db_path, "6491", "2025-12-01", "sell", 100, 900, seq_salt="c")
+        ps.add_split_adjustment("6491", "2025-09-01", 0.833333, db_path=db_path)
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        shinyo = [e for e in eps if e["code_s"] == "6491" and e["kind"] == "信用"][0]
+        assert shinyo["closed"] is True
+        assert shinyo["fills"][0]["qty"] == 300  # 現引は換算されず信用新規と同じ基準
+
+    def test_price_jump_detected_without_registration_marks_suspect(self, db_path):
+        # 1491相当 (保有中): 未換算のまま既存ロジックで処理すると併合前4,000株が
+        # 未消化のまま残り保有中になる (issue #398 の背景そのもの)。
+        self._add_1491_fills(db_path)  # split_adj は登録しない
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        open_ep = [e for e in eps if e["code_s"] == "1491" and e["kind"] == "現物"][0]
+        assert open_ep["closed"] is False
+        assert open_ep["split_suspect"] is True
+        # サマリー集計 (calc_trade_summary 相当) から除外されることを確認 (route側と同じ条件式)
+        fill_pls_1491 = [e["pl"] for e in eps if e["code_s"] == "1491" and e["closed"]
+                         and e["pl"] and not e.get("split_suspect")]
+        assert fill_pls_1491 == []
+
+        # クローズ済みでも split_suspect が付くこと (closed/open 双方への伝播確認)
+        _add(db_path, "5491", "2025-01-01", "buy", 8000, 45, seq_salt="a")
+        _add(db_path, "5491", "2025-06-01", "sell", 8000, 60, seq_salt="b")  # 未換算のまま0株で完結
+        _add(db_path, "5491", "2025-09-01", "buy", 100, 900, seq_salt="c")   # 単価ジャンプ
+        _add(db_path, "5491", "2025-09-15", "sell", 100, 950, seq_salt="d")
+        eps2 = helpers.build_fill_episodes(db_path=db_path)
+        closed_ep = [e for e in eps2 if e["code_s"] == "5491" and e["kind"] == "現物"][0]
+        assert closed_ep["closed"] is True
+        assert closed_ep["split_suspect"] is True
+
+    def test_pending_review_marks_suspect_without_price_jump(self, db_path):
+        # 9252相当: 現物fillの単価変化が小さく単価ジャンプ検知には引っかからないが、
+        # --check-splits の保有中総当たりチェックでのみ見つかるケース。
+        # build_fill_episodes は yfinance を呼ばないため、pending_review 経由で伝播する。
+        _add(db_path, "9252", "2025-08-06", "buy", 100, 3270, seq_salt="a")
+        _add(db_path, "9252", "2025-08-08", "sell", 83, 4250, trade_kind="現物(単元未満)", seq_salt="b")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = [e for e in eps if e["code_s"] == "9252" and e["kind"] == "現物"][0]
+        assert not ep.get("split_suspect")  # pending_review 未登録ならフラグは付かない
+
+        ps.mark_split_pending_review("9252", reason="保有中総当たりチェック", db_path=db_path)
+        eps2 = helpers.build_fill_episodes(db_path=db_path)
+        ep2 = [e for e in eps2 if e["code_s"] == "9252" and e["kind"] == "現物"][0]
+        assert ep2["split_suspect"] is True
+
+        # add_split_adjustment で登録すれば pending は自動解除される
+        ps.add_split_adjustment("9252", "2025-08-07", 0.833333, db_path=db_path)
+        assert "9252" not in ps.list_pending_review_codes(db_path=db_path)
+
+    def test_merger_ratio_closes_without_residual_qty(self, db_path):
+        # 20:1併合相当の比率で浮動小数の残差が出てもクローズ判定を妨げない
+        _add(db_path, "4491", "2025-01-01", "buy", 4000, 45, seq_salt="a")
+        _add(db_path, "4491", "2025-06-01", "sell", 3000, 60, seq_salt="b")
+        _add(db_path, "4491", "2025-06-15", "sell", 1000, 70, seq_salt="c")
+        ps.add_split_adjustment("4491", "2025-03-01", 0.05, db_path=db_path)
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = [e for e in eps if e["code_s"] == "4491"][0]
+        assert ep["closed"] is True  # 200株 - 200株 = 残差はあっても0扱い

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -673,11 +673,13 @@ class TestSplitAdjustment:
     def test_second_split_after_registration_still_marks_suspect(self, db_path):
         # PRレビュー #405 指摘: 「登録済みイベントが1件でもあれば安全」という判定は
         # 粗く、同一銘柄で後日発生した別の分割・併合 (未登録) を見逃す。
-        # 1回目 (登録済み) の後、単価が急変する2回目のジャンプが検知されるはず。
-        _add(db_path, "8491", "2025-01-01", "buy", 1000, 100, seq_salt="a")
-        _add(db_path, "8491", "2025-06-01", "sell", 500, 110, seq_salt="b")
+        # 1回目 (登録済み、1:2分割) の後、単価が急変する2回目のジャンプが検知されるはず。
+        # 換算後基準で残高が継続する構成にする (2回目レビュー対応: 未換算のまま検知
+        # すると残高追跡が崩れ、換算後の値で検知しないとジャンプを見逃す回帰がある)。
+        _add(db_path, "8491", "2025-01-01", "buy", 1000, 100, seq_salt="a")   # 分割前 (換算後500株)
         ps.add_split_adjustment("8491", "2025-03-01", 0.5, db_path=db_path)  # 1回目登録済み
-        _add(db_path, "8491", "2025-12-01", "sell", 100, 900, seq_salt="c")  # 2回目 (未登録) の痕跡
+        _add(db_path, "8491", "2025-06-01", "sell", 400, 220, seq_salt="b")  # 分割後基準、残100株
+        _add(db_path, "8491", "2025-12-01", "sell", 100, 900, seq_salt="c")  # 2回目 (未登録) ジャンプ
         eps = helpers.build_fill_episodes(db_path=db_path)
         ep = [e for e in eps if e["code_s"] == "8491" and e["kind"] == "現物"][0]
         assert ep["split_suspect"] is True  # 登録済みでも新規ジャンプがあれば要確認扱い

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -6,8 +6,11 @@ build_fill_episodes / _episode_pl_from_round のロジックを合成 fill で�
 """
 
 import pytest
+import pandas as pd
 
+import make_stock_db
 import portfolio_shelve as ps
+import show_fill_episodes
 from webapp import helpers
 
 
@@ -642,7 +645,7 @@ class TestSplitAdjustment:
 
     def test_pending_review_marks_suspect_without_price_jump(self, db_path):
         # 9252相当: 現物fillの単価変化が小さく単価ジャンプ検知には引っかからないが、
-        # --check-splits の保有中総当たりチェックでのみ見つかるケース。
+        # --check-splits のエピソード期間総当たりチェックでのみ見つかるケース。
         # build_fill_episodes は yfinance を呼ばないため、pending_review 経由で伝播する。
         _add(db_path, "9252", "2025-08-06", "buy", 100, 3270, seq_salt="a")
         _add(db_path, "9252", "2025-08-08", "sell", 83, 4250, trade_kind="現物(単元未満)", seq_salt="b")
@@ -659,6 +662,68 @@ class TestSplitAdjustment:
         # add_split_adjustment で同一 ex_date を登録すれば pending は自動解除される
         ps.add_split_adjustment("9252", "2025-08-07", 0.833333, db_path=db_path)
         assert "9252" not in ps.list_pending_review_codes(db_path=db_path)
+
+    def test_fractional_residual_after_split_keeps_suspect(self, db_path):
+        # PRレビュー #405 (4周目 P1): 100株 * 0.833333 = 83.3333株に対して
+        # CSVの売却が83株だけの場合、0.3333株は端株精算とみなして残高は閉じる。
+        # ただし精算額はCSV上確認できないため、比率登録後も suspect は維持する。
+        _add(db_path, "9498", "2025-08-06", "buy", 100, 3270, seq_salt="a")
+        _add(db_path, "9498", "2025-08-08", "sell", 83, 4250, seq_salt="b")
+        ps.mark_split_pending_review(
+            "9498", reason="エピソード期間総当たりチェック", ex_date="2025-08-07",
+            db_path=db_path)
+        ps.add_split_adjustment("9498", "2025-08-07", 0.833333, db_path=db_path)
+        assert "9498" not in ps.list_pending_review_codes(db_path=db_path)
+
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = [e for e in eps if e["code_s"] == "9498" and e["kind"] == "現物"][0]
+        assert ep["closed"] is True
+        assert ep["split_fractional_residual"] is True
+        assert ep["split_suspect"] is True
+
+    def test_pending_review_keeps_closed_episode_suspect(self, db_path):
+        # PRレビュー #405 (3周目 P1): pending が日付を持つ場合、後日売却でクローズしても
+        # その ex_date をまたぐエピソードは split_suspect を維持する。
+        _add(db_path, "9496", "2025-01-01", "buy", 100, 1000, seq_salt="a")
+        _add(db_path, "9496", "2025-06-01", "sell", 200, 600, seq_salt="b")
+        ps.mark_split_pending_review(
+            "9496", reason="エピソード期間総当たりチェック", ex_date="2025-03-01",
+            db_path=db_path)
+
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = [e for e in eps if e["code_s"] == "9496" and e["kind"] == "現物"][0]
+        assert ep["closed"] is True
+        assert ep["split_suspect"] is True
+
+    def test_check_splits_marks_closed_two_for_one_split(self, db_path, monkeypatch):
+        # PRレビュー #405 (3周目 P1): 2:1 分割は単価ジャンプ閾値(3倍)未満なので、
+        # クローズ済み現物エピソード期間も corporate action と照合する必要がある。
+        _add(db_path, "9497", "2025-01-01", "buy", 100, 1000, seq_salt="a")
+        _add(db_path, "9497", "2025-06-01", "sell", 200, 600, seq_salt="b")
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {})
+        monkeypatch.setattr(
+            show_fill_episodes.helpers,
+            "_bulk_resolve_stock_names",
+            lambda codes: {c: f"銘柄{c}" for c in codes},
+        )
+        monkeypatch.setattr(
+            show_fill_episodes,
+            "_yfinance_splits",
+            lambda code_s, stock_db: pd.Series(
+                [2.0], index=pd.to_datetime(["2025-03-01"])
+            ) if code_s == "9497" else pd.Series(dtype=float),
+        )
+
+        assert show_fill_episodes._check_splits(db_path) == 0
+        assert ps.list_pending_review_events(db_path=db_path)["9497"] == ["2025-03-01"]
+
+    def test_reject_split_cli_clears_pending(self, db_path):
+        # PRレビュー #405 (4周目 P2): 誤検知は CLI から pending 解除できる。
+        ps.mark_split_pending_review(
+            "9499", reason="単価ジャンプ検出", ex_date="2025-03-01", db_path=db_path)
+
+        assert show_fill_episodes._reject_split(["9499", "2025-03-01"], db_path) == 0
+        assert "9499" not in ps.list_pending_review_codes(db_path=db_path)
 
     def test_merger_ratio_closes_without_residual_qty(self, db_path):
         # 20:1併合相当の比率で浮動小数の残差が出てもクローズ判定を妨げない

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -695,6 +695,18 @@ class TestSplitAdjustment:
         assert ep["closed"] is True
         assert ep["split_suspect"] is True
 
+    def test_pending_review_ignores_ex_date_opening_buy(self, db_path):
+        # PRレビュー #405 (5周目 P2): pending 日付が open_date 当日なら分割後基準の新規買い。
+        _add(db_path, "9488", "2025-03-01", "buy", 100, 500, seq_salt="a")
+        _add(db_path, "9488", "2025-06-01", "sell", 100, 600, seq_salt="b")
+        ps.mark_split_pending_review(
+            "9488", reason="エピソード期間総当たりチェック", ex_date="2025-03-01",
+            db_path=db_path)
+
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = [e for e in eps if e["code_s"] == "9488" and e["kind"] == "現物"][0]
+        assert not ep.get("split_suspect")
+
     def test_check_splits_marks_closed_two_for_one_split(self, db_path, monkeypatch):
         # PRレビュー #405 (3周目 P1): 2:1 分割は単価ジャンプ閾値(3倍)未満なので、
         # クローズ済み現物エピソード期間も corporate action と照合する必要がある。
@@ -717,6 +729,27 @@ class TestSplitAdjustment:
         assert show_fill_episodes._check_splits(db_path) == 0
         assert ps.list_pending_review_events(db_path=db_path)["9497"] == ["2025-03-01"]
 
+    def test_check_splits_ignores_ex_date_opening_buy(self, db_path, monkeypatch):
+        # PRレビュー #405 (5周目 P2): 権利落ち日当日の新規買いは分割後基準なので対象外。
+        _add(db_path, "9490", "2025-03-01", "buy", 100, 500, seq_salt="a")
+        _add(db_path, "9490", "2025-06-01", "sell", 100, 600, seq_salt="b")
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {})
+        monkeypatch.setattr(
+            show_fill_episodes.helpers,
+            "_bulk_resolve_stock_names",
+            lambda codes: {c: f"銘柄{c}" for c in codes},
+        )
+        monkeypatch.setattr(
+            show_fill_episodes,
+            "_yfinance_splits",
+            lambda code_s, stock_db: pd.Series(
+                [2.0], index=pd.to_datetime(["2025-03-01"])
+            ) if code_s == "9490" else pd.Series(dtype=float),
+        )
+
+        assert show_fill_episodes._check_splits(db_path) == 0
+        assert "9490" not in ps.list_pending_review_codes(db_path=db_path)
+
     def test_reject_split_cli_clears_pending(self, db_path):
         # PRレビュー #405 (4周目 P2): 誤検知は CLI から pending 解除できる。
         ps.mark_split_pending_review(
@@ -724,6 +757,29 @@ class TestSplitAdjustment:
 
         assert show_fill_episodes._reject_split(["9499", "2025-03-01"], db_path) == 0
         assert "9499" not in ps.list_pending_review_codes(db_path=db_path)
+        assert ps.list_rejected_review_events(db_path=db_path)["9499"] == ["2025-03-01"]
+
+    def test_rejected_split_is_not_detected_again(self, db_path, monkeypatch):
+        # PRレビュー #405 (5周目 P2): 却下済みイベントは次回診断で pending に戻さない。
+        _add(db_path, "9489", "2025-01-01", "buy", 100, 1000, seq_salt="a")
+        _add(db_path, "9489", "2025-06-01", "sell", 200, 600, seq_salt="b")
+        ps.reject_split_pending_review("9489", ex_date="2025-03-01", db_path=db_path)
+        monkeypatch.setattr(make_stock_db, "load_stock_db", lambda: {})
+        monkeypatch.setattr(
+            show_fill_episodes.helpers,
+            "_bulk_resolve_stock_names",
+            lambda codes: {c: f"銘柄{c}" for c in codes},
+        )
+        monkeypatch.setattr(
+            show_fill_episodes,
+            "_yfinance_splits",
+            lambda code_s, stock_db: pd.Series(
+                [2.0], index=pd.to_datetime(["2025-03-01"])
+            ) if code_s == "9489" else pd.Series(dtype=float),
+        )
+
+        assert show_fill_episodes._check_splits(db_path) == 0
+        assert "9489" not in ps.list_pending_review_codes(db_path=db_path)
 
     def test_merger_ratio_closes_without_residual_qty(self, db_path):
         # 20:1併合相当の比率で浮動小数の残差が出てもクローズ判定を妨げない

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -665,3 +665,15 @@ class TestSplitAdjustment:
         eps = helpers.build_fill_episodes(db_path=db_path)
         ep = [e for e in eps if e["code_s"] == "4491"][0]
         assert ep["closed"] is True  # 200株 - 200株 = 残差はあっても0扱い
+
+    def test_second_split_after_registration_still_marks_suspect(self, db_path):
+        # PRレビュー #405 指摘: 「登録済みイベントが1件でもあれば安全」という判定は
+        # 粗く、同一銘柄で後日発生した別の分割・併合 (未登録) を見逃す。
+        # 1回目 (登録済み) の後、単価が急変する2回目のジャンプが検知されるはず。
+        _add(db_path, "8491", "2025-01-01", "buy", 1000, 100, seq_salt="a")
+        _add(db_path, "8491", "2025-06-01", "sell", 500, 110, seq_salt="b")
+        ps.add_split_adjustment("8491", "2025-03-01", 0.5, db_path=db_path)  # 1回目登録済み
+        _add(db_path, "8491", "2025-12-01", "sell", 100, 900, seq_salt="c")  # 2回目 (未登録) の痕跡
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        ep = [e for e in eps if e["code_s"] == "8491" and e["kind"] == "現物"][0]
+        assert ep["split_suspect"] is True  # 登録済みでも新規ジャンプがあれば要確認扱い

--- a/tests/test_fill_episodes.py
+++ b/tests/test_fill_episodes.py
@@ -627,11 +627,14 @@ class TestSplitAdjustment:
                          and e["pl"] and not e.get("split_suspect")]
         assert fill_pls_1491 == []
 
-        # クローズ済みでも split_suspect が付くこと (closed/open 双方への伝播確認)
+        # クローズ済みでも split_suspect が付くこと (closed/open 双方への伝播確認)。
+        # 建玉を保有継続したまま分割をまたいで売り切るケース (P2-2レビュー対応で
+        # 「保有していない期間の変動」を誤検知しないよう修正したため、単純な
+        # 売り切り→買い直しではなく同一保有内でジャンプが起きる形にする)。
         _add(db_path, "5491", "2025-01-01", "buy", 8000, 45, seq_salt="a")
-        _add(db_path, "5491", "2025-06-01", "sell", 8000, 60, seq_salt="b")  # 未換算のまま0株で完結
-        _add(db_path, "5491", "2025-09-01", "buy", 100, 900, seq_salt="c")   # 単価ジャンプ
-        _add(db_path, "5491", "2025-09-15", "sell", 100, 950, seq_salt="d")
+        _add(db_path, "5491", "2025-06-01", "sell", 4000, 60, seq_salt="b")   # 残4000株、保有継続
+        _add(db_path, "5491", "2025-09-01", "buy", 100, 900, seq_salt="c")    # 単価ジャンプ (同一保有内)
+        _add(db_path, "5491", "2025-09-15", "sell", 4100, 950, seq_salt="d")  # 残高0でクローズ
         eps2 = helpers.build_fill_episodes(db_path=db_path)
         closed_ep = [e for e in eps2 if e["code_s"] == "5491" and e["kind"] == "現物"][0]
         assert closed_ep["closed"] is True
@@ -647,12 +650,13 @@ class TestSplitAdjustment:
         ep = [e for e in eps if e["code_s"] == "9252" and e["kind"] == "現物"][0]
         assert not ep.get("split_suspect")  # pending_review 未登録ならフラグは付かない
 
-        ps.mark_split_pending_review("9252", reason="保有中総当たりチェック", db_path=db_path)
+        ps.mark_split_pending_review(
+            "9252", reason="保有中総当たりチェック", ex_date="2025-08-07", db_path=db_path)
         eps2 = helpers.build_fill_episodes(db_path=db_path)
         ep2 = [e for e in eps2 if e["code_s"] == "9252" and e["kind"] == "現物"][0]
         assert ep2["split_suspect"] is True
 
-        # add_split_adjustment で登録すれば pending は自動解除される
+        # add_split_adjustment で同一 ex_date を登録すれば pending は自動解除される
         ps.add_split_adjustment("9252", "2025-08-07", 0.833333, db_path=db_path)
         assert "9252" not in ps.list_pending_review_codes(db_path=db_path)
 
@@ -677,3 +681,28 @@ class TestSplitAdjustment:
         eps = helpers.build_fill_episodes(db_path=db_path)
         ep = [e for e in eps if e["code_s"] == "8491" and e["kind"] == "現物"][0]
         assert ep["split_suspect"] is True  # 登録済みでも新規ジャンプがあれば要確認扱い
+
+    def test_price_gap_across_holding_gap_is_not_a_split(self, db_path):
+        # PRレビュー #405 (P2) 指摘: 建玉を売り切ってから数年後に買い直した場合の
+        # 価格変動は分割・併合と無関係な通常の値上がり・値下がり。誤検知しない。
+        _add(db_path, "9492", "2022-01-01", "buy", 100, 500, seq_salt="a")
+        _add(db_path, "9492", "2022-02-01", "sell", 100, 550, seq_salt="b")   # 完結
+        _add(db_path, "9492", "2025-06-01", "buy", 100, 2000, seq_salt="c")  # 数年後の買い直し(3.6倍)
+        _add(db_path, "9492", "2025-12-01", "sell", 100, 2200, seq_salt="d")
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        for ep in eps:
+            if ep["code_s"] == "9492":
+                assert not ep.get("split_suspect")
+
+    def test_split_suspect_scoped_to_affected_episode_only(self, db_path):
+        # PRレビュー #405 (P2) 指摘: 未登録ジャンプが1件あっても、その期間と無関係な
+        # (分割前に完結した) 過去ラウンドまで split_suspect で隠してはいけない。
+        _add(db_path, "9491", "2025-01-01", "buy", 100, 1000, seq_salt="a")
+        _add(db_path, "9491", "2025-02-01", "sell", 100, 1100, seq_salt="b")  # 無関係ラウンド、完結
+        _add(db_path, "9491", "2025-06-01", "buy", 100, 900, seq_salt="c")
+        _add(db_path, "9491", "2025-12-01", "sell", 100, 3000, seq_salt="d")  # 単価ジャンプ (900->3000)
+        eps = helpers.build_fill_episodes(db_path=db_path)
+        genbutsu = {e["open_date"]: e for e in eps if e["code_s"] == "9491"}
+        assert not genbutsu["2025-01-01"].get("split_suspect")  # 無関係ラウンドは隠さない
+        assert genbutsu["2025-01-01"]["pl"]["profit_amount"] == 10000
+        assert genbutsu["2025-06-01"]["split_suspect"] is True  # 影響を受けるラウンドのみ

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1384,3 +1384,12 @@ class TestSplitAdjustment:
 
         ps.add_split_adjustment("9493", "2025-09-01", 0.8, db_path=db_path)
         assert "9493" not in ps.list_pending_review_codes(db_path=db_path)  # 全件解決
+
+    def test_unknown_pending_cleared_on_any_registration(self, db_path):
+        # PRレビュー #405 (2周目 P2) 指摘: yfinance 取得失敗時に ex_date 不明のまま
+        # "unknown" マーカーで積まれた pending は、通常の ex_date 一致判定では
+        # 永久に解除されない。以後 ex_date が判明して登録できた時点で解除する。
+        ps.mark_split_pending_review("9495", reason="yfinance取得失敗", db_path=db_path)
+        assert "9495" in ps.list_pending_review_codes(db_path=db_path)
+        ps.add_split_adjustment("9495", "2025-06-01", 0.5, db_path=db_path)
+        assert "9495" not in ps.list_pending_review_codes(db_path=db_path)

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1393,3 +1393,13 @@ class TestSplitAdjustment:
         assert "9495" in ps.list_pending_review_codes(db_path=db_path)
         ps.add_split_adjustment("9495", "2025-06-01", 0.5, db_path=db_path)
         assert "9495" not in ps.list_pending_review_codes(db_path=db_path)
+
+    def test_clear_pending_review_for_false_positive(self, db_path):
+        # PRレビュー #405 (4周目 P2): 分割ではない誤検知は比率を捏造せず解除できる。
+        ps.mark_split_pending_review("9496", reason="単価ジャンプ検出", ex_date="2025-06-01", db_path=db_path)
+        ps.mark_split_pending_review("9496", reason="単価ジャンプ検出", ex_date="2025-09-01", db_path=db_path)
+        assert ps.clear_split_pending_review("9496", ex_date="2025-06-01", db_path=db_path) is True
+        assert ps.list_pending_review_events(db_path=db_path)["9496"] == ["2025-09-01"]
+
+        assert ps.clear_split_pending_review("9496", db_path=db_path) is True
+        assert "9496" not in ps.list_pending_review_codes(db_path=db_path)

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1348,3 +1348,25 @@ class TestFillMemo:
         fills = ps.list_fills(db_path=db_path)
         assert len(fills) == 1
         assert all("review_memo" not in fl for fl in fills)
+
+
+class TestSplitAdjustment:
+    """分割・併合の換算比率キャッシュ (issue #398)。"""
+
+    def test_add_and_get_multiple_events_sorted(self, db_path):
+        assert ps.get_split_adjustments("1491", db_path=db_path) == []
+        ps.add_split_adjustment("1491", "2025-09-29", 0.05, db_path=db_path)
+        ps.add_split_adjustment("1491", "2020-01-01", 0.5, db_path=db_path)
+        events = ps.get_split_adjustments("1491", db_path=db_path)
+        assert events == [
+            {"ex_date": "2020-01-01", "ratio": 0.5},
+            {"ex_date": "2025-09-29", "ratio": 0.05},
+        ]
+        # 同一 ex_date は上書き (dedup)
+        ps.add_split_adjustment("1491", "2025-09-29", 0.1, db_path=db_path)
+        events2 = ps.get_split_adjustments("1491", db_path=db_path)
+        assert len(events2) == 2
+        assert {"ex_date": "2025-09-29", "ratio": 0.1} in events2
+        # list_all_split_adjustments は build_fill_episodes の N+1 回避用一括取得
+        all_adj = ps.list_all_split_adjustments(db_path=db_path)
+        assert all_adj["1491"] == events2

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1371,6 +1371,14 @@ class TestSplitAdjustment:
         all_adj = ps.list_all_split_adjustments(db_path=db_path)
         assert all_adj["1491"] == events2
 
+    def test_rejects_non_finite_ratio(self, db_path):
+        # PRレビュー #405 (5周目 P2): nan/inf は float 変換できても保存してはいけない。
+        with pytest.raises(ValueError):
+            ps.add_split_adjustment("1491", "2025-09-29", float("nan"), db_path=db_path)
+        with pytest.raises(ValueError):
+            ps.add_split_adjustment("1491", "2025-09-29", float("inf"), db_path=db_path)
+        assert ps.get_split_adjustments("1491", db_path=db_path) == []
+
     def test_pending_review_cleared_per_event_not_per_code(self, db_path):
         # PRレビュー #405 (P1) 指摘: 同一銘柄に複数の未登録イベントがある状態で
         # 1件だけ登録すると、銘柄単位で pending を丸ごと消してはいけない
@@ -1403,3 +1411,10 @@ class TestSplitAdjustment:
 
         assert ps.clear_split_pending_review("9496", db_path=db_path) is True
         assert "9496" not in ps.list_pending_review_codes(db_path=db_path)
+
+    def test_reject_pending_review_records_suppression(self, db_path):
+        # PRレビュー #405 (5周目 P2): 却下済みイベントは再検出抑止リストに残す。
+        ps.mark_split_pending_review("9497", reason="単価ジャンプ検出", ex_date="2025-06-01", db_path=db_path)
+        assert ps.reject_split_pending_review("9497", ex_date="2025-06-01", db_path=db_path) is True
+        assert "9497" not in ps.list_pending_review_codes(db_path=db_path)
+        assert ps.list_rejected_review_events(db_path=db_path)["9497"] == ["2025-06-01"]

--- a/tests/test_portfolio_shelve.py
+++ b/tests/test_portfolio_shelve.py
@@ -1370,3 +1370,17 @@ class TestSplitAdjustment:
         # list_all_split_adjustments は build_fill_episodes の N+1 回避用一括取得
         all_adj = ps.list_all_split_adjustments(db_path=db_path)
         assert all_adj["1491"] == events2
+
+    def test_pending_review_cleared_per_event_not_per_code(self, db_path):
+        # PRレビュー #405 (P1) 指摘: 同一銘柄に複数の未登録イベントがある状態で
+        # 1件だけ登録すると、銘柄単位で pending を丸ごと消してはいけない
+        # (残りの未登録イベントの警告が消えてしまう)。
+        ps.mark_split_pending_review("9493", reason="テスト", ex_date="2025-06-01", db_path=db_path)
+        ps.mark_split_pending_review("9493", reason="テスト", ex_date="2025-09-01", db_path=db_path)
+        assert "9493" in ps.list_pending_review_codes(db_path=db_path)
+
+        ps.add_split_adjustment("9493", "2025-06-01", 0.5, db_path=db_path)
+        assert "9493" in ps.list_pending_review_codes(db_path=db_path)  # 残り1件はまだ未解決
+
+        ps.add_split_adjustment("9493", "2025-09-01", 0.8, db_path=db_path)
+        assert "9493" not in ps.list_pending_review_codes(db_path=db_path)  # 全件解決


### PR DESCRIPTION
## Summary
- 証券会社CSVは分割・併合を調整しないため、fill基準のエピソード再構成が未換算のまま合算し、1491中外鉱業で保有中3,800株・含み益+1,858,094円という誤表示が発生していた(実際は残高0株、実現損益+27,100円)
- yfinanceのcorporate actionsで検知・換算するパイプラインを追加。信用は建単価/決済損益で証券会社側が既に調整済みのため対象外(現物のみ)
- 検知は(a)単価ジャンプ・(b)保有中現物の総当たりの2系統。比率登録は`show_fill_episodes.py --check-splits`/`--register-split`経由の手動確認とし、未登録の疑いは残高・損益を隠して「⚠分割・併合の疑い」表示にする
- 実データで1491(登録・0株クローズ+27,100円)と9252(未登録・要確認表示)の両パターンを確認済み

## Test plan
- [x] pytest tests/test_fill_episodes.py tests/test_portfolio_shelve.py tests/test_webapp_helpers.py tests/test_html_sanitizer.py tests/test_webapp_routes.py 全664件 pass
- [x] webapp起動 + Playwrightで /trade-history 確認 (1491換算済み表示・9252要確認表示)
- [x] show_fill_episodes.py --check-splits を実データで実行し検知結果を確認
- [x] simplifyレビュー(4エージェント並行)で発見した現引fillの分割換算バグ(信用ラウンドがクローズされない)を修正・回帰テスト追加

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)